### PR TITLE
changes for new API responses

### DIFF
--- a/coreDriverInterfaceSupported.json
+++ b/coreDriverInterfaceSupported.json
@@ -1,9 +1,6 @@
 {
     "_comment": "contains a list of core-driver interfaces branch names that this core supports",
     "versions": [
-        "2.0",
-        "2.1",
-        "2.2",
-        "2.3"
+        "2.4"
     ]
 }

--- a/lib/build/cookieAndHeaders.d.ts
+++ b/lib/build/cookieAndHeaders.d.ts
@@ -3,35 +3,35 @@ import * as express from "express";
 import { IncomingMessage, ServerResponse } from "http";
 export declare class CookieConfig {
     private static instance;
-    accessTokenPath: string | undefined;
-    refreshTokenPath: string | undefined;
+    accessTokenPath: string;
+    refreshTokenPath: string;
     cookieDomain: string | undefined;
-    cookieSecure: boolean | undefined;
-    cookieSameSite: "strict" | "lax" | "none" | undefined;
-    constructor(accessTokenPath?: string, refreshTokenPath?: string, cookieDomain?: string, cookieSecure?: boolean, cookieSameSite?: "strict" | "lax" | "none");
+    cookieSecure: boolean;
+    cookieSameSite: "strict" | "lax" | "none";
+    constructor(accessTokenPath: string, refreshTokenPath: string, cookieDomain: string | undefined, cookieSecure: boolean, cookieSameSite: "strict" | "lax" | "none");
     static init(accessTokenPath?: string, refreshTokenPath?: string, cookieDomain?: string, cookieSecure?: boolean, cookieSameSite?: "strict" | "lax" | "none"): void;
     static reset(): void;
-    static getInstance(): CookieConfig;
+    static getInstanceOrThrowError(): CookieConfig;
 }
 export declare function saveFrontendInfoFromRequest(req: express.Request): void;
 /**
  * @description clears all the auth cookies from the response
  */
-export declare function clearSessionFromCookie(res: express.Response, domain: string | undefined, secure: boolean, accessTokenPath: string, refreshTokenPath: string, idRefreshTokenPath: string, sameSite: "strict" | "lax" | "none"): void;
+export declare function clearSessionFromCookie(res: express.Response): void;
 /**
  * @param expiry: must be time in milliseconds from epoch time.
  */
-export declare function attachAccessTokenToCookie(res: express.Response, token: string, expiry: number, domain: string | undefined, path: string, secure: boolean, sameSite: "strict" | "lax" | "none"): void;
+export declare function attachAccessTokenToCookie(res: express.Response, token: string, expiry: number): void;
 /**
  * @param expiry: must be time in milliseconds from epoch time.
  */
-export declare function attachRefreshTokenToCookie(res: express.Response, token: string, expiry: number, domain: string | undefined, path: string, secure: boolean, sameSite: "strict" | "lax" | "none"): void;
+export declare function attachRefreshTokenToCookie(res: express.Response, token: string, expiry: number): void;
 export declare function getAccessTokenFromCookie(req: express.Request): string | undefined;
 export declare function getRefreshTokenFromCookie(req: express.Request): string | undefined;
 export declare function getAntiCsrfTokenFromHeaders(req: express.Request): string | undefined;
 export declare function getIdRefreshTokenFromCookie(req: express.Request): string | undefined;
 export declare function setAntiCsrfTokenInHeaders(res: express.Response, antiCsrfToken: string): void;
-export declare function setIdRefreshTokenInHeaderAndCookie(res: express.Response, idRefreshToken: string, expiry: number, domain: string | undefined, secure: boolean, path: string, sameSite: "strict" | "lax" | "none"): void;
+export declare function setIdRefreshTokenInHeaderAndCookie(res: express.Response, idRefreshToken: string, expiry: number): void;
 export declare function setFrontTokenInHeaders(res: express.Response, userId: string, atExpiry: number, jwtPayload: any): void;
 export declare function getHeader(req: express.Request, key: string): string | undefined;
 export declare function setOptionsAPIHeader(res: express.Response): void;
@@ -47,5 +47,5 @@ export declare function getCORSAllowedHeaders(): string[];
  * @param expires
  * @param path
  */
-export declare function setCookie(res: ServerResponse, name: string, value: string, domain: string | undefined, secure: boolean, httpOnly: boolean, expires: number, path: string, sameSite: "strict" | "lax" | "none", pathType?: "refreshTokenPath" | "accessTokenPath" | null): ServerResponse;
+export declare function setCookie(res: ServerResponse, name: string, value: string, expires: number, pathType: "refreshTokenPath" | "accessTokenPath"): ServerResponse;
 export declare function getCookieValue(req: IncomingMessage, key: string): string | undefined;

--- a/lib/build/cookieAndHeaders.js
+++ b/lib/build/cookieAndHeaders.js
@@ -39,11 +39,11 @@ class CookieConfig {
     static init(accessTokenPath, refreshTokenPath, cookieDomain, cookieSecure, cookieSameSite) {
         if (CookieConfig.instance === undefined) {
             CookieConfig.instance = new CookieConfig(
-                accessTokenPath,
-                refreshTokenPath,
+                accessTokenPath === undefined ? "/" : accessTokenPath,
+                refreshTokenPath === undefined ? "/session/refresh" : refreshTokenPath,
                 cookieDomain,
-                cookieSecure,
-                cookieSameSite
+                cookieSecure === undefined ? false : cookieSecure,
+                cookieSameSite === undefined ? "lax" : cookieSameSite
             );
         }
     }
@@ -56,9 +56,9 @@ class CookieConfig {
         }
         CookieConfig.instance = undefined;
     }
-    static getInstance() {
+    static getInstanceOrThrowError() {
         if (CookieConfig.instance === undefined) {
-            CookieConfig.instance = new CookieConfig();
+            throw new Error("Please call the init function before using SuperTokens");
         }
         return CookieConfig.instance;
     }
@@ -84,21 +84,10 @@ exports.saveFrontendInfoFromRequest = saveFrontendInfoFromRequest;
 /**
  * @description clears all the auth cookies from the response
  */
-function clearSessionFromCookie(res, domain, secure, accessTokenPath, refreshTokenPath, idRefreshTokenPath, sameSite) {
-    setCookie(res, accessTokenCookieKey, "", domain, secure, true, 0, accessTokenPath, sameSite, "accessTokenPath");
-    setCookie(res, refreshTokenCookieKey, "", domain, secure, true, 0, refreshTokenPath, sameSite, "refreshTokenPath");
-    setCookie(
-        res,
-        idRefreshTokenCookieKey,
-        "",
-        domain,
-        secure,
-        true,
-        0,
-        idRefreshTokenPath,
-        sameSite,
-        "accessTokenPath"
-    );
+function clearSessionFromCookie(res) {
+    setCookie(res, accessTokenCookieKey, "", 0, "accessTokenPath");
+    setCookie(res, refreshTokenCookieKey, "", 0, "refreshTokenPath");
+    setCookie(res, idRefreshTokenCookieKey, "", 0, "accessTokenPath");
     setHeader(res, idRefreshTokenHeaderKey, "remove", false);
     setHeader(res, "Access-Control-Expose-Headers", idRefreshTokenHeaderKey, true);
 }
@@ -106,15 +95,15 @@ exports.clearSessionFromCookie = clearSessionFromCookie;
 /**
  * @param expiry: must be time in milliseconds from epoch time.
  */
-function attachAccessTokenToCookie(res, token, expiry, domain, path, secure, sameSite) {
-    setCookie(res, accessTokenCookieKey, token, domain, secure, true, expiry, path, sameSite, "accessTokenPath");
+function attachAccessTokenToCookie(res, token, expiry) {
+    setCookie(res, accessTokenCookieKey, token, expiry, "accessTokenPath");
 }
 exports.attachAccessTokenToCookie = attachAccessTokenToCookie;
 /**
  * @param expiry: must be time in milliseconds from epoch time.
  */
-function attachRefreshTokenToCookie(res, token, expiry, domain, path, secure, sameSite) {
-    setCookie(res, refreshTokenCookieKey, token, domain, secure, true, expiry, path, sameSite, "refreshTokenPath");
+function attachRefreshTokenToCookie(res, token, expiry) {
+    setCookie(res, refreshTokenCookieKey, token, expiry, "refreshTokenPath");
 }
 exports.attachRefreshTokenToCookie = attachRefreshTokenToCookie;
 function getAccessTokenFromCookie(req) {
@@ -138,21 +127,10 @@ function setAntiCsrfTokenInHeaders(res, antiCsrfToken) {
     setHeader(res, "Access-Control-Expose-Headers", antiCsrfHeaderKey, true);
 }
 exports.setAntiCsrfTokenInHeaders = setAntiCsrfTokenInHeaders;
-function setIdRefreshTokenInHeaderAndCookie(res, idRefreshToken, expiry, domain, secure, path, sameSite) {
+function setIdRefreshTokenInHeaderAndCookie(res, idRefreshToken, expiry) {
     setHeader(res, idRefreshTokenHeaderKey, idRefreshToken + ";" + expiry, false);
     setHeader(res, "Access-Control-Expose-Headers", idRefreshTokenHeaderKey, true);
-    setCookie(
-        res,
-        idRefreshTokenCookieKey,
-        idRefreshToken,
-        domain,
-        secure,
-        true,
-        expiry,
-        path,
-        sameSite,
-        "accessTokenPath"
-    );
+    setCookie(res, idRefreshTokenCookieKey, idRefreshToken, expiry, "accessTokenPath");
 }
 exports.setIdRefreshTokenInHeaderAndCookie = setIdRefreshTokenInHeaderAndCookie;
 function setFrontTokenInHeaders(res, userId, atExpiry, jwtPayload) {
@@ -214,30 +192,17 @@ function setHeader(res, key, value, allowDuplicateKey) {
  * @param expires
  * @param path
  */
-function setCookie(res, name, value, domain, secure, httpOnly, expires, path, sameSite, pathType = null) {
-    let cookieDomain = CookieConfig.getInstance().cookieDomain;
-    let cookieSecure = CookieConfig.getInstance().cookieSecure;
-    let cookieSameSite = CookieConfig.getInstance().cookieSameSite;
-    if (cookieDomain !== undefined) {
-        domain = cookieDomain;
-    }
-    if (cookieSameSite !== undefined) {
-        sameSite = cookieSameSite;
-    }
-    if (cookieSecure !== undefined) {
-        secure = cookieSecure;
-    }
+function setCookie(res, name, value, expires, pathType) {
+    let domain = CookieConfig.getInstanceOrThrowError().cookieDomain;
+    let secure = CookieConfig.getInstanceOrThrowError().cookieSecure;
+    let sameSite = CookieConfig.getInstanceOrThrowError().cookieSameSite;
+    let path = "";
     if (pathType === "refreshTokenPath") {
-        let refreshTokenPath = CookieConfig.getInstance().refreshTokenPath;
-        if (refreshTokenPath !== undefined) {
-            path = refreshTokenPath;
-        }
+        path = CookieConfig.getInstanceOrThrowError().refreshTokenPath;
     } else if (pathType === "accessTokenPath") {
-        let accessTokenPath = CookieConfig.getInstance().accessTokenPath;
-        if (accessTokenPath !== undefined) {
-            path = accessTokenPath;
-        }
+        path = CookieConfig.getInstanceOrThrowError().accessTokenPath;
     }
+    let httpOnly = CookieConfig.getInstanceOrThrowError().cookieSecure;
     let opts = {
         domain,
         secure,

--- a/lib/build/cookieAndHeaders.js
+++ b/lib/build/cookieAndHeaders.js
@@ -17,6 +17,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const cookie_1 = require("cookie");
 const deviceInfo_1 = require("./deviceInfo");
 const error_1 = require("./error");
+const utils_1 = require("./utils");
 // TODO: set same-site value for cookies as chrome will soon make that compulsory.
 // Setting it to "lax" seems ideal, however there are bugs in safari regarding that. So setting it to "none" might make more sense.
 const accessTokenCookieKey = "sAccessToken";
@@ -37,6 +38,9 @@ class CookieConfig {
         this.cookieSecure = cookieSecure;
     }
     static init(accessTokenPath, refreshTokenPath, cookieDomain, cookieSecure, cookieSameSite) {
+        if (cookieSameSite !== undefined) {
+            cookieSameSite = utils_1.validateAndNormaliseCookieSameSite(cookieSameSite);
+        }
         if (CookieConfig.instance === undefined) {
             CookieConfig.instance = new CookieConfig(
                 accessTokenPath === undefined ? "/" : accessTokenPath,

--- a/lib/build/express.js
+++ b/lib/build/express.js
@@ -33,7 +33,6 @@ var __awaiter =
 Object.defineProperty(exports, "__esModule", { value: true });
 const cookieAndHeaders_1 = require("./cookieAndHeaders");
 const error_1 = require("./error");
-const handshakeInfo_1 = require("./handshakeInfo");
 const SessionFunctions = require("./session");
 const querier_1 = require("./querier");
 const axios_1 = require("axios");
@@ -107,11 +106,7 @@ function getSession(req, res, doAntiCsrfCheck) {
                 cookieAndHeaders_1.attachAccessTokenToCookie(
                     res,
                     response.accessToken.token,
-                    response.accessToken.expiry,
-                    response.accessToken.domain,
-                    response.accessToken.cookiePath,
-                    response.accessToken.cookieSecure,
-                    response.accessToken.sameSite
+                    response.accessToken.expiry
                 );
                 accessToken = response.accessToken.token;
             }
@@ -125,16 +120,7 @@ function getSession(req, res, doAntiCsrfCheck) {
             );
         } catch (err) {
             if (error_1.AuthError.isErrorFromAuth(err) && err.errType === error_1.AuthError.UNAUTHORISED) {
-                let handShakeInfo = yield handshakeInfo_1.HandshakeInfo.getInstance();
-                cookieAndHeaders_1.clearSessionFromCookie(
-                    res,
-                    handShakeInfo.cookieDomain,
-                    handShakeInfo.cookieSecure,
-                    handShakeInfo.accessTokenPath,
-                    handShakeInfo.refreshTokenPath,
-                    handShakeInfo.idRefreshTokenPath,
-                    handShakeInfo.cookieSameSite
-                );
+                cookieAndHeaders_1.clearSessionFromCookie(res);
             }
             throw err;
         }
@@ -178,16 +164,7 @@ function refreshSession(req, res) {
                 (err.errType === error_1.AuthError.UNAUTHORISED ||
                     err.errType === error_1.AuthError.TOKEN_THEFT_DETECTED)
             ) {
-                let handShakeInfo = yield handshakeInfo_1.HandshakeInfo.getInstance();
-                cookieAndHeaders_1.clearSessionFromCookie(
-                    res,
-                    handShakeInfo.cookieDomain,
-                    handShakeInfo.cookieSecure,
-                    handShakeInfo.accessTokenPath,
-                    handShakeInfo.refreshTokenPath,
-                    handShakeInfo.idRefreshTokenPath,
-                    handShakeInfo.cookieSameSite
-                );
+                cookieAndHeaders_1.clearSessionFromCookie(res);
             }
             throw err;
         }
@@ -401,16 +378,7 @@ class Session {
         this.revokeSession = () =>
             __awaiter(this, void 0, void 0, function* () {
                 if (yield SessionFunctions.revokeSession(this.sessionHandle)) {
-                    let handShakeInfo = yield handshakeInfo_1.HandshakeInfo.getInstance();
-                    cookieAndHeaders_1.clearSessionFromCookie(
-                        this.res,
-                        handShakeInfo.cookieDomain,
-                        handShakeInfo.cookieSecure,
-                        handShakeInfo.accessTokenPath,
-                        handShakeInfo.refreshTokenPath,
-                        handShakeInfo.idRefreshTokenPath,
-                        handShakeInfo.cookieSameSite
-                    );
+                    cookieAndHeaders_1.clearSessionFromCookie(this.res);
                 }
             });
         /**
@@ -425,16 +393,7 @@ class Session {
                     return yield SessionFunctions.getSessionData(this.sessionHandle);
                 } catch (err) {
                     if (error_1.AuthError.isErrorFromAuth(err) && err.errType === error_1.AuthError.UNAUTHORISED) {
-                        let handShakeInfo = yield handshakeInfo_1.HandshakeInfo.getInstance();
-                        cookieAndHeaders_1.clearSessionFromCookie(
-                            this.res,
-                            handShakeInfo.cookieDomain,
-                            handShakeInfo.cookieSecure,
-                            handShakeInfo.accessTokenPath,
-                            handShakeInfo.refreshTokenPath,
-                            handShakeInfo.idRefreshTokenPath,
-                            handShakeInfo.cookieSameSite
-                        );
+                        cookieAndHeaders_1.clearSessionFromCookie(this.res);
                     }
                     throw err;
                 }
@@ -450,16 +409,7 @@ class Session {
                     yield SessionFunctions.updateSessionData(this.sessionHandle, newSessionData);
                 } catch (err) {
                     if (error_1.AuthError.isErrorFromAuth(err) && err.errType === error_1.AuthError.UNAUTHORISED) {
-                        let handShakeInfo = yield handshakeInfo_1.HandshakeInfo.getInstance();
-                        cookieAndHeaders_1.clearSessionFromCookie(
-                            this.res,
-                            handShakeInfo.cookieDomain,
-                            handShakeInfo.cookieSecure,
-                            handShakeInfo.accessTokenPath,
-                            handShakeInfo.refreshTokenPath,
-                            handShakeInfo.idRefreshTokenPath,
-                            handShakeInfo.cookieSameSite
-                        );
+                        cookieAndHeaders_1.clearSessionFromCookie(this.res);
                     }
                     throw err;
                 }
@@ -483,16 +433,7 @@ class Session {
                     userDataInJWT: newJWTPayload,
                 });
                 if (response.status === "UNAUTHORISED") {
-                    let handShakeInfo = yield handshakeInfo_1.HandshakeInfo.getInstance();
-                    cookieAndHeaders_1.clearSessionFromCookie(
-                        this.res,
-                        handShakeInfo.cookieDomain,
-                        handShakeInfo.cookieSecure,
-                        handShakeInfo.accessTokenPath,
-                        handShakeInfo.refreshTokenPath,
-                        handShakeInfo.idRefreshTokenPath,
-                        handShakeInfo.cookieSameSite
-                    );
+                    cookieAndHeaders_1.clearSessionFromCookie(this.res);
                     throw error_1.generateError(error_1.AuthError.UNAUTHORISED, new Error(response.message));
                 }
                 this.userDataInJWT = response.session.userDataInJWT;
@@ -507,11 +448,7 @@ class Session {
                     cookieAndHeaders_1.attachAccessTokenToCookie(
                         this.res,
                         response.accessToken.token,
-                        response.accessToken.expiry,
-                        response.accessToken.domain,
-                        response.accessToken.cookiePath,
-                        response.accessToken.cookieSecure,
-                        response.accessToken.sameSite
+                        response.accessToken.expiry
                     );
                 }
             });

--- a/lib/build/faunadb/middleware.js
+++ b/lib/build/faunadb/middleware.js
@@ -47,7 +47,6 @@ var __awaiter =
 Object.defineProperty(exports, "__esModule", { value: true });
 const express_1 = require("./express");
 const cookieAndHeaders_1 = require("../cookieAndHeaders");
-const handshakeInfo_1 = require("../handshakeInfo");
 const OriginalMiddleware = require("../middleware");
 // We do not use the middleware functions from ../middleware, because we want the
 // refreshSession, getSession of the ones defined for faunadb to be called.
@@ -73,12 +72,7 @@ function autoRefreshMiddleware() {
 exports.autoRefreshMiddleware = autoRefreshMiddleware;
 function getRefreshPath() {
     return __awaiter(this, void 0, void 0, function* () {
-        let refreshTokenPathConfig = cookieAndHeaders_1.CookieConfig.getInstance().refreshTokenPath;
-        if (refreshTokenPathConfig !== undefined) {
-            return refreshTokenPathConfig;
-        }
-        let handShakeInfo = yield handshakeInfo_1.HandshakeInfo.getInstance();
-        return handShakeInfo.refreshTokenPath;
+        return cookieAndHeaders_1.CookieConfig.getInstanceOrThrowError().refreshTokenPath;
     });
 }
 function middleware(antiCsrfCheck) {

--- a/lib/build/handshakeInfo.d.ts
+++ b/lib/build/handshakeInfo.d.ts
@@ -1,18 +1,13 @@
 export declare class HandshakeInfo {
     static instance: HandshakeInfo | undefined;
     jwtSigningPublicKey: string;
-    cookieDomain?: string;
-    cookieSecure: boolean;
-    accessTokenPath: string;
-    refreshTokenPath: string;
     enableAntiCsrf: boolean;
     accessTokenBlacklistingEnabled: boolean;
     jwtSigningPublicKeyExpiryTime: number;
-    cookieSameSite: "none" | "lax" | "strict";
-    idRefreshTokenPath: string;
-    sessionExpiredStatusCode: number;
+    accessTokenVaildity: number;
+    refreshTokenVaildity: number;
     static reset(): void;
     static getInstance(): Promise<HandshakeInfo>;
-    constructor(jwtSigningPublicKey: string, cookieDomain: string | undefined, cookieSecure: boolean, accessTokenPath: string, refreshTokenPath: string, enableAntiCsrf: boolean, accessTokenBlacklistingEnabled: boolean, jwtSigningPublicKeyExpiryTime: number, cookieSameSite: "none" | "lax" | "strict", idRefreshTokenPath: string, sessionExpiredStatusCode: number);
+    constructor(jwtSigningPublicKey: string, enableAntiCsrf: boolean, accessTokenBlacklistingEnabled: boolean, jwtSigningPublicKeyExpiryTime: number, accessTokenVaildity: number, refreshTokenVaildity: number);
     updateJwtSigningPublicKeyInfo: (newKey: string, newExpiry: number) => void;
 }

--- a/lib/build/handshakeInfo.js
+++ b/lib/build/handshakeInfo.js
@@ -50,32 +50,22 @@ const querier_1 = require("./querier");
 class HandshakeInfo {
     constructor(
         jwtSigningPublicKey,
-        cookieDomain,
-        cookieSecure,
-        accessTokenPath,
-        refreshTokenPath,
         enableAntiCsrf,
         accessTokenBlacklistingEnabled,
         jwtSigningPublicKeyExpiryTime,
-        cookieSameSite,
-        idRefreshTokenPath,
-        sessionExpiredStatusCode
+        accessTokenVaildity,
+        refreshTokenVaildity
     ) {
         this.updateJwtSigningPublicKeyInfo = (newKey, newExpiry) => {
             this.jwtSigningPublicKey = newKey;
             this.jwtSigningPublicKeyExpiryTime = newExpiry;
         };
         this.jwtSigningPublicKey = jwtSigningPublicKey;
-        this.cookieDomain = cookieDomain;
-        this.cookieSecure = cookieSecure;
-        this.accessTokenPath = accessTokenPath;
-        this.refreshTokenPath = refreshTokenPath;
         this.enableAntiCsrf = enableAntiCsrf;
         this.accessTokenBlacklistingEnabled = accessTokenBlacklistingEnabled;
         this.jwtSigningPublicKeyExpiryTime = jwtSigningPublicKeyExpiryTime;
-        this.cookieSameSite = cookieSameSite;
-        this.idRefreshTokenPath = idRefreshTokenPath;
-        this.sessionExpiredStatusCode = sessionExpiredStatusCode;
+        this.accessTokenVaildity = accessTokenVaildity;
+        this.refreshTokenVaildity = refreshTokenVaildity;
     }
     static reset() {
         if (process.env.TEST_MODE !== "testing") {
@@ -93,16 +83,11 @@ class HandshakeInfo {
                 let response = yield querier_1.Querier.getInstance().sendPostRequest("/handshake", {});
                 HandshakeInfo.instance = new HandshakeInfo(
                     response.jwtSigningPublicKey,
-                    response.cookieDomain,
-                    response.cookieSecure,
-                    response.accessTokenPath,
-                    response.refreshTokenPath,
                     response.enableAntiCsrf,
                     response.accessTokenBlacklistingEnabled,
                     response.jwtSigningPublicKeyExpiryTime,
-                    response.cookieSameSite,
-                    response.idRefreshTokenPath,
-                    response.sessionExpiredStatusCode
+                    response.accessTokenVaildity,
+                    response.refreshTokenVaildity
                 );
             }
             return HandshakeInfo.instance;

--- a/lib/build/middleware.js
+++ b/lib/build/middleware.js
@@ -34,7 +34,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const express_1 = require("./express");
 const error_1 = require("./error");
 const cookieAndHeaders_1 = require("./cookieAndHeaders");
-const handshakeInfo_1 = require("./handshakeInfo");
+const session_1 = require("./session");
 function autoRefreshMiddleware() {
     return (request, response, next) =>
         __awaiter(this, void 0, void 0, function* () {
@@ -57,12 +57,7 @@ function autoRefreshMiddleware() {
 exports.autoRefreshMiddleware = autoRefreshMiddleware;
 function getRefreshPath() {
     return __awaiter(this, void 0, void 0, function* () {
-        let refreshTokenPathConfig = cookieAndHeaders_1.CookieConfig.getInstance().refreshTokenPath;
-        if (refreshTokenPathConfig !== undefined) {
-            return refreshTokenPathConfig;
-        }
-        let handShakeInfo = yield handshakeInfo_1.HandshakeInfo.getInstance();
-        return handShakeInfo.refreshTokenPath;
+        return cookieAndHeaders_1.CookieConfig.getInstanceOrThrowError().refreshTokenPath;
     });
 }
 function middleware(antiCsrfCheck) {
@@ -126,8 +121,11 @@ exports.errorHandler = errorHandler;
 function sendTryRefreshTokenResponse(err, request, response, next) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            let handshakeInfo = yield handshakeInfo_1.HandshakeInfo.getInstance();
-            sendResponse(response, "try refresh token", handshakeInfo.sessionExpiredStatusCode);
+            sendResponse(
+                response,
+                "try refresh token",
+                session_1.SessionConfig.getInstanceOrThrowError().sessionExpiredStatusCode
+            );
         } catch (err) {
             next(err);
         }
@@ -136,8 +134,11 @@ function sendTryRefreshTokenResponse(err, request, response, next) {
 function sendUnauthorisedResponse(err, request, response, next) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            let handshakeInfo = yield handshakeInfo_1.HandshakeInfo.getInstance();
-            sendResponse(response, "unauthorised", handshakeInfo.sessionExpiredStatusCode);
+            sendResponse(
+                response,
+                "unauthorised",
+                session_1.SessionConfig.getInstanceOrThrowError().sessionExpiredStatusCode
+            );
         } catch (err) {
             next(err);
         }
@@ -146,9 +147,12 @@ function sendUnauthorisedResponse(err, request, response, next) {
 function sendTokenTheftDetectedResponse(sessionHandle, userId, request, response, next) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            let handshakeInfo = yield handshakeInfo_1.HandshakeInfo.getInstance();
             yield express_1.revokeSession(sessionHandle);
-            sendResponse(response, "token theft detected", handshakeInfo.sessionExpiredStatusCode);
+            sendResponse(
+                response,
+                "token theft detected",
+                session_1.SessionConfig.getInstanceOrThrowError().sessionExpiredStatusCode
+            );
         } catch (err) {
             next(err);
         }

--- a/lib/build/session.d.ts
+++ b/lib/build/session.d.ts
@@ -1,5 +1,13 @@
 import { TypeInput, CreateOrRefreshAPIResponse } from "./types";
 export { AuthError as Error } from "./error";
+export declare class SessionConfig {
+    private static instance;
+    sessionExpiredStatusCode: number;
+    constructor(sessionExpiredStatusCode: number);
+    static init(sessionExpiredStatusCode?: number): void;
+    static reset(): void;
+    static getInstanceOrThrowError(): SessionConfig;
+}
 /**
  * @description: to be called by user of the library. This initiates all the modules necessary for this library to work.
  * Please create a database in your mysql instance before calling this function
@@ -25,10 +33,6 @@ export declare function getSession(accessToken: string, antiCsrfToken: string | 
         token: string;
         expiry: number;
         createdTime: number;
-        cookiePath: string;
-        cookieSecure: boolean;
-        domain?: string;
-        sameSite: "none" | "lax" | "strict";
     };
 }>;
 /**

--- a/lib/build/session.js
+++ b/lib/build/session.js
@@ -119,6 +119,18 @@ function createNewSession(userId, jwtPayload = {}, sessionData = {}) {
         delete response.status;
         delete response.jwtSigningPublicKey;
         delete response.jwtSigningPublicKeyExpiryTime;
+        // we check if sameSite is none, antiCsrfTokens is being sent - this is a security check
+        if (
+            cookieAndHeaders_1.CookieConfig.getInstanceOrThrowError().cookieSameSite === "none" &&
+            response.antiCsrfToken === undefined
+        ) {
+            throw error_1.generateError(
+                error_1.AuthError.GENERAL_ERROR,
+                new Error(
+                    'Security error: Cookie same site is "none" and anti-CSRF protection is disabled! Please either: \n- Change cookie same site to "lax" or to "strict". or \n- Enable anti-CSRF protection in the core by setting enable_anti_csrf to true.'
+                )
+            );
+        }
         return response;
     });
 }

--- a/lib/build/session.js
+++ b/lib/build/session.js
@@ -53,6 +53,35 @@ const querier_1 = require("./querier");
 const cookieAndHeaders_1 = require("./cookieAndHeaders");
 var error_2 = require("./error");
 exports.Error = error_2.AuthError;
+class SessionConfig {
+    constructor(sessionExpiredStatusCode) {
+        this.sessionExpiredStatusCode = sessionExpiredStatusCode;
+    }
+    static init(sessionExpiredStatusCode) {
+        if (SessionConfig.instance === undefined) {
+            SessionConfig.instance = new SessionConfig(
+                sessionExpiredStatusCode === undefined ? 401 : sessionExpiredStatusCode
+            );
+        }
+    }
+    static reset() {
+        if (process.env.TEST_MODE !== "testing") {
+            throw error_1.generateError(
+                error_1.AuthError.GENERAL_ERROR,
+                new Error("calling testing function in non testing env")
+            );
+        }
+        SessionConfig.instance = undefined;
+    }
+    static getInstanceOrThrowError() {
+        if (SessionConfig.instance === undefined) {
+            throw new Error("Please call the init function before using SuperTokens");
+        }
+        return SessionConfig.instance;
+    }
+}
+exports.SessionConfig = SessionConfig;
+SessionConfig.instance = undefined;
 /**
  * @description: to be called by user of the library. This initiates all the modules necessary for this library to work.
  * Please create a database in your mysql instance before calling this function
@@ -60,7 +89,6 @@ exports.Error = error_2.AuthError;
  */
 function init(config) {
     querier_1.Querier.initInstance(config.hosts, config.apiKey);
-    // TODO:
     cookieAndHeaders_1.CookieConfig.init(
         config.accessTokenPath,
         config.refreshTokenPath,
@@ -68,6 +96,7 @@ function init(config) {
         config.cookieSecure,
         config.cookieSameSite
     );
+    SessionConfig.init(config.sessionExpiredStatusCode);
     // this will also call the api version API
     handshakeInfo_1.HandshakeInfo.getInstance().catch((err) => {
         // ignored

--- a/lib/build/types.d.ts
+++ b/lib/build/types.d.ts
@@ -10,28 +10,16 @@ export declare type CreateOrRefreshAPIResponse = {
         token: string;
         expiry: number;
         createdTime: number;
-        cookiePath: string;
-        cookieSecure: boolean;
-        domain?: string;
-        sameSite: "none" | "lax" | "strict";
     };
     refreshToken: {
         token: string;
         expiry: number;
         createdTime: number;
-        cookiePath: string;
-        cookieSecure: boolean;
-        domain?: string;
-        sameSite: "none" | "lax" | "strict";
     };
     idRefreshToken: {
         token: string;
         expiry: number;
         createdTime: number;
-        cookiePath: string;
-        cookieSecure: boolean;
-        domain?: string;
-        sameSite: "none" | "lax" | "strict";
     };
     antiCsrfToken: string | undefined;
 };
@@ -47,6 +35,7 @@ export declare type TypeInput = {
     cookieSameSite?: "strict" | "lax" | "none";
     cookieSecure?: boolean;
     apiKey?: string;
+    sessionExpiredStatusCode?: number;
 };
 export interface SessionRequest extends Request {
     session: Session;

--- a/lib/build/utils.d.ts
+++ b/lib/build/utils.d.ts
@@ -1,5 +1,6 @@
 import { CreateOrRefreshAPIResponse } from "./types";
 import * as express from "express";
+export declare function validateAndNormaliseCookieSameSite(sameSite: string): "strict" | "lax" | "none";
 export declare function attachCreateOrRefreshSessionResponseToExpressRes(res: express.Response, response: CreateOrRefreshAPIResponse): void;
 export declare function getLargestVersionFromIntersection(v1: string[], v2: string[]): string | undefined;
 export declare function maxVersion(version1: string, version2: string): string;

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -1,6 +1,19 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const cookieAndHeaders_1 = require("./cookieAndHeaders");
+const error_1 = require("./error");
+function validateAndNormaliseCookieSameSite(sameSite) {
+    sameSite = sameSite.trim();
+    sameSite = sameSite.toLocaleLowerCase();
+    if (sameSite !== "strict" && sameSite !== "lax" && sameSite !== "none") {
+        throw error_1.generateError(
+            error_1.AuthError.GENERAL_ERROR,
+            new Error('cookie same site must be one of "strict", "lax", or "none"')
+        );
+    }
+    return sameSite;
+}
+exports.validateAndNormaliseCookieSameSite = validateAndNormaliseCookieSameSite;
 function attachCreateOrRefreshSessionResponseToExpressRes(res, response) {
     let accessToken = response.accessToken;
     let refreshToken = response.refreshToken;

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -11,33 +11,9 @@ function attachCreateOrRefreshSessionResponseToExpressRes(res, response) {
         response.accessToken.expiry,
         response.session.userDataInJWT
     );
-    cookieAndHeaders_1.attachAccessTokenToCookie(
-        res,
-        accessToken.token,
-        accessToken.expiry,
-        accessToken.domain,
-        accessToken.cookiePath,
-        accessToken.cookieSecure,
-        accessToken.sameSite
-    );
-    cookieAndHeaders_1.attachRefreshTokenToCookie(
-        res,
-        refreshToken.token,
-        refreshToken.expiry,
-        refreshToken.domain,
-        refreshToken.cookiePath,
-        refreshToken.cookieSecure,
-        refreshToken.sameSite
-    );
-    cookieAndHeaders_1.setIdRefreshTokenInHeaderAndCookie(
-        res,
-        idRefreshToken.token,
-        idRefreshToken.expiry,
-        idRefreshToken.domain,
-        idRefreshToken.cookieSecure,
-        idRefreshToken.cookiePath,
-        idRefreshToken.sameSite
-    );
+    cookieAndHeaders_1.attachAccessTokenToCookie(res, accessToken.token, accessToken.expiry);
+    cookieAndHeaders_1.attachRefreshTokenToCookie(res, refreshToken.token, refreshToken.expiry);
+    cookieAndHeaders_1.setIdRefreshTokenInHeaderAndCookie(res, idRefreshToken.token, idRefreshToken.expiry);
     if (response.antiCsrfToken !== undefined) {
         cookieAndHeaders_1.setAntiCsrfTokenInHeaders(res, response.antiCsrfToken);
     }

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,5 +15,5 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * under the License.
  */
 exports.version = "3.0.0";
-exports.cdiSupported = ["2.0", "2.1", "2.2", "2.3"];
+exports.cdiSupported = ["2.4"];
 //# sourceMappingURL=version.js.map

--- a/lib/ts/cookieAndHeaders.ts
+++ b/lib/ts/cookieAndHeaders.ts
@@ -18,6 +18,7 @@ import { IncomingMessage, ServerResponse } from "http";
 
 import { DeviceInfo } from "./deviceInfo";
 import { AuthError, generateError } from "./error";
+import { validateAndNormaliseCookieSameSite } from "./utils";
 
 // TODO: set same-site value for cookies as chrome will soon make that compulsory.
 // Setting it to "lax" seems ideal, however there are bugs in safari regarding that. So setting it to "none" might make more sense.
@@ -63,6 +64,10 @@ export class CookieConfig {
         cookieSecure?: boolean,
         cookieSameSite?: "strict" | "lax" | "none"
     ) {
+        if (cookieSameSite !== undefined) {
+            cookieSameSite = validateAndNormaliseCookieSameSite(cookieSameSite);
+        }
+
         if (CookieConfig.instance === undefined) {
             CookieConfig.instance = new CookieConfig(
                 accessTokenPath === undefined ? "/" : accessTokenPath,

--- a/lib/ts/cookieAndHeaders.ts
+++ b/lib/ts/cookieAndHeaders.ts
@@ -37,17 +37,17 @@ const frontTokenHeaderKey = "front-token";
 
 export class CookieConfig {
     private static instance: CookieConfig | undefined = undefined;
-    accessTokenPath: string | undefined;
-    refreshTokenPath: string | undefined;
+    accessTokenPath: string;
+    refreshTokenPath: string;
     cookieDomain: string | undefined;
-    cookieSecure: boolean | undefined;
-    cookieSameSite: "strict" | "lax" | "none" | undefined;
+    cookieSecure: boolean;
+    cookieSameSite: "strict" | "lax" | "none";
     constructor(
-        accessTokenPath?: string,
-        refreshTokenPath?: string,
-        cookieDomain?: string,
-        cookieSecure?: boolean,
-        cookieSameSite?: "strict" | "lax" | "none"
+        accessTokenPath: string,
+        refreshTokenPath: string,
+        cookieDomain: string | undefined,
+        cookieSecure: boolean,
+        cookieSameSite: "strict" | "lax" | "none"
     ) {
         this.accessTokenPath = accessTokenPath;
         this.refreshTokenPath = refreshTokenPath;
@@ -65,11 +65,11 @@ export class CookieConfig {
     ) {
         if (CookieConfig.instance === undefined) {
             CookieConfig.instance = new CookieConfig(
-                accessTokenPath,
-                refreshTokenPath,
+                accessTokenPath === undefined ? "/" : accessTokenPath,
+                refreshTokenPath === undefined ? "/session/refresh" : refreshTokenPath,
                 cookieDomain,
-                cookieSecure,
-                cookieSameSite
+                cookieSecure === undefined ? false : cookieSecure,
+                cookieSameSite === undefined ? "lax" : cookieSameSite
             );
         }
     }
@@ -81,9 +81,9 @@ export class CookieConfig {
         CookieConfig.instance = undefined;
     }
 
-    static getInstance() {
+    static getInstanceOrThrowError() {
         if (CookieConfig.instance === undefined) {
-            CookieConfig.instance = new CookieConfig();
+            throw new Error("Please call the init function before using SuperTokens");
         }
         return CookieConfig.instance;
     }
@@ -108,29 +108,10 @@ export function saveFrontendInfoFromRequest(req: express.Request) {
 /**
  * @description clears all the auth cookies from the response
  */
-export function clearSessionFromCookie(
-    res: express.Response,
-    domain: string | undefined,
-    secure: boolean,
-    accessTokenPath: string,
-    refreshTokenPath: string,
-    idRefreshTokenPath: string,
-    sameSite: "strict" | "lax" | "none"
-) {
-    setCookie(res, accessTokenCookieKey, "", domain, secure, true, 0, accessTokenPath, sameSite, "accessTokenPath");
-    setCookie(res, refreshTokenCookieKey, "", domain, secure, true, 0, refreshTokenPath, sameSite, "refreshTokenPath");
-    setCookie(
-        res,
-        idRefreshTokenCookieKey,
-        "",
-        domain,
-        secure,
-        true,
-        0,
-        idRefreshTokenPath,
-        sameSite,
-        "accessTokenPath"
-    );
+export function clearSessionFromCookie(res: express.Response) {
+    setCookie(res, accessTokenCookieKey, "", 0, "accessTokenPath");
+    setCookie(res, refreshTokenCookieKey, "", 0, "refreshTokenPath");
+    setCookie(res, idRefreshTokenCookieKey, "", 0, "accessTokenPath");
     setHeader(res, idRefreshTokenHeaderKey, "remove", false);
     setHeader(res, "Access-Control-Expose-Headers", idRefreshTokenHeaderKey, true);
 }
@@ -138,31 +119,15 @@ export function clearSessionFromCookie(
 /**
  * @param expiry: must be time in milliseconds from epoch time.
  */
-export function attachAccessTokenToCookie(
-    res: express.Response,
-    token: string,
-    expiry: number,
-    domain: string | undefined,
-    path: string,
-    secure: boolean,
-    sameSite: "strict" | "lax" | "none"
-) {
-    setCookie(res, accessTokenCookieKey, token, domain, secure, true, expiry, path, sameSite, "accessTokenPath");
+export function attachAccessTokenToCookie(res: express.Response, token: string, expiry: number) {
+    setCookie(res, accessTokenCookieKey, token, expiry, "accessTokenPath");
 }
 
 /**
  * @param expiry: must be time in milliseconds from epoch time.
  */
-export function attachRefreshTokenToCookie(
-    res: express.Response,
-    token: string,
-    expiry: number,
-    domain: string | undefined,
-    path: string,
-    secure: boolean,
-    sameSite: "strict" | "lax" | "none"
-) {
-    setCookie(res, refreshTokenCookieKey, token, domain, secure, true, expiry, path, sameSite, "refreshTokenPath");
+export function attachRefreshTokenToCookie(res: express.Response, token: string, expiry: number) {
+    setCookie(res, refreshTokenCookieKey, token, expiry, "refreshTokenPath");
 }
 
 export function getAccessTokenFromCookie(req: express.Request): string | undefined {
@@ -186,30 +151,11 @@ export function setAntiCsrfTokenInHeaders(res: express.Response, antiCsrfToken: 
     setHeader(res, "Access-Control-Expose-Headers", antiCsrfHeaderKey, true);
 }
 
-export function setIdRefreshTokenInHeaderAndCookie(
-    res: express.Response,
-    idRefreshToken: string,
-    expiry: number,
-    domain: string | undefined,
-    secure: boolean,
-    path: string,
-    sameSite: "strict" | "lax" | "none"
-) {
+export function setIdRefreshTokenInHeaderAndCookie(res: express.Response, idRefreshToken: string, expiry: number) {
     setHeader(res, idRefreshTokenHeaderKey, idRefreshToken + ";" + expiry, false);
     setHeader(res, "Access-Control-Expose-Headers", idRefreshTokenHeaderKey, true);
 
-    setCookie(
-        res,
-        idRefreshTokenCookieKey,
-        idRefreshToken,
-        domain,
-        secure,
-        true,
-        expiry,
-        path,
-        sameSite,
-        "accessTokenPath"
-    );
+    setCookie(res, idRefreshTokenCookieKey, idRefreshToken, expiry, "accessTokenPath");
 }
 
 export function setFrontTokenInHeaders(res: express.Response, userId: string, atExpiry: number, jwtPayload: any) {
@@ -276,37 +222,19 @@ export function setCookie(
     res: ServerResponse,
     name: string,
     value: string,
-    domain: string | undefined,
-    secure: boolean,
-    httpOnly: boolean,
     expires: number,
-    path: string,
-    sameSite: "strict" | "lax" | "none",
-    pathType: "refreshTokenPath" | "accessTokenPath" | null = null
+    pathType: "refreshTokenPath" | "accessTokenPath"
 ) {
-    let cookieDomain = CookieConfig.getInstance().cookieDomain;
-    let cookieSecure = CookieConfig.getInstance().cookieSecure;
-    let cookieSameSite = CookieConfig.getInstance().cookieSameSite;
-    if (cookieDomain !== undefined) {
-        domain = cookieDomain;
-    }
-    if (cookieSameSite !== undefined) {
-        sameSite = cookieSameSite;
-    }
-    if (cookieSecure !== undefined) {
-        secure = cookieSecure;
-    }
+    let domain = CookieConfig.getInstanceOrThrowError().cookieDomain;
+    let secure = CookieConfig.getInstanceOrThrowError().cookieSecure;
+    let sameSite = CookieConfig.getInstanceOrThrowError().cookieSameSite;
+    let path = "";
     if (pathType === "refreshTokenPath") {
-        let refreshTokenPath = CookieConfig.getInstance().refreshTokenPath;
-        if (refreshTokenPath !== undefined) {
-            path = refreshTokenPath;
-        }
+        path = CookieConfig.getInstanceOrThrowError().refreshTokenPath;
     } else if (pathType === "accessTokenPath") {
-        let accessTokenPath = CookieConfig.getInstance().accessTokenPath;
-        if (accessTokenPath !== undefined) {
-            path = accessTokenPath;
-        }
+        path = CookieConfig.getInstanceOrThrowError().accessTokenPath;
     }
+    let httpOnly = CookieConfig.getInstanceOrThrowError().cookieSecure;
     let opts = {
         domain,
         secure,

--- a/lib/ts/express.ts
+++ b/lib/ts/express.ts
@@ -16,21 +16,17 @@ import * as express from "express";
 
 import {
     attachAccessTokenToCookie,
-    attachRefreshTokenToCookie,
     clearSessionFromCookie,
     getAccessTokenFromCookie,
     getAntiCsrfTokenFromHeaders,
     getIdRefreshTokenFromCookie,
     getRefreshTokenFromCookie,
     saveFrontendInfoFromRequest,
-    setAntiCsrfTokenInHeaders,
-    setIdRefreshTokenInHeaderAndCookie,
     setOptionsAPIHeader,
     getCORSAllowedHeaders as getCORSAllowedHeadersFromCookiesAndHeaders,
     setFrontTokenInHeaders,
 } from "./cookieAndHeaders";
 import { AuthError, generateError } from "./error";
-import { HandshakeInfo } from "./handshakeInfo";
 import * as SessionFunctions from "./session";
 import { TypeInput, SessionRequest, auth0RequestBody } from "./types";
 import { Querier } from "./querier";
@@ -108,15 +104,7 @@ export async function getSession(
                 response.accessToken.expiry,
                 response.session.userDataInJWT
             );
-            attachAccessTokenToCookie(
-                res,
-                response.accessToken.token,
-                response.accessToken.expiry,
-                response.accessToken.domain,
-                response.accessToken.cookiePath,
-                response.accessToken.cookieSecure,
-                response.accessToken.sameSite
-            );
+            attachAccessTokenToCookie(res, response.accessToken.token, response.accessToken.expiry);
             accessToken = response.accessToken.token;
         }
         return new Session(
@@ -129,16 +117,7 @@ export async function getSession(
         );
     } catch (err) {
         if (AuthError.isErrorFromAuth(err) && err.errType === AuthError.UNAUTHORISED) {
-            let handShakeInfo = await HandshakeInfo.getInstance();
-            clearSessionFromCookie(
-                res,
-                handShakeInfo.cookieDomain,
-                handShakeInfo.cookieSecure,
-                handShakeInfo.accessTokenPath,
-                handShakeInfo.refreshTokenPath,
-                handShakeInfo.idRefreshTokenPath,
-                handShakeInfo.cookieSameSite
-            );
+            clearSessionFromCookie(res);
         }
         throw err;
     }
@@ -181,16 +160,7 @@ export async function refreshSession(req: express.Request, res: express.Response
             AuthError.isErrorFromAuth(err) &&
             (err.errType === AuthError.UNAUTHORISED || err.errType === AuthError.TOKEN_THEFT_DETECTED)
         ) {
-            let handShakeInfo = await HandshakeInfo.getInstance();
-            clearSessionFromCookie(
-                res,
-                handShakeInfo.cookieDomain,
-                handShakeInfo.cookieSecure,
-                handShakeInfo.accessTokenPath,
-                handShakeInfo.refreshTokenPath,
-                handShakeInfo.idRefreshTokenPath,
-                handShakeInfo.cookieSameSite
-            );
+            clearSessionFromCookie(res);
         }
         throw err;
     }
@@ -417,16 +387,7 @@ export class Session {
      */
     revokeSession = async () => {
         if (await SessionFunctions.revokeSession(this.sessionHandle)) {
-            let handShakeInfo = await HandshakeInfo.getInstance();
-            clearSessionFromCookie(
-                this.res,
-                handShakeInfo.cookieDomain,
-                handShakeInfo.cookieSecure,
-                handShakeInfo.accessTokenPath,
-                handShakeInfo.refreshTokenPath,
-                handShakeInfo.idRefreshTokenPath,
-                handShakeInfo.cookieSameSite
-            );
+            clearSessionFromCookie(this.res);
         }
     };
 
@@ -441,16 +402,7 @@ export class Session {
             return await SessionFunctions.getSessionData(this.sessionHandle);
         } catch (err) {
             if (AuthError.isErrorFromAuth(err) && err.errType === AuthError.UNAUTHORISED) {
-                let handShakeInfo = await HandshakeInfo.getInstance();
-                clearSessionFromCookie(
-                    this.res,
-                    handShakeInfo.cookieDomain,
-                    handShakeInfo.cookieSecure,
-                    handShakeInfo.accessTokenPath,
-                    handShakeInfo.refreshTokenPath,
-                    handShakeInfo.idRefreshTokenPath,
-                    handShakeInfo.cookieSameSite
-                );
+                clearSessionFromCookie(this.res);
             }
             throw err;
         }
@@ -466,16 +418,7 @@ export class Session {
             await SessionFunctions.updateSessionData(this.sessionHandle, newSessionData);
         } catch (err) {
             if (AuthError.isErrorFromAuth(err) && err.errType === AuthError.UNAUTHORISED) {
-                let handShakeInfo = await HandshakeInfo.getInstance();
-                clearSessionFromCookie(
-                    this.res,
-                    handShakeInfo.cookieDomain,
-                    handShakeInfo.cookieSecure,
-                    handShakeInfo.accessTokenPath,
-                    handShakeInfo.refreshTokenPath,
-                    handShakeInfo.idRefreshTokenPath,
-                    handShakeInfo.cookieSameSite
-                );
+                clearSessionFromCookie(this.res);
             }
             throw err;
         }
@@ -503,16 +446,7 @@ export class Session {
             userDataInJWT: newJWTPayload,
         });
         if (response.status === "UNAUTHORISED") {
-            let handShakeInfo = await HandshakeInfo.getInstance();
-            clearSessionFromCookie(
-                this.res,
-                handShakeInfo.cookieDomain,
-                handShakeInfo.cookieSecure,
-                handShakeInfo.accessTokenPath,
-                handShakeInfo.refreshTokenPath,
-                handShakeInfo.idRefreshTokenPath,
-                handShakeInfo.cookieSameSite
-            );
+            clearSessionFromCookie(this.res);
             throw generateError(AuthError.UNAUTHORISED, new Error(response.message));
         }
         this.userDataInJWT = response.session.userDataInJWT;
@@ -524,15 +458,7 @@ export class Session {
                 response.accessToken.expiry,
                 response.session.userDataInJWT
             );
-            attachAccessTokenToCookie(
-                this.res,
-                response.accessToken.token,
-                response.accessToken.expiry,
-                response.accessToken.domain,
-                response.accessToken.cookiePath,
-                response.accessToken.cookieSecure,
-                response.accessToken.sameSite
-            );
+            attachAccessTokenToCookie(this.res, response.accessToken.token, response.accessToken.expiry);
         }
     };
 }

--- a/lib/ts/express.ts
+++ b/lib/ts/express.ts
@@ -35,6 +35,7 @@ import * as qs from "querystring";
 import * as jwt from "jsonwebtoken";
 import { autoRefreshMiddleware } from "./middleware";
 import { attachCreateOrRefreshSessionResponseToExpressRes } from "./utils";
+import { CookieConfig } from "./cookieAndHeaders";
 
 // TODO: Make it also work with PassportJS
 

--- a/lib/ts/faunadb/middleware.ts
+++ b/lib/ts/faunadb/middleware.ts
@@ -42,12 +42,7 @@ export function autoRefreshMiddleware() {
 }
 
 async function getRefreshPath(): Promise<string> {
-    let refreshTokenPathConfig = CookieConfig.getInstance().refreshTokenPath;
-    if (refreshTokenPathConfig !== undefined) {
-        return refreshTokenPathConfig;
-    }
-    let handShakeInfo = await HandshakeInfo.getInstance();
-    return handShakeInfo.refreshTokenPath;
+    return CookieConfig.getInstanceOrThrowError().refreshTokenPath;
 }
 
 export function middleware(antiCsrfCheck?: boolean) {

--- a/lib/ts/handshakeInfo.ts
+++ b/lib/ts/handshakeInfo.ts
@@ -19,16 +19,11 @@ export class HandshakeInfo {
     static instance: HandshakeInfo | undefined;
 
     public jwtSigningPublicKey: string;
-    public cookieDomain?: string;
-    public cookieSecure: boolean;
-    public accessTokenPath: string;
-    public refreshTokenPath: string;
     public enableAntiCsrf: boolean;
     public accessTokenBlacklistingEnabled: boolean;
     public jwtSigningPublicKeyExpiryTime: number;
-    public cookieSameSite: "none" | "lax" | "strict";
-    public idRefreshTokenPath: string;
-    public sessionExpiredStatusCode: number;
+    public accessTokenVaildity: number;
+    public refreshTokenVaildity: number;
 
     static reset() {
         if (process.env.TEST_MODE !== "testing") {
@@ -43,16 +38,11 @@ export class HandshakeInfo {
             let response = await Querier.getInstance().sendPostRequest("/handshake", {});
             HandshakeInfo.instance = new HandshakeInfo(
                 response.jwtSigningPublicKey,
-                response.cookieDomain,
-                response.cookieSecure,
-                response.accessTokenPath,
-                response.refreshTokenPath,
                 response.enableAntiCsrf,
                 response.accessTokenBlacklistingEnabled,
                 response.jwtSigningPublicKeyExpiryTime,
-                response.cookieSameSite,
-                response.idRefreshTokenPath,
-                response.sessionExpiredStatusCode
+                response.accessTokenVaildity,
+                response.refreshTokenVaildity
             );
         }
         return HandshakeInfo.instance;
@@ -60,28 +50,18 @@ export class HandshakeInfo {
 
     constructor(
         jwtSigningPublicKey: string,
-        cookieDomain: string | undefined,
-        cookieSecure: boolean,
-        accessTokenPath: string,
-        refreshTokenPath: string,
         enableAntiCsrf: boolean,
         accessTokenBlacklistingEnabled: boolean,
         jwtSigningPublicKeyExpiryTime: number,
-        cookieSameSite: "none" | "lax" | "strict",
-        idRefreshTokenPath: string,
-        sessionExpiredStatusCode: number
+        accessTokenVaildity: number,
+        refreshTokenVaildity: number
     ) {
         this.jwtSigningPublicKey = jwtSigningPublicKey;
-        this.cookieDomain = cookieDomain;
-        this.cookieSecure = cookieSecure;
-        this.accessTokenPath = accessTokenPath;
-        this.refreshTokenPath = refreshTokenPath;
         this.enableAntiCsrf = enableAntiCsrf;
         this.accessTokenBlacklistingEnabled = accessTokenBlacklistingEnabled;
         this.jwtSigningPublicKeyExpiryTime = jwtSigningPublicKeyExpiryTime;
-        this.cookieSameSite = cookieSameSite;
-        this.idRefreshTokenPath = idRefreshTokenPath;
-        this.sessionExpiredStatusCode = sessionExpiredStatusCode;
+        this.accessTokenVaildity = accessTokenVaildity;
+        this.refreshTokenVaildity = refreshTokenVaildity;
     }
 
     updateJwtSigningPublicKeyInfo = (newKey: string, newExpiry: number) => {

--- a/lib/ts/session.ts
+++ b/lib/ts/session.ts
@@ -94,6 +94,15 @@ export async function createNewSession(
     delete response.status;
     delete response.jwtSigningPublicKey;
     delete response.jwtSigningPublicKeyExpiryTime;
+    // we check if sameSite is none, antiCsrfTokens is being sent - this is a security check
+    if (CookieConfig.getInstanceOrThrowError().cookieSameSite === "none" && response.antiCsrfToken === undefined) {
+        throw generateError(
+            AuthError.GENERAL_ERROR,
+            new Error(
+                'Security error: Cookie same site is "none" and anti-CSRF protection is disabled! Please either: \n- Change cookie same site to "lax" or to "strict". or \n- Enable anti-CSRF protection in the core by setting enable_anti_csrf to true.'
+            )
+        );
+    }
     return response;
 }
 

--- a/lib/ts/session.ts
+++ b/lib/ts/session.ts
@@ -21,6 +21,38 @@ import { CookieConfig } from "./cookieAndHeaders";
 import { TypeInput, CreateOrRefreshAPIResponse } from "./types";
 
 export { AuthError as Error } from "./error";
+
+export class SessionConfig {
+    private static instance: SessionConfig | undefined = undefined;
+    sessionExpiredStatusCode: number;
+
+    constructor(sessionExpiredStatusCode: number) {
+        this.sessionExpiredStatusCode = sessionExpiredStatusCode;
+    }
+
+    static init(sessionExpiredStatusCode?: number) {
+        if (SessionConfig.instance === undefined) {
+            SessionConfig.instance = new SessionConfig(
+                sessionExpiredStatusCode === undefined ? 401 : sessionExpiredStatusCode
+            );
+        }
+    }
+
+    static reset() {
+        if (process.env.TEST_MODE !== "testing") {
+            throw generateError(AuthError.GENERAL_ERROR, new Error("calling testing function in non testing env"));
+        }
+        SessionConfig.instance = undefined;
+    }
+
+    static getInstanceOrThrowError() {
+        if (SessionConfig.instance === undefined) {
+            throw new Error("Please call the init function before using SuperTokens");
+        }
+        return SessionConfig.instance;
+    }
+}
+
 /**
  * @description: to be called by user of the library. This initiates all the modules necessary for this library to work.
  * Please create a database in your mysql instance before calling this function
@@ -28,7 +60,6 @@ export { AuthError as Error } from "./error";
  */
 export function init(config: TypeInput) {
     Querier.initInstance(config.hosts, config.apiKey);
-    // TODO:
     CookieConfig.init(
         config.accessTokenPath,
         config.refreshTokenPath,
@@ -36,6 +67,7 @@ export function init(config: TypeInput) {
         config.cookieSecure,
         config.cookieSameSite
     );
+    SessionConfig.init(config.sessionExpiredStatusCode);
 
     // this will also call the api version API
     HandshakeInfo.getInstance().catch((err) => {
@@ -83,10 +115,6 @@ export async function getSession(
         token: string;
         expiry: number;
         createdTime: number;
-        cookiePath: string;
-        cookieSecure: boolean;
-        domain?: string;
-        sameSite: "none" | "lax" | "strict";
     };
 }> {
     let handShakeInfo = await HandshakeInfo.getInstance();

--- a/lib/ts/types.ts
+++ b/lib/ts/types.ts
@@ -25,28 +25,16 @@ export type CreateOrRefreshAPIResponse = {
         token: string;
         expiry: number;
         createdTime: number;
-        cookiePath: string;
-        cookieSecure: boolean;
-        domain?: string;
-        sameSite: "none" | "lax" | "strict";
     };
     refreshToken: {
         token: string;
         expiry: number;
         createdTime: number;
-        cookiePath: string;
-        cookieSecure: boolean;
-        domain?: string;
-        sameSite: "none" | "lax" | "strict";
     };
     idRefreshToken: {
         token: string;
         expiry: number;
         createdTime: number;
-        cookiePath: string;
-        cookieSecure: boolean;
-        domain?: string;
-        sameSite: "none" | "lax" | "strict";
     };
     antiCsrfToken: string | undefined;
 };
@@ -64,6 +52,7 @@ export type TypeInput = {
     cookieSameSite?: "strict" | "lax" | "none";
     cookieSecure?: boolean;
     apiKey?: string;
+    sessionExpiredStatusCode?: number;
 };
 
 export interface SessionRequest extends Request {

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -16,33 +16,9 @@ export function attachCreateOrRefreshSessionResponseToExpressRes(
     let refreshToken = response.refreshToken;
     let idRefreshToken = response.idRefreshToken;
     setFrontTokenInHeaders(res, response.session.userId, response.accessToken.expiry, response.session.userDataInJWT);
-    attachAccessTokenToCookie(
-        res,
-        accessToken.token,
-        accessToken.expiry,
-        accessToken.domain,
-        accessToken.cookiePath,
-        accessToken.cookieSecure,
-        accessToken.sameSite
-    );
-    attachRefreshTokenToCookie(
-        res,
-        refreshToken.token,
-        refreshToken.expiry,
-        refreshToken.domain,
-        refreshToken.cookiePath,
-        refreshToken.cookieSecure,
-        refreshToken.sameSite
-    );
-    setIdRefreshTokenInHeaderAndCookie(
-        res,
-        idRefreshToken.token,
-        idRefreshToken.expiry,
-        idRefreshToken.domain,
-        idRefreshToken.cookieSecure,
-        idRefreshToken.cookiePath,
-        idRefreshToken.sameSite
-    );
+    attachAccessTokenToCookie(res, accessToken.token, accessToken.expiry);
+    attachRefreshTokenToCookie(res, refreshToken.token, refreshToken.expiry);
+    setIdRefreshTokenInHeaderAndCookie(res, idRefreshToken.token, idRefreshToken.expiry);
     if (response.antiCsrfToken !== undefined) {
         setAntiCsrfTokenInHeaders(res, response.antiCsrfToken);
     }

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -7,6 +7,19 @@ import {
     setAntiCsrfTokenInHeaders,
 } from "./cookieAndHeaders";
 import * as express from "express";
+import { AuthError, generateError } from "./error";
+
+export function validateAndNormaliseCookieSameSite(sameSite: string): "strict" | "lax" | "none" {
+    sameSite = sameSite.trim();
+    sameSite = sameSite.toLocaleLowerCase();
+    if (sameSite !== "strict" && sameSite !== "lax" && sameSite !== "none") {
+        throw generateError(
+            AuthError.GENERAL_ERROR,
+            new Error('cookie same site must be one of "strict", "lax", or "none"')
+        );
+    }
+    return sameSite;
+}
 
 export function attachCreateOrRefreshSessionResponseToExpressRes(
     res: express.Response,

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -14,4 +14,4 @@
  */
 export const version = "3.0.0";
 
-export const cdiSupported = ["2.0", "2.1", "2.2", "2.3"];
+export const cdiSupported = ["2.4"];

--- a/test/auth0Handler.test.js
+++ b/test/auth0Handler.test.js
@@ -35,7 +35,10 @@ describe(`Auth0Handler: ${printPath("[test/auth0Handler.test.js]")}`, function (
 
     it("test auth0Handler login, no callback", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080" });
+        ST.init({
+            hosts: "http://localhost:8080",
+            refreshTokenPath: "/refresh",
+        });
         nock(`https://${constants.AUTH0_DOMAIN}`)
             .post("/oauth/token")
             .reply(200, {
@@ -79,7 +82,7 @@ describe(`Auth0Handler: ${printPath("[test/auth0Handler.test.js]")}`, function (
 
     it("test auth0Handler login, with callback, no error thrown", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080" });
+        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
         nock(`https://${constants.AUTH0_DOMAIN}`)
             .post("/oauth/token")
             .reply(200, {
@@ -144,7 +147,7 @@ describe(`Auth0Handler: ${printPath("[test/auth0Handler.test.js]")}`, function (
 
     it("test auth0Handler login, with callback, error thrown", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080" });
+        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
         nock(`https://${constants.AUTH0_DOMAIN}`)
             .post("/oauth/token")
             .reply(200, {
@@ -193,7 +196,7 @@ describe(`Auth0Handler: ${printPath("[test/auth0Handler.test.js]")}`, function (
 
     it("test auth0Handler login, non 200 response", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080" });
+        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
         nock(`https://${constants.AUTH0_DOMAIN}`).post("/oauth/token").reply(403, {});
 
         let app = express();
@@ -228,7 +231,7 @@ describe(`Auth0Handler: ${printPath("[test/auth0Handler.test.js]")}`, function (
 
     it("test auth0Handler login, invalid id_token", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080" });
+        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
         nock(`https://${constants.AUTH0_DOMAIN}`)
             .post("/oauth/token")
             .reply(200, {
@@ -272,7 +275,7 @@ describe(`Auth0Handler: ${printPath("[test/auth0Handler.test.js]")}`, function (
 
     it("test auth0Handler logout, with middleware", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080" });
+        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
         nock(`https://${constants.AUTH0_DOMAIN}`)
             .post("/oauth/token")
             .reply(200, {
@@ -352,7 +355,7 @@ describe(`Auth0Handler: ${printPath("[test/auth0Handler.test.js]")}`, function (
 
     it("test auth0Handler logout, without middleware", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080" });
+        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
         nock(`https://${constants.AUTH0_DOMAIN}`)
             .post("/oauth/token")
             .reply(200, {
@@ -436,7 +439,7 @@ describe(`Auth0Handler: ${printPath("[test/auth0Handler.test.js]")}`, function (
 
     it("test auth0Handler refresh, with session data", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080" });
+        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
         nock(`https://${constants.AUTH0_DOMAIN}`)
             .post("/oauth/token")
             .reply(200, {
@@ -520,7 +523,7 @@ describe(`Auth0Handler: ${printPath("[test/auth0Handler.test.js]")}`, function (
 
     it("test auth0Handler refresh, no session data", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080" });
+        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
         nock(`https://${constants.AUTH0_DOMAIN}`)
             .post("/oauth/token")
             .reply(200, {
@@ -595,7 +598,7 @@ describe(`Auth0Handler: ${printPath("[test/auth0Handler.test.js]")}`, function (
 
     it("test auth0Handler refresh, non 200 response", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080" });
+        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
         nock(`https://${constants.AUTH0_DOMAIN}`)
             .post("/oauth/token")
             .reply(200, {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,157 @@
+/* Copyright (c) 2020, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+const { printPath, setupST, startST, stopST, killAllST, cleanST, extractInfoFromResponse } = require("./utils");
+let ST = require("../lib/build/session");
+let STExpress = require("../index");
+let assert = require("assert");
+const nock = require("nock");
+let { version } = require("../lib/build/version");
+const express = require("express");
+const request = require("supertest");
+let { HandshakeInfo } = require("../lib/build/handshakeInfo");
+let { ProcessState } = require("../lib/build/processState");
+let { CookieConfig } = require("../lib/build/cookieAndHeaders");
+let { resetAll } = require("./utils");
+
+describe(`configTest: ${printPath("[test/config.test.js]")}`, function () {
+    beforeEach(async function () {
+        await killAllST();
+        await setupST();
+        ProcessState.getInstance().reset();
+    });
+
+    after(async function () {
+        await killAllST();
+        await cleanST();
+    });
+
+    it("various sameSite values", async function () {
+        await startST();
+
+        {
+            STExpress.init({
+                hosts: "http://localhost:8080",
+                cookieSameSite: " Lax ",
+            });
+
+            assert(CookieConfig.getInstanceOrThrowError().cookieSameSite === "lax");
+
+            resetAll();
+        }
+
+        {
+            STExpress.init({
+                hosts: "http://localhost:8080",
+                cookieSameSite: "None ",
+            });
+
+            assert(CookieConfig.getInstanceOrThrowError().cookieSameSite === "none");
+
+            resetAll();
+        }
+
+        {
+            STExpress.init({
+                hosts: "http://localhost:8080",
+                cookieSameSite: " STRICT",
+            });
+
+            assert(CookieConfig.getInstanceOrThrowError().cookieSameSite === "strict");
+
+            resetAll();
+        }
+
+        {
+            try {
+                STExpress.init({
+                    hosts: "http://localhost:8080",
+                    cookieSameSite: "random",
+                });
+            } catch (err) {
+                if (
+                    !ST.Error.isErrorFromAuth(err) ||
+                    err.errType !== ST.Error.GENERAL_ERROR ||
+                    err.err.message !== 'cookie same site must be one of "strict", "lax", or "none"'
+                ) {
+                    throw error;
+                }
+            }
+
+            resetAll();
+        }
+
+        {
+            try {
+                STExpress.init({
+                    hosts: "http://localhost:8080",
+                    cookieSameSite: " ",
+                });
+            } catch (err) {
+                if (
+                    !ST.Error.isErrorFromAuth(err) ||
+                    err.errType !== ST.Error.GENERAL_ERROR ||
+                    err.err.message !== 'cookie same site must be one of "strict", "lax", or "none"'
+                ) {
+                    throw error;
+                }
+            }
+
+            resetAll();
+        }
+
+        {
+            STExpress.init({
+                hosts: "http://localhost:8080",
+                cookieSameSite: "lax",
+            });
+
+            assert(CookieConfig.getInstanceOrThrowError().cookieSameSite === "lax");
+
+            resetAll();
+        }
+
+        {
+            STExpress.init({
+                hosts: "http://localhost:8080",
+                cookieSameSite: "none",
+            });
+
+            assert(CookieConfig.getInstanceOrThrowError().cookieSameSite === "none");
+
+            resetAll();
+        }
+
+        {
+            STExpress.init({
+                hosts: "http://localhost:8080",
+                cookieSameSite: "strict",
+            });
+
+            assert(CookieConfig.getInstanceOrThrowError().cookieSameSite === "strict");
+
+            resetAll();
+        }
+
+        {
+            STExpress.init({
+                hosts: "http://localhost:8080",
+            });
+
+            assert(CookieConfig.getInstanceOrThrowError().cookieSameSite === "lax");
+
+            resetAll();
+        }
+    });
+});

--- a/test/deviceDriverInfo.test.js
+++ b/test/deviceDriverInfo.test.js
@@ -66,14 +66,14 @@ describe(`deviceDriverInfo: ${printPath("[test/deviceDriverInfo.test.js]")}`, fu
                 } catch (err) {}
                 return [200, { success: success }];
             });
-        ST.init({ hosts: "http://localhost:8080" });
+        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
         let response = await ST.createNewSession("", {}, {});
         assert.equal(response.success, true);
     });
 
     it("driver info check with frontendSDKs", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080" });
+        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
         // server.
         let server;
         const app = express();

--- a/test/faunadb.test.js
+++ b/test/faunadb.test.js
@@ -55,6 +55,7 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
                 faunadbSecret: "fnAD2HH-Q6ACBSJxMjwU5YT7hvkaVo6Te8PJWqsT",
                 userCollectionName: "users",
                 accessFaunadbTokenFromFrontend: true,
+                refreshTokenPath: "/refresh",
             })
         );
 
@@ -160,6 +161,7 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
                 faunadbSecret: "fnAD2HH-Q6ACBSJxMjwU5YT7hvkaVo6Te8PJWqsT",
                 userCollectionName: "users",
                 accessFaunadbTokenFromFrontend: true,
+                refreshTokenPath: "/refresh",
             })
         );
 
@@ -268,6 +270,7 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
                 hosts: "http://localhost:8080",
                 faunadbSecret: "fnAD2HH-Q6ACBSJxMjwU5YT7hvkaVo6Te8PJWqsT",
                 userCollectionName: "users",
+                refreshTokenPath: "/refresh",
             })
         );
 
@@ -337,6 +340,7 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
             faunadbSecret: "fnAD2HH-Q6ACBSJxMjwU5YT7hvkaVo6Te8PJWqsT",
             userCollectionName: "users",
             accessFaunadbTokenFromFrontend: true,
+            refreshTokenPath: "/refresh",
         });
 
         // if version >= 2.3
@@ -537,6 +541,7 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
             faunadbSecret: "fnAD2HH-Q6ACBSJxMjwU5YT7hvkaVo6Te8PJWqsT",
             userCollectionName: "users",
             accessFaunadbTokenFromFrontend: true,
+            refreshTokenPath: "/refresh",
         });
 
         // if version >= 2.3

--- a/test/frontendIntegration/index.js
+++ b/test/frontendIntegration/index.js
@@ -36,7 +36,7 @@ app.use(urlencodedParser);
 app.use(jsonParser);
 app.use(cookieParser());
 
-SuperTokens.init({ hosts: "http://localhost:9000", cookieSameSite: "lax" });
+SuperTokens.init({ hosts: "http://localhost:9000", cookieSameSite: "lax", refreshTokenPath: "/refresh" });
 
 app.post("/login", async (req, res) => {
     let userId = req.body.userId;

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -327,4 +327,39 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
         assert(response3.session != undefined);
         assert(Object.keys(response3.session).length === 3);
     });
+
+    it("test that anti-csrf disabled and sameSite none throws an error", async function () {
+        await setKeyValueInConfig("enable_anti_csrf", "false");
+        await startST();
+
+        ST.init({ hosts: "http://localhost:8080", cookieSameSite: "none" });
+
+        try {
+            await ST.createNewSession("", {}, {});
+            assert(false);
+        } catch (err) {
+            if (
+                !ST.Error.isErrorFromAuth(err) ||
+                err.errType !== ST.Error.GENERAL_ERROR ||
+                err.err.message !==
+                    'Security error: Cookie same site is "none" and anti-CSRF protection is disabled! Please either: \n- Change cookie same site to "lax" or to "strict". or \n- Enable anti-CSRF protection in the core by setting enable_anti_csrf to true.'
+            ) {
+                throw error;
+            }
+        }
+    });
+
+    it("test that anti-csrf disabled and sameSite lax does now throw an error", async function () {
+        await setKeyValueInConfig("enable_anti_csrf", "false");
+        await startST();
+        ST.init({ hosts: "http://localhost:8080", cookieSameSite: "lax" });
+        await ST.createNewSession("", {}, {});
+    });
+
+    it("test that anti-csrf disabled and sameSite strict does now throw an error", async function () {
+        await setKeyValueInConfig("enable_anti_csrf", "false");
+        await startST();
+        ST.init({ hosts: "http://localhost:8080", cookieSameSite: "strict" });
+        await ST.createNewSession("", {}, {});
+    });
 });

--- a/test/sessionExpress.test.js
+++ b/test/sessionExpress.test.js
@@ -49,7 +49,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
     //- check for token theft detection
     it("express token theft detection", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080" });
+        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
 
         const app = express();
         app.post("/create", async (req, res) => {
@@ -224,7 +224,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
     //check basic usage of session
     it("test basic usage of express sessions", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080" });
+        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
 
         const app = express();
 
@@ -485,7 +485,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
     //check session verify for with / without anti-csrf present
     it("test express session verify with anti-csrf present", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080" });
+        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
 
         const app = express();
         app.post("/create", async (req, res) => {
@@ -540,7 +540,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
     // check session verify for with / without anti-csrf present
     it("test session verify without anti-csrf present express", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080" });
+        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
 
         const app = express();
 
@@ -600,7 +600,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
     //check revoking session(s)**
     it("test revoking express sessions", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080" });
+        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
         const app = express();
         app.post("/create", async (req, res) => {
             await STExpress.createNewSession(res, "", {}, {});
@@ -707,7 +707,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
     //check manipulating session data
     it("test manipulating session data with express", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080" });
+        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
         const app = express();
         app.post("/create", async (req, res) => {
             await STExpress.createNewSession(res, "", {}, {});
@@ -833,7 +833,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
     //check manipulating jwt payload
     it("test manipulating jwt payload with express", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080" });
+        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
         const app = express();
         app.post("/create", async (req, res) => {
             await STExpress.createNewSession(res, "user1", {}, {});
@@ -1018,7 +1018,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
     // test with existing header params being there and that the lib appends to those and not overrides those
     it("test that express appends to existing header params and does not override", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080" });
+        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
         const app = express();
         app.post("/create", async (req, res) => {
             res.header("testHeader", "testValue");
@@ -1056,7 +1056,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
     it("test that when anti-csrf is disabled from from ST core, not having to input in verify session is fine in express", async function () {
         await setKeyValueInConfig("enable_anti_csrf", "false");
         await startST();
-        ST.init({ hosts: "http://localhost:8080" });
+        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
 
         const app = express();
         app.post("/create", async (req, res) => {
@@ -1127,7 +1127,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
 
     it("test that getSession does not clear cookies if a session does not exist in the first place", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080" });
+        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
 
         const app = express();
 
@@ -1166,7 +1166,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
 
     it("test that refreshSession does not clear cookies if a session does not exist in the first place", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080" });
+        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
 
         const app = express();
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -17,6 +17,7 @@ let { HandshakeInfo } = require("../lib/build/handshakeInfo");
 let { DeviceInfo } = require("../lib/build/deviceInfo");
 let { Querier } = require("../lib/build/querier");
 let { CookieConfig } = require("../lib/build/cookieAndHeaders");
+let { SessionConfig } = require("../lib/build/session");
 const nock = require("nock");
 let fs = require("fs");
 
@@ -130,7 +131,6 @@ module.exports.setupST = async function () {
         await module.exports.executeCommand("cd " + installationPath + " && cp temp/licenseKey ./licenseKey");
     } catch (ignore) {}
     await module.exports.executeCommand("cd " + installationPath + " && cp temp/config.yaml ./config.yaml");
-    await module.exports.setKeyValueInConfig("refresh_api_path", "/refresh");
     await module.exports.setKeyValueInConfig("enable_anti_csrf", "true");
 };
 
@@ -172,6 +172,7 @@ module.exports.killAllST = async function () {
     DeviceInfo.reset();
     Querier.reset();
     CookieConfig.reset();
+    SessionConfig.reset();
     nock.cleanAll();
 };
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -163,16 +163,20 @@ module.exports.stopST = async function (pid) {
     throw new Error("error while stopping ST with PID: " + pid);
 };
 
-module.exports.killAllST = async function () {
-    let pids = await getListOfPids();
-    for (let i = 0; i < pids.length; i++) {
-        await module.exports.stopST(pids[i]);
-    }
+module.exports.resetAll = function () {
     HandshakeInfo.reset();
     DeviceInfo.reset();
     Querier.reset();
     CookieConfig.reset();
     SessionConfig.reset();
+};
+
+module.exports.killAllST = async function () {
+    let pids = await getListOfPids();
+    for (let i = 0; i < pids.length; i++) {
+        await module.exports.stopST(pids[i]);
+    }
+    module.exports.resetAll();
     nock.cleanAll();
 };
 


### PR DESCRIPTION
Issues this is related to:
- https://github.com/supertokens/supertokens-core/issues/11
- https://github.com/supertokens/core-driver-interface/issues/1
- https://github.com/supertokens/supertokens-core/issues/20

Changes:
- To handshakeInfo
   - Removed `accessTokenPath`, `refreshTokenPath`, `cookieSecure`, `cookieSameSite`, `idRefreshTokenPath`, `cookieDomain`, `sessionExpiredStatusCode`
   - Added `accessTokenValidity` and `refreshTokenValidity` 
- To the user's input
   - Added `sessionExpiredStatusCode`
- Changes of types returned by API
   - From APIs that returned `tokenInfo`, removed `cookieSecure`, `cookieSameSite`, `domain`, `path`
- Not supporting older CDI versions
- Added validation and normalisation of cookie same site (or throwing error in case validation fails)
- Throws an error in `createNewSession` if `samesite` is `none` and anti CSRF is disabled.
- To tests
   - Calling `reset` on `SessionConfig`
   - Mostly all `init` functions take a `refreshTokenPath: "/refresh"`
   - Added config tests to test various input of same site
- Changes to docs (commit hash for main-website repo `5267bb8a955c1a4414defe6801defc100da76577`):
   -  Remove the part where it says that the configs given to the SDK can be overridden by the core.
   - Added default values for all the configs

Migration:
Same as https://github.com/supertokens/supertokens-core/pull/79#issue-505954585