### PR TITLE
Changes to config

### DIFF
--- a/lib/build/cookieAndHeaders.d.ts
+++ b/lib/build/cookieAndHeaders.d.ts
@@ -9,7 +9,7 @@ export declare class CookieConfig {
     cookieSecure: boolean;
     cookieSameSite: "strict" | "lax" | "none";
     constructor(accessTokenPath: string, refreshTokenPath: string, cookieDomain: string | undefined, cookieSecure: boolean, cookieSameSite: "strict" | "lax" | "none");
-    static init(accessTokenPath?: string, refreshTokenPath?: string, cookieDomain?: string, cookieSecure?: boolean, cookieSameSite?: "strict" | "lax" | "none"): void;
+    static init(accessTokenPath: string, apiBasePath: string, cookieDomain: string | undefined, cookieSecure: boolean, cookieSameSite: "strict" | "lax" | "none"): void;
     static reset(): void;
     static getInstanceOrThrowError(): CookieConfig;
 }

--- a/lib/build/cookieAndHeaders.js
+++ b/lib/build/cookieAndHeaders.js
@@ -17,7 +17,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const cookie_1 = require("cookie");
 const deviceInfo_1 = require("./deviceInfo");
 const error_1 = require("./error");
-const utils_1 = require("./utils");
 // TODO: set same-site value for cookies as chrome will soon make that compulsory.
 // Setting it to "lax" seems ideal, however there are bugs in safari regarding that. So setting it to "none" might make more sense.
 const accessTokenCookieKey = "sAccessToken";
@@ -37,17 +36,14 @@ class CookieConfig {
         this.cookieSameSite = cookieSameSite;
         this.cookieSecure = cookieSecure;
     }
-    static init(accessTokenPath, refreshTokenPath, cookieDomain, cookieSecure, cookieSameSite) {
-        if (cookieSameSite !== undefined) {
-            cookieSameSite = utils_1.validateAndNormaliseCookieSameSite(cookieSameSite);
-        }
+    static init(accessTokenPath, apiBasePath, cookieDomain, cookieSecure, cookieSameSite) {
         if (CookieConfig.instance === undefined) {
             CookieConfig.instance = new CookieConfig(
-                accessTokenPath === undefined ? "/" : accessTokenPath,
-                refreshTokenPath === undefined ? "/session/refresh" : refreshTokenPath,
+                accessTokenPath,
+                apiBasePath + "/session/refresh",
                 cookieDomain,
-                cookieSecure === undefined ? false : cookieSecure,
-                cookieSameSite === undefined ? "lax" : cookieSameSite
+                cookieSecure,
+                cookieSameSite
             );
         }
     }

--- a/lib/build/express.js
+++ b/lib/build/express.js
@@ -428,10 +428,13 @@ class Session {
         };
         this.updateJWTPayload = (newJWTPayload) =>
             __awaiter(this, void 0, void 0, function* () {
-                let response = yield querier_1.Querier.getInstance().sendPostRequest("/session/regenerate", {
-                    accessToken: this.accessToken,
-                    userDataInJWT: newJWTPayload,
-                });
+                let response = yield querier_1.Querier.getInstanceOrThrowError().sendPostRequest(
+                    "/session/regenerate",
+                    {
+                        accessToken: this.accessToken,
+                        userDataInJWT: newJWTPayload,
+                    }
+                );
                 if (response.status === "UNAUTHORISED") {
                     cookieAndHeaders_1.clearSessionFromCookie(this.res);
                     throw error_1.generateError(error_1.AuthError.UNAUTHORISED, new Error(response.message));

--- a/lib/build/handshakeInfo.js
+++ b/lib/build/handshakeInfo.js
@@ -80,7 +80,7 @@ class HandshakeInfo {
     static getInstance() {
         return __awaiter(this, void 0, void 0, function* () {
             if (HandshakeInfo.instance == undefined) {
-                let response = yield querier_1.Querier.getInstance().sendPostRequest("/handshake", {});
+                let response = yield querier_1.Querier.getInstanceOrThrowError().sendPostRequest("/handshake", {});
                 HandshakeInfo.instance = new HandshakeInfo(
                     response.jwtSigningPublicKey,
                     response.enableAntiCsrf,

--- a/lib/build/querier.d.ts
+++ b/lib/build/querier.d.ts
@@ -9,8 +9,8 @@ export declare class Querier {
     getAPIVersion: () => Promise<string>;
     static reset(): void;
     getHostsAliveForTesting: () => Set<string>;
-    static getInstance(): Querier;
-    static initInstance(hosts?: string, apiKey?: string): void;
+    static getInstanceOrThrowError(): Querier;
+    static initInstance(hosts: string, apiKey?: string): void;
     sendPostRequest: (path: string, body: any) => Promise<any>;
     sendDeleteRequest: (path: string, body: any) => Promise<any>;
     sendGetRequest: (path: string, params: any) => Promise<any>;

--- a/lib/build/querier.js
+++ b/lib/build/querier.js
@@ -51,6 +51,7 @@ const error_1 = require("./error");
 const version_1 = require("./version");
 const utils_1 = require("./utils");
 const version_2 = require("./version");
+const utils_2 = require("./utils");
 class Querier {
     constructor(hosts, apiKey) {
         this.lastTriedIndex = 0;
@@ -256,10 +257,7 @@ class Querier {
                     }
                 }
             });
-        if (hosts === undefined) {
-            hosts = "http://localhost:3567";
-        }
-        this.hosts = hosts.split(";").map((h) => (h.slice(-1) === "/" ? h.slice(0, -1) : h));
+        this.hosts = hosts.split(";").map((h) => utils_2.normaliseURLDomainOrThrowError(h));
         this.apiKey = apiKey;
     }
     static reset() {
@@ -271,9 +269,12 @@ class Querier {
         }
         Querier.instance = undefined;
     }
-    static getInstance() {
+    static getInstanceOrThrowError() {
         if (Querier.instance === undefined) {
-            Querier.instance = new Querier();
+            throw error_1.generateError(
+                error_1.AuthError.GENERAL_ERROR,
+                new Error("Please call the init function before using SuperTokens")
+            );
         }
         return Querier.instance;
     }

--- a/lib/build/session.d.ts
+++ b/lib/build/session.d.ts
@@ -1,4 +1,4 @@
-import { TypeInput, CreateOrRefreshAPIResponse } from './types';
+import { TypeInput, CreateOrRefreshAPIResponse } from "./types";
 export { AuthError as Error } from "./error";
 export declare class SessionConfig {
     private static instance;

--- a/lib/build/session.d.ts
+++ b/lib/build/session.d.ts
@@ -1,10 +1,10 @@
-import { TypeInput, CreateOrRefreshAPIResponse } from "./types";
+import { TypeInput, CreateOrRefreshAPIResponse } from './types';
 export { AuthError as Error } from "./error";
 export declare class SessionConfig {
     private static instance;
     sessionExpiredStatusCode: number;
     constructor(sessionExpiredStatusCode: number);
-    static init(sessionExpiredStatusCode?: number): void;
+    static init(sessionExpiredStatusCode: number): void;
     static reset(): void;
     static getInstanceOrThrowError(): SessionConfig;
 }

--- a/lib/build/session.js
+++ b/lib/build/session.js
@@ -51,6 +51,7 @@ const handshakeInfo_1 = require("./handshakeInfo");
 const processState_1 = require("./processState");
 const querier_1 = require("./querier");
 const cookieAndHeaders_1 = require("./cookieAndHeaders");
+const utils_1 = require("./utils");
 var error_2 = require("./error");
 exports.Error = error_2.AuthError;
 class SessionConfig {
@@ -59,9 +60,7 @@ class SessionConfig {
     }
     static init(sessionExpiredStatusCode) {
         if (SessionConfig.instance === undefined) {
-            SessionConfig.instance = new SessionConfig(
-                sessionExpiredStatusCode === undefined ? 401 : sessionExpiredStatusCode
-            );
+            SessionConfig.instance = new SessionConfig(sessionExpiredStatusCode);
         }
     }
     static reset() {
@@ -88,15 +87,16 @@ SessionConfig.instance = undefined;
  * @throws AuthError GENERAL_ERROR in case anything fails.
  */
 function init(config) {
-    querier_1.Querier.initInstance(config.hosts, config.apiKey);
+    let normalisedInput = utils_1.validateAndNormaliseUserInput(config);
+    querier_1.Querier.initInstance(normalisedInput.hosts, normalisedInput.apiKey);
     cookieAndHeaders_1.CookieConfig.init(
-        config.accessTokenPath,
-        config.refreshTokenPath,
-        config.cookieDomain,
-        config.cookieSecure,
-        config.cookieSameSite
+        normalisedInput.accessTokenPath,
+        normalisedInput.apiBasePath,
+        normalisedInput.cookieDomain,
+        normalisedInput.cookieSecure,
+        normalisedInput.cookieSameSite
     );
-    SessionConfig.init(config.sessionExpiredStatusCode);
+    SessionConfig.init(normalisedInput.sessionExpiredStatusCode);
     // this will also call the api version API
     handshakeInfo_1.HandshakeInfo.getInstance().catch((err) => {
         // ignored
@@ -109,7 +109,7 @@ exports.init = init;
  */
 function createNewSession(userId, jwtPayload = {}, sessionData = {}) {
     return __awaiter(this, void 0, void 0, function* () {
-        let response = yield querier_1.Querier.getInstance().sendPostRequest("/session", {
+        let response = yield querier_1.Querier.getInstanceOrThrowError().sendPostRequest("/session", {
             userId,
             userDataInJWT: jwtPayload,
             userDataInDatabase: sessionData,
@@ -190,7 +190,7 @@ function getSession(accessToken, antiCsrfToken, doAntiCsrfCheck) {
             }
         }
         processState_1.ProcessState.getInstance().addState(processState_1.PROCESS_STATE.CALLING_SERVICE_IN_VERIFY);
-        let response = yield querier_1.Querier.getInstance().sendPostRequest("/session/verify", {
+        let response = yield querier_1.Querier.getInstanceOrThrowError().sendPostRequest("/session/verify", {
             accessToken,
             antiCsrfToken,
             doAntiCsrfCheck,
@@ -220,7 +220,7 @@ exports.getSession = getSession;
  */
 function refreshSession(refreshToken, antiCsrfToken) {
     return __awaiter(this, void 0, void 0, function* () {
-        let response = yield querier_1.Querier.getInstance().sendPostRequest("/session/refresh", {
+        let response = yield querier_1.Querier.getInstanceOrThrowError().sendPostRequest("/session/refresh", {
             refreshToken,
             antiCsrfToken,
         });
@@ -245,7 +245,7 @@ exports.refreshSession = refreshSession;
  */
 function revokeAllSessionsForUser(userId) {
     return __awaiter(this, void 0, void 0, function* () {
-        let response = yield querier_1.Querier.getInstance().sendPostRequest("/session/remove", {
+        let response = yield querier_1.Querier.getInstanceOrThrowError().sendPostRequest("/session/remove", {
             userId,
         });
         return response.sessionHandlesRevoked;
@@ -258,7 +258,7 @@ exports.revokeAllSessionsForUser = revokeAllSessionsForUser;
  */
 function getAllSessionHandlesForUser(userId) {
     return __awaiter(this, void 0, void 0, function* () {
-        let response = yield querier_1.Querier.getInstance().sendGetRequest("/session/user", {
+        let response = yield querier_1.Querier.getInstanceOrThrowError().sendGetRequest("/session/user", {
             userId,
         });
         return response.sessionHandles;
@@ -272,7 +272,7 @@ exports.getAllSessionHandlesForUser = getAllSessionHandlesForUser;
  */
 function revokeSession(sessionHandle) {
     return __awaiter(this, void 0, void 0, function* () {
-        let response = yield querier_1.Querier.getInstance().sendPostRequest("/session/remove", {
+        let response = yield querier_1.Querier.getInstanceOrThrowError().sendPostRequest("/session/remove", {
             sessionHandles: [sessionHandle],
         });
         return response.sessionHandlesRevoked.length === 1;
@@ -286,7 +286,7 @@ exports.revokeSession = revokeSession;
  */
 function revokeMultipleSessions(sessionHandles) {
     return __awaiter(this, void 0, void 0, function* () {
-        let response = yield querier_1.Querier.getInstance().sendPostRequest("/session/remove", {
+        let response = yield querier_1.Querier.getInstanceOrThrowError().sendPostRequest("/session/remove", {
             sessionHandles,
         });
         return response.sessionHandlesRevoked;
@@ -300,7 +300,7 @@ exports.revokeMultipleSessions = revokeMultipleSessions;
  */
 function getSessionData(sessionHandle) {
     return __awaiter(this, void 0, void 0, function* () {
-        let response = yield querier_1.Querier.getInstance().sendGetRequest("/session/data", {
+        let response = yield querier_1.Querier.getInstanceOrThrowError().sendGetRequest("/session/data", {
             sessionHandle,
         });
         if (response.status === "OK") {
@@ -317,7 +317,7 @@ exports.getSessionData = getSessionData;
  */
 function updateSessionData(sessionHandle, newSessionData) {
     return __awaiter(this, void 0, void 0, function* () {
-        let response = yield querier_1.Querier.getInstance().sendPutRequest("/session/data", {
+        let response = yield querier_1.Querier.getInstanceOrThrowError().sendPutRequest("/session/data", {
             sessionHandle,
             userDataInDatabase: newSessionData,
         });
@@ -333,7 +333,7 @@ exports.updateSessionData = updateSessionData;
  */
 function getJWTPayload(sessionHandle) {
     return __awaiter(this, void 0, void 0, function* () {
-        let response = yield querier_1.Querier.getInstance().sendGetRequest("/jwt/data", {
+        let response = yield querier_1.Querier.getInstanceOrThrowError().sendGetRequest("/jwt/data", {
             sessionHandle,
         });
         if (response.status === "OK") {
@@ -349,7 +349,7 @@ exports.getJWTPayload = getJWTPayload;
  */
 function updateJWTPayload(sessionHandle, newJWTPayload) {
     return __awaiter(this, void 0, void 0, function* () {
-        let response = yield querier_1.Querier.getInstance().sendPutRequest("/jwt/data", {
+        let response = yield querier_1.Querier.getInstanceOrThrowError().sendPutRequest("/jwt/data", {
             sessionHandle,
             userDataInJWT: newJWTPayload,
         });

--- a/lib/build/types.d.ts
+++ b/lib/build/types.d.ts
@@ -30,12 +30,22 @@ export declare type TypeAuthError = {
 export declare type TypeInput = {
     hosts?: string;
     accessTokenPath?: string;
-    refreshTokenPath?: string;
+    apiBasePath?: string;
     cookieDomain?: string;
     cookieSameSite?: "strict" | "lax" | "none";
     cookieSecure?: boolean;
     apiKey?: string;
     sessionExpiredStatusCode?: number;
+};
+export declare type TypeNormalisedInput = {
+    hosts: string;
+    accessTokenPath: string;
+    apiBasePath: string;
+    cookieDomain: string | undefined;
+    cookieSameSite: "strict" | "lax" | "none";
+    cookieSecure: boolean;
+    apiKey?: string;
+    sessionExpiredStatusCode: number;
 };
 export interface SessionRequest extends Request {
     session: Session;

--- a/lib/build/utils.d.ts
+++ b/lib/build/utils.d.ts
@@ -1,6 +1,10 @@
-import { CreateOrRefreshAPIResponse } from "./types";
+import { CreateOrRefreshAPIResponse, TypeInput, TypeNormalisedInput } from "./types";
 import * as express from "express";
-export declare function validateAndNormaliseCookieSameSite(sameSite: string): "strict" | "lax" | "none";
+export declare function normaliseURLPathOrThrowError(input: string): string;
+export declare function normaliseURLDomainOrThrowError(input: string): string;
+export declare function normaliseSessionScopeOrThrowError(sessionScope: string): string;
+export declare function validateAndNormaliseUserInput(config: TypeInput): TypeNormalisedInput;
+export declare function normaliseSameSiteOrThrowError(sameSite: string): "strict" | "lax" | "none";
 export declare function attachCreateOrRefreshSessionResponseToExpressRes(res: express.Response, response: CreateOrRefreshAPIResponse): void;
 export declare function getLargestVersionFromIntersection(v1: string[], v2: string[]): string | undefined;
 export declare function maxVersion(version1: string, version2: string): string;

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -2,7 +2,143 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const cookieAndHeaders_1 = require("./cookieAndHeaders");
 const error_1 = require("./error");
-function validateAndNormaliseCookieSameSite(sameSite) {
+const url_1 = require("url");
+function normaliseURLPathOrThrowError(input) {
+    input = input.trim().toLowerCase();
+    try {
+        if (!input.startsWith("http://") && !input.startsWith("https://")) {
+            throw new Error("converting to proper URL");
+        }
+        let urlObj = new url_1.URL(input);
+        input = urlObj.pathname;
+        if (input.charAt(input.length - 1) === "/") {
+            return input.substr(0, input.length - 1);
+        }
+        return input;
+    } catch (err) {}
+    // not a valid URL
+    // If the input contains a . it means they have given a domain name.
+    // So we try assuming that they have given a domain name + path
+    if (
+        (input.indexOf(".") !== -1 || input.startsWith("localhost")) &&
+        !input.startsWith("http://") &&
+        !input.startsWith("https://")
+    ) {
+        input = "http://" + input;
+        return normaliseURLPathOrThrowError(input);
+    }
+    if (input.charAt(0) !== "/") {
+        input = "/" + input;
+    }
+    // at this point, we should be able to convert it into a fake URL and recursively call this function.
+    try {
+        // test that we can convert this to prevent an infinite loop
+        new url_1.URL("http://example.com" + input);
+        return normaliseURLPathOrThrowError("http://example.com" + input);
+    } catch (err) {
+        throw error_1.generateError(error_1.AuthError.GENERAL_ERROR, new Error("Please provide a valid URL path"));
+    }
+}
+exports.normaliseURLPathOrThrowError = normaliseURLPathOrThrowError;
+function normaliseURLDomainOrThrowError(input) {
+    function isAnIpAddress(ipaddress) {
+        return /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(
+            ipaddress
+        );
+    }
+    input = input.trim().toLowerCase();
+    try {
+        if (!input.startsWith("http://") && !input.startsWith("https://") && !input.startsWith("supertokens://")) {
+            throw new Error("converting to proper URL");
+        }
+        let urlObj = new url_1.URL(input);
+        if (urlObj.protocol === "supertokens:") {
+            if (urlObj.hostname.startsWith("localhost") || isAnIpAddress(urlObj.hostname)) {
+                input = "http://" + urlObj.host;
+            } else {
+                input = "https://" + urlObj.host;
+            }
+        } else {
+            input = urlObj.protocol + "//" + urlObj.host;
+        }
+        return input;
+    } catch (err) {}
+    // not a valid URL
+    if (input.indexOf(".") === 0) {
+        input = input.substr(1);
+    }
+    // If the input contains a . it means they have given a domain name.
+    // So we try assuming that they have given a domain name
+    if (
+        (input.indexOf(".") !== -1 || input.startsWith("localhost")) &&
+        !input.startsWith("http://") &&
+        !input.startsWith("https://")
+    ) {
+        // The supertokens:// signifies to the recursive call that the call was made by us.
+        input = "supertokens://" + input;
+        // at this point, it should be a valid URL. So we test that before doing a recursive call
+        try {
+            new url_1.URL(input);
+            return normaliseURLDomainOrThrowError(input);
+        } catch (err) {}
+    }
+    throw error_1.generateError(error_1.AuthError.GENERAL_ERROR, new Error("Please provide a valid domain name"));
+}
+exports.normaliseURLDomainOrThrowError = normaliseURLDomainOrThrowError;
+function normaliseSessionScopeOrThrowError(sessionScope) {
+    sessionScope = sessionScope.trim().toLowerCase();
+    // first we convert it to a URL so that we can use the URL class
+    if (sessionScope.startsWith(".")) {
+        sessionScope = sessionScope.substr(1);
+    }
+    if (!sessionScope.startsWith("http://") && !sessionScope.startsWith("https://")) {
+        sessionScope = "http://" + sessionScope;
+    }
+    try {
+        let urlObj = new url_1.URL(sessionScope);
+        sessionScope = urlObj.hostname;
+        // add a leading dot
+        if (!sessionScope.startsWith(".")) {
+            sessionScope = "." + sessionScope;
+        }
+        return sessionScope;
+    } catch (err) {
+        throw error_1.generateError(error_1.AuthError.GENERAL_ERROR, new Error("Please provide a valid sessionScope"));
+    }
+}
+exports.normaliseSessionScopeOrThrowError = normaliseSessionScopeOrThrowError;
+function validateAndNormaliseUserInput(config) {
+    let hosts = config.hosts === undefined ? normaliseURLDomainOrThrowError("http://localhost:3567") : config.hosts;
+    let accessTokenPath =
+        config.accessTokenPath === undefined ? "" : normaliseURLPathOrThrowError(config.accessTokenPath);
+    if (accessTokenPath === "") {
+        // cookie path being an empty string doesn't work.
+        accessTokenPath = "/";
+    }
+    let apiBasePath =
+        config.apiBasePath === undefined
+            ? normaliseURLPathOrThrowError("/auth")
+            : normaliseURLPathOrThrowError(config.apiBasePath);
+    let cookieDomain =
+        config.cookieDomain === undefined ? undefined : normaliseSessionScopeOrThrowError(config.cookieDomain);
+    let cookieSameSite =
+        config.cookieSameSite === undefined ? "lax" : normaliseSameSiteOrThrowError(config.cookieSameSite);
+    let cookieSecure = config.cookieSecure === undefined ? false : config.cookieSecure;
+    let sessionExpiredStatusCode =
+        config.sessionExpiredStatusCode === undefined ? 401 : config.sessionExpiredStatusCode;
+    return {
+        hosts,
+        accessTokenPath,
+        apiBasePath,
+        cookieDomain,
+        cookieSameSite,
+        cookieSecure,
+        apiKey: config.apiKey,
+        sessionExpiredStatusCode,
+    };
+}
+exports.validateAndNormaliseUserInput = validateAndNormaliseUserInput;
+function normaliseSameSiteOrThrowError(sameSite) {
     sameSite = sameSite.trim();
     sameSite = sameSite.toLocaleLowerCase();
     if (sameSite !== "strict" && sameSite !== "lax" && sameSite !== "none") {
@@ -13,7 +149,7 @@ function validateAndNormaliseCookieSameSite(sameSite) {
     }
     return sameSite;
 }
-exports.validateAndNormaliseCookieSameSite = validateAndNormaliseCookieSameSite;
+exports.normaliseSameSiteOrThrowError = normaliseSameSiteOrThrowError;
 function attachCreateOrRefreshSessionResponseToExpressRes(res, response) {
     let accessToken = response.accessToken;
     let refreshToken = response.refreshToken;

--- a/lib/ts/cookieAndHeaders.ts
+++ b/lib/ts/cookieAndHeaders.ts
@@ -18,7 +18,7 @@ import { IncomingMessage, ServerResponse } from "http";
 
 import { DeviceInfo } from "./deviceInfo";
 import { AuthError, generateError } from "./error";
-import { validateAndNormaliseCookieSameSite } from "./utils";
+import { normaliseSameSiteOrThrowError } from "./utils";
 
 // TODO: set same-site value for cookies as chrome will soon make that compulsory.
 // Setting it to "lax" seems ideal, however there are bugs in safari regarding that. So setting it to "none" might make more sense.
@@ -58,23 +58,19 @@ export class CookieConfig {
     }
 
     static init(
-        accessTokenPath?: string,
-        refreshTokenPath?: string,
-        cookieDomain?: string,
-        cookieSecure?: boolean,
-        cookieSameSite?: "strict" | "lax" | "none"
+        accessTokenPath: string,
+        apiBasePath: string,
+        cookieDomain: string | undefined,
+        cookieSecure: boolean,
+        cookieSameSite: "strict" | "lax" | "none"
     ) {
-        if (cookieSameSite !== undefined) {
-            cookieSameSite = validateAndNormaliseCookieSameSite(cookieSameSite);
-        }
-
         if (CookieConfig.instance === undefined) {
             CookieConfig.instance = new CookieConfig(
-                accessTokenPath === undefined ? "/" : accessTokenPath,
-                refreshTokenPath === undefined ? "/session/refresh" : refreshTokenPath,
+                accessTokenPath,
+                apiBasePath + "/session/refresh",
                 cookieDomain,
-                cookieSecure === undefined ? false : cookieSecure,
-                cookieSameSite === undefined ? "lax" : cookieSameSite
+                cookieSecure,
+                cookieSameSite
             );
         }
     }

--- a/lib/ts/express.ts
+++ b/lib/ts/express.ts
@@ -442,7 +442,7 @@ export class Session {
     };
 
     updateJWTPayload = async (newJWTPayload: any) => {
-        let response = await Querier.getInstance().sendPostRequest("/session/regenerate", {
+        let response = await Querier.getInstanceOrThrowError().sendPostRequest("/session/regenerate", {
             accessToken: this.accessToken,
             userDataInJWT: newJWTPayload,
         });

--- a/lib/ts/handshakeInfo.ts
+++ b/lib/ts/handshakeInfo.ts
@@ -35,7 +35,7 @@ export class HandshakeInfo {
     // @throws GENERAL_ERROR
     static async getInstance(): Promise<HandshakeInfo> {
         if (HandshakeInfo.instance == undefined) {
-            let response = await Querier.getInstance().sendPostRequest("/handshake", {});
+            let response = await Querier.getInstanceOrThrowError().sendPostRequest("/handshake", {});
             HandshakeInfo.instance = new HandshakeInfo(
                 response.jwtSigningPublicKey,
                 response.enableAntiCsrf,

--- a/lib/ts/types.ts
+++ b/lib/ts/types.ts
@@ -47,12 +47,23 @@ export type TypeAuthError = {
 export type TypeInput = {
     hosts?: string;
     accessTokenPath?: string;
-    refreshTokenPath?: string;
+    apiBasePath?: string;
     cookieDomain?: string;
     cookieSameSite?: "strict" | "lax" | "none";
     cookieSecure?: boolean;
     apiKey?: string;
     sessionExpiredStatusCode?: number;
+};
+
+export type TypeNormalisedInput = {
+    hosts: string;
+    accessTokenPath: string;
+    apiBasePath: string;
+    cookieDomain: string | undefined;
+    cookieSameSite: "strict" | "lax" | "none";
+    cookieSecure: boolean;
+    apiKey?: string;
+    sessionExpiredStatusCode: number;
 };
 
 export interface SessionRequest extends Request {

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -1,4 +1,4 @@
-import { CreateOrRefreshAPIResponse } from "./types";
+import { CreateOrRefreshAPIResponse, TypeInput, TypeNormalisedInput } from "./types";
 import {
     setFrontTokenInHeaders,
     attachAccessTokenToCookie,
@@ -8,8 +8,170 @@ import {
 } from "./cookieAndHeaders";
 import * as express from "express";
 import { AuthError, generateError } from "./error";
+import { URL } from "url";
 
-export function validateAndNormaliseCookieSameSite(sameSite: string): "strict" | "lax" | "none" {
+export function normaliseURLPathOrThrowError(input: string): string {
+    input = input.trim().toLowerCase();
+
+    try {
+        if (!input.startsWith("http://") && !input.startsWith("https://")) {
+            throw new Error("converting to proper URL");
+        }
+        let urlObj = new URL(input);
+        input = urlObj.pathname;
+
+        if (input.charAt(input.length - 1) === "/") {
+            return input.substr(0, input.length - 1);
+        }
+
+        return input;
+    } catch (err) {}
+    // not a valid URL
+
+    // If the input contains a . it means they have given a domain name.
+    // So we try assuming that they have given a domain name + path
+    if (
+        (input.indexOf(".") !== -1 || input.startsWith("localhost")) &&
+        !input.startsWith("http://") &&
+        !input.startsWith("https://")
+    ) {
+        input = "http://" + input;
+        return normaliseURLPathOrThrowError(input);
+    }
+
+    if (input.charAt(0) !== "/") {
+        input = "/" + input;
+    }
+
+    // at this point, we should be able to convert it into a fake URL and recursively call this function.
+    try {
+        // test that we can convert this to prevent an infinite loop
+        new URL("http://example.com" + input);
+
+        return normaliseURLPathOrThrowError("http://example.com" + input);
+    } catch (err) {
+        throw generateError(AuthError.GENERAL_ERROR, new Error("Please provide a valid URL path"));
+    }
+}
+
+export function normaliseURLDomainOrThrowError(input: string): string {
+    function isAnIpAddress(ipaddress: string) {
+        return /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(
+            ipaddress
+        );
+    }
+
+    input = input.trim().toLowerCase();
+
+    try {
+        if (!input.startsWith("http://") && !input.startsWith("https://") && !input.startsWith("supertokens://")) {
+            throw new Error("converting to proper URL");
+        }
+        let urlObj = new URL(input);
+        if (urlObj.protocol === "supertokens:") {
+            if (urlObj.hostname.startsWith("localhost") || isAnIpAddress(urlObj.hostname)) {
+                input = "http://" + urlObj.host;
+            } else {
+                input = "https://" + urlObj.host;
+            }
+        } else {
+            input = urlObj.protocol + "//" + urlObj.host;
+        }
+
+        return input;
+    } catch (err) {}
+    // not a valid URL
+
+    if (input.indexOf(".") === 0) {
+        input = input.substr(1);
+    }
+
+    // If the input contains a . it means they have given a domain name.
+    // So we try assuming that they have given a domain name
+    if (
+        (input.indexOf(".") !== -1 || input.startsWith("localhost")) &&
+        !input.startsWith("http://") &&
+        !input.startsWith("https://")
+    ) {
+        // The supertokens:// signifies to the recursive call that the call was made by us.
+        input = "supertokens://" + input;
+
+        // at this point, it should be a valid URL. So we test that before doing a recursive call
+        try {
+            new URL(input);
+            return normaliseURLDomainOrThrowError(input);
+        } catch (err) {}
+    }
+
+    throw generateError(AuthError.GENERAL_ERROR, new Error("Please provide a valid domain name"));
+}
+
+export function normaliseSessionScopeOrThrowError(sessionScope: string): string {
+    sessionScope = sessionScope.trim().toLowerCase();
+
+    // first we convert it to a URL so that we can use the URL class
+    if (sessionScope.startsWith(".")) {
+        sessionScope = sessionScope.substr(1);
+    }
+
+    if (!sessionScope.startsWith("http://") && !sessionScope.startsWith("https://")) {
+        sessionScope = "http://" + sessionScope;
+    }
+
+    try {
+        let urlObj = new URL(sessionScope);
+        sessionScope = urlObj.hostname;
+
+        // add a leading dot
+        if (!sessionScope.startsWith(".")) {
+            sessionScope = "." + sessionScope;
+        }
+
+        return sessionScope;
+    } catch (err) {
+        throw generateError(AuthError.GENERAL_ERROR, new Error("Please provide a valid sessionScope"));
+    }
+}
+
+export function validateAndNormaliseUserInput(config: TypeInput): TypeNormalisedInput {
+    let hosts = config.hosts === undefined ? normaliseURLDomainOrThrowError("http://localhost:3567") : config.hosts;
+
+    let accessTokenPath =
+        config.accessTokenPath === undefined ? "" : normaliseURLPathOrThrowError(config.accessTokenPath);
+    if (accessTokenPath === "") {
+        // cookie path being an empty string doesn't work.
+        accessTokenPath = "/";
+    }
+
+    let apiBasePath =
+        config.apiBasePath === undefined
+            ? normaliseURLPathOrThrowError("/auth")
+            : normaliseURLPathOrThrowError(config.apiBasePath);
+
+    let cookieDomain =
+        config.cookieDomain === undefined ? undefined : normaliseSessionScopeOrThrowError(config.cookieDomain);
+
+    let cookieSameSite =
+        config.cookieSameSite === undefined ? "lax" : normaliseSameSiteOrThrowError(config.cookieSameSite);
+
+    let cookieSecure = config.cookieSecure === undefined ? false : config.cookieSecure;
+
+    let sessionExpiredStatusCode =
+        config.sessionExpiredStatusCode === undefined ? 401 : config.sessionExpiredStatusCode;
+
+    return {
+        hosts,
+        accessTokenPath,
+        apiBasePath,
+        cookieDomain,
+        cookieSameSite,
+        cookieSecure,
+        apiKey: config.apiKey,
+        sessionExpiredStatusCode,
+    };
+}
+
+export function normaliseSameSiteOrThrowError(sameSite: string): "strict" | "lax" | "none" {
     sameSite = sameSite.trim();
     sameSite = sameSite.toLocaleLowerCase();
     if (sameSite !== "strict" && sameSite !== "lax" && sameSite !== "none") {

--- a/test/auth0Handler.test.js
+++ b/test/auth0Handler.test.js
@@ -37,7 +37,6 @@ describe(`Auth0Handler: ${printPath("[test/auth0Handler.test.js]")}`, function (
         await startST();
         ST.init({
             hosts: "http://localhost:8080",
-            refreshTokenPath: "/refresh",
         });
         nock(`https://${constants.AUTH0_DOMAIN}`)
             .post("/oauth/token")
@@ -82,7 +81,7 @@ describe(`Auth0Handler: ${printPath("[test/auth0Handler.test.js]")}`, function (
 
     it("test auth0Handler login, with callback, no error thrown", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
         nock(`https://${constants.AUTH0_DOMAIN}`)
             .post("/oauth/token")
             .reply(200, {
@@ -147,7 +146,7 @@ describe(`Auth0Handler: ${printPath("[test/auth0Handler.test.js]")}`, function (
 
     it("test auth0Handler login, with callback, error thrown", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
         nock(`https://${constants.AUTH0_DOMAIN}`)
             .post("/oauth/token")
             .reply(200, {
@@ -196,7 +195,7 @@ describe(`Auth0Handler: ${printPath("[test/auth0Handler.test.js]")}`, function (
 
     it("test auth0Handler login, non 200 response", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
         nock(`https://${constants.AUTH0_DOMAIN}`).post("/oauth/token").reply(403, {});
 
         let app = express();
@@ -231,7 +230,7 @@ describe(`Auth0Handler: ${printPath("[test/auth0Handler.test.js]")}`, function (
 
     it("test auth0Handler login, invalid id_token", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
         nock(`https://${constants.AUTH0_DOMAIN}`)
             .post("/oauth/token")
             .reply(200, {
@@ -275,7 +274,7 @@ describe(`Auth0Handler: ${printPath("[test/auth0Handler.test.js]")}`, function (
 
     it("test auth0Handler logout, with middleware", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
         nock(`https://${constants.AUTH0_DOMAIN}`)
             .post("/oauth/token")
             .reply(200, {
@@ -355,7 +354,7 @@ describe(`Auth0Handler: ${printPath("[test/auth0Handler.test.js]")}`, function (
 
     it("test auth0Handler logout, without middleware", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
         nock(`https://${constants.AUTH0_DOMAIN}`)
             .post("/oauth/token")
             .reply(200, {
@@ -439,7 +438,7 @@ describe(`Auth0Handler: ${printPath("[test/auth0Handler.test.js]")}`, function (
 
     it("test auth0Handler refresh, with session data", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
         nock(`https://${constants.AUTH0_DOMAIN}`)
             .post("/oauth/token")
             .reply(200, {
@@ -523,7 +522,7 @@ describe(`Auth0Handler: ${printPath("[test/auth0Handler.test.js]")}`, function (
 
     it("test auth0Handler refresh, no session data", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
         nock(`https://${constants.AUTH0_DOMAIN}`)
             .post("/oauth/token")
             .reply(200, {
@@ -598,7 +597,7 @@ describe(`Auth0Handler: ${printPath("[test/auth0Handler.test.js]")}`, function (
 
     it("test auth0Handler refresh, non 200 response", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
         nock(`https://${constants.AUTH0_DOMAIN}`)
             .post("/oauth/token")
             .reply(200, {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -12,18 +12,17 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-const { printPath, setupST, startST, stopST, killAllST, cleanST, extractInfoFromResponse } = require("./utils");
+const { printPath, setupST, startST, stopST, killAllST, cleanST, resetAll } = require("./utils");
 let ST = require("../lib/build/session");
 let STExpress = require("../index");
 let assert = require("assert");
-const nock = require("nock");
-let { version } = require("../lib/build/version");
-const express = require("express");
-const request = require("supertest");
-let { HandshakeInfo } = require("../lib/build/handshakeInfo");
 let { ProcessState } = require("../lib/build/processState");
 let { CookieConfig } = require("../lib/build/cookieAndHeaders");
-let { resetAll } = require("./utils");
+let {
+    normaliseURLPathOrThrowError,
+    normaliseSessionScopeOrThrowError,
+    normaliseURLDomainOrThrowError,
+} = require("../lib/build/utils");
 
 describe(`configTest: ${printPath("[test/config.test.js]")}`, function () {
     beforeEach(async function () {
@@ -152,6 +151,111 @@ describe(`configTest: ${printPath("[test/config.test.js]")}`, function () {
             assert(CookieConfig.getInstanceOrThrowError().cookieSameSite === "lax");
 
             resetAll();
+        }
+    });
+
+    it("testing sessionScope normalisation", async function () {
+        assert(normaliseSessionScopeOrThrowError("api.example.com") === ".api.example.com");
+        assert(normaliseSessionScopeOrThrowError("http://api.example.com") === ".api.example.com");
+        assert(normaliseSessionScopeOrThrowError("https://api.example.com") === ".api.example.com");
+        assert(normaliseSessionScopeOrThrowError("http://api.example.com?hello=1") === ".api.example.com");
+        assert(normaliseSessionScopeOrThrowError("http://api.example.com/hello") === ".api.example.com");
+        assert(normaliseSessionScopeOrThrowError("http://api.example.com/") === ".api.example.com");
+        assert(normaliseSessionScopeOrThrowError("http://api.example.com:8080") === ".api.example.com");
+        assert(normaliseSessionScopeOrThrowError("http://api.example.com#random2") === ".api.example.com");
+        assert(normaliseSessionScopeOrThrowError("api.example.com/") === ".api.example.com");
+        assert(normaliseSessionScopeOrThrowError("api.example.com#random") === ".api.example.com");
+        assert(normaliseSessionScopeOrThrowError(".example.com") === ".example.com");
+        assert(normaliseSessionScopeOrThrowError("api.example.com/?hello=1&bye=2") === ".api.example.com");
+        try {
+            normaliseSessionScopeOrThrowError("http://");
+            assert(false);
+        } catch (err) {
+            assert(err.err.message === "Please provide a valid sessionScope");
+        }
+    });
+
+    it("testing URL path normalisation", async function () {
+        assert(normaliseURLPathOrThrowError("http://api.example.com") === "");
+        assert(normaliseURLPathOrThrowError("https://api.example.com") === "");
+        assert(normaliseURLPathOrThrowError("http://api.example.com?hello=1") === "");
+        assert(normaliseURLPathOrThrowError("http://api.example.com/hello") === "/hello");
+        assert(normaliseURLPathOrThrowError("http://api.example.com/") === "");
+        assert(normaliseURLPathOrThrowError("http://api.example.com:8080") === "");
+        assert(normaliseURLPathOrThrowError("http://api.example.com#random2") === "");
+        assert(normaliseURLPathOrThrowError("api.example.com/") === "");
+        assert(normaliseURLPathOrThrowError("api.example.com#random") === "");
+        assert(normaliseURLPathOrThrowError(".example.com") === "");
+        assert(normaliseURLPathOrThrowError("api.example.com/?hello=1&bye=2") === "");
+
+        assert(normaliseURLPathOrThrowError("http://api.example.com/one/two") === "/one/two");
+        assert(normaliseURLPathOrThrowError("http://1.2.3.4/one/two") === "/one/two");
+        assert(normaliseURLPathOrThrowError("1.2.3.4/one/two") === "/one/two");
+        assert(normaliseURLPathOrThrowError("https://api.example.com/one/two/") === "/one/two");
+        assert(normaliseURLPathOrThrowError("http://api.example.com/one/two?hello=1") === "/one/two");
+        assert(normaliseURLPathOrThrowError("http://api.example.com/hello/") === "/hello");
+        assert(normaliseURLPathOrThrowError("http://api.example.com/one/two/") === "/one/two");
+        assert(normaliseURLPathOrThrowError("http://api.example.com:8080/one/two") === "/one/two");
+        assert(normaliseURLPathOrThrowError("http://api.example.com/one/two#random2") === "/one/two");
+        assert(normaliseURLPathOrThrowError("api.example.com/one/two") === "/one/two");
+        assert(normaliseURLPathOrThrowError("api.example.com/one/two/#random") === "/one/two");
+        assert(normaliseURLPathOrThrowError(".example.com/one/two") === "/one/two");
+        assert(normaliseURLPathOrThrowError("api.example.com/one/two?hello=1&bye=2") === "/one/two");
+
+        assert(normaliseURLPathOrThrowError("/one/two") === "/one/two");
+        assert(normaliseURLPathOrThrowError("one/two") === "/one/two");
+        assert(normaliseURLPathOrThrowError("one/two/") === "/one/two");
+        assert(normaliseURLPathOrThrowError("/one") === "/one");
+        assert(normaliseURLPathOrThrowError("one") === "/one");
+        assert(normaliseURLPathOrThrowError("one/") === "/one");
+        assert(normaliseURLPathOrThrowError("/one/two/") === "/one/two");
+        assert(normaliseURLPathOrThrowError("/one/two?hello=1") === "/one/two");
+        assert(normaliseURLPathOrThrowError("one/two?hello=1") === "/one/two");
+        assert(normaliseURLPathOrThrowError("/one/two/#random") === "/one/two");
+        assert(normaliseURLPathOrThrowError("one/two#random") === "/one/two");
+
+        assert(normaliseURLPathOrThrowError("localhost:4000/one/two") === "/one/two");
+        assert(normaliseURLPathOrThrowError("127.0.0.1:4000/one/two") === "/one/two");
+        assert(normaliseURLPathOrThrowError("127.0.0.1/one/two") === "/one/two");
+        assert(normaliseURLPathOrThrowError("https://127.0.0.1:80/one/two") === "/one/two");
+    });
+
+    it("testing URL domain normalisation", async function () {
+        assert(normaliseURLDomainOrThrowError("http://api.example.com") === "http://api.example.com");
+        assert(normaliseURLDomainOrThrowError("https://api.example.com") === "https://api.example.com");
+        assert(normaliseURLDomainOrThrowError("http://api.example.com?hello=1") === "http://api.example.com");
+        assert(normaliseURLDomainOrThrowError("http://api.example.com/hello") === "http://api.example.com");
+        assert(normaliseURLDomainOrThrowError("http://api.example.com/") === "http://api.example.com");
+        assert(normaliseURLDomainOrThrowError("http://api.example.com:8080") === "http://api.example.com:8080");
+        assert(normaliseURLDomainOrThrowError("http://api.example.com#random2") === "http://api.example.com");
+        assert(normaliseURLDomainOrThrowError("api.example.com/") === "https://api.example.com");
+        assert(normaliseURLDomainOrThrowError("api.example.com") === "https://api.example.com");
+        assert(normaliseURLDomainOrThrowError("api.example.com#random") === "https://api.example.com");
+        assert(normaliseURLDomainOrThrowError(".example.com") === "https://example.com");
+        assert(normaliseURLDomainOrThrowError("api.example.com/?hello=1&bye=2") === "https://api.example.com");
+        assert(normaliseURLDomainOrThrowError("localhost") === "http://localhost");
+        assert(normaliseURLDomainOrThrowError("https://localhost") === "https://localhost");
+
+        assert(normaliseURLDomainOrThrowError("http://api.example.com/one/two") === "http://api.example.com");
+        assert(normaliseURLDomainOrThrowError("http://1.2.3.4/one/two") === "http://1.2.3.4");
+        assert(normaliseURLDomainOrThrowError("https://1.2.3.4/one/two") === "https://1.2.3.4");
+        assert(normaliseURLDomainOrThrowError("1.2.3.4/one/two") === "http://1.2.3.4");
+        assert(normaliseURLDomainOrThrowError("https://api.example.com/one/two/") === "https://api.example.com");
+        assert(normaliseURLDomainOrThrowError("http://api.example.com/one/two?hello=1") === "http://api.example.com");
+        assert(normaliseURLDomainOrThrowError("http://api.example.com/one/two#random2") === "http://api.example.com");
+        assert(normaliseURLDomainOrThrowError("api.example.com/one/two") === "https://api.example.com");
+        assert(normaliseURLDomainOrThrowError("api.example.com/one/two/#random") === "https://api.example.com");
+        assert(normaliseURLDomainOrThrowError(".example.com/one/two") === "https://example.com");
+        assert(normaliseURLDomainOrThrowError("localhost:4000") === "http://localhost:4000");
+        assert(normaliseURLDomainOrThrowError("127.0.0.1:4000") === "http://127.0.0.1:4000");
+        assert(normaliseURLDomainOrThrowError("127.0.0.1") === "http://127.0.0.1");
+        assert(normaliseURLDomainOrThrowError("https://127.0.0.1:80/") === "https://127.0.0.1:80");
+
+        try {
+            normaliseURLDomainOrThrowError("/one/two");
+            assert(false);
+        } catch (err) {
+            assert(err.err.message === "Please provide a valid domain name");
         }
     });
 });

--- a/test/deviceDriverInfo.test.js
+++ b/test/deviceDriverInfo.test.js
@@ -66,14 +66,14 @@ describe(`deviceDriverInfo: ${printPath("[test/deviceDriverInfo.test.js]")}`, fu
                 } catch (err) {}
                 return [200, { success: success }];
             });
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
         let response = await ST.createNewSession("", {}, {});
         assert.equal(response.success, true);
     });
 
     it("driver info check with frontendSDKs", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
         // server.
         let server;
         const app = express();

--- a/test/faunadb.test.js
+++ b/test/faunadb.test.js
@@ -55,7 +55,6 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
                 faunadbSecret: "fnAD2HH-Q6ACBSJxMjwU5YT7hvkaVo6Te8PJWqsT",
                 userCollectionName: "users",
                 accessFaunadbTokenFromFrontend: true,
-                refreshTokenPath: "/refresh",
             })
         );
 
@@ -116,7 +115,7 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
         let res3 = extractInfoFromResponse(
             await new Promise((resolve) =>
                 request(app)
-                    .post("/refresh")
+                    .post("/auth/session/refresh")
                     .set("Cookie", ["sRefreshToken=" + res.refreshToken])
                     .set("anti-csrf", res.antiCsrf)
                     .end((err, res) => {
@@ -161,7 +160,6 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
                 faunadbSecret: "fnAD2HH-Q6ACBSJxMjwU5YT7hvkaVo6Te8PJWqsT",
                 userCollectionName: "users",
                 accessFaunadbTokenFromFrontend: true,
-                refreshTokenPath: "/refresh",
             })
         );
 
@@ -223,7 +221,7 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
         let res3 = extractInfoFromResponse(
             await new Promise((resolve) =>
                 request(app)
-                    .post("/refresh")
+                    .post("/auth/session/refresh")
                     .set("Cookie", ["sRefreshToken=" + res.refreshToken])
                     .set("anti-csrf", res.antiCsrf)
                     .end((err, res) => {
@@ -270,7 +268,6 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
                 hosts: "http://localhost:8080",
                 faunadbSecret: "fnAD2HH-Q6ACBSJxMjwU5YT7hvkaVo6Te8PJWqsT",
                 userCollectionName: "users",
-                refreshTokenPath: "/refresh",
             })
         );
 
@@ -340,13 +337,12 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
             faunadbSecret: "fnAD2HH-Q6ACBSJxMjwU5YT7hvkaVo6Te8PJWqsT",
             userCollectionName: "users",
             accessFaunadbTokenFromFrontend: true,
-            refreshTokenPath: "/refresh",
         });
 
         // if version >= 2.3
         if (
-            maxVersion(await Querier.getInstance().getAPIVersion(), "2.3") !==
-            (await Querier.getInstance().getAPIVersion())
+            maxVersion(await Querier.getInstanceOrThrowError().getAPIVersion(), "2.3") !==
+            (await Querier.getInstanceOrThrowError().getAPIVersion())
         ) {
             return;
         }
@@ -362,7 +358,7 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
             res.status(200).send("");
         });
 
-        app.post("/session/refresh", async (req, res) => {
+        app.post("/auth/session/refresh", async (req, res) => {
             try {
                 await STExpress.refreshSession(req, res);
                 res.status(200).send(JSON.stringify({ success: false }));
@@ -388,7 +384,7 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
         let res2 = extractInfoFromResponse(
             await new Promise((resolve) =>
                 request(app)
-                    .post("/session/refresh")
+                    .post("/auth/session/refresh")
                     .set("Cookie", ["sRefreshToken=" + res.refreshToken])
                     .set("anti-csrf", res.antiCsrf)
                     .end((err, res) => {
@@ -411,7 +407,7 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
 
         let res3 = await new Promise((resolve) =>
             request(app)
-                .post("/session/refresh")
+                .post("/auth/session/refresh")
                 .set("Cookie", ["sRefreshToken=" + res.refreshToken])
                 .set("anti-csrf", res.antiCsrf)
                 .end((err, res) => {
@@ -429,7 +425,7 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
         assert.deepEqual(cookies.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
         assert.deepEqual(cookies.idRefreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
         assert.deepEqual(cookies.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
-        let currCDIVersion = await Querier.getInstance().getAPIVersion();
+        let currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
         if (maxVersion(currCDIVersion, "2.1") === "2.1") {
             assert(cookies.accessTokenDomain === "localhost" || cookies.accessTokenDomain === "supertokens.io");
             assert(cookies.refreshTokenDomain === "localhost" || cookies.refreshTokenDomain === "supertokens.io");
@@ -449,7 +445,6 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
         app.use(
             STExpress.init({
                 hosts: "http://localhost:8080",
-                refreshTokenPath: "/session/refresh",
                 faunadbSecret: "fnAD2HH-Q6ACBSJxMjwU5YT7hvkaVo6Te8PJWqsT",
                 userCollectionName: "users",
                 accessFaunadbTokenFromFrontend: true,
@@ -458,8 +453,8 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
 
         // if version >= 2.3
         if (
-            maxVersion(await Querier.getInstance().getAPIVersion(), "2.3") !==
-            (await Querier.getInstance().getAPIVersion())
+            maxVersion(await Querier.getInstanceOrThrowError().getAPIVersion(), "2.3") !==
+            (await Querier.getInstanceOrThrowError().getAPIVersion())
         ) {
             return;
         }
@@ -489,7 +484,7 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
         let res2 = extractInfoFromResponse(
             await new Promise((resolve) =>
                 request(app)
-                    .post("/session/refresh")
+                    .post("/auth/session/refresh")
                     .set("Cookie", ["sRefreshToken=" + res.refreshToken])
                     .set("anti-csrf", res.antiCsrf)
                     .end((err, res) => {
@@ -512,7 +507,7 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
 
         let res3 = await new Promise((resolve) =>
             request(app)
-                .post("/session/refresh")
+                .post("/auth/session/refresh")
                 .set("Cookie", ["sRefreshToken=" + res.refreshToken])
                 .set("anti-csrf", res.antiCsrf)
                 .end((err, res) => {
@@ -541,13 +536,12 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
             faunadbSecret: "fnAD2HH-Q6ACBSJxMjwU5YT7hvkaVo6Te8PJWqsT",
             userCollectionName: "users",
             accessFaunadbTokenFromFrontend: true,
-            refreshTokenPath: "/refresh",
         });
 
         // if version >= 2.3
         if (
-            maxVersion(await Querier.getInstance().getAPIVersion(), "2.3") !==
-            (await Querier.getInstance().getAPIVersion())
+            maxVersion(await Querier.getInstanceOrThrowError().getAPIVersion(), "2.3") !==
+            (await Querier.getInstanceOrThrowError().getAPIVersion())
         ) {
             return;
         }
@@ -563,7 +557,7 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
             await STExpress.getSession(req, res, true);
             res.status(200).send("");
         });
-        app.post("/session/refresh", async (req, res) => {
+        app.post("/auth/session/refresh", async (req, res) => {
             await STExpress.refreshSession(req, res);
             res.status(200).send("");
         });
@@ -606,7 +600,7 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
         let res2 = extractInfoFromResponse(
             await new Promise((resolve) =>
                 request(app)
-                    .post("/session/refresh")
+                    .post("/auth/session/refresh")
                     .set("Cookie", ["sRefreshToken=" + res.refreshToken])
                     .set("anti-csrf", res.antiCsrf)
                     .end((err, res) => {
@@ -685,7 +679,6 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
         app.use(
             STExpress.init({
                 hosts: "http://localhost:8080",
-                refreshTokenPath: "/session/refresh",
                 faunadbSecret: "fnAD2HH-Q6ACBSJxMjwU5YT7hvkaVo6Te8PJWqsT",
                 userCollectionName: "users",
             })
@@ -741,7 +734,7 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
         let res2 = extractInfoFromResponse(
             await new Promise((resolve) =>
                 request(app)
-                    .post("/session/refresh")
+                    .post("/auth/session/refresh")
                     .set("Cookie", ["sRefreshToken=" + res.refreshToken])
                     .set("anti-csrf", res.antiCsrf)
                     .end((err, res) => {

--- a/test/frontendIntegration/index.js
+++ b/test/frontendIntegration/index.js
@@ -36,7 +36,7 @@ app.use(urlencodedParser);
 app.use(jsonParser);
 app.use(cookieParser());
 
-SuperTokens.init({ hosts: "http://localhost:9000", cookieSameSite: "lax", refreshTokenPath: "/refresh" });
+SuperTokens.init({ hosts: "http://localhost:9000", cookieSameSite: "lax" });
 
 app.post("/login", async (req, res) => {
     let userId = req.body.userId;
@@ -95,7 +95,7 @@ app.post("/revokeAll", SuperTokens.middleware(), async (req, res) => {
     res.send("success");
 });
 
-app.post("/refresh", SuperTokens.middleware(), async (req, res) => {
+app.post("/auth/session/refresh", SuperTokens.middleware(), async (req, res) => {
     refreshCalled = true;
     noOfTimesRefreshCalledDuringTest += 1;
     res.send("refresh success");

--- a/test/handshake.test.js
+++ b/test/handshake.test.js
@@ -33,7 +33,7 @@ describe(`Handshake: ${printPath("[test/handshake.test.js]")}`, function () {
     });
 
     it("core not available", async function () {
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
         try {
             await ST.createNewSession("", {}, {});
             throw new Error("should not have come here");
@@ -50,7 +50,7 @@ describe(`Handshake: ${printPath("[test/handshake.test.js]")}`, function () {
 
     it("successful handshake and update JWT", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
         let info = await HandshakeInfo.getInstance();
         assert.equal(typeof info.jwtSigningPublicKey, "string");
         assert.equal(info.enableAntiCsrf, true);
@@ -69,12 +69,12 @@ describe(`Handshake: ${printPath("[test/handshake.test.js]")}`, function () {
         assert.equal(CookieConfig.getInstanceOrThrowError().cookieDomain, undefined);
         assert.equal(CookieConfig.getInstanceOrThrowError().cookieSameSite, "lax");
         assert.equal(CookieConfig.getInstanceOrThrowError().cookieSecure, false);
-        assert.equal(CookieConfig.getInstanceOrThrowError().refreshTokenPath, "/session/refresh");
+        assert.equal(CookieConfig.getInstanceOrThrowError().refreshTokenPath, "/auth/session/refresh");
     });
 
     it("checking for default session expired status code", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
         assert.equal(SessionConfig.getInstanceOrThrowError().sessionExpiredStatusCode, 401);
     });
 });

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -37,7 +37,6 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
         await startST();
         STExpress.init({
             hosts: "http://localhost:8080",
-            refreshTokenPath: "/refresh",
         });
         const app = express();
         app.post("/create", async (req, res) => {
@@ -53,7 +52,7 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
             res.status(200).json({ message: req.session.getHandle() });
         });
 
-        app.post("/refresh", STExpress.middleware(), async (req, res, next) => {
+        app.post("/auth/session/refresh", STExpress.middleware(), async (req, res, next) => {
             res.status(200).json({ message: true });
         });
 
@@ -158,7 +157,7 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
         let res2 = extractInfoFromResponse(
             await new Promise((resolve) =>
                 request(app)
-                    .post("/refresh")
+                    .post("/auth/session/refresh")
                     .expect(200)
                     .set("Cookie", ["sRefreshToken=" + res1.refreshToken])
                     .set("anti-csrf", res1.antiCsrf)
@@ -196,7 +195,7 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
         );
         let r4 = await new Promise((resolve) =>
             request(app)
-                .post("/refresh")
+                .post("/auth/session/refresh")
                 .set("Cookie", ["sRefreshToken=" + res1.refreshToken])
                 .set("anti-csrf", res1.antiCsrf)
                 .expect(403)
@@ -251,7 +250,6 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
         app.use(
             STExpress.init({
                 hosts: "http://localhost:8080",
-                refreshTokenPath: "/refresh",
             })
         );
 
@@ -369,7 +367,7 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
         let res2 = extractInfoFromResponse(
             await new Promise((resolve) =>
                 request(app)
-                    .post("/refresh")
+                    .post("/auth/session/refresh")
                     .expect(200)
                     .set("Cookie", ["sRefreshToken=" + res1.refreshToken])
                     .set("anti-csrf", res1.antiCsrf)
@@ -407,7 +405,7 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
         );
         let r4 = await new Promise((resolve) =>
             request(app)
-                .post("/refresh")
+                .post("/auth/session/refresh")
                 .set("Cookie", ["sRefreshToken=" + res1.refreshToken])
                 .set("anti-csrf", res1.antiCsrf)
                 .expect(403)
@@ -460,7 +458,7 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
         STExpress.init({
             hosts: "http://localhost:8080",
             accessTokenPath: "/custom",
-            refreshTokenPath: "/custom/refresh",
+            apiBasePath: "/custom",
             cookieDomain: "test-driver",
             cookieSecure: true,
             cookieSameSite: "strict",
@@ -479,7 +477,7 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
             res.status(200).json({ message: req.session.getHandle() });
         });
 
-        app.post("/custom/refresh", STExpress.middleware(), async (req, res, next) => {
+        app.post("/custom/session/refresh", STExpress.middleware(), async (req, res, next) => {
             res.status(200).json({ message: true });
         });
 
@@ -588,7 +586,7 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
         let res2 = extractInfoFromResponse(
             await new Promise((resolve) =>
                 request(app)
-                    .post("/custom/refresh")
+                    .post("/custom/session/refresh")
                     .expect(200)
                     .set("Cookie", ["sRefreshToken=" + res1.refreshToken])
                     .set("anti-csrf", res1.antiCsrf)
@@ -628,7 +626,7 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
 
         let r4 = await new Promise((resolve) =>
             request(app)
-                .post("/custom/refresh")
+                .post("/custom/session/refresh")
                 .set("Cookie", ["sRefreshToken=" + res1.refreshToken])
                 .set("anti-csrf", res1.antiCsrf)
                 .expect(403)
@@ -684,7 +682,7 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
             STExpress.init({
                 hosts: "http://localhost:8080",
                 accessTokenPath: "/custom",
-                refreshTokenPath: "/custom/refresh",
+                apiBasePath: "/custom",
                 cookieDomain: "test-driver",
                 cookieSecure: true,
                 cookieSameSite: "strict",
@@ -809,7 +807,7 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
         let res2 = extractInfoFromResponse(
             await new Promise((resolve) =>
                 request(app)
-                    .post("/custom/refresh")
+                    .post("/custom/session/refresh")
                     .expect(200)
                     .set("Cookie", ["sRefreshToken=" + res1.refreshToken])
                     .set("anti-csrf", res1.antiCsrf)
@@ -849,7 +847,7 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
 
         let r4 = await new Promise((resolve) =>
             request(app)
-                .post("/custom/refresh")
+                .post("/custom/session/refresh")
                 .set("Cookie", ["sRefreshToken=" + res1.refreshToken])
                 .set("anti-csrf", res1.antiCsrf)
                 .expect(403)

--- a/test/querier.test.js
+++ b/test/querier.test.js
@@ -30,14 +30,10 @@ describe(`Querier: ${printPath("[test/querier.test.js]")}`, function () {
         await cleanST();
     });
 
-    it("querier called without init", async function () {
-        Querier.getInstance();
-    });
-
     it("core not available", async function () {
         ST.init({ hosts: "http://localhost:8080;http://localhost:8081/" });
         try {
-            let q = Querier.getInstance();
+            let q = Querier.getInstanceOrThrowError();
             await q.sendGetRequest("/", {});
             throw new Error();
         } catch (err) {
@@ -56,7 +52,7 @@ describe(`Querier: ${printPath("[test/querier.test.js]")}`, function () {
         await startST("localhost", 8081);
         await startST("localhost", 8082);
         ST.init({ hosts: "http://localhost:8080;http://localhost:8081/;http://localhost:8082" });
-        let q = Querier.getInstance();
+        let q = Querier.getInstanceOrThrowError();
         assert.equal(await q.sendGetRequest("/hello", {}), "Hello\n");
         assert.equal(await q.sendDeleteRequest("/hello", {}), "Hello\n");
         let hostsAlive = q.getHostsAliveForTesting();
@@ -73,7 +69,7 @@ describe(`Querier: ${printPath("[test/querier.test.js]")}`, function () {
         await startST();
         await startST("localhost", 8082);
         ST.init({ hosts: "http://localhost:8080;http://localhost:8081/;http://localhost:8082" });
-        let q = Querier.getInstance();
+        let q = Querier.getInstanceOrThrowError();
         assert.equal(await q.sendGetRequest("/hello", {}), "Hello\n");
         assert.equal(await q.sendPostRequest("/hello", {}), "Hello\n");
         let hostsAlive = q.getHostsAliveForTesting();

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -98,7 +98,7 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
             hosts: "http://localhost:8080",
         });
         try {
-            let version = await Querier.getInstance().getAPIVersion();
+            let version = await Querier.getInstanceOrThrowError().getAPIVersion();
             if (
                 (version !== "2.0" && process.env.INSTALL_PATH.includes("com-")) ||
                 (maxVersion(version, "2.3") === version && process.env.INSTALL_PATH.includes("supertokens-"))
@@ -227,7 +227,7 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
         let res = await ST.createNewSession("someUniqueUserId", {}, {});
         let res2 = await ST.revokeSession(res.session.handle);
         assert(res2 === true);
-        const CDI_VERSION = await Querier.getInstance().getAPIVersion();
+        const CDI_VERSION = await Querier.getInstanceOrThrowError().getAPIVersion();
 
         let res3 = await ST.getAllSessionHandlesForUser("someUniqueUserId");
         assert(res3.length === 0);

--- a/test/sessionExpress.test.js
+++ b/test/sessionExpress.test.js
@@ -49,7 +49,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
     //- check for token theft detection
     it("express token theft detection", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
 
         const app = express();
         app.post("/create", async (req, res) => {
@@ -62,7 +62,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
             res.status(200).send("");
         });
 
-        app.post("/session/refresh", async (req, res) => {
+        app.post("/auth/session/refresh", async (req, res) => {
             try {
                 await STExpress.refreshSession(req, res);
                 res.status(200).send(JSON.stringify({ success: false }));
@@ -87,7 +87,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
         let res2 = extractInfoFromResponse(
             await new Promise((resolve) =>
                 request(app)
-                    .post("/session/refresh")
+                    .post("/auth/session/refresh")
                     .set("Cookie", ["sRefreshToken=" + res.refreshToken])
                     .set("anti-csrf", res.antiCsrf)
                     .end((err, res) => {
@@ -110,7 +110,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
 
         let res3 = await new Promise((resolve) =>
             request(app)
-                .post("/session/refresh")
+                .post("/auth/session/refresh")
                 .set("Cookie", ["sRefreshToken=" + res.refreshToken])
                 .set("anti-csrf", res.antiCsrf)
                 .end((err, res) => {
@@ -128,7 +128,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
         assert.deepEqual(cookies.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
         assert.deepEqual(cookies.idRefreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
         assert.deepEqual(cookies.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
-        let currCDIVersion = await Querier.getInstance().getAPIVersion();
+        let currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
         if (maxVersion(currCDIVersion, "2.1") === "2.1") {
             assert(cookies.accessTokenDomain === "localhost" || cookies.accessTokenDomain === "supertokens.io");
             assert(cookies.refreshTokenDomain === "localhost" || cookies.refreshTokenDomain === "supertokens.io");
@@ -148,7 +148,6 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
         app.use(
             STExpress.init({
                 hosts: "http://localhost:8080",
-                refreshTokenPath: "/session/refresh",
             })
         );
 
@@ -177,7 +176,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
         let res2 = extractInfoFromResponse(
             await new Promise((resolve) =>
                 request(app)
-                    .post("/session/refresh")
+                    .post("/auth/session/refresh")
                     .set("Cookie", ["sRefreshToken=" + res.refreshToken])
                     .set("anti-csrf", res.antiCsrf)
                     .end((err, res) => {
@@ -200,7 +199,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
 
         let res3 = await new Promise((resolve) =>
             request(app)
-                .post("/session/refresh")
+                .post("/auth/session/refresh")
                 .set("Cookie", ["sRefreshToken=" + res.refreshToken])
                 .set("anti-csrf", res.antiCsrf)
                 .end((err, res) => {
@@ -224,7 +223,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
     //check basic usage of session
     it("test basic usage of express sessions", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
 
         const app = express();
 
@@ -237,7 +236,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
             await STExpress.getSession(req, res, true);
             res.status(200).send("");
         });
-        app.post("/session/refresh", async (req, res) => {
+        app.post("/auth/session/refresh", async (req, res) => {
             await STExpress.refreshSession(req, res);
             res.status(200).send("");
         });
@@ -280,7 +279,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
         let res2 = extractInfoFromResponse(
             await new Promise((resolve) =>
                 request(app)
-                    .post("/session/refresh")
+                    .post("/auth/session/refresh")
                     .set("Cookie", ["sRefreshToken=" + res.refreshToken])
                     .set("anti-csrf", res.antiCsrf)
                     .end((err, res) => {
@@ -358,7 +357,6 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
         app.use(
             STExpress.init({
                 hosts: "http://localhost:8080",
-                refreshTokenPath: "/session/refresh",
             })
         );
 
@@ -412,7 +410,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
         let res2 = extractInfoFromResponse(
             await new Promise((resolve) =>
                 request(app)
-                    .post("/session/refresh")
+                    .post("/auth/session/refresh")
                     .set("Cookie", ["sRefreshToken=" + res.refreshToken])
                     .set("anti-csrf", res.antiCsrf)
                     .end((err, res) => {
@@ -485,7 +483,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
     //check session verify for with / without anti-csrf present
     it("test express session verify with anti-csrf present", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
 
         const app = express();
         app.post("/create", async (req, res) => {
@@ -540,7 +538,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
     // check session verify for with / without anti-csrf present
     it("test session verify without anti-csrf present express", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
 
         const app = express();
 
@@ -600,7 +598,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
     //check revoking session(s)**
     it("test revoking express sessions", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
         const app = express();
         app.post("/create", async (req, res) => {
             await STExpress.createNewSession(res, "", {}, {});
@@ -707,7 +705,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
     //check manipulating session data
     it("test manipulating session data with express", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
         const app = express();
         app.post("/create", async (req, res) => {
             await STExpress.createNewSession(res, "", {}, {});
@@ -833,7 +831,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
     //check manipulating jwt payload
     it("test manipulating jwt payload with express", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
         const app = express();
         app.post("/create", async (req, res) => {
             await STExpress.createNewSession(res, "user1", {}, {});
@@ -847,7 +845,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
             let statusCode = accessTokenBefore !== accessTokenAfter && typeof accessTokenAfter === "string" ? 200 : 500;
             res.status(statusCode).send("");
         });
-        app.post("/session/refresh", async (req, res) => {
+        app.post("/auth/session/refresh", async (req, res) => {
             await STExpress.refreshSession(req, res);
             res.status(200).send("");
         });
@@ -935,7 +933,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
         response2 = extractInfoFromResponse(
             await new Promise((resolve) =>
                 request(app)
-                    .post("/session/refresh")
+                    .post("/auth/session/refresh")
                     .set("Cookie", [
                         "sRefreshToken=" +
                             response.refreshToken +
@@ -1018,7 +1016,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
     // test with existing header params being there and that the lib appends to those and not overrides those
     it("test that express appends to existing header params and does not override", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
         const app = express();
         app.post("/create", async (req, res) => {
             res.header("testHeader", "testValue");
@@ -1056,7 +1054,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
     it("test that when anti-csrf is disabled from from ST core, not having to input in verify session is fine in express", async function () {
         await setKeyValueInConfig("enable_anti_csrf", "false");
         await startST();
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
 
         const app = express();
         app.post("/create", async (req, res) => {
@@ -1127,7 +1125,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
 
     it("test that getSession does not clear cookies if a session does not exist in the first place", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
 
         const app = express();
 
@@ -1166,11 +1164,11 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
 
     it("test that refreshSession does not clear cookies if a session does not exist in the first place", async function () {
         await startST();
-        ST.init({ hosts: "http://localhost:8080", refreshTokenPath: "/refresh" });
+        ST.init({ hosts: "http://localhost:8080" });
 
         const app = express();
 
-        app.post("/session/refresh", async (req, res) => {
+        app.post("/auth/session/refresh", async (req, res) => {
             try {
                 await STExpress.refreshSession(req, res);
             } catch (err) {
@@ -1184,7 +1182,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
 
         let res = await new Promise((resolve) =>
             request(app)
-                .post("/session/refresh")
+                .post("/auth/session/refresh")
                 .end((err, res) => {
                     resolve(res);
                 })


### PR DESCRIPTION
Related issues:
- supertokens/supertokens-core#65

Changes:
- Normalising of all user input
- Removed `refreshTokenPath` and replaced it with `apiBasePath`
- Refactor of `init` code
- Added tests for checking of `init` and user configuration

Migration:
- Remove `refreshTokenPath` and use `apiBasePath` instead. The refresh API will always be `apiBasePath + "/session/refresh"`. This will require a change in the `init` config and the refresh API

Docs change - commit hash `c5dbab42672457b5d41b2ed63a486b3ba666e6bf` in main-website repo