### PR TITLE
Conforms to cdi 2.4 for sessions

### DIFF
--- a/lib/build/normalisedURLPath.d.ts
+++ b/lib/build/normalisedURLPath.d.ts
@@ -5,5 +5,6 @@ export default class NormalisedURLPath {
     appendPath: (rId: string, other: NormalisedURLPath) => NormalisedURLPath;
     getAsStringDangerous: () => string;
     equals: (other: NormalisedURLPath) => boolean;
+    isARecipePath: () => boolean;
 }
 export declare function normaliseURLPathOrThrowError(rId: string, input: string): string;

--- a/lib/build/normalisedURLPath.js
+++ b/lib/build/normalisedURLPath.js
@@ -30,6 +30,9 @@ class NormalisedURLPath {
         this.equals = (other) => {
             return this.value === other.value;
         };
+        this.isARecipePath = () => {
+            return this.value === "/recipe" || this.value.startsWith("/recipe/");
+        };
         this.value = normaliseURLPathOrThrowError(rId, url);
     }
 }

--- a/lib/build/querier.d.ts
+++ b/lib/build/querier.d.ts
@@ -1,4 +1,5 @@
 import NormalisedURLDomain from "./normalisedURLDomain";
+import NormalisedURLPath from "./normalisedURLPath";
 export declare class Querier {
     private static initCalled;
     private static hosts;
@@ -14,9 +15,9 @@ export declare class Querier {
     getHostsAliveForTesting: () => Set<string>;
     static getInstanceOrThrowError(rId: string): Querier;
     static init(hosts: NormalisedURLDomain[], apiKey?: string): void;
-    sendPostRequest: (path: string, body: any) => Promise<any>;
-    sendDeleteRequest: (path: string, body: any) => Promise<any>;
-    sendGetRequest: (path: string, params: any) => Promise<any>;
-    sendPutRequest: (path: string, body: any) => Promise<any>;
+    sendPostRequest: (path: NormalisedURLPath, body: any) => Promise<any>;
+    sendDeleteRequest: (path: NormalisedURLPath, body: any) => Promise<any>;
+    sendGetRequest: (path: NormalisedURLPath, params: any) => Promise<any>;
+    sendPutRequest: (path: NormalisedURLPath, body: any) => Promise<any>;
     private sendRequestHelper;
 }

--- a/lib/build/querier.js
+++ b/lib/build/querier.js
@@ -49,6 +49,7 @@ const axios_1 = require("axios");
 const utils_1 = require("./utils");
 const version_1 = require("./version");
 const error_1 = require("./error");
+const normalisedURLPath_1 = require("./normalisedURLPath");
 class Querier {
     constructor(hosts, rId) {
         this.getAPIVersion = () =>
@@ -57,7 +58,7 @@ class Querier {
                     return Querier.apiVersion;
                 }
                 let response = yield this.sendRequestHelper(
-                    "/apiversion",
+                    new normalisedURLPath_1.default(this.rId, "/apiversion"),
                     "GET",
                     (url) => {
                         let headers = {};
@@ -112,6 +113,9 @@ class Querier {
                             if (Querier.apiKey !== undefined) {
                                 headers = Object.assign(Object.assign({}, headers), { "api-key": Querier.apiKey });
                             }
+                            if (path.isARecipePath()) {
+                                headers = Object.assign(Object.assign({}, headers), { rid: this.rId });
+                            }
                             return yield axios_1.default({
                                 method: "POST",
                                 url,
@@ -134,6 +138,9 @@ class Querier {
                             let headers = { "cdi-version": apiVersion };
                             if (Querier.apiKey !== undefined) {
                                 headers = Object.assign(Object.assign({}, headers), { "api-key": Querier.apiKey });
+                            }
+                            if (path.isARecipePath()) {
+                                headers = Object.assign(Object.assign({}, headers), { rid: this.rId });
                             }
                             return yield axios_1.default({
                                 method: "DELETE",
@@ -158,6 +165,9 @@ class Querier {
                             if (Querier.apiKey !== undefined) {
                                 headers = Object.assign(Object.assign({}, headers), { "api-key": Querier.apiKey });
                             }
+                            if (path.isARecipePath()) {
+                                headers = Object.assign(Object.assign({}, headers), { rid: this.rId });
+                            }
                             return yield axios_1.default.get(url, {
                                 params,
                                 headers,
@@ -178,6 +188,9 @@ class Querier {
                             let headers = { "cdi-version": apiVersion };
                             if (Querier.apiKey !== undefined) {
                                 headers = Object.assign(Object.assign({}, headers), { "api-key": Querier.apiKey });
+                            }
+                            if (path.isARecipePath()) {
+                                headers = Object.assign(Object.assign({}, headers), { rid: this.rId });
                             }
                             return yield axios_1.default({
                                 method: "PUT",
@@ -203,7 +216,7 @@ class Querier {
                 Querier.lastTriedIndex++;
                 Querier.lastTriedIndex = Querier.lastTriedIndex % this.__hosts.length;
                 try {
-                    let response = yield axiosFunction(currentHost + path);
+                    let response = yield axiosFunction(currentHost + path.getAsStringDangerous());
                     if (process.env.TEST_MODE === "testing") {
                         Querier.hostsAliveForTesting.add(currentHost);
                     }
@@ -227,7 +240,7 @@ class Querier {
                                 "SuperTokens core threw an error for a " +
                                     method +
                                     " request to path: '" +
-                                    path +
+                                    path.getAsStringDangerous() +
                                     "' with status code: " +
                                     err.response.status +
                                     " and message: " +

--- a/lib/build/recipe/session/faunadb/sessionClass.d.ts
+++ b/lib/build/recipe/session/faunadb/sessionClass.d.ts
@@ -2,6 +2,6 @@ import OriginalSessionClass from "../sessionClass";
 import * as express from "express";
 import OriginalSessionRecipe from "../sessionRecipe";
 export default class Session extends OriginalSessionClass {
-    constructor(recipeInstance: OriginalSessionRecipe, accessToken: string, sessionHandle: string, userId: string, userDataInJWT: any, accessTokenExpiry: number | undefined, res: express.Response);
+    constructor(recipeInstance: OriginalSessionRecipe, accessToken: string, sessionHandle: string, userId: string, userDataInJWT: any, res: express.Response);
     getFaunadbToken: () => Promise<string>;
 }

--- a/lib/build/recipe/session/faunadb/sessionClass.js
+++ b/lib/build/recipe/session/faunadb/sessionClass.js
@@ -48,8 +48,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const sessionClass_1 = require("../sessionClass");
 const constants_1 = require("./constants");
 class Session extends sessionClass_1.default {
-    constructor(recipeInstance, accessToken, sessionHandle, userId, userDataInJWT, accessTokenExpiry, res) {
-        super(recipeInstance, accessToken, sessionHandle, userId, userDataInJWT, accessTokenExpiry, res);
+    constructor(recipeInstance, accessToken, sessionHandle, userId, userDataInJWT, res) {
+        super(recipeInstance, accessToken, sessionHandle, userId, userDataInJWT, res);
         this.getFaunadbToken = () =>
             __awaiter(this, void 0, void 0, function* () {
                 let jwtPayload = this.getJWTPayload();

--- a/lib/build/recipe/session/faunadb/sessionRecipe.js
+++ b/lib/build/recipe/session/faunadb/sessionRecipe.js
@@ -79,11 +79,7 @@ class SessionRecipe extends recipeModule_1.default {
                     }
                     return constants_1.FAUNADB_TOKEN_TIME_LAG_MILLI;
                 }
-                let accessTokenExpiry = session.getAccessTokenExpiry();
-                if (accessTokenExpiry === undefined) {
-                    throw new Error("Should not come here");
-                }
-                let accessTokenLifetime = accessTokenExpiry - Date.now();
+                let accessTokenLifetime = (yield this.parentRecipe.getHandshakeInfo()).accessTokenValidity;
                 let faunaResponse = yield this.faunaDBClient.query(
                     this.q.Create(this.q.Tokens(), {
                         instance: this.q.Ref(this.q.Collection(this.config.userCollectionName), session.getUserId()),
@@ -106,7 +102,6 @@ class SessionRecipe extends recipeModule_1.default {
                     originalSession.getHandle(),
                     originalSession.getUserId(),
                     originalSession.getJWTPayload(),
-                    originalSession.getAccessTokenExpiry(), // TODO: remove this field from session once handshake info has access token expiry
                     res
                 );
                 try {
@@ -140,7 +135,6 @@ class SessionRecipe extends recipeModule_1.default {
                     originalSession.getHandle(),
                     originalSession.getUserId(),
                     originalSession.getJWTPayload(),
-                    originalSession.getAccessTokenExpiry(),
                     res
                 );
             });
@@ -153,7 +147,6 @@ class SessionRecipe extends recipeModule_1.default {
                     originalSession.getHandle(),
                     originalSession.getUserId(),
                     originalSession.getJWTPayload(),
-                    originalSession.getAccessTokenExpiry(),
                     res
                 );
                 try {

--- a/lib/build/recipe/session/sessionClass.d.ts
+++ b/lib/build/recipe/session/sessionClass.d.ts
@@ -6,10 +6,8 @@ export default class Session {
     private userDataInJWT;
     private res;
     private accessToken;
-    private accessTokenExpiry;
     private recipeInstance;
-    constructor(recipeInstance: SessionRecipe, accessToken: string, sessionHandle: string, userId: string, userDataInJWT: any, accessTokenExpiry: number | undefined, res: express.Response);
-    getAccessTokenExpiry: () => number | undefined;
+    constructor(recipeInstance: SessionRecipe, accessToken: string, sessionHandle: string, userId: string, userDataInJWT: any, res: express.Response);
     /**
      * @description call this to logout the current user.
      * This only invalidates the refresh token. The access token can still be used after

--- a/lib/build/recipe/session/sessionClass.js
+++ b/lib/build/recipe/session/sessionClass.js
@@ -34,12 +34,9 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const SessionFunctions = require("./sessionFunctions");
 const cookieAndHeaders_1 = require("./cookieAndHeaders");
 const error_1 = require("./error");
+const normalisedURLPath_1 = require("../../normalisedURLPath");
 class Session {
-    constructor(recipeInstance, accessToken, sessionHandle, userId, userDataInJWT, accessTokenExpiry, res) {
-        // TODO: remove when handshakeInfo has accessToken lifetime param
-        this.getAccessTokenExpiry = () => {
-            return this.accessTokenExpiry;
-        };
+    constructor(recipeInstance, accessToken, sessionHandle, userId, userDataInJWT, res) {
         /**
          * @description call this to logout the current user.
          * This only invalidates the refresh token. The access token can still be used after
@@ -99,10 +96,18 @@ class Session {
         };
         this.updateJWTPayload = (newJWTPayload) =>
             __awaiter(this, void 0, void 0, function* () {
-                let response = yield this.recipeInstance.getQuerier().sendPostRequest("/session/regenerate", {
-                    accessToken: this.accessToken,
-                    userDataInJWT: newJWTPayload,
-                });
+                let response = yield this.recipeInstance
+                    .getQuerier()
+                    .sendPostRequest(
+                        new normalisedURLPath_1.default(
+                            this.recipeInstance.getRecipeId(),
+                            "/recipe/session/regenerate"
+                        ),
+                        {
+                            accessToken: this.accessToken,
+                            userDataInJWT: newJWTPayload,
+                        }
+                    );
                 if (response.status === "UNAUTHORISED") {
                     cookieAndHeaders_1.clearSessionFromCookie(this.recipeInstance, this.res);
                     throw new error_1.default(
@@ -136,7 +141,6 @@ class Session {
         this.userDataInJWT = userDataInJWT;
         this.res = res;
         this.accessToken = accessToken;
-        this.accessTokenExpiry = accessTokenExpiry;
         this.recipeInstance = recipeInstance;
     }
 }

--- a/lib/build/recipe/session/sessionFunctions.js
+++ b/lib/build/recipe/session/sessionFunctions.js
@@ -48,17 +48,20 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const accessToken_1 = require("./accessToken");
 const error_1 = require("./error");
 const processState_1 = require("../../processState");
+const normalisedURLPath_1 = require("../../normalisedURLPath");
 /**
  * @description call this to "login" a user.
  * @throws GENERAL_ERROR in case anything fails.
  */
 function createNewSession(recipeInstance, userId, jwtPayload = {}, sessionData = {}) {
     return __awaiter(this, void 0, void 0, function* () {
-        let response = yield recipeInstance.getQuerier().sendPostRequest("/session", {
-            userId,
-            userDataInJWT: jwtPayload,
-            userDataInDatabase: sessionData,
-        });
+        let response = yield recipeInstance
+            .getQuerier()
+            .sendPostRequest(new normalisedURLPath_1.default(recipeInstance.getRecipeId(), "/recipe/session"), {
+                userId,
+                userDataInJWT: jwtPayload,
+                userDataInDatabase: sessionData,
+            });
         recipeInstance.updateJwtSigningPublicKeyInfo(
             response.jwtSigningPublicKey,
             response.jwtSigningPublicKeyExpiryTime
@@ -143,11 +146,13 @@ function getSession(recipeInstance, accessToken, antiCsrfToken, doAntiCsrfCheck)
             }
         }
         processState_1.ProcessState.getInstance().addState(processState_1.PROCESS_STATE.CALLING_SERVICE_IN_VERIFY);
-        let response = yield recipeInstance.getQuerier().sendPostRequest("/session/verify", {
-            accessToken,
-            antiCsrfToken,
-            doAntiCsrfCheck,
-        });
+        let response = yield recipeInstance
+            .getQuerier()
+            .sendPostRequest(new normalisedURLPath_1.default(recipeInstance.getRecipeId(), "/recipe/session/verify"), {
+                accessToken,
+                antiCsrfToken,
+                doAntiCsrfCheck,
+            });
         if (response.status == "OK") {
             recipeInstance.updateJwtSigningPublicKeyInfo(
                 response.jwtSigningPublicKey,
@@ -184,10 +189,12 @@ exports.getSession = getSession;
  */
 function refreshSession(recipeInstance, refreshToken, antiCsrfToken) {
     return __awaiter(this, void 0, void 0, function* () {
-        let response = yield recipeInstance.getQuerier().sendPostRequest("/session/refresh", {
-            refreshToken,
-            antiCsrfToken,
-        });
+        let response = yield recipeInstance
+            .getQuerier()
+            .sendPostRequest(new normalisedURLPath_1.default(recipeInstance.getRecipeId(), "/recipe/session/refresh"), {
+                refreshToken,
+                antiCsrfToken,
+            });
         if (response.status == "OK") {
             delete response.status;
             return response;
@@ -222,9 +229,11 @@ exports.refreshSession = refreshSession;
  */
 function revokeAllSessionsForUser(recipeInstance, userId) {
     return __awaiter(this, void 0, void 0, function* () {
-        let response = yield recipeInstance.getQuerier().sendPostRequest("/session/remove", {
-            userId,
-        });
+        let response = yield recipeInstance
+            .getQuerier()
+            .sendPostRequest(new normalisedURLPath_1.default(recipeInstance.getRecipeId(), "/recipe/session/remove"), {
+                userId,
+            });
         return response.sessionHandlesRevoked;
     });
 }
@@ -235,9 +244,11 @@ exports.revokeAllSessionsForUser = revokeAllSessionsForUser;
  */
 function getAllSessionHandlesForUser(recipeInstance, userId) {
     return __awaiter(this, void 0, void 0, function* () {
-        let response = yield recipeInstance.getQuerier().sendGetRequest("/session/user", {
-            userId,
-        });
+        let response = yield recipeInstance
+            .getQuerier()
+            .sendGetRequest(new normalisedURLPath_1.default(recipeInstance.getRecipeId(), "/recipe/session/user"), {
+                userId,
+            });
         return response.sessionHandles;
     });
 }
@@ -249,9 +260,11 @@ exports.getAllSessionHandlesForUser = getAllSessionHandlesForUser;
  */
 function revokeSession(recipeInstance, sessionHandle) {
     return __awaiter(this, void 0, void 0, function* () {
-        let response = yield recipeInstance.getQuerier().sendPostRequest("/session/remove", {
-            sessionHandles: [sessionHandle],
-        });
+        let response = yield recipeInstance
+            .getQuerier()
+            .sendPostRequest(new normalisedURLPath_1.default(recipeInstance.getRecipeId(), "/recipe/session/remove"), {
+                sessionHandles: [sessionHandle],
+            });
         return response.sessionHandlesRevoked.length === 1;
     });
 }
@@ -263,9 +276,11 @@ exports.revokeSession = revokeSession;
  */
 function revokeMultipleSessions(recipeInstance, sessionHandles) {
     return __awaiter(this, void 0, void 0, function* () {
-        let response = yield recipeInstance.getQuerier().sendPostRequest("/session/remove", {
-            sessionHandles,
-        });
+        let response = yield recipeInstance
+            .getQuerier()
+            .sendPostRequest(new normalisedURLPath_1.default(recipeInstance.getRecipeId(), "/recipe/session/remove"), {
+                sessionHandles,
+            });
         return response.sessionHandlesRevoked;
     });
 }
@@ -277,9 +292,11 @@ exports.revokeMultipleSessions = revokeMultipleSessions;
  */
 function getSessionData(recipeInstance, sessionHandle) {
     return __awaiter(this, void 0, void 0, function* () {
-        let response = yield recipeInstance.getQuerier().sendGetRequest("/session/data", {
-            sessionHandle,
-        });
+        let response = yield recipeInstance
+            .getQuerier()
+            .sendGetRequest(new normalisedURLPath_1.default(recipeInstance.getRecipeId(), "/recipe/session/data"), {
+                sessionHandle,
+            });
         if (response.status === "OK") {
             return response.userDataInDatabase;
         } else {
@@ -300,10 +317,12 @@ exports.getSessionData = getSessionData;
  */
 function updateSessionData(recipeInstance, sessionHandle, newSessionData) {
     return __awaiter(this, void 0, void 0, function* () {
-        let response = yield recipeInstance.getQuerier().sendPutRequest("/session/data", {
-            sessionHandle,
-            userDataInDatabase: newSessionData,
-        });
+        let response = yield recipeInstance
+            .getQuerier()
+            .sendPutRequest(new normalisedURLPath_1.default(recipeInstance.getRecipeId(), "/recipe/session/data"), {
+                sessionHandle,
+                userDataInDatabase: newSessionData,
+            });
         if (response.status === "UNAUTHORISED") {
             throw new error_1.default(
                 {
@@ -322,9 +341,11 @@ exports.updateSessionData = updateSessionData;
  */
 function getJWTPayload(recipeInstance, sessionHandle) {
     return __awaiter(this, void 0, void 0, function* () {
-        let response = yield recipeInstance.getQuerier().sendGetRequest("/jwt/data", {
-            sessionHandle,
-        });
+        let response = yield recipeInstance
+            .getQuerier()
+            .sendGetRequest(new normalisedURLPath_1.default(recipeInstance.getRecipeId(), "/recipe/jwt/data"), {
+                sessionHandle,
+            });
         if (response.status === "OK") {
             return response.userDataInJWT;
         } else {
@@ -344,10 +365,12 @@ exports.getJWTPayload = getJWTPayload;
  */
 function updateJWTPayload(recipeInstance, sessionHandle, newJWTPayload) {
     return __awaiter(this, void 0, void 0, function* () {
-        let response = yield recipeInstance.getQuerier().sendPutRequest("/jwt/data", {
-            sessionHandle,
-            userDataInJWT: newJWTPayload,
-        });
+        let response = yield recipeInstance
+            .getQuerier()
+            .sendPutRequest(new normalisedURLPath_1.default(recipeInstance.getRecipeId(), "/recipe/jwt/data"), {
+                sessionHandle,
+                userDataInJWT: newJWTPayload,
+            });
         if (response.status === "UNAUTHORISED") {
             throw new error_1.default(
                 {

--- a/lib/build/recipe/session/sessionRecipe.js
+++ b/lib/build/recipe/session/sessionRecipe.js
@@ -98,14 +98,17 @@ class SessionRecipe extends recipeModule_1.default {
         this.getHandshakeInfo = () =>
             __awaiter(this, void 0, void 0, function* () {
                 if (this.handshakeInfo == undefined) {
-                    let response = yield this.getQuerier().sendPostRequest("/handshake", {});
+                    let response = yield this.getQuerier().sendPostRequest(
+                        new normalisedURLPath_1.default(this.getRecipeId(), "/recipe/handshake"),
+                        {}
+                    );
                     this.handshakeInfo = {
                         jwtSigningPublicKey: response.jwtSigningPublicKey,
                         enableAntiCsrf: response.enableAntiCsrf,
                         accessTokenBlacklistingEnabled: response.accessTokenBlacklistingEnabled,
                         jwtSigningPublicKeyExpiryTime: response.jwtSigningPublicKeyExpiryTime,
-                        accessTokenVaildity: response.accessTokenVaildity,
-                        refreshTokenVaildity: response.refreshTokenVaildity,
+                        accessTokenValidity: response.accessTokenValidity,
+                        refreshTokenValidity: response.refreshTokenValidity,
                     };
                 }
                 return this.handshakeInfo;
@@ -126,7 +129,6 @@ class SessionRecipe extends recipeModule_1.default {
                     response.session.handle,
                     response.session.userId,
                     response.session.userDataInJWT,
-                    response.accessToken.expiry,
                     res
                 );
             });
@@ -181,7 +183,6 @@ class SessionRecipe extends recipeModule_1.default {
                         response.session.handle,
                         response.session.userId,
                         response.session.userDataInJWT,
-                        response.accessToken !== undefined ? response.accessToken.expiry : undefined,
                         res
                     );
                 } catch (err) {
@@ -216,7 +217,6 @@ class SessionRecipe extends recipeModule_1.default {
                         response.session.handle,
                         response.session.userId,
                         response.session.userDataInJWT,
-                        response.accessToken.expiry,
                         res
                     );
                 } catch (err) {

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -5,8 +5,8 @@ export declare type HandshakeInfo = {
     enableAntiCsrf: boolean;
     accessTokenBlacklistingEnabled: boolean;
     jwtSigningPublicKeyExpiryTime: number;
-    accessTokenVaildity: number;
-    refreshTokenVaildity: number;
+    accessTokenValidity: number;
+    refreshTokenValidity: number;
 };
 export declare type CreateOrRefreshAPIResponse = {
     session: {

--- a/lib/ts/normalisedURLPath.ts
+++ b/lib/ts/normalisedURLPath.ts
@@ -38,6 +38,10 @@ export default class NormalisedURLPath {
     equals = (other: NormalisedURLPath) => {
         return this.value === other.value;
     };
+
+    isARecipePath = () => {
+        return this.value === "/recipe" || this.value.startsWith("/recipe/");
+    };
 }
 
 export function normaliseURLPathOrThrowError(rId: string, input: string): string {

--- a/lib/ts/recipe/session/faunadb/sessionClass.ts
+++ b/lib/ts/recipe/session/faunadb/sessionClass.ts
@@ -25,10 +25,9 @@ export default class Session extends OriginalSessionClass {
         sessionHandle: string,
         userId: string,
         userDataInJWT: any,
-        accessTokenExpiry: number | undefined,
         res: express.Response
     ) {
-        super(recipeInstance, accessToken, sessionHandle, userId, userDataInJWT, accessTokenExpiry, res);
+        super(recipeInstance, accessToken, sessionHandle, userId, userDataInJWT, res);
     }
 
     getFaunadbToken = async (): Promise<string> => {

--- a/lib/ts/recipe/session/faunadb/sessionRecipe.ts
+++ b/lib/ts/recipe/session/faunadb/sessionRecipe.ts
@@ -165,11 +165,7 @@ export default class SessionRecipe extends RecipeModule {
             return FAUNADB_TOKEN_TIME_LAG_MILLI;
         }
 
-        let accessTokenExpiry = session.getAccessTokenExpiry();
-        if (accessTokenExpiry === undefined) {
-            throw new Error("Should not come here");
-        }
-        let accessTokenLifetime = accessTokenExpiry - Date.now();
+        let accessTokenLifetime = (await this.parentRecipe.getHandshakeInfo()).accessTokenValidity;
 
         let faunaResponse: any = await this.faunaDBClient.query(
             this.q.Create(this.q.Tokens(), {
@@ -194,7 +190,6 @@ export default class SessionRecipe extends RecipeModule {
             originalSession.getHandle(),
             originalSession.getUserId(),
             originalSession.getJWTPayload(),
-            originalSession.getAccessTokenExpiry(), // TODO: remove this field from session once handshake info has access token expiry
             res
         );
         try {
@@ -234,7 +229,6 @@ export default class SessionRecipe extends RecipeModule {
             originalSession.getHandle(),
             originalSession.getUserId(),
             originalSession.getJWTPayload(),
-            originalSession.getAccessTokenExpiry(),
             res
         );
     };
@@ -247,7 +241,6 @@ export default class SessionRecipe extends RecipeModule {
             originalSession.getHandle(),
             originalSession.getUserId(),
             originalSession.getJWTPayload(),
-            originalSession.getAccessTokenExpiry(),
             res
         );
         try {

--- a/lib/ts/recipe/session/sessionRecipe.ts
+++ b/lib/ts/recipe/session/sessionRecipe.ts
@@ -164,14 +164,17 @@ export default class SessionRecipe extends RecipeModule {
 
     getHandshakeInfo = async (): Promise<HandshakeInfo> => {
         if (this.handshakeInfo == undefined) {
-            let response = await this.getQuerier().sendPostRequest("/handshake", {});
+            let response = await this.getQuerier().sendPostRequest(
+                new NormalisedURLPath(this.getRecipeId(), "/recipe/handshake"),
+                {}
+            );
             this.handshakeInfo = {
                 jwtSigningPublicKey: response.jwtSigningPublicKey,
                 enableAntiCsrf: response.enableAntiCsrf,
                 accessTokenBlacklistingEnabled: response.accessTokenBlacklistingEnabled,
                 jwtSigningPublicKeyExpiryTime: response.jwtSigningPublicKeyExpiryTime,
-                accessTokenVaildity: response.accessTokenVaildity,
-                refreshTokenVaildity: response.refreshTokenVaildity,
+                accessTokenValidity: response.accessTokenValidity,
+                refreshTokenValidity: response.refreshTokenValidity,
             };
         }
         return this.handshakeInfo;
@@ -198,7 +201,6 @@ export default class SessionRecipe extends RecipeModule {
             response.session.handle,
             response.session.userId,
             response.session.userDataInJWT,
-            response.accessToken.expiry,
             res
         );
     };
@@ -248,7 +250,6 @@ export default class SessionRecipe extends RecipeModule {
                 response.session.handle,
                 response.session.userId,
                 response.session.userDataInJWT,
-                response.accessToken !== undefined ? response.accessToken.expiry : undefined,
                 res
             );
         } catch (err) {
@@ -284,7 +285,6 @@ export default class SessionRecipe extends RecipeModule {
                 response.session.handle,
                 response.session.userId,
                 response.session.userDataInJWT,
-                response.accessToken.expiry,
                 res
             );
         } catch (err) {

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -20,8 +20,8 @@ export type HandshakeInfo = {
     enableAntiCsrf: boolean;
     accessTokenBlacklistingEnabled: boolean;
     jwtSigningPublicKeyExpiryTime: number;
-    accessTokenVaildity: number;
-    refreshTokenVaildity: number;
+    accessTokenValidity: number;
+    refreshTokenValidity: number;
 };
 
 export type CreateOrRefreshAPIResponse = {

--- a/test/handshake.test.js
+++ b/test/handshake.test.js
@@ -75,6 +75,8 @@ describe(`Handshake: ${printPath("[test/handshake.test.js]")}`, function () {
         assert.equal(info.enableAntiCsrf, true);
         assert.equal(info.accessTokenBlacklistingEnabled, false);
         assert.equal(typeof info.jwtSigningPublicKeyExpiryTime, "number");
+        assert.equal(info.accessTokenValidity, 3600 * 1000);
+        assert.equal(info.refreshTokenValidity, 144000 * 60 * 1000);
         SessionRecipe.getInstanceOrThrowError().updateJwtSigningPublicKeyInfo("hello", 100);
         let info2 = await SessionRecipe.getInstanceOrThrowError().getHandshakeInfo();
         assert.equal(info2.jwtSigningPublicKey, "hello");

--- a/test/querier.test.js
+++ b/test/querier.test.js
@@ -18,11 +18,13 @@ let { Querier } = require("../lib/build/querier");
 let assert = require("assert");
 let { ProcessState } = require("../lib/build/processState");
 let Session = require("../recipe/session");
+const { default: NormalisedURLPath } = require("../lib/build/normalisedURLPath");
 
 /**
  *
  * TODO: Test that if the querier throws an error from a recipe, that recipe's ID is there
  * TODO: Check that once the API version is there, it doesn't need to query again
+ * TODO: Check that rid is added to the header iff it's a "/recipe" || "/recipe/*" request.
  */
 
 describe(`Querier: ${printPath("[test/querier.test.js]")}`, function () {
@@ -51,7 +53,7 @@ describe(`Querier: ${printPath("[test/querier.test.js]")}`, function () {
         });
         try {
             let q = Querier.getInstanceOrThrowError("");
-            await q.sendGetRequest("/", {});
+            await q.sendGetRequest(new NormalisedURLPath("", "/"), {});
             throw new Error();
         } catch (err) {
             if (err.type !== ST.Error.GENERAL_ERROR || err.message !== "No SuperTokens core available to query") {
@@ -76,11 +78,11 @@ describe(`Querier: ${printPath("[test/querier.test.js]")}`, function () {
             recipeList: [Session.init()],
         });
         let q = Querier.getInstanceOrThrowError("");
-        assert.equal(await q.sendGetRequest("/hello", {}), "Hello\n");
-        assert.equal(await q.sendDeleteRequest("/hello", {}), "Hello\n");
+        assert.equal(await q.sendGetRequest(new NormalisedURLPath("", "/hello"), {}), "Hello\n");
+        assert.equal(await q.sendDeleteRequest(new NormalisedURLPath("", "/hello"), {}), "Hello\n");
         let hostsAlive = q.getHostsAliveForTesting();
         assert.equal(hostsAlive.size, 3);
-        assert.equal(await q.sendGetRequest("/hello", {}), "Hello\n"); // this will be the 4th API call
+        assert.equal(await q.sendGetRequest(new NormalisedURLPath("", "/hello"), {}), "Hello\n"); // this will be the 4th API call
         hostsAlive = q.getHostsAliveForTesting();
         assert.equal(hostsAlive.size, 3);
         assert.equal(hostsAlive.has("http://localhost:8080"), true);
@@ -103,11 +105,11 @@ describe(`Querier: ${printPath("[test/querier.test.js]")}`, function () {
             recipeList: [Session.init()],
         });
         let q = Querier.getInstanceOrThrowError("");
-        assert.equal(await q.sendGetRequest("/hello", {}), "Hello\n");
-        assert.equal(await q.sendPostRequest("/hello", {}), "Hello\n");
+        assert.equal(await q.sendGetRequest(new NormalisedURLPath("", "/hello"), {}), "Hello\n");
+        assert.equal(await q.sendPostRequest(new NormalisedURLPath("", "/hello"), {}), "Hello\n");
         let hostsAlive = q.getHostsAliveForTesting();
         assert.equal(hostsAlive.size, 2);
-        assert.equal(await q.sendPutRequest("/hello", {}), "Hello\n"); // this will be the 4th API call
+        assert.equal(await q.sendPutRequest(new NormalisedURLPath("", "/hello"), {}), "Hello\n"); // this will be the 4th API call
         hostsAlive = q.getHostsAliveForTesting();
         assert.equal(hostsAlive.size, 2);
         assert.equal(hostsAlive.has("http://localhost:8080"), true);


### PR DESCRIPTION
## Related Issues:
- https://github.com/supertokens/supertokens-node/issues/18

## Changes:
- Adds `rid` to header for queries to `/recipe` or to `/recipe/*`
- Changes all session related APIs to be prefixed with `/recipe/*`
- Enforced use of `NormalisedUrlPath` for querying
- Removes `accessTokenValidity` from `Session` class (a TODO in the code)
- Corrects typo in code `accessTokenValiatity` => `accessTokenValidity`. Likewise for `refreshSessionValiatity`

## Migration:
- Use with core with CDI >= 2.4