### PR TITLE
Misc changes

### DIFF
--- a/lib/build/recipe/emailpassword/api/generatePasswordResetToken.js
+++ b/lib/build/recipe/emailpassword/api/generatePasswordResetToken.js
@@ -87,11 +87,17 @@ function generatePasswordResetToken(recipeInstance, req, res, next) {
             token +
             "&rid=" +
             recipeInstance.getRecipeId();
-        // step 5 & 6
-        yield recipeInstance.config.resetPasswordUsingTokenFeature.createAndSendCustomEmail(user, passwordResetLink);
-        return utils_1.send200Response(res, {
+        // step 5
+        utils_1.send200Response(res, {
             status: "OK",
         });
+        // step 6 & 7
+        try {
+            yield recipeInstance.config.resetPasswordUsingTokenFeature.createAndSendCustomEmail(
+                user,
+                passwordResetLink
+            );
+        } catch (ignored) {}
     });
 }
 exports.default = generatePasswordResetToken;

--- a/lib/build/recipe/emailpassword/api/utils.js
+++ b/lib/build/recipe/emailpassword/api/utils.js
@@ -65,7 +65,6 @@ function validateFormFieldsOrThrowError(recipeInstance, configFormFields, formFi
         });
         // then run validators through them-----------------------
         yield validateFormOrThrowError(recipeInstance, formFields, configFormFields);
-        // TODO: normalise email as per https://github.com/supertokens/supertokens-core/issues/89
         return formFields;
     });
 }

--- a/lib/build/recipe/emailpassword/passwordResetFunctions.js
+++ b/lib/build/recipe/emailpassword/passwordResetFunctions.js
@@ -45,6 +45,7 @@ var __awaiter =
         });
     };
 Object.defineProperty(exports, "__esModule", { value: true });
+const axios_1 = require("axios");
 function getResetPasswordURL(appInfo) {
     return (ignored) =>
         __awaiter(this, void 0, void 0, function* () {
@@ -61,7 +62,20 @@ function createAndSendCustomEmail(appInfo) {
     return (user, passwordResetURLWithToken) =>
         __awaiter(this, void 0, void 0, function* () {
             // related issue: https://github.com/supertokens/supertokens-node/issues/38
-            // TODO: Call our API with email, appName, passwordResetURLWithToken
+            try {
+                yield axios_1.default({
+                    method: "POST",
+                    url: "https://api.supertokens.io/0/st/auth/password/reset",
+                    data: {
+                        email: user.email,
+                        appName: appInfo.appName,
+                        passwordResetURL: passwordResetURLWithToken,
+                    },
+                    headers: {
+                        "api-version": 0,
+                    },
+                });
+            } catch (ignored) {}
         });
 }
 exports.createAndSendCustomEmail = createAndSendCustomEmail;

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -64,7 +64,6 @@ export interface TokenTheftErrorHandlerMiddleware {
 }
 export interface ErrorHandlers {
     onUnauthorised?: ErrorHandlerMiddleware;
-    onTryRefreshToken?: ErrorHandlerMiddleware;
     onTokenTheftDetected?: TokenTheftErrorHandlerMiddleware;
 }
 export interface NormalisedErrorHandlers {

--- a/lib/build/recipe/session/utils.js
+++ b/lib/build/recipe/session/utils.js
@@ -107,9 +107,6 @@ function validateAndNormaliseUserInput(recipeInstance, appInfo, config) {
         if (config.errorHandlers.onTokenTheftDetected !== undefined) {
             errorHandlers.onTokenTheftDetected = config.errorHandlers.onTokenTheftDetected;
         }
-        if (config.errorHandlers.onTryRefreshToken !== undefined) {
-            errorHandlers.onTryRefreshToken = config.errorHandlers.onTryRefreshToken;
-        }
         if (config.errorHandlers.onUnauthorised !== undefined) {
             errorHandlers.onUnauthorised = config.errorHandlers.onUnauthorised;
         }

--- a/lib/ts/recipe/emailpassword/api/generatePasswordResetToken.ts
+++ b/lib/ts/recipe/emailpassword/api/generatePasswordResetToken.ts
@@ -71,12 +71,15 @@ export default async function generatePasswordResetToken(
         "&rid=" +
         recipeInstance.getRecipeId();
 
-    // step 5 & 6
-    await recipeInstance.config.resetPasswordUsingTokenFeature.createAndSendCustomEmail(user, passwordResetLink);
-
-    return send200Response(res, {
+    // step 5
+    send200Response(res, {
         status: "OK",
     });
+
+    // step 6 & 7
+    try {
+        await recipeInstance.config.resetPasswordUsingTokenFeature.createAndSendCustomEmail(user, passwordResetLink);
+    } catch (ignored) {}
 }
 
 async function pauseForRandomTime() {

--- a/lib/ts/recipe/emailpassword/api/utils.ts
+++ b/lib/ts/recipe/emailpassword/api/utils.ts
@@ -69,8 +69,6 @@ export async function validateFormFieldsOrThrowError(
     // then run validators through them-----------------------
     await validateFormOrThrowError(recipeInstance, formFields, configFormFields);
 
-    // TODO: normalise email as per https://github.com/supertokens/supertokens-core/issues/89
-
     return formFields;
 }
 

--- a/lib/ts/recipe/emailpassword/passwordResetFunctions.ts
+++ b/lib/ts/recipe/emailpassword/passwordResetFunctions.ts
@@ -15,6 +15,7 @@
 
 import { User } from "./types";
 import { NormalisedAppinfo } from "../../types";
+import axios from "axios";
 
 export function getResetPasswordURL(appInfo: NormalisedAppinfo) {
     return async (ignored: User): Promise<string> => {
@@ -30,6 +31,19 @@ export function getResetPasswordURL(appInfo: NormalisedAppinfo) {
 export function createAndSendCustomEmail(appInfo: NormalisedAppinfo) {
     return async (user: User, passwordResetURLWithToken: string) => {
         // related issue: https://github.com/supertokens/supertokens-node/issues/38
-        // TODO: Call our API with email, appName, passwordResetURLWithToken
+        try {
+            await axios({
+                method: "POST",
+                url: "https://api.supertokens.io/0/st/auth/password/reset",
+                data: {
+                    email: user.email,
+                    appName: appInfo.appName,
+                    passwordResetURL: passwordResetURLWithToken,
+                },
+                headers: {
+                    "api-version": 0,
+                },
+            });
+        } catch (ignored) {}
     };
 }

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -86,7 +86,6 @@ export interface TokenTheftErrorHandlerMiddleware {
 
 export interface ErrorHandlers {
     onUnauthorised?: ErrorHandlerMiddleware;
-    onTryRefreshToken?: ErrorHandlerMiddleware;
     onTokenTheftDetected?: TokenTheftErrorHandlerMiddleware;
 }
 

--- a/lib/ts/recipe/session/utils.ts
+++ b/lib/ts/recipe/session/utils.ts
@@ -145,9 +145,6 @@ export function validateAndNormaliseUserInput(
         if (config.errorHandlers.onTokenTheftDetected !== undefined) {
             errorHandlers.onTokenTheftDetected = config.errorHandlers.onTokenTheftDetected;
         }
-        if (config.errorHandlers.onTryRefreshToken !== undefined) {
-            errorHandlers.onTryRefreshToken = config.errorHandlers.onTryRefreshToken;
-        }
         if (config.errorHandlers.onUnauthorised !== undefined) {
             errorHandlers.onUnauthorised = config.errorHandlers.onUnauthorised;
         }

--- a/test/frontendIntegration/index.js
+++ b/test/frontendIntegration/index.js
@@ -36,9 +36,6 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             errorHandlers: {
-                onTryRefreshToken: (err, req, res) => {
-                    res.status(401).send();
-                },
                 onUnauthorised: (err, req, res) => {
                     res.status(401).send();
                 },

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -53,12 +53,6 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
             recipeList: [
                 Session.init({
                     errorHandlers: {
-                        onTryRefreshToken: (err, req, res, next) => {
-                            res.statusCode = 401;
-                            return res.json({
-                                message: "try refresh token",
-                            });
-                        },
                         onTokenTheftDetected: (sessionHandle, userId, req, res, next) => {
                             res.statusCode = 403;
                             return res.json({
@@ -304,12 +298,6 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
             recipeList: [
                 Session.init({
                     errorHandlers: {
-                        onTryRefreshToken: (err, req, res, next) => {
-                            res.statusCode = 401;
-                            return res.json({
-                                message: "try refresh token",
-                            });
-                        },
                         onTokenTheftDetected: (sessionHandle, userId, req, res, next) => {
                             res.statusCode = 403;
                             return res.json({
@@ -563,12 +551,6 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
                     cookieSecure: true,
                     cookieSameSite: "strict",
                     errorHandlers: {
-                        onTryRefreshToken: (err, req, res, next) => {
-                            res.statusCode = 401;
-                            return res.json({
-                                message: "try refresh token",
-                            });
-                        },
                         onTokenTheftDetected: (sessionHandle, userId, req, res, next) => {
                             res.statusCode = 403;
                             return res.json({
@@ -825,12 +807,6 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
                     cookieSecure: true,
                     cookieSameSite: "strict",
                     errorHandlers: {
-                        onTryRefreshToken: (err, req, res, next) => {
-                            res.statusCode = 401;
-                            return res.json({
-                                message: "try refresh token",
-                            });
-                        },
                         onTokenTheftDetected: (sessionHandle, userId, req, res, next) => {
                             res.statusCode = 403;
                             return res.json({


### PR DESCRIPTION
## Related issues:
- https://github.com/supertokens/supertokens-core/issues/98
- https://github.com/supertokens/supertokens-node/issues/38

## Changes
- Removes the ability for the user to override the try refresh token callback in error handlers
- Changes to password reset email API to send the email after the response.
- Implements calling the supertokens API to send an email for password reset

## Migration:
- Users can no longer override the try refresh token callback in error handlers