### PR TITLE
add SuperTokensVerifySession middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [3.3.0] - 2020-12-21
+### Added
+- Add superTokensVerifySession middleware for NextJS
+
 ## [3.2.2] - 2020-12-18
 ### Fixed
 - Removes the need for Proxy in NextJS so that if a session is created manually by the user, it still works

--- a/lib/build/nextjs.d.ts
+++ b/lib/build/nextjs.d.ts
@@ -1,4 +1,6 @@
 export default class NextJS {
     static superTokensMiddleware(request: any, response: any): Promise<any>;
+    static superTokensVerifySession(request: any, response: any): Promise<any>;
 }
 export declare let superTokensMiddleware: typeof NextJS.superTokensMiddleware;
+export declare let superTokensVerifySession: typeof NextJS.superTokensVerifySession;

--- a/lib/build/nextjs.js
+++ b/lib/build/nextjs.js
@@ -46,26 +46,42 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * under the License.
  */
 const _1 = require(".");
+const session_1 = require("./recipe/session");
+function next(request, response, resolve, reject) {
+    return function (middlewareError) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (middlewareError !== undefined) {
+                _1.default.errorHandler()(middlewareError, request, response, (errorHandlerError) => {
+                    if (errorHandlerError !== undefined) {
+                        reject(errorHandlerError);
+                    }
+                    return resolve();
+                });
+                return;
+            }
+            return resolve();
+        });
+    };
+}
 class NextJS {
     static superTokensMiddleware(request, response) {
         return new Promise((resolve, reject) => {
-            _1.default.middleware()(request, response, (middlewareError) =>
-                __awaiter(this, void 0, void 0, function* () {
-                    if (middlewareError !== undefined) {
-                        _1.default.errorHandler()(middlewareError, request, response, (errorHandlerError) => {
-                            if (errorHandlerError !== undefined) {
-                                return reject(errorHandlerError);
-                            }
-                            resolve();
-                        });
-                        return;
-                    }
+            return _1.default.middleware()(request, response, next(request, response, resolve, reject));
+        });
+    }
+    static superTokensVerifySession(request, response) {
+        return new Promise((resolve, reject) => {
+            //  When called from getServerSideProps, we want to resolve and use req.session afterwards to check for existing session.
+            if (response.json === undefined) {
+                response.json = () => {
                     return resolve();
-                })
-            );
+                };
+            }
+            return session_1.default.verifySession()(request, response, next(request, response, resolve, reject));
         });
     }
 }
 exports.default = NextJS;
 exports.superTokensMiddleware = NextJS.superTokensMiddleware;
+exports.superTokensVerifySession = NextJS.superTokensVerifySession;
 //# sourceMappingURL=nextjs.js.map

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,2 +1,2 @@
-export declare const version = "3.2.2";
+export declare const version = "3.3.0";
 export declare const cdiSupported: string[];

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -14,6 +14,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "3.2.2";
+exports.version = "3.3.0";
 exports.cdiSupported = ["2.4"];
 //# sourceMappingURL=version.js.map

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,6 +12,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "3.2.2";
+export const version = "3.3.0";
 
 export const cdiSupported = ["2.4"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "supertokens-node",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supertokens-node",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "NodeJS driver for SuperTokens core",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- add SuperTokensVerifySession method (same idea as SuperTokensMiddleware).

`SuperTokensVerifySession ` can be called in two ways:
  - 1/ From a NextJS api file, in this case, the response object contains a `json` method which can be called if unauthorised (from sendNon200Response supertokens-node method). Otherwise, if session exists, the middleware will simply create request.session object which can be used afterwards.
  
  - 2/ From `getServerSideProps` in order to first verify a session before fetching user data and send them to props to the front end. In that case, the response object does not have a `json` method. In case of failure, we want to fail silently, and the users can do whatever they want after checking if (request.session === undefined).
  
# Issue

There is an issue with SSR and refreshing sessions. 

When using `SuperTokensVerifySession` from `getServerSideProps` method returns `401` because the token is out dated, we are redirecting to `/auth` and we are not refreshing the token. And then from `/auth`, `doesSessionExist` redirects to `/` which will lead in an infinite loop of redirecting.

A fix would be to instead redirect to `/auth/session/refresh?rid=session&path=/previous/path` on the frontend, and for `supertokens-react` to load a component that will make an AJAX call to the refresh API and redirects to the specified `path`.

Leaving this PR on hold for now.

 