### PR TITLE
Email verification tests

### DIFF
--- a/test/emailpassword/emailverify.test.js
+++ b/test/emailpassword/emailverify.test.js
@@ -116,9 +116,9 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 .post("/auth/user/email/verify/token")
                 .set("Cookie", [
                     "sAccessToken=" +
-                    infoFromResponse.accessToken +
-                    ";sIdRefreshToken=" +
-                    infoFromResponse.idRefreshTokenFromCookie,
+                        infoFromResponse.accessToken +
+                        ";sIdRefreshToken=" +
+                        infoFromResponse.idRefreshTokenFromCookie,
                 ])
                 .set("anti-csrf", infoFromResponse.antiCsrf)
                 .send({
@@ -173,9 +173,9 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 .post("/auth/user/email/verify/token")
                 .set("Cookie", [
                     "sAccessToken=" +
-                    infoFromResponse.accessToken +
-                    ";sIdRefreshToken=" +
-                    infoFromResponse.idRefreshTokenFromCookie,
+                        infoFromResponse.accessToken +
+                        ";sIdRefreshToken=" +
+                        infoFromResponse.idRefreshTokenFromCookie,
                 ])
                 .set("anti-csrf", infoFromResponse.antiCsrf)
                 .send({
@@ -217,12 +217,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         let response = await new Promise((resolve) =>
             request(app)
                 .post("/auth/user/email/verify/token")
-                .set("Cookie", [
-                    "sAccessToken=" +
-                    "randmAccessToken" +
-                    ";sIdRefreshToken=" +
-                    "randomRefreshToken",
-                ])
+                .set("Cookie", ["sAccessToken=" + "randmAccessToken" + ";sIdRefreshToken=" + "randomRefreshToken"])
                 .set("anti-csrf", "randomAntiCsrf")
                 .send({
                     userId: "randomUserId",
@@ -235,9 +230,8 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                     }
                 })
         );
-        
-        assert(response.status === 401)
-        assert(JSON.parse(response.text).message === "try refresh token")
 
+        assert(response.status === 401);
+        assert(JSON.parse(response.text).message === "try refresh token");
     });
 });

--- a/test/emailpassword/emailverify.test.js
+++ b/test/emailpassword/emailverify.test.js
@@ -24,7 +24,7 @@ const {
     signUPRequest,
     extractInfoFromResponse,
     setKeyValueInConfig,
-    emailVerifyTokenRequest
+    emailVerifyTokenRequest,
 } = require("../utils");
 let STExpress = require("../..");
 let Session = require("../../recipe/session");
@@ -113,8 +113,13 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         let userId = JSON.parse(response.text).user.id;
         let infoFromResponse = extractInfoFromResponse(response);
 
-        response = await emailVerifyTokenRequest(app, infoFromResponse.accessToken,
-            infoFromResponse.idRefreshTokenFromCookie, infoFromResponse.antiCsrf, userId)
+        response = await emailVerifyTokenRequest(
+            app,
+            infoFromResponse.accessToken,
+            infoFromResponse.idRefreshTokenFromCookie,
+            infoFromResponse.antiCsrf,
+            userId
+        );
 
         assert(JSON.parse(response.text).status === "OK");
     });
@@ -150,11 +155,16 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         let verifyToken = await EmailPassword.createEmailVerificationToken(userId);
         await EmailPassword.verifyEmailUsingToken(verifyToken);
 
-        response = await emailVerifyTokenRequest(app, infoFromResponse.accessToken,
-            infoFromResponse.idRefreshTokenFromCookie, infoFromResponse.antiCsrf, userId)
+        response = await emailVerifyTokenRequest(
+            app,
+            infoFromResponse.accessToken,
+            infoFromResponse.idRefreshTokenFromCookie,
+            infoFromResponse.antiCsrf,
+            userId
+        );
 
-        assert(JSON.parse(response.text).status === "EMAIL_ALREADY_VERIFIED_ERROR")
-        assert(response.status === 200)
+        assert(JSON.parse(response.text).status === "EMAIL_ALREADY_VERIFIED_ERROR");
+        assert(response.status === 200);
     });
 
     // Call the API with no session and see the output
@@ -178,8 +188,13 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
 
         app.use(STExpress.errorHandler());
 
-        let response = await emailVerifyTokenRequest(app, "randomAccessToken",
-            "randomRefreshToken", "randomAntiCsrf", "randomUserId")
+        let response = await emailVerifyTokenRequest(
+            app,
+            "randomAccessToken",
+            "randomRefreshToken",
+            "randomAntiCsrf",
+            "randomUserId"
+        );
 
         assert(response.status === 401);
         assert(JSON.parse(response.text).message === "try refresh token");
@@ -217,8 +232,13 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
 
         await new Promise((r) => setTimeout(r, 5000));
 
-        let response2 = await emailVerifyTokenRequest(app, infoFromResponse.accessToken,
-            infoFromResponse.idRefreshTokenFromCookie, infoFromResponse.antiCsrf, userId)
+        let response2 = await emailVerifyTokenRequest(
+            app,
+            infoFromResponse.accessToken,
+            infoFromResponse.idRefreshTokenFromCookie,
+            infoFromResponse.antiCsrf,
+            userId
+        );
 
         assert(response2.status === 401);
         assert(JSON.parse(response2.text).message === "try refresh token");
@@ -241,19 +261,24 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
             )
         );
 
-        let response3 = response = await emailVerifyTokenRequest(app, refreshedResponse.accessToken,
-            refreshedResponse.idRefreshTokenFromCookie, refreshedResponse.antiCsrf, userId)
+        let response3 = (response = await emailVerifyTokenRequest(
+            app,
+            refreshedResponse.accessToken,
+            refreshedResponse.idRefreshTokenFromCookie,
+            refreshedResponse.antiCsrf,
+            userId
+        ));
 
-        assert(response3.status === 200)
-        assert(JSON.parse(response3.text).status === "OK")
+        assert(response3.status === 200);
+        assert(JSON.parse(response3.text).status === "OK");
     });
 
     // Provide your own email callback and make sure that is called
     it("test that providing your own email callback and make sure it is called", async function () {
         await startST();
 
-        let userInfo = null
-        let emailToken = null
+        let userInfo = null;
+        let emailToken = null;
 
         STExpress.init({
             supertokens: {
@@ -264,14 +289,17 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [EmailPassword.init({
-                emailVerificationFeature: {
-                    createAndSendCustomEmail: (user, emailVerificationURLWithToken) => {
-                        userInfo = user
-                        emailToken = emailVerificationURLWithToken
-                    }
-                }
-            }), Session.init()],
+            recipeList: [
+                EmailPassword.init({
+                    emailVerificationFeature: {
+                        createAndSendCustomEmail: (user, emailVerificationURLWithToken) => {
+                            userInfo = user;
+                            emailToken = emailVerificationURLWithToken;
+                        },
+                    },
+                }),
+                Session.init(),
+            ],
         });
 
         const app = express();
@@ -287,13 +315,18 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         let userId = JSON.parse(response.text).user.id;
         let infoFromResponse = extractInfoFromResponse(response);
 
-        let response2 = await emailVerifyTokenRequest(app, infoFromResponse.accessToken,
-            infoFromResponse.idRefreshTokenFromCookie, infoFromResponse.antiCsrf, userId)
+        let response2 = await emailVerifyTokenRequest(
+            app,
+            infoFromResponse.accessToken,
+            infoFromResponse.idRefreshTokenFromCookie,
+            infoFromResponse.antiCsrf,
+            userId
+        );
 
-        assert(response2.status === 200)
-        assert(userInfo.id === userId)
-        assert(userInfo.email === "test@gmail.com")
-        assert(emailToken !== null)
+        assert(response2.status === 200);
+        assert(userInfo.id === userId);
+        assert(userInfo.email === "test@gmail.com");
+        assert(emailToken !== null);
     });
 
     /*
@@ -311,7 +344,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
     it("test the email verify API with valid input", async function () {
         await startST();
 
-        let token = null
+        let token = null;
         STExpress.init({
             supertokens: {
                 connectionURI: "http://localhost:8080",
@@ -321,13 +354,16 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [EmailPassword.init({
-                emailVerificationFeature: {
-                    createAndSendCustomEmail: (user, emailVerificationURLWithToken) => {
-                        token = emailVerificationURLWithToken.split("?token=")[1].split("&rid=")[0]
-                    }
-                }
-            }), Session.init()],
+            recipeList: [
+                EmailPassword.init({
+                    emailVerificationFeature: {
+                        createAndSendCustomEmail: (user, emailVerificationURLWithToken) => {
+                            token = emailVerificationURLWithToken.split("?token=")[1].split("&rid=")[0];
+                        },
+                    },
+                }),
+                Session.init(),
+            ],
         });
 
         const app = express();
@@ -343,8 +379,13 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         let userId = JSON.parse(response.text).user.id;
         let infoFromResponse = extractInfoFromResponse(response);
 
-        response = await await emailVerifyTokenRequest(app, infoFromResponse.accessToken,
-            infoFromResponse.idRefreshTokenFromCookie, infoFromResponse.antiCsrf, userId)
+        response = await await emailVerifyTokenRequest(
+            app,
+            infoFromResponse.accessToken,
+            infoFromResponse.idRefreshTokenFromCookie,
+            infoFromResponse.antiCsrf,
+            userId
+        );
         assert(JSON.parse(response.text).status === "OK");
 
         let response2 = await new Promise((resolve) =>
@@ -352,7 +393,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 .post("/auth/user/email/verify")
                 .send({
                     method: "token",
-                    token
+                    token,
                 })
                 .expect(200)
                 .end((err, res) => {
@@ -364,7 +405,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 })
         );
 
-        assert(JSON.parse(response2.text).status === "OK")
+        assert(JSON.parse(response2.text).status === "OK");
     });
 
     // Call the API with an invalid token and see the error
@@ -394,7 +435,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 .post("/auth/user/email/verify")
                 .send({
                     method: "token",
-                    token: "randomToken"
+                    token: "randomToken",
                 })
                 .expect(200)
                 .end((err, res) => {
@@ -405,7 +446,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                     }
                 })
         );
-        assert(JSON.parse(response.text).status === "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR")
+        assert(JSON.parse(response.text).status === "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR");
     });
 
     // token is not of type string from input
@@ -435,7 +476,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 .post("/auth/user/email/verify")
                 .send({
                     method: "token",
-                    token: 2000
+                    token: 2000,
                 })
                 .end((err, res) => {
                     if (err) {
@@ -445,16 +486,16 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                     }
                 })
         );
-        assert(response.status === 400)
-        assert(JSON.parse(response.text).message === "The email verification token must be a string")
+        assert(response.status === 400);
+        assert(JSON.parse(response.text).message === "The email verification token must be a string");
     });
 
     // provide a handlePostEmailVerification callback and make sure it's called on success verification
     it("test that the handlePostEmailVerification callback is called on successfull verification, if given", async function () {
         await startST();
 
-        let userInfoFromCallback = null
-        let token = null
+        let userInfoFromCallback = null;
+        let token = null;
 
         STExpress.init({
             supertokens: {
@@ -465,16 +506,19 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [EmailPassword.init({
-                emailVerificationFeature: {
-                    handlePostEmailVerification: (user) => {
-                        userInfoFromCallback = user
+            recipeList: [
+                EmailPassword.init({
+                    emailVerificationFeature: {
+                        handlePostEmailVerification: (user) => {
+                            userInfoFromCallback = user;
+                        },
+                        createAndSendCustomEmail: (user, emailVerificationURLWithToken) => {
+                            token = emailVerificationURLWithToken.split("?token=")[1].split("&rid=")[0];
+                        },
                     },
-                    createAndSendCustomEmail: (user, emailVerificationURLWithToken) => {
-                        token = emailVerificationURLWithToken.split("?token=")[1].split("&rid=")[0]
-                    }
-                }
-            }), Session.init()],
+                }),
+                Session.init(),
+            ],
         });
 
         const app = express();
@@ -490,8 +534,13 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         let userId = JSON.parse(response.text).user.id;
         let infoFromResponse = extractInfoFromResponse(response);
 
-        response = await await emailVerifyTokenRequest(app, infoFromResponse.accessToken,
-            infoFromResponse.idRefreshTokenFromCookie, infoFromResponse.antiCsrf, userId)
+        response = await await emailVerifyTokenRequest(
+            app,
+            infoFromResponse.accessToken,
+            infoFromResponse.idRefreshTokenFromCookie,
+            infoFromResponse.antiCsrf,
+            userId
+        );
         assert(JSON.parse(response.text).status === "OK");
 
         let response2 = await new Promise((resolve) =>
@@ -499,7 +548,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 .post("/auth/user/email/verify")
                 .send({
                     method: "token",
-                    token
+                    token,
                 })
                 .expect(200)
                 .end((err, res) => {
@@ -511,17 +560,17 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 })
         );
 
-        assert(JSON.parse(response2.text).status === "OK")
+        assert(JSON.parse(response2.text).status === "OK");
 
-        assert(userInfoFromCallback.id === userId)
-        assert(userInfoFromCallback.email === "test@gmail.com")
+        assert(userInfoFromCallback.id === userId);
+        assert(userInfoFromCallback.email === "test@gmail.com");
     });
 
     // Call the API with valid input
     it("test the email verify with valid input, using the get method", async function () {
         await startST();
 
-        let token = null
+        let token = null;
 
         STExpress.init({
             supertokens: {
@@ -532,13 +581,16 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [EmailPassword.init({
-                emailVerificationFeature: {
-                    createAndSendCustomEmail: (user, emailVerificationURLWithToken) => {
-                        token = emailVerificationURLWithToken.split("?token=")[1].split("&rid=")[0]
-                    }
-                }
-            }), Session.init()],
+            recipeList: [
+                EmailPassword.init({
+                    emailVerificationFeature: {
+                        createAndSendCustomEmail: (user, emailVerificationURLWithToken) => {
+                            token = emailVerificationURLWithToken.split("?token=")[1].split("&rid=")[0];
+                        },
+                    },
+                }),
+                Session.init(),
+            ],
         });
 
         const app = express();
@@ -554,8 +606,13 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         let userId = JSON.parse(response.text).user.id;
         let infoFromResponse = extractInfoFromResponse(response);
 
-        response = await await emailVerifyTokenRequest(app, infoFromResponse.accessToken,
-            infoFromResponse.idRefreshTokenFromCookie, infoFromResponse.antiCsrf, userId)
+        response = await await emailVerifyTokenRequest(
+            app,
+            infoFromResponse.accessToken,
+            infoFromResponse.idRefreshTokenFromCookie,
+            infoFromResponse.antiCsrf,
+            userId
+        );
         assert(JSON.parse(response.text).status === "OK");
 
         let response2 = await new Promise((resolve) =>
@@ -563,7 +620,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 .post("/auth/user/email/verify")
                 .send({
                     method: "token",
-                    token
+                    token,
                 })
                 .expect(200)
                 .end((err, res) => {
@@ -575,16 +632,16 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 })
         );
 
-        assert(JSON.parse(response2.text).status === "OK")
-       
+        assert(JSON.parse(response2.text).status === "OK");
+
         let response3 = await new Promise((resolve) =>
             request(app)
                 .get("/auth/user/email/verify")
                 .set("Cookie", [
                     "sAccessToken=" +
-                    infoFromResponse.accessToken +
-                    ";sIdRefreshToken=" +
-                    infoFromResponse.idRefreshTokenFromCookie,
+                        infoFromResponse.accessToken +
+                        ";sIdRefreshToken=" +
+                        infoFromResponse.idRefreshTokenFromCookie,
                 ])
                 .set("anti-csrf", infoFromResponse.antiCsrf)
                 .expect(200)
@@ -596,8 +653,8 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                     }
                 })
         );
-        assert(JSON.parse(response3.text).status === "OK")
-        assert(JSON.parse(response3.text).isVerified)        
+        assert(JSON.parse(response3.text).status === "OK");
+        assert(JSON.parse(response3.text).isVerified);
     });
 
     // Call the API with no session and see the error
@@ -621,16 +678,11 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         app.use(STExpress.middleware());
 
         app.use(STExpress.errorHandler());
-       
+
         let response = await new Promise((resolve) =>
             request(app)
                 .get("/auth/user/email/verify")
-                .set("Cookie", [
-                    "sAccessToken=" +
-                    "randomAccessToken" +
-                    ";sIdRefreshToken=" +
-                    "randomRefreshToken",
-                ])
+                .set("Cookie", ["sAccessToken=" + "randomAccessToken" + ";sIdRefreshToken=" + "randomRefreshToken"])
                 .set("anti-csrf", "randomAntiCsrfToken")
                 .end((err, res) => {
                     if (err) {
@@ -640,9 +692,9 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                     }
                 })
         );
-        
-        assert(response.status === 401)
-        assert(JSON.parse(response.text).message === "try refresh token")        
+
+        assert(response.status === 401);
+        assert(JSON.parse(response.text).message === "try refresh token");
     });
 
     // Call the API with an expired access token and see that try refresh token is returned
@@ -650,7 +702,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         await setKeyValueInConfig("access_token_validity", 2);
         await startST();
 
-        let token = null
+        let token = null;
 
         STExpress.init({
             supertokens: {
@@ -661,13 +713,16 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [EmailPassword.init({
-                emailVerificationFeature: {
-                    createAndSendCustomEmail: (user, emailVerificationURLWithToken) => {
-                        token = emailVerificationURLWithToken.split("?token=")[1].split("&rid=")[0]
-                    }
-                }
-            }), Session.init()],
+            recipeList: [
+                EmailPassword.init({
+                    emailVerificationFeature: {
+                        createAndSendCustomEmail: (user, emailVerificationURLWithToken) => {
+                            token = emailVerificationURLWithToken.split("?token=")[1].split("&rid=")[0];
+                        },
+                    },
+                }),
+                Session.init(),
+            ],
         });
 
         const app = express();
@@ -683,8 +738,13 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         let userId = JSON.parse(response.text).user.id;
         let infoFromResponse = extractInfoFromResponse(response);
 
-        response = await await emailVerifyTokenRequest(app, infoFromResponse.accessToken,
-            infoFromResponse.idRefreshTokenFromCookie, infoFromResponse.antiCsrf, userId)
+        response = await await emailVerifyTokenRequest(
+            app,
+            infoFromResponse.accessToken,
+            infoFromResponse.idRefreshTokenFromCookie,
+            infoFromResponse.antiCsrf,
+            userId
+        );
         assert(JSON.parse(response.text).status === "OK");
 
         let response2 = await new Promise((resolve) =>
@@ -692,7 +752,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 .post("/auth/user/email/verify")
                 .send({
                     method: "token",
-                    token
+                    token,
                 })
                 .expect(200)
                 .end((err, res) => {
@@ -704,18 +764,18 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 })
         );
 
-        assert(JSON.parse(response2.text).status === "OK")
+        assert(JSON.parse(response2.text).status === "OK");
 
         await new Promise((r) => setTimeout(r, 5000));
-       
+
         let response3 = await new Promise((resolve) =>
             request(app)
                 .get("/auth/user/email/verify")
                 .set("Cookie", [
                     "sAccessToken=" +
-                    infoFromResponse.accessToken +
-                    ";sIdRefreshToken=" +
-                    infoFromResponse.idRefreshTokenFromCookie,
+                        infoFromResponse.accessToken +
+                        ";sIdRefreshToken=" +
+                        infoFromResponse.idRefreshTokenFromCookie,
                 ])
                 .set("anti-csrf", infoFromResponse.antiCsrf)
                 .end((err, res) => {
@@ -726,7 +786,47 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                     }
                 })
         );
-        assert(response3.status === 401)
-        assert(JSON.parse(response3.text).message === "try refresh token")        
+        assert(response3.status === 401);
+        assert(JSON.parse(response3.text).message === "try refresh token");
+
+        let refreshedResponse = extractInfoFromResponse(
+            await new Promise((resolve) =>
+                request(app)
+                    .post("/auth/session/refresh")
+                    .expect(200)
+                    .set("Cookie", ["sRefreshToken=" + infoFromResponse.refreshToken])
+                    .set("anti-csrf", infoFromResponse.antiCsrf)
+                    .expect(200)
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                            resolve(res);
+                        }
+                    })
+            )
+        );
+
+        let response4 = await new Promise((resolve) =>
+            request(app)
+                .get("/auth/user/email/verify")
+                .set("Cookie", [
+                    "sAccessToken=" +
+                        refreshedResponse.accessToken +
+                        ";sIdRefreshToken=" +
+                        refreshedResponse.idRefreshTokenFromCookie,
+                ])
+                .set("anti-csrf", refreshedResponse.antiCsrf)
+                .expect(200)
+                .end((err, res) => {
+                    if (err) {
+                        resolve(err);
+                    } else {
+                        resolve(res);
+                    }
+                })
+        );
+        assert(JSON.parse(response4.text).status === "OK");
+        assert(JSON.parse(response4.text).isVerified);
     });
 });

--- a/test/emailpassword/emailverify.test.js
+++ b/test/emailpassword/emailverify.test.js
@@ -188,16 +188,20 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
 
         app.use(STExpress.errorHandler());
 
-        let response = await emailVerifyTokenRequest(
-            app,
-            "randomAccessToken",
-            "randomRefreshToken",
-            "randomAntiCsrf",
-            "randomUserId"
+        let response = await new Promise((resolve) =>
+            request(app)
+                .post("/auth/user/email/verify/token")
+                .end((err, res) => {
+                    if (err) {
+                        resolve(undefined);
+                    } else {
+                        resolve(res);
+                    }
+                })
         );
 
         assert(response.status === 401);
-        assert(JSON.parse(response.text).message === "try refresh token");
+        assert(JSON.parse(response.text).message === "unauthorised");
     });
 
     // Call the API with an expired access token and see that try refresh token is returned
@@ -379,7 +383,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         let userId = JSON.parse(response.text).user.id;
         let infoFromResponse = extractInfoFromResponse(response);
 
-        response = await await emailVerifyTokenRequest(
+        response = await emailVerifyTokenRequest(
             app,
             infoFromResponse.accessToken,
             infoFromResponse.idRefreshTokenFromCookie,
@@ -534,7 +538,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         let userId = JSON.parse(response.text).user.id;
         let infoFromResponse = extractInfoFromResponse(response);
 
-        response = await await emailVerifyTokenRequest(
+        response = await emailVerifyTokenRequest(
             app,
             infoFromResponse.accessToken,
             infoFromResponse.idRefreshTokenFromCookie,
@@ -606,7 +610,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         let userId = JSON.parse(response.text).user.id;
         let infoFromResponse = extractInfoFromResponse(response);
 
-        response = await await emailVerifyTokenRequest(
+        response = await emailVerifyTokenRequest(
             app,
             infoFromResponse.accessToken,
             infoFromResponse.idRefreshTokenFromCookie,
@@ -654,7 +658,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 })
         );
         assert(JSON.parse(response3.text).status === "OK");
-        assert(JSON.parse(response3.text).isVerified);
+        assert(JSON.parse(response3.text).isVerified === true);
     });
 
     // Call the API with no session and see the error
@@ -682,8 +686,6 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         let response = await new Promise((resolve) =>
             request(app)
                 .get("/auth/user/email/verify")
-                .set("Cookie", ["sAccessToken=" + "randomAccessToken" + ";sIdRefreshToken=" + "randomRefreshToken"])
-                .set("anti-csrf", "randomAntiCsrfToken")
                 .end((err, res) => {
                     if (err) {
                         resolve(undefined);
@@ -694,7 +696,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         );
 
         assert(response.status === 401);
-        assert(JSON.parse(response.text).message === "try refresh token");
+        assert(JSON.parse(response.text).message === "unauthorised");
     });
 
     // Call the API with an expired access token and see that try refresh token is returned
@@ -738,7 +740,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         let userId = JSON.parse(response.text).user.id;
         let infoFromResponse = extractInfoFromResponse(response);
 
-        response = await await emailVerifyTokenRequest(
+        response = await emailVerifyTokenRequest(
             app,
             infoFromResponse.accessToken,
             infoFromResponse.idRefreshTokenFromCookie,
@@ -827,6 +829,6 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 })
         );
         assert(JSON.parse(response4.text).status === "OK");
-        assert(JSON.parse(response4.text).isVerified);
+        assert(JSON.parse(response4.text).isVerified === true);
     });
 });

--- a/test/emailpassword/emailverify.test.js
+++ b/test/emailpassword/emailverify.test.js
@@ -168,7 +168,6 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         let verifyToken = await EmailPassword.createEmailVerificationToken(userId);
         await EmailPassword.verifyEmailUsingToken(verifyToken);
 
-        // doesnt throw error when asking to generate the verify token with verified email.
         response = await new Promise((resolve) =>
             request(app)
                 .post("/auth/user/email/verify/token")
@@ -191,7 +190,8 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                     }
                 })
         );
-        assert(JSON.parse(response.text).status === "OK");
+        assert(JSON.parse(response.text).status === "EMAIL_ALREADY_VERIFIED_ERROR")
+        assert(response.status === 200)
     });
 
     // Call the API with no session and see the output
@@ -290,10 +290,74 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 })
         );
 
-        console.log(JSON.parse(response2.text));
-        console.log(response2.status);
+        assert(response2.status === 401);
+        assert(JSON.parse(response2.text).message === "try refresh token");
+    });
 
-        // assert(response.status === 401);
-        // assert(JSON.parse(response.text).message === "try refresh token");
+    // Provide your own email callback and make sure that is called
+    it("test that providing your own email callback and make sure it is called", async function () {
+        await startST();
+
+        let userInfo = null
+        let emailToken = null
+
+        STExpress.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [EmailPassword.init({
+                emailVerificationFeature: {
+                    createAndSendCustomEmail: (user, emailVerificationURLWithToken) => {
+                        userInfo = user
+                        emailToken = emailVerificationURLWithToken
+                    }
+                }
+            }), Session.init()],
+        });
+
+        const app = express();
+
+        app.use(STExpress.middleware());
+
+        app.use(STExpress.errorHandler());
+
+        let response = await signUPRequest(app, "test@gmail.com", "testPass123");
+        assert(JSON.parse(response.text).status === "OK");
+        assert(response.status === 200);
+
+        let userId = JSON.parse(response.text).user.id;
+        let infoFromResponse = extractInfoFromResponse(response);
+
+
+        let response2 = await new Promise((resolve) =>
+            request(app)
+                .post("/auth/user/email/verify/token")
+                .set("Cookie", [
+                    "sAccessToken=" +
+                        infoFromResponse.accessToken +
+                        ";sIdRefreshToken=" +
+                        infoFromResponse.idRefreshTokenFromCookie,
+                ])
+                .set("anti-csrf", infoFromResponse.antiCsrf)
+                .send({
+                    userId,
+                })
+                .end((err, res) => {
+                    if (err) {
+                        resolve(err);
+                    } else {
+                        resolve(res);
+                    }
+                })
+        );
+        assert(response2.status === 200)
+        assert(userInfo.id === userId)
+        assert(userInfo.email === "test@gmail.com")
+        assert(emailToken !== null)
     });
 });

--- a/test/emailpassword/emailverify.test.js
+++ b/test/emailpassword/emailverify.test.js
@@ -117,9 +117,9 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 .post("/auth/user/email/verify/token")
                 .set("Cookie", [
                     "sAccessToken=" +
-                        infoFromResponse.accessToken +
-                        ";sIdRefreshToken=" +
-                        infoFromResponse.idRefreshTokenFromCookie,
+                    infoFromResponse.accessToken +
+                    ";sIdRefreshToken=" +
+                    infoFromResponse.idRefreshTokenFromCookie,
                 ])
                 .set("anti-csrf", infoFromResponse.antiCsrf)
                 .send({
@@ -173,9 +173,9 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 .post("/auth/user/email/verify/token")
                 .set("Cookie", [
                     "sAccessToken=" +
-                        infoFromResponse.accessToken +
-                        ";sIdRefreshToken=" +
-                        infoFromResponse.idRefreshTokenFromCookie,
+                    infoFromResponse.accessToken +
+                    ";sIdRefreshToken=" +
+                    infoFromResponse.idRefreshTokenFromCookie,
                 ])
                 .set("anti-csrf", infoFromResponse.antiCsrf)
                 .send({
@@ -273,9 +273,9 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 .post("/auth/user/email/verify/token")
                 .set("Cookie", [
                     "sAccessToken=" +
-                        infoFromResponse.accessToken +
-                        ";sIdRefreshToken=" +
-                        infoFromResponse.idRefreshTokenFromCookie,
+                    infoFromResponse.accessToken +
+                    ";sIdRefreshToken=" +
+                    infoFromResponse.idRefreshTokenFromCookie,
                 ])
                 .set("anti-csrf", infoFromResponse.antiCsrf)
                 .send({
@@ -292,6 +292,47 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
 
         assert(response2.status === 401);
         assert(JSON.parse(response2.text).message === "try refresh token");
+
+        let refreshedResponse = extractInfoFromResponse(
+            await new Promise((resolve) =>
+                request(app)
+                    .post("/auth/session/refresh")
+                    .expect(200)
+                    .set("Cookie", ["sRefreshToken=" + infoFromResponse.refreshToken])
+                    .set("anti-csrf", infoFromResponse.antiCsrf)
+                    .expect(200)
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                            resolve(res);
+                        }
+                    })
+            )
+        );
+        let response3 = await new Promise((resolve) =>
+            request(app)
+                .post("/auth/user/email/verify/token")
+                .set("Cookie", [
+                    "sAccessToken=" +
+                    refreshedResponse.accessToken +
+                    ";sIdRefreshToken=" +
+                    refreshedResponse.idRefreshTokenFromCookie,
+                ])
+                .set("anti-csrf", refreshedResponse.antiCsrf)
+                .send({
+                    userId,
+                })
+                .end((err, res) => {
+                    if (err) {
+                        resolve(err);
+                    } else {
+                        resolve(res);
+                    }
+                })
+        );
+        assert(response3.status === 200)
+        assert(JSON.parse(response3.text).status === "OK")
     });
 
     // Provide your own email callback and make sure that is called
@@ -339,9 +380,9 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 .post("/auth/user/email/verify/token")
                 .set("Cookie", [
                     "sAccessToken=" +
-                        infoFromResponse.accessToken +
-                        ";sIdRefreshToken=" +
-                        infoFromResponse.idRefreshTokenFromCookie,
+                    infoFromResponse.accessToken +
+                    ";sIdRefreshToken=" +
+                    infoFromResponse.idRefreshTokenFromCookie,
                 ])
                 .set("anti-csrf", infoFromResponse.antiCsrf)
                 .send({
@@ -360,4 +401,18 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         assert(userInfo.email === "test@gmail.com")
         assert(emailToken !== null)
     });
+
+    /*
+    email verify API:
+        POST:
+          - Call the API with valid input
+          - Call the API with an invalid token and see the error
+          - token is not of type string from input
+          - provide a handlePostEmailVerification callback and make sure it's called on success verification
+        GET:
+          - Call the API with valid input
+          - Call the API with no session and see the error
+          - Call the API with an expired access token and see that try refresh token is returned
+    */
+
 });

--- a/test/emailpassword/emailverify.test.js
+++ b/test/emailpassword/emailverify.test.js
@@ -24,6 +24,7 @@ const {
     signUPRequest,
     extractInfoFromResponse,
     setKeyValueInConfig,
+    emailVerifyTokenRequest
 } = require("../utils");
 let STExpress = require("../..");
 let Session = require("../../recipe/session");
@@ -112,28 +113,9 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         let userId = JSON.parse(response.text).user.id;
         let infoFromResponse = extractInfoFromResponse(response);
 
-        response = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/user/email/verify/token")
-                .set("Cookie", [
-                    "sAccessToken=" +
-                    infoFromResponse.accessToken +
-                    ";sIdRefreshToken=" +
-                    infoFromResponse.idRefreshTokenFromCookie,
-                ])
-                .set("anti-csrf", infoFromResponse.antiCsrf)
-                .send({
-                    userId,
-                })
-                .expect(200)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(err);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
+        response = await emailVerifyTokenRequest(app, infoFromResponse.accessToken,
+            infoFromResponse.idRefreshTokenFromCookie, infoFromResponse.antiCsrf, userId)
+
         assert(JSON.parse(response.text).status === "OK");
     });
 
@@ -168,28 +150,9 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         let verifyToken = await EmailPassword.createEmailVerificationToken(userId);
         await EmailPassword.verifyEmailUsingToken(verifyToken);
 
-        response = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/user/email/verify/token")
-                .set("Cookie", [
-                    "sAccessToken=" +
-                    infoFromResponse.accessToken +
-                    ";sIdRefreshToken=" +
-                    infoFromResponse.idRefreshTokenFromCookie,
-                ])
-                .set("anti-csrf", infoFromResponse.antiCsrf)
-                .send({
-                    userId,
-                })
-                .expect(200)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(err);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
+        response = await emailVerifyTokenRequest(app, infoFromResponse.accessToken,
+            infoFromResponse.idRefreshTokenFromCookie, infoFromResponse.antiCsrf, userId)
+
         assert(JSON.parse(response.text).status === "EMAIL_ALREADY_VERIFIED_ERROR")
         assert(response.status === 200)
     });
@@ -215,22 +178,8 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
 
         app.use(STExpress.errorHandler());
 
-        let response = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/user/email/verify/token")
-                .set("Cookie", ["sAccessToken=" + "randmAccessToken" + ";sIdRefreshToken=" + "randomRefreshToken"])
-                .set("anti-csrf", "randomAntiCsrf")
-                .send({
-                    userId: "randomUserId",
-                })
-                .end((err, res) => {
-                    if (err) {
-                        resolve(err);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
+        let response = await emailVerifyTokenRequest(app, "randomAccessToken",
+            "randomRefreshToken", "randomAntiCsrf", "randomUserId")
 
         assert(response.status === 401);
         assert(JSON.parse(response.text).message === "try refresh token");
@@ -268,27 +217,8 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
 
         await new Promise((r) => setTimeout(r, 5000));
 
-        let response2 = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/user/email/verify/token")
-                .set("Cookie", [
-                    "sAccessToken=" +
-                    infoFromResponse.accessToken +
-                    ";sIdRefreshToken=" +
-                    infoFromResponse.idRefreshTokenFromCookie,
-                ])
-                .set("anti-csrf", infoFromResponse.antiCsrf)
-                .send({
-                    userId,
-                })
-                .end((err, res) => {
-                    if (err) {
-                        resolve(err);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
+        let response2 = await emailVerifyTokenRequest(app, infoFromResponse.accessToken,
+            infoFromResponse.idRefreshTokenFromCookie, infoFromResponse.antiCsrf, userId)
 
         assert(response2.status === 401);
         assert(JSON.parse(response2.text).message === "try refresh token");
@@ -310,27 +240,10 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                     })
             )
         );
-        let response3 = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/user/email/verify/token")
-                .set("Cookie", [
-                    "sAccessToken=" +
-                    refreshedResponse.accessToken +
-                    ";sIdRefreshToken=" +
-                    refreshedResponse.idRefreshTokenFromCookie,
-                ])
-                .set("anti-csrf", refreshedResponse.antiCsrf)
-                .send({
-                    userId,
-                })
-                .end((err, res) => {
-                    if (err) {
-                        resolve(err);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
+
+        let response3 = response = await emailVerifyTokenRequest(app, refreshedResponse.accessToken,
+            refreshedResponse.idRefreshTokenFromCookie, refreshedResponse.antiCsrf, userId)
+
         assert(response3.status === 200)
         assert(JSON.parse(response3.text).status === "OK")
     });
@@ -374,28 +287,9 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         let userId = JSON.parse(response.text).user.id;
         let infoFromResponse = extractInfoFromResponse(response);
 
+        let response2 = await emailVerifyTokenRequest(app, infoFromResponse.accessToken,
+            infoFromResponse.idRefreshTokenFromCookie, infoFromResponse.antiCsrf, userId)
 
-        let response2 = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/user/email/verify/token")
-                .set("Cookie", [
-                    "sAccessToken=" +
-                    infoFromResponse.accessToken +
-                    ";sIdRefreshToken=" +
-                    infoFromResponse.idRefreshTokenFromCookie,
-                ])
-                .set("anti-csrf", infoFromResponse.antiCsrf)
-                .send({
-                    userId,
-                })
-                .end((err, res) => {
-                    if (err) {
-                        resolve(err);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
         assert(response2.status === 200)
         assert(userInfo.id === userId)
         assert(userInfo.email === "test@gmail.com")
@@ -414,5 +308,106 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
           - Call the API with no session and see the error
           - Call the API with an expired access token and see that try refresh token is returned
     */
+    it("test the email verify API with valid input", async function () {
+        await startST();
+
+        let token = null
+        STExpress.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [EmailPassword.init({
+                emailVerificationFeature: {
+                    createAndSendCustomEmail: (user, emailVerificationURLWithToken) => {
+                        token = emailVerificationURLWithToken.split("?token=")[1].split("&rid=")[0]
+                    }
+                }
+            }), Session.init()],
+        });
+
+        const app = express();
+
+        app.use(STExpress.middleware());
+
+        app.use(STExpress.errorHandler());
+
+        let response = await signUPRequest(app, "test@gmail.com", "testPass123");
+        assert(JSON.parse(response.text).status === "OK");
+        assert(response.status === 200);
+
+        let userId = JSON.parse(response.text).user.id;
+        let infoFromResponse = extractInfoFromResponse(response);
+
+        response = await await emailVerifyTokenRequest(app, infoFromResponse.accessToken,
+            infoFromResponse.idRefreshTokenFromCookie, infoFromResponse.antiCsrf, userId)
+        assert(JSON.parse(response.text).status === "OK");
+
+        let response2 = await new Promise((resolve) =>
+            request(app)
+                .post("/auth/user/email/verify")
+                .send({
+                    method: "token",
+                    token
+                })
+                .expect(200)
+                .end((err, res) => {
+                    if (err) {
+                        resolve(err);
+                    } else {
+                        resolve(res);
+                    }
+                })
+        );
+
+        assert(JSON.parse(response2.text).status === "OK")
+    });
+
+    // Call the API with an invalid token and see the error
+    it("test the email verify API with invalid token and check error", async function () {
+        await startST();
+
+        STExpress.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [EmailPassword.init(), Session.init()],
+        });
+
+        const app = express();
+
+        app.use(STExpress.middleware());
+
+        app.use(STExpress.errorHandler());
+
+        response = await new Promise((resolve) =>
+            request(app)
+                .post("/auth/user/email/verify")
+                .send({
+                    method: "token",
+                    token: "randomToken"
+                })
+                .expect(200)
+                .end((err, res) => {
+                    if (err) {
+                        resolve(err);
+                    } else {
+                        resolve(res);
+                    }
+                })
+        );
+        assert(JSON.parse(response.text).status === "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR")
+    });
+
+    // token is not of type string from input
 
 });

--- a/test/emailpassword/emailverify.test.js
+++ b/test/emailpassword/emailverify.test.js
@@ -122,6 +122,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         );
 
         assert(JSON.parse(response.text).status === "OK");
+        assert(Object.keys(JSON.parse(response.text)).length === 1);
     });
 
     //Call the API with valid input, email verified and test error
@@ -165,6 +166,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
 
         assert(JSON.parse(response.text).status === "EMAIL_ALREADY_VERIFIED_ERROR");
         assert(response.status === 200);
+        assert(Object.keys(JSON.parse(response.text)).length === 1);
     });
 
     // Call the API with no session and see the output
@@ -202,6 +204,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
 
         assert(response.status === 401);
         assert(JSON.parse(response.text).message === "unauthorised");
+        assert(Object.keys(JSON.parse(response.text)).length === 1);
     });
 
     // Call the API with an expired access token and see that try refresh token is returned
@@ -246,6 +249,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
 
         assert(response2.status === 401);
         assert(JSON.parse(response2.text).message === "try refresh token");
+        assert(Object.keys(JSON.parse(response2.text)).length === 1);
 
         let refreshedResponse = extractInfoFromResponse(
             await new Promise((resolve) =>
@@ -275,6 +279,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
 
         assert(response3.status === 200);
         assert(JSON.parse(response3.text).status === "OK");
+        assert(Object.keys(JSON.parse(response3.text)).length === 1);
     });
 
     // Provide your own email callback and make sure that is called
@@ -328,6 +333,10 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         );
 
         assert(response2.status === 200);
+
+        assert(JSON.parse(response2.text).status === "OK");
+        assert(Object.keys(JSON.parse(response2.text)).length === 1);
+
         assert(userInfo.id === userId);
         assert(userInfo.email === "test@gmail.com");
         assert(emailToken !== null);
@@ -391,6 +400,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
             userId
         );
         assert(JSON.parse(response.text).status === "OK");
+        assert(Object.keys(JSON.parse(response.text)).length === 1);
 
         let response2 = await new Promise((resolve) =>
             request(app)
@@ -410,6 +420,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         );
 
         assert(JSON.parse(response2.text).status === "OK");
+        assert(Object.keys(JSON.parse(response2.text)).length === 1);
     });
 
     // Call the API with an invalid token and see the error
@@ -451,6 +462,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 })
         );
         assert(JSON.parse(response.text).status === "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR");
+        assert(Object.keys(JSON.parse(response.text)).length === 1);
     });
 
     // token is not of type string from input
@@ -492,6 +504,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         );
         assert(response.status === 400);
         assert(JSON.parse(response.text).message === "The email verification token must be a string");
+        assert(Object.keys(JSON.parse(response.text)).length === 1);
     });
 
     // provide a handlePostEmailVerification callback and make sure it's called on success verification
@@ -565,6 +578,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         );
 
         assert(JSON.parse(response2.text).status === "OK");
+        assert(Object.keys(JSON.parse(response2.text)).length === 1);
 
         assert(userInfoFromCallback.id === userId);
         assert(userInfoFromCallback.email === "test@gmail.com");
@@ -659,6 +673,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         );
         assert(JSON.parse(response3.text).status === "OK");
         assert(JSON.parse(response3.text).isVerified === true);
+        assert(Object.keys(JSON.parse(response3.text)).length === 2);
     });
 
     // Call the API with no session and see the error
@@ -697,6 +712,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
 
         assert(response.status === 401);
         assert(JSON.parse(response.text).message === "unauthorised");
+        assert(Object.keys(JSON.parse(response.text)).length === 1);
     });
 
     // Call the API with an expired access token and see that try refresh token is returned
@@ -790,6 +806,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         );
         assert(response3.status === 401);
         assert(JSON.parse(response3.text).message === "try refresh token");
+        assert(Object.keys(JSON.parse(response3.text)).length === 1);
 
         let refreshedResponse = extractInfoFromResponse(
             await new Promise((resolve) =>
@@ -830,5 +847,6 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         );
         assert(JSON.parse(response4.text).status === "OK");
         assert(JSON.parse(response4.text).isVerified === true);
+        assert(Object.keys(JSON.parse(response.text)).length === 1);
     });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -130,7 +130,7 @@ module.exports.setupST = async function () {
     let installationPath = process.env.INSTALL_PATH;
     try {
         await module.exports.executeCommand("cd " + installationPath + " && cp temp/licenseKey ./licenseKey");
-    } catch (ignore) { }
+    } catch (ignore) {}
     await module.exports.executeCommand("cd " + installationPath + " && cp temp/config.yaml ./config.yaml");
     await module.exports.setKeyValueInConfig("enable_anti_csrf", "true");
 };
@@ -139,7 +139,7 @@ module.exports.cleanST = async function () {
     let installationPath = process.env.INSTALL_PATH;
     try {
         await module.exports.executeCommand("cd " + installationPath + " && rm licenseKey");
-    } catch (ignore) { }
+    } catch (ignore) {}
     await module.exports.executeCommand("cd " + installationPath + " && rm config.yaml");
     await module.exports.executeCommand("cd " + installationPath + " && rm -rf .webserver-temp-*");
     await module.exports.executeCommand("cd " + installationPath + " && rm -rf .started");
@@ -189,11 +189,11 @@ module.exports.startST = async function (host = "localhost", port = 8080) {
         module.exports
             .executeCommand(
                 "cd " +
-                installationPath +
-                ` && java -Djava.security.egd=file:/dev/urandom -classpath "./core/*:./plugin-interface/*" io.supertokens.Main ./ DEV host=` +
-                host +
-                " port=" +
-                port
+                    installationPath +
+                    ` && java -Djava.security.egd=file:/dev/urandom -classpath "./core/*:./plugin-interface/*" io.supertokens.Main ./ DEV host=` +
+                    host +
+                    " port=" +
+                    port
             )
             .catch((err) => {
                 if (!returned) {
@@ -247,7 +247,7 @@ async function getListOfPids() {
             let pid = (await module.exports.executeCommand("cd " + installationPath + " && cat .started/" + item))
                 .stdout;
             result.push(pid);
-        } catch (err) { }
+        } catch (err) {}
     }
     return result;
 }
@@ -322,12 +322,7 @@ module.exports.emailVerifyTokenRequest = async function (app, accessToken, idRef
     return new Promise(function (resolve) {
         request(app)
             .post("/auth/user/email/verify/token")
-            .set("Cookie", [
-                "sAccessToken=" +
-                accessToken +
-                ";sIdRefreshToken=" +
-                idRefreshTokenFromCookie,
-            ])
+            .set("Cookie", ["sAccessToken=" + accessToken + ";sIdRefreshToken=" + idRefreshTokenFromCookie])
             .set("anti-csrf", antiCsrf)
             .send({
                 userId,

--- a/test/utils.js
+++ b/test/utils.js
@@ -130,7 +130,7 @@ module.exports.setupST = async function () {
     let installationPath = process.env.INSTALL_PATH;
     try {
         await module.exports.executeCommand("cd " + installationPath + " && cp temp/licenseKey ./licenseKey");
-    } catch (ignore) {}
+    } catch (ignore) { }
     await module.exports.executeCommand("cd " + installationPath + " && cp temp/config.yaml ./config.yaml");
     await module.exports.setKeyValueInConfig("enable_anti_csrf", "true");
 };
@@ -139,7 +139,7 @@ module.exports.cleanST = async function () {
     let installationPath = process.env.INSTALL_PATH;
     try {
         await module.exports.executeCommand("cd " + installationPath + " && rm licenseKey");
-    } catch (ignore) {}
+    } catch (ignore) { }
     await module.exports.executeCommand("cd " + installationPath + " && rm config.yaml");
     await module.exports.executeCommand("cd " + installationPath + " && rm -rf .webserver-temp-*");
     await module.exports.executeCommand("cd " + installationPath + " && rm -rf .started");
@@ -189,11 +189,11 @@ module.exports.startST = async function (host = "localhost", port = 8080) {
         module.exports
             .executeCommand(
                 "cd " +
-                    installationPath +
-                    ` && java -Djava.security.egd=file:/dev/urandom -classpath "./core/*:./plugin-interface/*" io.supertokens.Main ./ DEV host=` +
-                    host +
-                    " port=" +
-                    port
+                installationPath +
+                ` && java -Djava.security.egd=file:/dev/urandom -classpath "./core/*:./plugin-interface/*" io.supertokens.Main ./ DEV host=` +
+                host +
+                " port=" +
+                port
             )
             .catch((err) => {
                 if (!returned) {
@@ -247,7 +247,7 @@ async function getListOfPids() {
             let pid = (await module.exports.executeCommand("cd " + installationPath + " && cat .started/" + item))
                 .stdout;
             result.push(pid);
-        } catch (err) {}
+        } catch (err) { }
     }
     return result;
 }
@@ -307,6 +307,30 @@ module.exports.signUPRequest = async function (app, email, password) {
                         value: email,
                     },
                 ],
+            })
+            .end((err, res) => {
+                if (err) {
+                    resolve(undefined);
+                } else {
+                    resolve(res);
+                }
+            });
+    });
+};
+
+module.exports.emailVerifyTokenRequest = async function (app, accessToken, idRefreshTokenFromCookie, antiCsrf, userId) {
+    return new Promise(function (resolve) {
+        request(app)
+            .post("/auth/user/email/verify/token")
+            .set("Cookie", [
+                "sAccessToken=" +
+                accessToken +
+                ";sIdRefreshToken=" +
+                idRefreshTokenFromCookie,
+            ])
+            .set("anti-csrf", antiCsrf)
+            .send({
+                userId,
             })
             .end((err, res) => {
                 if (err) {


### PR DESCRIPTION
## Related Issues
- 

## Changes
- Adds emailVerifyTokenRequest() in utils for testing
- Tests added:
  - generate token API:
     - Call the API with valid input, email not verified
     - Call the API with valid input, email verified and test error
     - Call the API with no session and see the output (should be 401)
     - Call the API with an expired access token and see that try refresh token is returned
     - Provide your own email callback and make sure that is called
   - email verify API:
     - POST:
       - Call the API with valid input
       - Call the API with an invalid token and see the error
       - token is not of type string from input
       - provide a handlePostEmailVerification callback and make sure it's called on success verification
     - GET:
       - Call the API with valid input
       - Call the API with no session and see the error
       - Call the API with an expired access token and see that try refresh token is returned

## Migration:
  - none
 
