### PR TITLE
useSuperTokensFromNextJs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Email verification feature
 - Change the User object to include timeJoined
 - Sends emails to our APIs only if not testing mode
-- Add useSuperTokensFromNextJs generic express middleware wrapper
+- Add superTokensNextWrapper generic express middleware wrapper
 
 ## [3.2.2] - 2020-12-18
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.3.0] - 2021-01-09
 ### Added
 - Email verification feature
-- Change to User object to include timeJoined
+- Change the User object to include timeJoined
 - Sends emails to our APIs only if not testing mode
+- Add useSuperTokensFromNextJs generic express middleware wrapper
 
 ## [3.2.2] - 2020-12-18
 ### Fixed

--- a/lib/build/nextjs.d.ts
+++ b/lib/build/nextjs.d.ts
@@ -1,4 +1,6 @@
 export default class NextJS {
+    static useSuperTokensFromNextJs(middleware: (next: (middlewareError: any) => void) => Promise<void>, request: any, response: any): Promise<void>;
     static superTokensMiddleware(request: any, response: any): Promise<any>;
 }
 export declare let superTokensMiddleware: typeof NextJS.superTokensMiddleware;
+export declare let useSuperTokensFromNextJs: typeof NextJS.useSuperTokensFromNextJs;

--- a/lib/build/nextjs.d.ts
+++ b/lib/build/nextjs.d.ts
@@ -1,6 +1,6 @@
 export default class NextJS {
-    static useSuperTokensFromNextJs(middleware: (next: (middlewareError: any) => void) => Promise<void>, request: any, response: any): Promise<void>;
+    static superTokensNextWrapper(middleware: (next: (middlewareError: any) => void) => Promise<void>, request: any, response: any): Promise<void>;
     static superTokensMiddleware(request: any, response: any): Promise<any>;
 }
 export declare let superTokensMiddleware: typeof NextJS.superTokensMiddleware;
-export declare let useSuperTokensFromNextJs: typeof NextJS.useSuperTokensFromNextJs;
+export declare let superTokensNextWrapper: typeof NextJS.superTokensNextWrapper;

--- a/lib/build/nextjs.js
+++ b/lib/build/nextjs.js
@@ -46,26 +46,37 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * under the License.
  */
 const _1 = require(".");
+function next(request, response, resolve, reject) {
+    return function (middlewareError) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (middlewareError === undefined) {
+                return resolve();
+            }
+            return _1.default.errorHandler()(middlewareError, request, response, (errorHandlerError) => {
+                if (errorHandlerError !== undefined) {
+                    return reject(errorHandlerError);
+                }
+                return resolve();
+            });
+        });
+    };
+}
 class NextJS {
+    static useSuperTokensFromNextJs(middleware, request, response) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return new Promise((resolve, reject) => {
+                return middleware(next(request, response, resolve, reject));
+            });
+        });
+    }
+    /* Backward compatibility */
     static superTokensMiddleware(request, response) {
         return new Promise((resolve, reject) => {
-            _1.default.middleware()(request, response, (middlewareError) =>
-                __awaiter(this, void 0, void 0, function* () {
-                    if (middlewareError !== undefined) {
-                        _1.default.errorHandler()(middlewareError, request, response, (errorHandlerError) => {
-                            if (errorHandlerError !== undefined) {
-                                return reject(errorHandlerError);
-                            }
-                            resolve();
-                        });
-                        return;
-                    }
-                    return resolve();
-                })
-            );
+            return _1.default.middleware()(request, response, next(request, response, resolve, reject));
         });
     }
 }
 exports.default = NextJS;
 exports.superTokensMiddleware = NextJS.superTokensMiddleware;
+exports.useSuperTokensFromNextJs = NextJS.useSuperTokensFromNextJs;
 //# sourceMappingURL=nextjs.js.map

--- a/lib/build/nextjs.js
+++ b/lib/build/nextjs.js
@@ -62,7 +62,7 @@ function next(request, response, resolve, reject) {
     };
 }
 class NextJS {
-    static useSuperTokensFromNextJs(middleware, request, response) {
+    static superTokensNextWrapper(middleware, request, response) {
         return __awaiter(this, void 0, void 0, function* () {
             return new Promise((resolve, reject) => {
                 return middleware(next(request, response, resolve, reject));
@@ -78,5 +78,5 @@ class NextJS {
 }
 exports.default = NextJS;
 exports.superTokensMiddleware = NextJS.superTokensMiddleware;
-exports.useSuperTokensFromNextJs = NextJS.useSuperTokensFromNextJs;
+exports.superTokensNextWrapper = NextJS.superTokensNextWrapper;
 //# sourceMappingURL=nextjs.js.map

--- a/lib/ts/nextjs.ts
+++ b/lib/ts/nextjs.ts
@@ -36,7 +36,7 @@ function next(
 }
 
 export default class NextJS {
-    static async useSuperTokensFromNextJs(
+    static async superTokensNextWrapper(
         middleware: (next: (middlewareError: any) => void) => Promise<void>,
         request: any,
         response: any
@@ -55,4 +55,4 @@ export default class NextJS {
 }
 
 export let superTokensMiddleware = NextJS.superTokensMiddleware;
-export let useSuperTokensFromNextJs = NextJS.useSuperTokensFromNextJs;
+export let superTokensNextWrapper = NextJS.superTokensNextWrapper;

--- a/test/nextjs.test.js
+++ b/test/nextjs.test.js
@@ -17,215 +17,540 @@ const { printPath, setupST, startST, stopST, killAllST, cleanST } = require("./u
 let assert = require("assert");
 const httpMocks = require("node-mocks-http");
 let { ProcessState } = require("../lib/build/processState");
-let SuperTokens = require("../lib/build/supertokens").default;
+let SuperTokens = require("../lib/build/").default;
 const Session = require("../lib/build/recipe/session");
 const EmailPassword = require("../lib/build/recipe/emailpassword");
 const superTokensMiddleware = require("../lib/build/nextjs").superTokensMiddleware;
-const noOp = () => {};
+const useSuperTokensFromNextJs = require("../lib/build/nextjs").useSuperTokensFromNextJs;
 
 describe(`NextJS Middleware Test: ${printPath("[test/helpers/nextjs/index.test.js]")}`, function () {
-    before(async function () {
-        await killAllST();
-        await setupST();
-        await startST();
-        ProcessState.getInstance().reset();
-        SuperTokens.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                apiBasePath: "/api/auth",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [EmailPassword.init(), Session.init()],
+    describe("Backward compatbility superTokensMiddleware", function () {
+        before(async function () {
+            await killAllST();
+            await setupST();
+            await startST();
+            ProcessState.getInstance().reset();
+            SuperTokens.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                },
+                appInfo: {
+                    apiDomain: "api.supertokens.io",
+                    appName: "SuperTokens",
+                    apiBasePath: "/api/auth",
+                    websiteDomain: "supertokens.io",
+                },
+                recipeList: [EmailPassword.init(), Session.init()],
+            });
+        });
+
+        after(async function () {
+            await killAllST();
+            await cleanST();
+        });
+
+        it("Sign Up", function (done) {
+            const request = httpMocks.createRequest({
+                method: "POST",
+                headers: {
+                    rid: "emailpassword",
+                },
+                url: "/api/auth/signup/",
+                body: {
+                    formFields: [
+                        {
+                            id: "email",
+                            value: "john.doe@supertokens.io",
+                        },
+                        {
+                            id: "password",
+                            value: "P@sSW0rd",
+                        },
+                    ],
+                },
+            });
+
+            const response = httpMocks.createResponse({
+                eventEmitter: require("events").EventEmitter,
+            });
+
+            response.on("end", () => {
+                assert.deepStrictEqual(response._getJSONData().status, "OK");
+                assert.deepStrictEqual(response._getJSONData().user.email, "john.doe@supertokens.io");
+                assert(response._getHeaders()["front-token"] !== undefined);
+                assert(response._getHeaders()["set-cookie"][0].startsWith("sAccessToken="));
+                assert(response._getHeaders()["set-cookie"][1].startsWith("sRefreshToken="));
+                return done();
+            });
+
+            superTokensMiddleware(request, response);
+        });
+
+        it("Sign In", function (done) {
+            const request = httpMocks.createRequest({
+                method: "POST",
+                headers: {
+                    rid: "emailpassword",
+                },
+                url: "/api/auth/signin/",
+                body: {
+                    formFields: [
+                        {
+                            id: "email",
+                            value: "john.doe@supertokens.io",
+                        },
+                        {
+                            id: "password",
+                            value: "P@sSW0rd",
+                        },
+                    ],
+                },
+            });
+
+            const response = httpMocks.createResponse({
+                eventEmitter: require("events").EventEmitter,
+            });
+
+            response.on("end", () => {
+                assert.deepStrictEqual(response._getJSONData().status, "OK");
+                assert.deepStrictEqual(response._getJSONData().user.email, "john.doe@supertokens.io");
+                assert(response._getHeaders()["front-token"] !== undefined);
+                assert(response._getHeaders()["set-cookie"][0].startsWith("sAccessToken="));
+                assert(response._getHeaders()["set-cookie"][1].startsWith("sRefreshToken="));
+                return done();
+            });
+
+            superTokensMiddleware(request, response);
+        });
+
+        it("Reset Password Send Email", function (done) {
+            const request = httpMocks.createRequest({
+                method: "POST",
+                headers: {
+                    rid: "emailpassword",
+                },
+                url: "/api/auth/user/password/reset/token",
+                body: {
+                    formFields: [
+                        {
+                            id: "email",
+                            value: "john.do@supertokens.io",
+                        },
+                    ],
+                },
+            });
+
+            const response = httpMocks.createResponse({
+                eventEmitter: require("events").EventEmitter,
+            });
+
+            response.on("end", () => {
+                assert.deepStrictEqual(response._getJSONData().status, "OK");
+                return done();
+            });
+
+            superTokensMiddleware(request, response);
+        });
+
+        it("Reset Password Send Email", function (done) {
+            const request = httpMocks.createRequest({
+                method: "POST",
+                headers: {
+                    rid: "emailpassword",
+                },
+                url: "/api/auth/user/password/reset/",
+                body: {
+                    formFields: [
+                        {
+                            id: "password",
+                            value: "NewP@sSW0rd",
+                        },
+                    ],
+                    token: "RandomToken",
+                },
+            });
+
+            const response = httpMocks.createResponse({
+                eventEmitter: require("events").EventEmitter,
+            });
+
+            response.on("end", () => {
+                assert.deepStrictEqual(response._getJSONData().status, "RESET_PASSWORD_INVALID_TOKEN_ERROR");
+                return done();
+            });
+
+            superTokensMiddleware(request, response);
+        });
+
+        it("does Email Exist with existing email", function (done) {
+            const request = httpMocks.createRequest({
+                method: "GET",
+                headers: {
+                    rid: "emailpassword",
+                },
+                url: "/api/auth/signup/email/exists",
+                query: {
+                    email: "john.doe@supertokens.io",
+                },
+            });
+
+            const response = httpMocks.createResponse({
+                eventEmitter: require("events").EventEmitter,
+            });
+
+            response.on("end", () => {
+                assert.deepStrictEqual(response._getJSONData(), { status: "OK", exists: true });
+                return done();
+            });
+
+            superTokensMiddleware(request, response);
+        });
+
+        it("does Email Exist with unknown email", function (done) {
+            const request = httpMocks.createRequest({
+                method: "GET",
+                headers: {
+                    rid: "emailpassword",
+                },
+                url: "/api/auth/signup/email/exists",
+                query: {
+                    email: "unknown@supertokens.io",
+                },
+            });
+
+            const response = httpMocks.createResponse({
+                eventEmitter: require("events").EventEmitter,
+            });
+
+            response.on("end", () => {
+                assert.deepStrictEqual(response._getJSONData().exists, false);
+                return done();
+            });
+
+            superTokensMiddleware(request, response);
         });
     });
 
-    after(async function () {
-        await killAllST();
-        await cleanST();
-    });
+    describe("with useSuperTokensFromNextJs", function () {
+        before(async function () {
+            await killAllST();
+            await setupST();
+            await startST();
+            ProcessState.getInstance().reset();
+            SuperTokens.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                },
+                appInfo: {
+                    apiDomain: "api.supertokens.io",
+                    appName: "SuperTokens",
+                    apiBasePath: "/api/auth",
+                    websiteDomain: "supertokens.io",
+                },
+                recipeList: [EmailPassword.init(), Session.init()],
+            });
+        });
 
-    it("Sign Up", function (done) {
-        const request = httpMocks.createRequest({
-            method: "POST",
-            headers: {
-                rid: "emailpassword",
-            },
-            url: "/api/auth/signup/",
-            body: {
-                formFields: [
-                    {
-                        id: "email",
-                        value: "john.doe@supertokens.io",
+        after(async function () {
+            await killAllST();
+            await cleanST();
+        });
+
+        it("Sign Up", function (done) {
+            const request = httpMocks.createRequest({
+                method: "POST",
+                headers: {
+                    rid: "emailpassword",
+                },
+                url: "/api/auth/signup/",
+                body: {
+                    formFields: [
+                        {
+                            id: "email",
+                            value: "john.doe@supertokens.io",
+                        },
+                        {
+                            id: "password",
+                            value: "P@sSW0rd",
+                        },
+                    ],
+                },
+            });
+
+            const response = httpMocks.createResponse({
+                eventEmitter: require("events").EventEmitter,
+            });
+
+            response.on("end", () => {
+                assert.deepStrictEqual(response._getJSONData().status, "OK");
+                assert.deepStrictEqual(response._getJSONData().user.email, "john.doe@supertokens.io");
+                assert(response._getHeaders()["front-token"] !== undefined);
+                assert(response._getHeaders()["set-cookie"][0].startsWith("sAccessToken="));
+                assert(response._getHeaders()["set-cookie"][1].startsWith("sRefreshToken="));
+                return done();
+            });
+
+            useSuperTokensFromNextJs(
+                async (next) => {
+                    return SuperTokens.middleware()(request, response, next);
+                },
+                request,
+                response
+            );
+        });
+
+        it("Sign In", function (done) {
+            const loginRequest = httpMocks.createRequest({
+                method: "POST",
+                headers: {
+                    rid: "emailpassword",
+                },
+                url: "/api/auth/signin/",
+                body: {
+                    formFields: [
+                        {
+                            id: "email",
+                            value: "john.doe@supertokens.io",
+                        },
+                        {
+                            id: "password",
+                            value: "P@sSW0rd",
+                        },
+                    ],
+                },
+            });
+
+            const loginResponse = httpMocks.createResponse({
+                eventEmitter: require("events").EventEmitter,
+            });
+
+            loginResponse.on("end", async () => {
+                assert.deepStrictEqual(loginResponse._getJSONData().status, "OK");
+                assert.deepStrictEqual(loginResponse._getJSONData().user.email, "john.doe@supertokens.io");
+                assert(loginResponse._getHeaders()["front-token"] !== undefined);
+                assert(loginResponse._getHeaders()["set-cookie"][0].startsWith("sAccessToken=") !== undefined);
+                assert(loginResponse._getHeaders()["set-cookie"][1].startsWith("sRefreshToken=") !== undefined);
+
+                // Verify if session exists next middleware tests:
+
+                // Case 1: Successful => add session to request object.
+                const getUserRequestWithSession = httpMocks.createRequest({
+                    method: "GET",
+                    cookies: getSessionCookiesFromResponse(loginResponse),
+                    url: "/api/user/",
+                });
+                const getUserResponseWithSession = httpMocks.createResponse({});
+
+                await useSuperTokensFromNextJs(
+                    (next) => {
+                        Session.verifySession()(getUserRequestWithSession, getUserResponseWithSession, next);
                     },
-                    {
-                        id: "password",
-                        value: "P@sSW0rd",
+                    getUserRequestWithSession,
+                    getUserResponseWithSession
+                );
+
+                assert(getUserRequestWithSession.session !== undefined);
+
+                // Case 2: Unauthenticated => return 401.
+                const getUserRequestWithoutSession = httpMocks.createRequest({
+                    method: "GET",
+                    url: "/api/user/",
+                });
+
+                const getUserResponseWithoutSession = httpMocks.createResponse({
+                    eventEmitter: require("events").EventEmitter,
+                });
+
+                getUserResponseWithoutSession.on("end", () => {
+                    assert.strictEqual(getUserResponseWithoutSession.statusCode, 401);
+                    return done();
+                });
+
+                useSuperTokensFromNextJs(
+                    (next) => {
+                        Session.verifySession()(getUserRequestWithoutSession, getUserResponseWithoutSession, next);
                     },
-                ],
-            },
+                    getUserRequestWithoutSession,
+                    getUserResponseWithoutSession
+                );
+            });
+
+            useSuperTokensFromNextJs(
+                async (next) => {
+                    return SuperTokens.middleware()(loginRequest, loginResponse, next);
+                },
+                loginRequest,
+                loginResponse
+            );
         });
 
-        const response = httpMocks.createResponse({
-            eventEmitter: require("events").EventEmitter,
+        it("Reset Password Send Email", function (done) {
+            const request = httpMocks.createRequest({
+                method: "POST",
+                headers: {
+                    rid: "emailpassword",
+                },
+                url: "/api/auth/user/password/reset/token",
+                body: {
+                    formFields: [
+                        {
+                            id: "email",
+                            value: "john.doe@supertokens.io",
+                        },
+                    ],
+                },
+            });
+
+            const response = httpMocks.createResponse({
+                eventEmitter: require("events").EventEmitter,
+            });
+
+            response.on("end", () => {
+                assert.deepStrictEqual(response._getJSONData().status, "OK");
+                return done();
+            });
+
+            useSuperTokensFromNextJs(
+                async (next) => {
+                    return SuperTokens.middleware()(request, response, next);
+                },
+                request,
+                response
+            );
         });
 
-        response.on("end", () => {
-            assert.deepStrictEqual(response._getJSONData().status, "OK");
-            assert.deepStrictEqual(response._getJSONData().user.email, "john.doe@supertokens.io");
-            assert(response._getHeaders()["front-token"] !== undefined);
-            assert(response._getHeaders()["set-cookie"][0].startsWith("sAccessToken="));
-            assert(response._getHeaders()["set-cookie"][1].startsWith("sRefreshToken="));
-            return done();
+        it("Reset Password Send Email", function (done) {
+            const request = httpMocks.createRequest({
+                method: "POST",
+                headers: {
+                    rid: "emailpassword",
+                },
+                url: "/api/auth/user/password/reset/",
+                body: {
+                    formFields: [
+                        {
+                            id: "password",
+                            value: "NewP@sSW0rd",
+                        },
+                    ],
+                    token: "RandomToken",
+                },
+            });
+
+            const response = httpMocks.createResponse({
+                eventEmitter: require("events").EventEmitter,
+            });
+
+            response.on("end", () => {
+                assert.deepStrictEqual(response._getJSONData().status, "RESET_PASSWORD_INVALID_TOKEN_ERROR");
+                return done();
+            });
+
+            useSuperTokensFromNextJs(
+                async (next) => {
+                    return SuperTokens.middleware()(request, response, next);
+                },
+                request,
+                response
+            );
         });
 
-        superTokensMiddleware(request, response, noOp);
-    });
+        it("does Email Exist with existing email", function (done) {
+            const request = httpMocks.createRequest({
+                method: "GET",
+                headers: {
+                    rid: "emailpassword",
+                },
+                url: "/api/auth/signup/email/exists",
+                query: {
+                    email: "john.doe@supertokens.io",
+                },
+            });
 
-    it("Sign In", function (done) {
-        const request = httpMocks.createRequest({
-            method: "POST",
-            headers: {
-                rid: "emailpassword",
-            },
-            url: "/api/auth/signin/",
-            body: {
-                formFields: [
-                    {
-                        id: "email",
-                        value: "john.doe@supertokens.io",
-                    },
-                    {
-                        id: "password",
-                        value: "P@sSW0rd",
-                    },
-                ],
-            },
+            const response = httpMocks.createResponse({
+                eventEmitter: require("events").EventEmitter,
+            });
+
+            response.on("end", () => {
+                assert.deepStrictEqual(response._getJSONData(), { status: "OK", exists: true });
+                return done();
+            });
+
+            useSuperTokensFromNextJs(
+                async (next) => {
+                    return SuperTokens.middleware()(request, response, next);
+                },
+                request,
+                response
+            );
         });
 
-        const response = httpMocks.createResponse({
-            eventEmitter: require("events").EventEmitter,
+        it("does Email Exist with unknown email", function (done) {
+            const request = httpMocks.createRequest({
+                method: "GET",
+                headers: {
+                    rid: "emailpassword",
+                },
+                url: "/api/auth/signup/email/exists",
+                query: {
+                    email: "unknown@supertokens.io",
+                },
+            });
+
+            const response = httpMocks.createResponse({
+                eventEmitter: require("events").EventEmitter,
+            });
+
+            response.on("end", () => {
+                assert.deepStrictEqual(response._getJSONData().exists, false);
+                return done();
+            });
+
+            useSuperTokensFromNextJs(
+                async (next) => {
+                    return SuperTokens.middleware()(request, response, next);
+                },
+                request,
+                response
+            );
         });
 
-        response.on("end", () => {
-            assert.deepStrictEqual(response._getJSONData().status, "OK");
-            assert.deepStrictEqual(response._getJSONData().user.email, "john.doe@supertokens.io");
-            assert(response._getHeaders()["front-token"] !== undefined);
-            assert(response._getHeaders()["set-cookie"][0].startsWith("sAccessToken="));
-            assert(response._getHeaders()["set-cookie"][1].startsWith("sRefreshToken="));
-            return done();
+        it("Verify session successfully when session is present", function (done) {
+            const request = httpMocks.createRequest({
+                method: "GET",
+                url: "/api/auth/user/info",
+            });
+
+            const response = httpMocks.createResponse({
+                eventEmitter: require("events").EventEmitter,
+            });
+
+            response.on("end", () => {
+                assert.deepStrictEqual(response._getStatusCode(), 401);
+                return done();
+            });
+
+            useSuperTokensFromNextJs(
+                (next) => {
+                    Session.verifySession()(request, response, next);
+                },
+                request,
+                response
+            );
         });
-
-        superTokensMiddleware(request, response, noOp);
-    });
-
-    it("Reset Password Send Email", function (done) {
-        const request = httpMocks.createRequest({
-            method: "POST",
-            headers: {
-                rid: "emailpassword",
-            },
-            url: "/api/auth/user/password/reset/token",
-            body: {
-                formFields: [
-                    {
-                        id: "email",
-                        value: "john.do@supertokens.io",
-                    },
-                ],
-            },
-        });
-
-        const response = httpMocks.createResponse({
-            eventEmitter: require("events").EventEmitter,
-        });
-
-        response.on("end", () => {
-            assert.deepStrictEqual(response._getJSONData().status, "OK");
-            return done();
-        });
-
-        superTokensMiddleware(request, response, noOp);
-    });
-
-    it("Reset Password Send Email", function (done) {
-        const request = httpMocks.createRequest({
-            method: "POST",
-            headers: {
-                rid: "emailpassword",
-            },
-            url: "/api/auth/user/password/reset/",
-            body: {
-                formFields: [
-                    {
-                        id: "password",
-                        value: "NewP@sSW0rd",
-                    },
-                ],
-                token: "RandomToken",
-            },
-        });
-
-        const response = httpMocks.createResponse({
-            eventEmitter: require("events").EventEmitter,
-        });
-
-        response.on("end", () => {
-            assert.deepStrictEqual(response._getJSONData().status, "RESET_PASSWORD_INVALID_TOKEN_ERROR");
-            return done();
-        });
-
-        superTokensMiddleware(request, response, noOp);
-    });
-
-    it("does Email Exist with existing email", function (done) {
-        const request = httpMocks.createRequest({
-            method: "GET",
-            headers: {
-                rid: "emailpassword",
-            },
-            url: "/api/auth/signup/email/exists",
-            query: {
-                email: "john.doe@supertokens.io",
-            },
-        });
-
-        const response = httpMocks.createResponse({
-            eventEmitter: require("events").EventEmitter,
-        });
-
-        response.on("end", () => {
-            assert.deepStrictEqual(response._getJSONData(), { status: "OK", exists: true });
-            return done();
-        });
-
-        superTokensMiddleware(request, response, noOp);
-    });
-
-    it("does Email Exist with unknown email", function (done) {
-        const request = httpMocks.createRequest({
-            method: "GET",
-            headers: {
-                rid: "emailpassword",
-            },
-            url: "/api/auth/signup/email/exists",
-            query: {
-                email: "unknown@supertokens.io",
-            },
-        });
-
-        const response = httpMocks.createResponse({
-            eventEmitter: require("events").EventEmitter,
-        });
-
-        response.on("end", () => {
-            assert.deepStrictEqual(response._getJSONData().exists, false);
-            return done();
-        });
-
-        superTokensMiddleware(request, response, noOp);
     });
 });
+
+function getSessionCookiesFromResponse(response) {
+    return {
+        sAccessToken: decodeURIComponent(
+            response._getHeaders()["set-cookie"][0].split("sAccessToken=")[1].split(";")[0]
+        ),
+        sRefreshToken: decodeURIComponent(
+            response._getHeaders()["set-cookie"][1].split("sRefreshToken=")[1].split(";")[0]
+        ),
+        sIdRefreshToken: decodeURIComponent(
+            response._getHeaders()["set-cookie"][2].split("sIdRefreshToken=")[1].split(";")[0]
+        ),
+    };
+}

--- a/test/nextjs.test.js
+++ b/test/nextjs.test.js
@@ -21,7 +21,7 @@ let SuperTokens = require("../lib/build/").default;
 const Session = require("../lib/build/recipe/session");
 const EmailPassword = require("../lib/build/recipe/emailpassword");
 const superTokensMiddleware = require("../lib/build/nextjs").superTokensMiddleware;
-const useSuperTokensFromNextJs = require("../lib/build/nextjs").useSuperTokensFromNextJs;
+const superTokensNextWrapper = require("../lib/build/nextjs").superTokensNextWrapper;
 
 describe(`NextJS Middleware Test: ${printPath("[test/helpers/nextjs/index.test.js]")}`, function () {
     describe("Backward compatbility superTokensMiddleware", function () {
@@ -231,7 +231,7 @@ describe(`NextJS Middleware Test: ${printPath("[test/helpers/nextjs/index.test.j
         });
     });
 
-    describe("with useSuperTokensFromNextJs", function () {
+    describe("with superTokensNextWrapper", function () {
         before(async function () {
             await killAllST();
             await setupST();
@@ -290,7 +290,7 @@ describe(`NextJS Middleware Test: ${printPath("[test/helpers/nextjs/index.test.j
                 return done();
             });
 
-            useSuperTokensFromNextJs(
+            superTokensNextWrapper(
                 async (next) => {
                     return SuperTokens.middleware()(request, response, next);
                 },
@@ -341,7 +341,7 @@ describe(`NextJS Middleware Test: ${printPath("[test/helpers/nextjs/index.test.j
                 });
                 const getUserResponseWithSession = httpMocks.createResponse({});
 
-                await useSuperTokensFromNextJs(
+                await superTokensNextWrapper(
                     (next) => {
                         Session.verifySession()(getUserRequestWithSession, getUserResponseWithSession, next);
                     },
@@ -366,7 +366,7 @@ describe(`NextJS Middleware Test: ${printPath("[test/helpers/nextjs/index.test.j
                     return done();
                 });
 
-                useSuperTokensFromNextJs(
+                superTokensNextWrapper(
                     (next) => {
                         Session.verifySession()(getUserRequestWithoutSession, getUserResponseWithoutSession, next);
                     },
@@ -375,7 +375,7 @@ describe(`NextJS Middleware Test: ${printPath("[test/helpers/nextjs/index.test.j
                 );
             });
 
-            useSuperTokensFromNextJs(
+            superTokensNextWrapper(
                 async (next) => {
                     return SuperTokens.middleware()(loginRequest, loginResponse, next);
                 },
@@ -410,7 +410,7 @@ describe(`NextJS Middleware Test: ${printPath("[test/helpers/nextjs/index.test.j
                 return done();
             });
 
-            useSuperTokensFromNextJs(
+            superTokensNextWrapper(
                 async (next) => {
                     return SuperTokens.middleware()(request, response, next);
                 },
@@ -446,7 +446,7 @@ describe(`NextJS Middleware Test: ${printPath("[test/helpers/nextjs/index.test.j
                 return done();
             });
 
-            useSuperTokensFromNextJs(
+            superTokensNextWrapper(
                 async (next) => {
                     return SuperTokens.middleware()(request, response, next);
                 },
@@ -476,7 +476,7 @@ describe(`NextJS Middleware Test: ${printPath("[test/helpers/nextjs/index.test.j
                 return done();
             });
 
-            useSuperTokensFromNextJs(
+            superTokensNextWrapper(
                 async (next) => {
                     return SuperTokens.middleware()(request, response, next);
                 },
@@ -506,7 +506,7 @@ describe(`NextJS Middleware Test: ${printPath("[test/helpers/nextjs/index.test.j
                 return done();
             });
 
-            useSuperTokensFromNextJs(
+            superTokensNextWrapper(
                 async (next) => {
                     return SuperTokens.middleware()(request, response, next);
                 },
@@ -530,7 +530,7 @@ describe(`NextJS Middleware Test: ${printPath("[test/helpers/nextjs/index.test.j
                 return done();
             });
 
-            useSuperTokensFromNextJs(
+            superTokensNextWrapper(
                 (next) => {
                     Session.verifySession()(request, response, next);
                 },


### PR DESCRIPTION
Expose a general middleware that can be used with any methods:

```js
import {superTokensNextWrapper} from "supertokens-node/nextjs";

// Example for Middleware
superTokensNextWrapper(async (next) => {
  return SuperTokens.middleware(request, response, next)
}, request, response);

// Example for Verify Session
superTokensNextWrapper(async (next) => {
  return SuperTokens.verifySession(request, response, next)
}, request, response);
```

Used in demo repo https://github.com/supertokens/supertokens-nextjs-demo/pull/5
