### PR TITLE
3.3 tests refacto

### DIFF
--- a/test/emailpassword/config.test.js
+++ b/test/emailpassword/config.test.js
@@ -12,27 +12,28 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-const { printPath, setupST, startST, stopST, killAllST, cleanST, resetAll } = require("../utils");
-let STExpress = require("../../");
-let Session = require("../../recipe/session");
-let SessionRecipe = require("../../lib/build/recipe/session/sessionRecipe").default;
-let assert = require("assert");
-let { ProcessState } = require("../../lib/build/processState");
-let { normaliseURLPathOrThrowError } = require("../../lib/build/normalisedURLPath");
-let { normaliseURLDomainOrThrowError } = require("../../lib/build/normalisedURLDomain");
-let { normaliseSessionScopeOrThrowError } = require("../../lib/build/recipe/session/utils");
-const { Querier } = require("../../lib/build/querier");
-let EmailPassword = require("../../recipe/emailpassword");
-let EmailPasswordRecipe = require("../../lib/build/recipe/emailpassword/recipe").default;
-let utils = require("../../lib/build/recipe/emailpassword/utils");
+const { printPath, setupST, startST, killAllST, cleanST } = require("../utils");
+const STExpress = require("../../");
+const SessionRecipe = require("../../lib/build/recipe/session/sessionRecipe").default;
+const assert = require("assert");
+const { ProcessState } = require("../../lib/build/processState");
+const EmailPassword = require("../../recipe/emailpassword");
+const SuperTokens = require("../../lib/build/supertokens").default;
+const EmailPasswordRecipe = require("../../lib/build/recipe/emailpassword/recipe").default;
 
 describe(`configTest: ${printPath("[test/emailpassword/config.test.js]")}`, function () {
-    beforeEach(async function () {
+    before(async function () {
         await killAllST();
         await setupST();
-        ProcessState.getInstance().reset();
+        await startST();
     });
 
+    beforeEach(async function () {
+        ProcessState.getInstance().reset();
+        SuperTokens.reset();
+        SessionRecipe.reset();
+        EmailPasswordRecipe.reset();
+    });
     after(async function () {
         await killAllST();
         await cleanST();
@@ -41,7 +42,6 @@ describe(`configTest: ${printPath("[test/emailpassword/config.test.js]")}`, func
     // test config for emailpassword module
     // Failure condition: passing custom data or data of invalid type/ syntax to the module
     it("test default config for emailpassword module", async function () {
-        await startST();
         STExpress.init({
             supertokens: {
                 connectionURI: "http://localhost:8080",
@@ -87,7 +87,6 @@ describe(`configTest: ${printPath("[test/emailpassword/config.test.js]")}`, func
 
     // Failure condition: passing data of invalid type/ syntax to the module
     it("test config for emailpassword module", async function () {
-        await startST();
         STExpress.init({
             supertokens: {
                 connectionURI: "http://localhost:8080",
@@ -123,12 +122,12 @@ describe(`configTest: ${printPath("[test/emailpassword/config.test.js]")}`, func
             ],
         });
 
-        let emailpassword = await EmailPasswordRecipe.getInstanceOrThrowError();
+        const emailpassword = await EmailPasswordRecipe.getInstanceOrThrowError();
 
-        let formFields = emailpassword.config.signUpFeature.formFields;
-        assert(formFields.length === 3);
+        const formFields = emailpassword.config.signUpFeature.formFields;
+        assert.deepStrictEqual(formFields.length, 3);
 
-        let testFormField = await emailpassword.config.signUpFeature.formFields.filter((f) => f.id === "test")[0];
+        const testFormField = await emailpassword.config.signUpFeature.formFields.filter((f) => f.id === "test")[0];
         assert(testFormField !== undefined);
         assert(testFormField.optional === false);
         assert(testFormField.validate("") === "test");
@@ -145,7 +144,6 @@ describe(`configTest: ${printPath("[test/emailpassword/config.test.js]")}`, func
      *         - Check that the default password and email validators work fine
      */
     it("test that no email/password validators given should add them", async function () {
-        await startST();
         STExpress.init({
             supertokens: {
                 connectionURI: "http://localhost:8080",
@@ -177,7 +175,6 @@ describe(`configTest: ${printPath("[test/emailpassword/config.test.js]")}`, func
     });
 
     it("test that giving optional true in email / password field should be ignored", async function () {
-        await startST();
         STExpress.init({
             supertokens: {
                 connectionURI: "http://localhost:8080",
@@ -212,7 +209,6 @@ describe(`configTest: ${printPath("[test/emailpassword/config.test.js]")}`, func
 
     //Check that the default password and email validators work fine
     it("test that default password and email validators work fine", async function () {
-        await startST();
         STExpress.init({
             supertokens: {
                 connectionURI: "http://localhost:8080",

--- a/test/emailpassword/emailverify.test.js
+++ b/test/emailpassword/emailverify.test.js
@@ -17,10 +17,8 @@ const {
     printPath,
     setupST,
     startST,
-    stopST,
     killAllST,
     cleanST,
-    resetAll,
     signUPRequest,
     extractInfoFromResponse,
     setKeyValueInConfig,
@@ -43,848 +41,513 @@ const request = require("supertest");
  */
 
 describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`, function () {
+    let shouldRunTest = true;
+
     beforeEach(async function () {
-        await killAllST();
-        await setupST();
         ProcessState.getInstance().reset();
     });
 
-    after(async function () {
-        await killAllST();
-        await cleanST();
-    });
+    describe("With default config", function () {
+        let app, userId, infoFromResponse;
 
-    /*
-    generate token API:
-        - Call the API with valid input, email not verified
-        - Call the API with valid input, email verified and test error
-        - Call the API with no session and see the output (should be 401)
-        - Call the API with an expired access token and see that try refresh token is returned
-        - Provide your own email callback and make sure that is called
-    */
+        before(async function () {
+            await killAllST();
+            await setupST();
+            await setKeyValueInConfig("access_token_validity", 1);
+            await startST();
 
-    // Call the API with valid input, email not verified
-    it("test the generate token api with valid input, email not verified", async function () {
-        await startST();
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [EmailPassword.init(), Session.init()],
+            STExpress.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                },
+                appInfo: {
+                    apiDomain: "api.supertokens.io",
+                    appName: "SuperTokens",
+                    websiteDomain: "supertokens.io",
+                },
+                recipeList: [EmailPassword.init(), Session.init()],
+            });
+
+            app = express();
+
+            app.use(STExpress.middleware());
+
+            app.use(STExpress.errorHandler());
+
+            const currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
+            shouldRunTest = maxVersion(currCDIVersion, "2.4") !== "2.4";
+
+            const response = await signUPRequest(app, "exist@supertokens.io", "testPass123");
+            assert(JSON.parse(response.text).status === "OK");
+            assert(response.status === 200);
+
+            userId = JSON.parse(response.text).user.id;
+            infoFromResponse = extractInfoFromResponse(response);
         });
 
-        let currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
-        if (maxVersion(currCDIVersion, "2.4") === "2.4") {
-            return;
-        }
-
-        const app = express();
-
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        let response = await signUPRequest(app, "test@gmail.com", "testPass123");
-        assert(JSON.parse(response.text).status === "OK");
-        assert(response.status === 200);
-
-        let userId = JSON.parse(response.text).user.id;
-        let infoFromResponse = extractInfoFromResponse(response);
-
-        response = await emailVerifyTokenRequest(
-            app,
-            infoFromResponse.accessToken,
-            infoFromResponse.idRefreshTokenFromCookie,
-            infoFromResponse.antiCsrf,
-            userId
-        );
-
-        assert(JSON.parse(response.text).status === "OK");
-        assert(Object.keys(JSON.parse(response.text)).length === 1);
-    });
-
-    //Call the API with valid input, email verified and test error
-    it("test the generate token api with valid input, email verified and test error", async function () {
-        await startST();
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [EmailPassword.init(), Session.init()],
+        after(async function () {
+            await killAllST();
+            await cleanST();
         });
 
-        let currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
-        if (maxVersion(currCDIVersion, "2.4") === "2.4") {
-            return;
+        /*
+        generate token API:
+            - Call the API with valid input, email not verified
+            - Call the API with valid input, email verified and test error
+            - Call the API with no session and see the output (should be 401)
+            - Call the API with an expired access token and see that try refresh token is returned
+            - Provide your own email callback and make sure that is called
+        */
+
+        if (shouldRunTest === true) {
+            it("test the generate token api with valid input, email not verified", async function () {
+                response = await emailVerifyTokenRequest(
+                    app,
+                    infoFromResponse.accessToken,
+                    infoFromResponse.idRefreshTokenFromCookie,
+                    infoFromResponse.antiCsrf,
+                    userId
+                );
+
+                assert(JSON.parse(response.text).status === "OK");
+                assert(Object.keys(JSON.parse(response.text)).length === 1);
+            });
+
+            it("test the generate token api with valid input, email verified and test error", async function () {
+                const verifyToken = await EmailPassword.createEmailVerificationToken(userId);
+                await EmailPassword.verifyEmailUsingToken(verifyToken);
+                response = await emailVerifyTokenRequest(
+                    app,
+                    infoFromResponse.accessToken,
+                    infoFromResponse.idRefreshTokenFromCookie,
+                    infoFromResponse.antiCsrf,
+                    userId
+                );
+
+                assert(JSON.parse(response.text).status === "EMAIL_ALREADY_VERIFIED_ERROR");
+                assert(response.status === 200);
+                assert(Object.keys(JSON.parse(response.text)).length === 1);
+            });
+
+            it("test the generate token api with valid input, no session and check output", async function () {
+                const response = await new Promise((resolve) =>
+                    request(app)
+                        .post("/auth/user/email/verify/token")
+                        .end((err, res) => {
+                            if (err) {
+                                resolve(undefined);
+                            } else {
+                                resolve(res);
+                            }
+                        })
+                );
+
+                assert(response.status === 401);
+                assert(JSON.parse(response.text).message === "unauthorised");
+                assert(Object.keys(JSON.parse(response.text)).length === 1);
+            });
+
+            it("test the email verify API with invalid token and check error", async function () {
+                const response = await new Promise((resolve) =>
+                    request(app)
+                        .post("/auth/user/email/verify")
+                        .send({
+                            method: "token",
+                            token: "randomToken",
+                        })
+                        .expect(200)
+                        .end((err, res) => {
+                            if (err) {
+                                resolve(err);
+                            } else {
+                                resolve(res);
+                            }
+                        })
+                );
+                assert(JSON.parse(response.text).status === "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR");
+                assert(Object.keys(JSON.parse(response.text)).length === 1);
+            });
+
+            it("test the email verify API with token of not type string", async function () {
+                const response = await new Promise((resolve) =>
+                    request(app)
+                        .post("/auth/user/email/verify")
+                        .send({
+                            method: "token",
+                            token: 2000,
+                        })
+                        .end((err, res) => {
+                            if (err) {
+                                resolve(undefined);
+                            } else {
+                                resolve(res);
+                            }
+                        })
+                );
+                assert(response.status === 400);
+                assert(JSON.parse(response.text).message === "The email verification token must be a string");
+                assert(Object.keys(JSON.parse(response.text)).length === 1);
+            });
+
+            it("test the email verify with no session, using the get method", async function () {
+                const response = await new Promise((resolve) =>
+                    request(app)
+                        .get("/auth/user/email/verify")
+                        .end((err, res) => {
+                            if (err) {
+                                resolve(undefined);
+                            } else {
+                                resolve(res);
+                            }
+                        })
+                );
+
+                assert(response.status === 401);
+                assert(JSON.parse(response.text).message === "unauthorised");
+                assert(Object.keys(JSON.parse(response.text)).length === 1);
+            });
+
+            it("test the generate token api with an expired access token and see that try refresh token is returned", async function () {
+                // Create and use new user for this test.
+                const response = await signUPRequest(app, "exist2@supertokens.io", "testPass123");
+                const userId = JSON.parse(response.text).user.id;
+                const infoFromResponse = extractInfoFromResponse(response);
+                await new Promise((r) => setTimeout(r, 1100));
+
+                let emailVerifyTokenResponse = await emailVerifyTokenRequest(
+                    app,
+                    infoFromResponse.accessToken,
+                    infoFromResponse.idRefreshTokenFromCookie,
+                    infoFromResponse.antiCsrf,
+                    userId
+                );
+
+                assert(emailVerifyTokenResponse.status === 401);
+                assert(JSON.parse(emailVerifyTokenResponse.text).message === "try refresh token");
+                assert(Object.keys(JSON.parse(emailVerifyTokenResponse.text)).length === 1);
+
+                const refreshedResponse = extractInfoFromResponse(
+                    await new Promise((resolve) =>
+                        request(app)
+                            .post("/auth/session/refresh")
+                            .expect(200)
+                            .set("Cookie", ["sRefreshToken=" + infoFromResponse.refreshToken])
+                            .set("anti-csrf", infoFromResponse.antiCsrf)
+                            .expect(200)
+                            .end((err, res) => {
+                                if (err) {
+                                    resolve(undefined);
+                                } else {
+                                    resolve(res);
+                                }
+                            })
+                    )
+                );
+
+                emailVerifyTokenResponse = await emailVerifyTokenRequest(
+                    app,
+                    refreshedResponse.accessToken,
+                    refreshedResponse.idRefreshTokenFromCookie,
+                    refreshedResponse.antiCsrf,
+                    userId
+                );
+
+                assert.deepStrictEqual(emailVerifyTokenResponse.status, 200);
+                assert.deepStrictEqual(JSON.parse(emailVerifyTokenResponse.text).status, "OK");
+                assert.deepStrictEqual(Object.keys(JSON.parse(emailVerifyTokenResponse.text)).length, 1);
+            });
         }
-
-        const app = express();
-
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        let response = await signUPRequest(app, "test@gmail.com", "testPass123");
-        assert(JSON.parse(response.text).status === "OK");
-        assert(response.status === 200);
-
-        let userId = JSON.parse(response.text).user.id;
-        let infoFromResponse = extractInfoFromResponse(response);
-
-        let verifyToken = await EmailPassword.createEmailVerificationToken(userId);
-        await EmailPassword.verifyEmailUsingToken(verifyToken);
-
-        response = await emailVerifyTokenRequest(
-            app,
-            infoFromResponse.accessToken,
-            infoFromResponse.idRefreshTokenFromCookie,
-            infoFromResponse.antiCsrf,
-            userId
-        );
-
-        assert(JSON.parse(response.text).status === "EMAIL_ALREADY_VERIFIED_ERROR");
-        assert(response.status === 200);
-        assert(Object.keys(JSON.parse(response.text)).length === 1);
     });
 
-    // Call the API with no session and see the output
-    it("test the generate token api with valid input, no session and check output", async function () {
-        await startST();
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [EmailPassword.init(), Session.init()],
-        });
+    describe("With custom callbacks", function () {
+        let app, userId, infoFromResponse, userInfo;
+        let emailToken, token, userInfoFromCallback;
 
-        let currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
-        if (maxVersion(currCDIVersion, "2.4") === "2.4") {
-            return;
-        }
+        before(async function () {
+            await killAllST();
+            await setupST();
 
-        const app = express();
+            // Set key value in config.
+            await setKeyValueInConfig("access_token_validity", 1);
+            await startST();
 
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        let response = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/user/email/verify/token")
-                .end((err, res) => {
-                    if (err) {
-                        resolve(undefined);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
-
-        assert(response.status === 401);
-        assert(JSON.parse(response.text).message === "unauthorised");
-        assert(Object.keys(JSON.parse(response.text)).length === 1);
-    });
-
-    // Call the API with an expired access token and see that try refresh token is returned
-    it("test the generate token api with an expired access token and see that try refresh token is returned", async function () {
-        await setKeyValueInConfig("access_token_validity", 2);
-        await startST();
-
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [EmailPassword.init(), Session.init()],
-        });
-
-        let currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
-        if (maxVersion(currCDIVersion, "2.4") === "2.4") {
-            return;
-        }
-
-        const app = express();
-
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        let response = await signUPRequest(app, "test@gmail.com", "testPass123");
-        assert(JSON.parse(response.text).status === "OK");
-        assert(response.status === 200);
-
-        let userId = JSON.parse(response.text).user.id;
-        let infoFromResponse = extractInfoFromResponse(response);
-
-        await new Promise((r) => setTimeout(r, 5000));
-
-        let response2 = await emailVerifyTokenRequest(
-            app,
-            infoFromResponse.accessToken,
-            infoFromResponse.idRefreshTokenFromCookie,
-            infoFromResponse.antiCsrf,
-            userId
-        );
-
-        assert(response2.status === 401);
-        assert(JSON.parse(response2.text).message === "try refresh token");
-        assert(Object.keys(JSON.parse(response2.text)).length === 1);
-
-        let refreshedResponse = extractInfoFromResponse(
-            await new Promise((resolve) =>
-                request(app)
-                    .post("/auth/session/refresh")
-                    .expect(200)
-                    .set("Cookie", ["sRefreshToken=" + infoFromResponse.refreshToken])
-                    .set("anti-csrf", infoFromResponse.antiCsrf)
-                    .expect(200)
-                    .end((err, res) => {
-                        if (err) {
-                            resolve(undefined);
-                        } else {
-                            resolve(res);
-                        }
-                    })
-            )
-        );
-
-        let response3 = (response = await emailVerifyTokenRequest(
-            app,
-            refreshedResponse.accessToken,
-            refreshedResponse.idRefreshTokenFromCookie,
-            refreshedResponse.antiCsrf,
-            userId
-        ));
-
-        assert(response3.status === 200);
-        assert(JSON.parse(response3.text).status === "OK");
-        assert(Object.keys(JSON.parse(response3.text)).length === 1);
-    });
-
-    // Provide your own email callback and make sure that is called
-    it("test that providing your own email callback and make sure it is called", async function () {
-        await startST();
-
-        let userInfo = null;
-        let emailToken = null;
-
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [
-                EmailPassword.init({
-                    emailVerificationFeature: {
-                        createAndSendCustomEmail: (user, emailVerificationURLWithToken) => {
-                            userInfo = user;
-                            emailToken = emailVerificationURLWithToken;
+            STExpress.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                },
+                appInfo: {
+                    apiDomain: "api.supertokens.io",
+                    appName: "SuperTokens",
+                    websiteDomain: "supertokens.io",
+                },
+                recipeList: [
+                    EmailPassword.init({
+                        emailVerificationFeature: {
+                            handlePostEmailVerification: (user) => {
+                                userInfoFromCallback = user;
+                            },
+                            createAndSendCustomEmail: (user, emailVerificationURLWithToken) => {
+                                userInfo = user;
+                                emailToken = emailVerificationURLWithToken;
+                                token = emailVerificationURLWithToken.split("?token=")[1].split("&rid=")[0];
+                            },
                         },
-                    },
-                }),
-                Session.init(),
-            ],
+                    }),
+                    Session.init(),
+                ],
+            });
+
+            app = express();
+            app.use(STExpress.middleware());
+            app.use(STExpress.errorHandler());
+
+            const currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
+            shouldRunTest = maxVersion(currCDIVersion, "2.4") !== "2.4";
+
+            const response = await signUPRequest(app, "test@gmail.com", "testPass123");
+            assert(JSON.parse(response.text).status === "OK");
+            assert(response.status === 200);
+
+            userId = JSON.parse(response.text).user.id;
+            infoFromResponse = extractInfoFromResponse(response);
         });
 
-        let currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
-        if (maxVersion(currCDIVersion, "2.4") === "2.4") {
-            return;
-        }
-
-        const app = express();
-
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        let response = await signUPRequest(app, "test@gmail.com", "testPass123");
-        assert(JSON.parse(response.text).status === "OK");
-        assert(response.status === 200);
-
-        let userId = JSON.parse(response.text).user.id;
-        let infoFromResponse = extractInfoFromResponse(response);
-
-        let response2 = await emailVerifyTokenRequest(
-            app,
-            infoFromResponse.accessToken,
-            infoFromResponse.idRefreshTokenFromCookie,
-            infoFromResponse.antiCsrf,
-            userId
-        );
-
-        assert(response2.status === 200);
-
-        assert(JSON.parse(response2.text).status === "OK");
-        assert(Object.keys(JSON.parse(response2.text)).length === 1);
-
-        assert(userInfo.id === userId);
-        assert(userInfo.email === "test@gmail.com");
-        assert(emailToken !== null);
-    });
-
-    /*
-    email verify API:
-        POST:
-          - Call the API with valid input
-          - Call the API with an invalid token and see the error
-          - token is not of type string from input
-          - provide a handlePostEmailVerification callback and make sure it's called on success verification
-        GET:
-          - Call the API with valid input
-          - Call the API with no session and see the error
-          - Call the API with an expired access token and see that try refresh token is returned
-    */
-    it("test the email verify API with valid input", async function () {
-        await startST();
-
-        let token = null;
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [
-                EmailPassword.init({
-                    emailVerificationFeature: {
-                        createAndSendCustomEmail: (user, emailVerificationURLWithToken) => {
-                            token = emailVerificationURLWithToken.split("?token=")[1].split("&rid=")[0];
-                        },
-                    },
-                }),
-                Session.init(),
-            ],
+        after(async function () {
+            await killAllST();
+            await cleanST();
         });
 
-        let currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
-        if (maxVersion(currCDIVersion, "2.4") === "2.4") {
-            return;
-        }
-
-        const app = express();
-
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        let response = await signUPRequest(app, "test@gmail.com", "testPass123");
-        assert(JSON.parse(response.text).status === "OK");
-        assert(response.status === 200);
-
-        let userId = JSON.parse(response.text).user.id;
-        let infoFromResponse = extractInfoFromResponse(response);
-
-        response = await emailVerifyTokenRequest(
-            app,
-            infoFromResponse.accessToken,
-            infoFromResponse.idRefreshTokenFromCookie,
-            infoFromResponse.antiCsrf,
-            userId
-        );
-        assert(JSON.parse(response.text).status === "OK");
-        assert(Object.keys(JSON.parse(response.text)).length === 1);
-
-        let response2 = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/user/email/verify")
-                .send({
-                    method: "token",
-                    token,
-                })
-                .expect(200)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(err);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
-
-        assert(JSON.parse(response2.text).status === "OK");
-        assert(Object.keys(JSON.parse(response2.text)).length === 1);
-    });
-
-    // Call the API with an invalid token and see the error
-    it("test the email verify API with invalid token and check error", async function () {
-        await startST();
-
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [EmailPassword.init(), Session.init()],
+        afterEach(async function () {
+            emailToken = undefined;
+            token = undefined;
+            userInfoFromCallback = undefined;
         });
 
-        let currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
-        if (maxVersion(currCDIVersion, "2.4") === "2.4") {
-            return;
+        if (shouldRunTest === true) {
+            // Provide your own email callback and make sure that is called
+            it("test custom callbacks (handlePostEmailVerification and createAndSendCustomEmail)", async function () {
+                const response = await emailVerifyTokenRequest(
+                    app,
+                    infoFromResponse.accessToken,
+                    infoFromResponse.idRefreshTokenFromCookie,
+                    infoFromResponse.antiCsrf,
+                    userId
+                );
+
+                assert.deepStrictEqual(response.status, 200);
+
+                assert.deepStrictEqual(JSON.parse(response.text).status, "OK");
+                assert.deepStrictEqual(Object.keys(JSON.parse(response.text)).length, 1);
+
+                assert.deepStrictEqual(userInfo.id, userId);
+                assert.deepStrictEqual(userInfo.email, "test@gmail.com");
+                assert.notDeepStrictEqual(emailToken, null);
+            });
+
+            /*
+            email verify API:
+                POST:
+                - Call the API with valid input
+                - Call the API with an invalid token and see the error
+                - token is not of type string from input
+                - provide a handlePostEmailVerification callback and make sure it's called on success verification
+                GET:
+                - Call the API with valid input
+                - Call the API with no session and see the error
+                - Call the API with an expired access token and see that try refresh token is returned
+            */
+            it("test the email verify API with valid input", async function () {
+                const emailVerifyTokenResponse = await emailVerifyTokenRequest(
+                    app,
+                    infoFromResponse.accessToken,
+                    infoFromResponse.idRefreshTokenFromCookie,
+                    infoFromResponse.antiCsrf,
+                    userId
+                );
+                assert(JSON.parse(emailVerifyTokenResponse.text).status === "OK");
+                assert(Object.keys(JSON.parse(emailVerifyTokenResponse.text)).length === 1);
+
+                let response = await new Promise((resolve) =>
+                    request(app)
+                        .post("/auth/user/email/verify")
+                        .send({
+                            method: "token",
+                            token,
+                        })
+                        .expect(200)
+                        .end((err, res) => {
+                            if (err) {
+                                resolve(err);
+                            } else {
+                                resolve(res);
+                            }
+                        })
+                );
+
+                assert(JSON.parse(response.text).status === "OK");
+                assert(Object.keys(JSON.parse(response.text)).length === 1);
+                assert.deepStrictEqual(userInfoFromCallback.id, userId);
+                assert.deepStrictEqual(userInfoFromCallback.email, "test@gmail.com");
+            });
+
+            it("test the email verify API with valid input, using the get method", async function () {
+                const signUPResponse = await signUPRequest(app, "test2@gmail.com", "testPass123");
+                assert(JSON.parse(signUPResponse.text).status === "OK");
+                assert(signUPResponse.status === 200);
+
+                const userId = JSON.parse(signUPResponse.text).user.id;
+                const infoFromResponse = extractInfoFromResponse(signUPResponse);
+
+                const emailVerifyTokenResponse = await emailVerifyTokenRequest(
+                    app,
+                    infoFromResponse.accessToken,
+                    infoFromResponse.idRefreshTokenFromCookie,
+                    infoFromResponse.antiCsrf,
+                    userId
+                );
+                assert(JSON.parse(emailVerifyTokenResponse.text).status === "OK");
+
+                const sendEmailVerifyAPIResponse = await new Promise((resolve) =>
+                    request(app)
+                        .post("/auth/user/email/verify")
+                        .send({
+                            method: "token",
+                            token,
+                        })
+                        .expect(200)
+                        .end((err, res) => {
+                            if (err) {
+                                resolve(err);
+                            } else {
+                                resolve(res);
+                            }
+                        })
+                );
+
+                assert(JSON.parse(sendEmailVerifyAPIResponse.text).status === "OK");
+
+                const emailVerifyAPIResponse = await new Promise((resolve) =>
+                    request(app)
+                        .get("/auth/user/email/verify")
+                        .set("Cookie", [
+                            "sAccessToken=" +
+                                infoFromResponse.accessToken +
+                                ";sIdRefreshToken=" +
+                                infoFromResponse.idRefreshTokenFromCookie,
+                        ])
+                        .set("anti-csrf", infoFromResponse.antiCsrf)
+                        .expect(200)
+                        .end((err, res) => {
+                            if (err) {
+                                resolve(err);
+                            } else {
+                                resolve(res);
+                            }
+                        })
+                );
+                assert(JSON.parse(emailVerifyAPIResponse.text).status === "OK");
+                assert(JSON.parse(emailVerifyAPIResponse.text).isVerified === true);
+                assert(Object.keys(JSON.parse(emailVerifyAPIResponse.text)).length === 2);
+            });
+
+            it("test the email verify API with an expired access token, using the get method", async function () {
+                // Create and use new user.
+                const response = await signUPRequest(app, "exist2@supertokens.io", "testPass123");
+                const userId = JSON.parse(response.text).user.id;
+                const infoFromResponse = extractInfoFromResponse(response);
+
+                const emailVerifyTokenResponse = await emailVerifyTokenRequest(
+                    app,
+                    infoFromResponse.accessToken,
+                    infoFromResponse.idRefreshTokenFromCookie,
+                    infoFromResponse.antiCsrf,
+                    userId
+                );
+                assert(JSON.parse(emailVerifyTokenResponse.text).status === "OK");
+
+                let emailVerifyTokenAPIResponse = await new Promise((resolve) =>
+                    request(app)
+                        .post("/auth/user/email/verify")
+                        .send({
+                            method: "token",
+                            token,
+                        })
+                        .expect(200)
+                        .end((err, res) => {
+                            if (err) {
+                                resolve(err);
+                            } else {
+                                resolve(res);
+                            }
+                        })
+                );
+
+                assert(JSON.parse(emailVerifyTokenAPIResponse.text).status === "OK");
+
+                await new Promise((r) => setTimeout(r, 1100));
+
+                emailVerifyTokenAPIResponse = await new Promise((resolve) =>
+                    request(app)
+                        .get("/auth/user/email/verify")
+                        .set("Cookie", [
+                            "sAccessToken=" +
+                                infoFromResponse.accessToken +
+                                ";sIdRefreshToken=" +
+                                infoFromResponse.idRefreshTokenFromCookie,
+                        ])
+                        .set("anti-csrf", infoFromResponse.antiCsrf)
+                        .end((err, res) => {
+                            if (err) {
+                                resolve(err);
+                            } else {
+                                resolve(res);
+                            }
+                        })
+                );
+                assert(emailVerifyTokenAPIResponse.status === 401);
+                assert(JSON.parse(emailVerifyTokenAPIResponse.text).message === "try refresh token");
+                assert(Object.keys(JSON.parse(emailVerifyTokenAPIResponse.text)).length === 1);
+
+                let refreshedResponse = extractInfoFromResponse(
+                    await new Promise((resolve) =>
+                        request(app)
+                            .post("/auth/session/refresh")
+                            .expect(200)
+                            .set("Cookie", ["sRefreshToken=" + infoFromResponse.refreshToken])
+                            .set("anti-csrf", infoFromResponse.antiCsrf)
+                            .expect(200)
+                            .end((err, res) => {
+                                if (err) {
+                                    resolve(undefined);
+                                } else {
+                                    resolve(res);
+                                }
+                            })
+                    )
+                );
+
+                emailVerifyTokenAPIResponse = await new Promise((resolve) =>
+                    request(app)
+                        .get("/auth/user/email/verify")
+                        .set("Cookie", [
+                            "sAccessToken=" +
+                                refreshedResponse.accessToken +
+                                ";sIdRefreshToken=" +
+                                refreshedResponse.idRefreshTokenFromCookie,
+                        ])
+                        .set("anti-csrf", refreshedResponse.antiCsrf)
+                        .expect(200)
+                        .end((err, res) => {
+                            if (err) {
+                                resolve(err);
+                            } else {
+                                resolve(res);
+                            }
+                        })
+                );
+                assert(JSON.parse(emailVerifyTokenAPIResponse.text).status === "OK");
+                assert(JSON.parse(emailVerifyTokenAPIResponse.text).isVerified === true);
+            });
         }
-
-        const app = express();
-
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        response = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/user/email/verify")
-                .send({
-                    method: "token",
-                    token: "randomToken",
-                })
-                .expect(200)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(err);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
-        assert(JSON.parse(response.text).status === "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR");
-        assert(Object.keys(JSON.parse(response.text)).length === 1);
-    });
-
-    // token is not of type string from input
-    it("test the email verify API with token of not type string", async function () {
-        await startST();
-
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [EmailPassword.init(), Session.init()],
-        });
-
-        let currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
-        if (maxVersion(currCDIVersion, "2.4") === "2.4") {
-            return;
-        }
-
-        const app = express();
-
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        response = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/user/email/verify")
-                .send({
-                    method: "token",
-                    token: 2000,
-                })
-                .end((err, res) => {
-                    if (err) {
-                        resolve(undefined);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
-        assert(response.status === 400);
-        assert(JSON.parse(response.text).message === "The email verification token must be a string");
-        assert(Object.keys(JSON.parse(response.text)).length === 1);
-    });
-
-    // provide a handlePostEmailVerification callback and make sure it's called on success verification
-    it("test that the handlePostEmailVerification callback is called on successfull verification, if given", async function () {
-        await startST();
-
-        let userInfoFromCallback = null;
-        let token = null;
-
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [
-                EmailPassword.init({
-                    emailVerificationFeature: {
-                        handlePostEmailVerification: (user) => {
-                            userInfoFromCallback = user;
-                        },
-                        createAndSendCustomEmail: (user, emailVerificationURLWithToken) => {
-                            token = emailVerificationURLWithToken.split("?token=")[1].split("&rid=")[0];
-                        },
-                    },
-                }),
-                Session.init(),
-            ],
-        });
-
-        let currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
-        if (maxVersion(currCDIVersion, "2.4") === "2.4") {
-            return;
-        }
-
-        const app = express();
-
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        let response = await signUPRequest(app, "test@gmail.com", "testPass123");
-        assert(JSON.parse(response.text).status === "OK");
-        assert(response.status === 200);
-
-        let userId = JSON.parse(response.text).user.id;
-        let infoFromResponse = extractInfoFromResponse(response);
-
-        response = await emailVerifyTokenRequest(
-            app,
-            infoFromResponse.accessToken,
-            infoFromResponse.idRefreshTokenFromCookie,
-            infoFromResponse.antiCsrf,
-            userId
-        );
-        assert(JSON.parse(response.text).status === "OK");
-
-        let response2 = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/user/email/verify")
-                .send({
-                    method: "token",
-                    token,
-                })
-                .expect(200)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(err);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
-
-        assert(JSON.parse(response2.text).status === "OK");
-        assert(Object.keys(JSON.parse(response2.text)).length === 1);
-
-        assert(userInfoFromCallback.id === userId);
-        assert(userInfoFromCallback.email === "test@gmail.com");
-    });
-
-    // Call the API with valid input
-    it("test the email verify with valid input, using the get method", async function () {
-        await startST();
-
-        let token = null;
-
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [
-                EmailPassword.init({
-                    emailVerificationFeature: {
-                        createAndSendCustomEmail: (user, emailVerificationURLWithToken) => {
-                            token = emailVerificationURLWithToken.split("?token=")[1].split("&rid=")[0];
-                        },
-                    },
-                }),
-                Session.init(),
-            ],
-        });
-
-        let currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
-        if (maxVersion(currCDIVersion, "2.4") === "2.4") {
-            return;
-        }
-
-        const app = express();
-
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        let response = await signUPRequest(app, "test@gmail.com", "testPass123");
-        assert(JSON.parse(response.text).status === "OK");
-        assert(response.status === 200);
-
-        let userId = JSON.parse(response.text).user.id;
-        let infoFromResponse = extractInfoFromResponse(response);
-
-        response = await emailVerifyTokenRequest(
-            app,
-            infoFromResponse.accessToken,
-            infoFromResponse.idRefreshTokenFromCookie,
-            infoFromResponse.antiCsrf,
-            userId
-        );
-        assert(JSON.parse(response.text).status === "OK");
-
-        let response2 = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/user/email/verify")
-                .send({
-                    method: "token",
-                    token,
-                })
-                .expect(200)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(err);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
-
-        assert(JSON.parse(response2.text).status === "OK");
-
-        let response3 = await new Promise((resolve) =>
-            request(app)
-                .get("/auth/user/email/verify")
-                .set("Cookie", [
-                    "sAccessToken=" +
-                        infoFromResponse.accessToken +
-                        ";sIdRefreshToken=" +
-                        infoFromResponse.idRefreshTokenFromCookie,
-                ])
-                .set("anti-csrf", infoFromResponse.antiCsrf)
-                .expect(200)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(err);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
-        assert(JSON.parse(response3.text).status === "OK");
-        assert(JSON.parse(response3.text).isVerified === true);
-        assert(Object.keys(JSON.parse(response3.text)).length === 2);
-    });
-
-    // Call the API with no session and see the error
-    it("test the email verify with no session, using the get method", async function () {
-        await startST();
-
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [EmailPassword.init(), Session.init()],
-        });
-
-        let currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
-        if (maxVersion(currCDIVersion, "2.4") === "2.4") {
-            return;
-        }
-
-        const app = express();
-
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        let response = await new Promise((resolve) =>
-            request(app)
-                .get("/auth/user/email/verify")
-                .end((err, res) => {
-                    if (err) {
-                        resolve(undefined);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
-
-        assert(response.status === 401);
-        assert(JSON.parse(response.text).message === "unauthorised");
-        assert(Object.keys(JSON.parse(response.text)).length === 1);
-    });
-
-    // Call the API with an expired access token and see that try refresh token is returned
-    it("test the email verify with an expired access token, using the get method", async function () {
-        await setKeyValueInConfig("access_token_validity", 2);
-        await startST();
-
-        let token = null;
-
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [
-                EmailPassword.init({
-                    emailVerificationFeature: {
-                        createAndSendCustomEmail: (user, emailVerificationURLWithToken) => {
-                            token = emailVerificationURLWithToken.split("?token=")[1].split("&rid=")[0];
-                        },
-                    },
-                }),
-                Session.init(),
-            ],
-        });
-
-        let currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
-        if (maxVersion(currCDIVersion, "2.4") === "2.4") {
-            return;
-        }
-
-        const app = express();
-
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        let response = await signUPRequest(app, "test@gmail.com", "testPass123");
-        assert(JSON.parse(response.text).status === "OK");
-        assert(response.status === 200);
-
-        let userId = JSON.parse(response.text).user.id;
-        let infoFromResponse = extractInfoFromResponse(response);
-
-        response = await emailVerifyTokenRequest(
-            app,
-            infoFromResponse.accessToken,
-            infoFromResponse.idRefreshTokenFromCookie,
-            infoFromResponse.antiCsrf,
-            userId
-        );
-        assert(JSON.parse(response.text).status === "OK");
-
-        let response2 = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/user/email/verify")
-                .send({
-                    method: "token",
-                    token,
-                })
-                .expect(200)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(err);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
-
-        assert(JSON.parse(response2.text).status === "OK");
-
-        await new Promise((r) => setTimeout(r, 5000));
-
-        let response3 = await new Promise((resolve) =>
-            request(app)
-                .get("/auth/user/email/verify")
-                .set("Cookie", [
-                    "sAccessToken=" +
-                        infoFromResponse.accessToken +
-                        ";sIdRefreshToken=" +
-                        infoFromResponse.idRefreshTokenFromCookie,
-                ])
-                .set("anti-csrf", infoFromResponse.antiCsrf)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(err);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
-        assert(response3.status === 401);
-        assert(JSON.parse(response3.text).message === "try refresh token");
-        assert(Object.keys(JSON.parse(response3.text)).length === 1);
-
-        let refreshedResponse = extractInfoFromResponse(
-            await new Promise((resolve) =>
-                request(app)
-                    .post("/auth/session/refresh")
-                    .expect(200)
-                    .set("Cookie", ["sRefreshToken=" + infoFromResponse.refreshToken])
-                    .set("anti-csrf", infoFromResponse.antiCsrf)
-                    .expect(200)
-                    .end((err, res) => {
-                        if (err) {
-                            resolve(undefined);
-                        } else {
-                            resolve(res);
-                        }
-                    })
-            )
-        );
-
-        let response4 = await new Promise((resolve) =>
-            request(app)
-                .get("/auth/user/email/verify")
-                .set("Cookie", [
-                    "sAccessToken=" +
-                        refreshedResponse.accessToken +
-                        ";sIdRefreshToken=" +
-                        refreshedResponse.idRefreshTokenFromCookie,
-                ])
-                .set("anti-csrf", refreshedResponse.antiCsrf)
-                .expect(200)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(err);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
-        assert(JSON.parse(response4.text).status === "OK");
-        assert(JSON.parse(response4.text).isVerified === true);
-        assert(Object.keys(JSON.parse(response.text)).length === 1);
     });
 });

--- a/test/emailpassword/signinFeature.test.js
+++ b/test/emailpassword/signinFeature.test.js
@@ -13,994 +13,672 @@
  * under the License.
  */
 
-const {
-    printPath,
-    setupST,
-    startST,
-    stopST,
-    killAllST,
-    cleanST,
-    resetAll,
-    signUPRequest,
-    extractInfoFromResponse,
-} = require("../utils");
+const { printPath, setupST, startST, killAllST, cleanST, signUPRequest, extractInfoFromResponse } = require("../utils");
 let STExpress = require("../../");
 let Session = require("../../recipe/session");
-let SessionRecipe = require("../../lib/build/recipe/session/sessionRecipe").default;
 let assert = require("assert");
 let { ProcessState } = require("../../lib/build/processState");
-let { normaliseURLPathOrThrowError } = require("../../lib/build/normalisedURLPath");
-let { normaliseURLDomainOrThrowError } = require("../../lib/build/normalisedURLDomain");
-let { normaliseSessionScopeOrThrowError } = require("../../lib/build/recipe/session/utils");
-const { Querier } = require("../../lib/build/querier");
 let EmailPassword = require("../../recipe/emailpassword");
 let EmailPasswordRecipe = require("../../lib/build/recipe/emailpassword/recipe").default;
-let utils = require("../../lib/build/recipe/emailpassword/utils");
 const express = require("express");
 const request = require("supertest");
-const { default: NormalisedURLPath } = require("../../lib/build/normalisedURLPath");
 
 describe(`signinFeature: ${printPath("[test/emailpassword/signinFeature.test.js]")}`, function () {
-    beforeEach(async function () {
-        await killAllST();
-        await setupST();
-        ProcessState.getInstance().reset();
-    });
+    describe("With default implementation enabled", function () {
+        let app, signUpUserInfo;
 
-    after(async function () {
-        await killAllST();
-        await cleanST();
-    });
+        before(async function () {
+            await killAllST();
+            await setupST();
+            await startST();
+            STExpress.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                },
+                appInfo: {
+                    apiDomain: "api.supertokens.io",
+                    appName: "SuperTokens",
+                    websiteDomain: "supertokens.io",
+                },
+                recipeList: [EmailPassword.init(), Session.init()],
+            });
 
-    // check if disableDefaultImplementation is true, the default signin API does not work - you get a 404
-    /*
-    Failure condition:
-    Set  disableDefaultImplementation to false in the signInFeature
-    */
-    it("test that disableDefaultImplementation is true, the default signin API does not work", async function () {
-        await startST();
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [
-                EmailPassword.init({
-                    signInFeature: {
-                        disableDefaultImplementation: true,
-                    },
-                }),
-            ],
+            app = express();
+
+            app.use(STExpress.middleware());
+
+            app.use(STExpress.errorHandler());
+
+            const signUPResponse = await signUPRequest(app, "random@gmail.com", "validpass123");
+            assert.deepStrictEqual(JSON.parse(signUPResponse.text).status, "OK");
+            assert.deepStrictEqual(signUPResponse.status, 200);
+            signUpUserInfo = JSON.parse(signUPResponse.text).user;
         });
 
-        const app = express();
-
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        let response = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/signin")
-                .send({
-                    formFields: [
-                        {
-                            id: "password",
-                            value: "validpass123",
-                        },
-                        {
-                            id: "email",
-                            value: "random@gmail.com",
-                        },
-                    ],
-                })
-                .end((err, res) => {
-                    if (err) {
-                        resolve(undefined);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
-        assert(response.status === 404);
-    });
-
-    /*
-     * test signInAPI for:
-     *        - it works when the input is fine (sign up, and then sign in and check you get the user's info)
-     *        - throws an error if the email does not match
-     *        - throws an error if the password is incorrect
-     */
-
-    /*
-    Failure condition:
-    Setting  invalid email or password values in the request body when sending a request to /signin 
-    */
-    it("test singinAPI works when input is fine", async function () {
-        await startST();
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [EmailPassword.init(), Session.init()],
+        beforeEach(async function () {
+            ProcessState.getInstance().reset();
         });
 
-        const app = express();
-
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        let response = await signUPRequest(app, "random@gmail.com", "validpass123");
-        assert(JSON.parse(response.text).status === "OK");
-        assert(response.status === 200);
-
-        let signUpUserInfo = JSON.parse(response.text).user;
-
-        let userInfo = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/signin")
-                .send({
-                    formFields: [
-                        {
-                            id: "password",
-                            value: "validpass123",
-                        },
-                        {
-                            id: "email",
-                            value: "random@gmail.com",
-                        },
-                    ],
-                })
-                .expect(200)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(undefined);
-                    } else {
-                        resolve(JSON.parse(res.text).user);
-                    }
-                })
-        );
-        assert(userInfo.id === signUpUserInfo.id);
-        assert(userInfo.email === signUpUserInfo.email);
-    });
-
-    /*
-    Setting the email value in form field as random@gmail.com causes the test to fail
-    */
-    it("test singinAPI throws an error when email does not match", async function () {
-        await startST();
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [EmailPassword.init(), Session.init()],
+        after(async function () {
+            await killAllST();
+            await cleanST();
         });
 
-        const app = express();
+        /*
+         * test signInAPI for:
+         *        - it works when the input is fine (sign up, and then sign in and check you get the user's info)
+         *        - throws an error if the email does not match
+         *        - throws an error if the password is incorrect
+         */
 
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        let signUpResponse = await signUPRequest(app, "random@gmail.com", "validpass123");
-        assert(JSON.parse(signUpResponse.text).status === "OK");
-        assert(signUpResponse.status === 200);
-
-        let invalidEmailResponse = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/signin")
-                .send({
-                    formFields: [
-                        {
-                            id: "password",
-                            value: "validpass123",
-                        },
-                        {
-                            id: "email",
-                            value: "ran@gmail.com",
-                        },
-                    ],
-                })
-                .expect(200)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(undefined);
-                    } else {
-                        resolve(JSON.parse(res.text));
-                    }
-                })
-        );
-        assert(invalidEmailResponse.status === "WRONG_CREDENTIALS_ERROR");
-    });
-
-    // throws an error if the password is incorrect
-    /*
-    passing the correct password "validpass123" causes the test to fail
-    */
-    it("test singinAPI throws an error if password is incorrect", async function () {
-        await startST();
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [EmailPassword.init(), Session.init()],
-        });
-
-        const app = express();
-
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        let signUpResponse = await signUPRequest(app, "random@gmail.com", "validpass123");
-        assert(JSON.parse(signUpResponse.text).status === "OK");
-        assert(signUpResponse.status === 200);
-
-        let invalidPasswordResponse = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/signin")
-                .send({
-                    formFields: [
-                        {
-                            id: "password",
-                            value: "validpass12345",
-                        },
-                        {
-                            id: "email",
-                            value: "random@gmail.com",
-                        },
-                    ],
-                })
-                .expect(200)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(undefined);
-                    } else {
-                        resolve(JSON.parse(res.text));
-                    }
-                })
-        );
-        assert(invalidPasswordResponse.status === "WRONG_CREDENTIALS_ERROR");
-    });
-
-    /*
-     * pass a bad input to the /signin API and test that it throws a 400 error.
-     *        - Not a JSON
-     *        - No POST body
-     *        - Input is JSON, but wrong structure.
-     */
-    /*
-    Failure condition:
-    setting valid JSON body to /singin API
-    */
-    it("test bad input, not a JSON to /signin API", async function () {
-        await startST();
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [EmailPassword.init(), Session.init()],
-        });
-
-        const app = express();
-
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        let signUpResponse = await signUPRequest(app, "random@gmail.com", "validpass123");
-        assert(JSON.parse(signUpResponse.text).status === "OK");
-        assert(signUpResponse.status === 200);
-
-        let badInputResponse = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/signin")
-                .send("hello")
-                .expect(400)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(undefined);
-                    } else {
-                        resolve(JSON.parse(res.text));
-                    }
-                })
-        );
-        assert(badInputResponse.message === "Missing input param: formFields");
-    });
-
-    /*
-    Failure condition:
-    setting valid formFields JSON body to /singin API
-    */
-    it("test bad input, no POST body to /signin API", async function () {
-        await startST();
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [EmailPassword.init(), Session.init()],
-        });
-
-        const app = express();
-
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        let signUpResponse = await signUPRequest(app, "random@gmail.com", "validpass123");
-        assert(JSON.parse(signUpResponse.text).status === "OK");
-        assert(signUpResponse.status === 200);
-
-        let badInputResponse = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/signin")
-                .expect(400)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(undefined);
-                    } else {
-                        resolve(JSON.parse(res.text));
-                    }
-                })
-        );
-        assert(badInputResponse.message === "Missing input param: formFields");
-    });
-
-    /*
-    Failure condition:
-    setting valid JSON body to /singin API
-    */
-    it("test bad input, input is Json but incorrect structure to /signin API", async function () {
-        await startST();
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [EmailPassword.init(), Session.init()],
-        });
-        const app = express();
-
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        let signUpResponse = await signUPRequest(app, "random@gmail.com", "validpass123");
-        assert(JSON.parse(signUpResponse.text).status === "OK");
-        assert(signUpResponse.status === 200);
-
-        let badInputResponse = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/signin")
-                .send({
-                    randomKey: "randomValue",
-                })
-                .expect(400)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(undefined);
-                    } else {
-                        resolve(JSON.parse(res.text));
-                    }
-                })
-        );
-        assert(badInputResponse.message === "Missing input param: formFields");
-    });
-
-    // Make sure that a successful sign in yields a session
-    /*
-    Passing invalid credentials to the /signin API fails the test
-    */
-    it("test that a successfull signin yields a session", async function () {
-        await startST();
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [EmailPassword.init(), Session.init()],
-        });
-        const app = express();
-
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        let signUpResponse = await signUPRequest(app, "random@gmail.com", "validpass123");
-        assert(JSON.parse(signUpResponse.text).status === "OK");
-        assert(signUpResponse.status === 200);
-
-        let response = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/signin")
-                .send({
-                    formFields: [
-                        {
-                            id: "password",
-                            value: "validpass123",
-                        },
-                        {
-                            id: "email",
-                            value: "random@gmail.com",
-                        },
-                    ],
-                })
-                .expect(200)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(undefined);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
-
-        let cookies = extractInfoFromResponse(response);
-        assert(cookies.accessToken !== undefined);
-        assert(cookies.refreshToken !== undefined);
-        assert(cookies.antiCsrf !== undefined);
-        assert(cookies.idRefreshTokenFromHeader !== undefined);
-        assert(cookies.idRefreshTokenFromCookie !== undefined);
-        assert(cookies.accessTokenExpiry !== undefined);
-        assert(cookies.refreshTokenExpiry !== undefined);
-        assert(cookies.idRefreshTokenExpiry !== undefined);
-        assert(cookies.refreshToken !== undefined);
-        assert(cookies.accessTokenDomain === undefined);
-        assert(cookies.refreshTokenDomain === undefined);
-        assert(cookies.idRefreshTokenDomain === undefined);
-        assert(cookies.frontToken !== undefined);
-    });
-
-    /*
-     * formField validation testing:
-     *        - Provide custom email validators to sign up and make sure they are applied to sign in
-     *        - Provide custom password validators to sign up and make sure they are not applied to sign in.
-     *        - Test password field validation error. The result should not be a FORM_FIELD_ERROR, but should be WRONG_CREDENTIALS_ERROR
-     *        - Test email field validation error
-     *        - Input formFields has no email field
-     *        - Input formFields has no password field
-     *        - Provide invalid (wrong syntax) email and wrong password, and you should get form field error
-     */
-    /*
-    having the email start with "test" (requierment of the custom validator) will cause the test to fail
-    */
-    it("test custom email validators to sign up and make sure they are applied to sign in", async function () {
-        await startST();
-
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [
-                EmailPassword.init({
-                    signUpFeature: {
-                        formFields: [
-                            {
-                                id: "email",
-                                validate: (value) => {
-                                    if (value.startsWith("test")) {
-                                        return undefined;
-                                    }
-                                    return "email does not start with test";
-                                },
-                            },
-                        ],
-                    },
-                }),
-                Session.init(),
-            ],
-        });
-        const app = express();
-
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        let signUpResponse = await signUPRequest(app, "testrandom@gmail.com", "validpass123");
-
-        assert(JSON.parse(signUpResponse.text).status === "OK");
-        assert(signUpResponse.status === 200);
-
-        let response = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/signin")
-                .send({
-                    formFields: [
-                        {
-                            id: "password",
-                            value: "validpass123",
-                        },
-                        {
-                            id: "email",
-                            value: "random@gmail.com",
-                        },
-                    ],
-                })
-                .expect(200)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(undefined);
-                    } else {
-                    }
-                    resolve(JSON.parse(res.text));
-                })
-        );
-        assert(response.status === "FIELD_ERROR");
-        assert(response.formFields[0].error === "email does not start with test");
-        assert(response.formFields[0].id === "email");
-    });
-
-    //- Provide custom password validators to sign up and make sure they are not applied to sign in.
-    /*
-    sending the correct password "valid" will cause the test to fail
-    */
-    it("test custom password validators to sign up and make sure they are applied to sign in", async function () {
-        await startST();
-
-        let failsValidatorCtr = 0;
-        let passesValidatorCtr = 0;
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [
-                EmailPassword.init({
-                    signUpFeature: {
+        /*
+        Failure condition:
+        Setting  invalid email or password values in the request body when sending a request to /signin 
+        */
+        it("test singinAPI works when input is fine", async function () {
+            const userInfo = await new Promise((resolve) =>
+                request(app)
+                    .post("/auth/signin")
+                    .send({
                         formFields: [
                             {
                                 id: "password",
-                                validate: (value) => {
-                                    if (value.length <= 5) {
-                                        passesValidatorCtr++;
-                                        return undefined;
-                                    }
-                                    failsValidatorCtr++;
-                                    return "password is greater than 5 characters";
-                                },
+                                value: "validpass123",
+                            },
+                            {
+                                id: "email",
+                                value: "random@gmail.com",
                             },
                         ],
-                    },
-                }),
-                Session.init(),
-            ],
+                    })
+                    .expect(200)
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                            resolve(JSON.parse(res.text).user);
+                        }
+                    })
+            );
+            assert.deepStrictEqual(userInfo.id, signUpUserInfo.id);
+            assert.deepStrictEqual(userInfo.email, signUpUserInfo.email);
         });
-        const app = express();
 
-        app.use(STExpress.middleware());
+        /*
+        Setting the email value in form field as random@gmail.com causes the test to fail
+        */
+        it("test singinAPI throws an error when email does not match", async function () {
+            const invalidEmailResponse = await new Promise((resolve) =>
+                request(app)
+                    .post("/auth/signin")
+                    .send({
+                        formFields: [
+                            {
+                                id: "password",
+                                value: "validpass123",
+                            },
+                            {
+                                id: "email",
+                                value: "ran@gmail.com",
+                            },
+                        ],
+                    })
+                    .expect(200)
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                            resolve(JSON.parse(res.text));
+                        }
+                    })
+            );
+            assert.deepStrictEqual(invalidEmailResponse.status, "WRONG_CREDENTIALS_ERROR");
+        });
 
-        app.use(STExpress.errorHandler());
+        // throws an error if the password is incorrect
+        /*
+        passing the correct password "validpass123" causes the test to fail
+        */
+        it("test singinAPI throws an error if password is incorrect", async function () {
+            const invalidPasswordResponse = await new Promise((resolve) =>
+                request(app)
+                    .post("/auth/signin")
+                    .send({
+                        formFields: [
+                            {
+                                id: "password",
+                                value: "validpass12345",
+                            },
+                            {
+                                id: "email",
+                                value: "random@gmail.com",
+                            },
+                        ],
+                    })
+                    .expect(200)
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                            resolve(JSON.parse(res.text));
+                        }
+                    })
+            );
+            assert.deepStrictEqual(invalidPasswordResponse.status, "WRONG_CREDENTIALS_ERROR");
+        });
 
-        let signUpResponse = await signUPRequest(app, "random@gmail.com", "valid");
-        assert(JSON.parse(signUpResponse.text).status === "OK");
-        assert(signUpResponse.status === 200);
+        /*
+         * pass a bad input to the /signin API and test that it throws a 400 error.
+         *        - Not a JSON
+         *        - No POST body
+         *        - Input is JSON, but wrong structure.
+         */
+        /*
+        Failure condition:
+        setting valid JSON body to /singin API
+        */
+        it("test bad input, not a JSON to /signin API", async function () {
+            const badInputResponse = await new Promise((resolve) =>
+                request(app)
+                    .post("/auth/signin")
+                    .send("hello")
+                    .expect(400)
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                            resolve(JSON.parse(res.text));
+                        }
+                    })
+            );
+            assert.deepStrictEqual(badInputResponse.message, "Missing input param: formFields");
+        });
 
-        assert(passesValidatorCtr === 1);
-        assert(failsValidatorCtr === 0);
+        /*
+        Failure condition:
+        setting valid formFields JSON body to /singin API
+        */
+        it("test bad input, no POST body to /signin API", async function () {
+            const badInputResponse = await new Promise((resolve) =>
+                request(app)
+                    .post("/auth/signin")
+                    .expect(400)
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                            resolve(JSON.parse(res.text));
+                        }
+                    })
+            );
+            assert.deepStrictEqual(badInputResponse.message, "Missing input param: formFields");
+        });
 
-        let response = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/signin")
-                .send({
-                    formFields: [
-                        {
-                            id: "password",
-                            value: "invalid",
-                        },
-                        {
-                            id: "email",
-                            value: "random@gmail.com",
-                        },
-                    ],
-                })
-                .expect(200)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(undefined);
-                    } else {
-                    }
-                    resolve(JSON.parse(res.text));
-                })
-        );
+        /*
+        Failure condition:
+        setting valid JSON body to /singin API
+        */
+        it("test bad input, input is Json but incorrect structure to /signin API", async function () {
+            const badInputResponse = await new Promise((resolve) =>
+                request(app)
+                    .post("/auth/signin")
+                    .send({
+                        randomKey: "randomValue",
+                    })
+                    .expect(400)
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                            resolve(JSON.parse(res.text));
+                        }
+                    })
+            );
+            assert.deepStrictEqual(badInputResponse.message, "Missing input param: formFields");
+        });
 
-        assert(response.status === "WRONG_CREDENTIALS_ERROR");
-        assert(failsValidatorCtr === 0);
-        assert(passesValidatorCtr === 1);
+        // Make sure that a successful sign in yields a session
+        /*
+        Passing invalid credentials to the /signin API fails the test
+        */
+        it("test that a successfull signin yields a session", async function () {
+            const response = await new Promise((resolve) =>
+                request(app)
+                    .post("/auth/signin")
+                    .send({
+                        formFields: [
+                            {
+                                id: "password",
+                                value: "validpass123",
+                            },
+                            {
+                                id: "email",
+                                value: "random@gmail.com",
+                            },
+                        ],
+                    })
+                    .expect(200)
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                            resolve(res);
+                        }
+                    })
+            );
+
+            let cookies = extractInfoFromResponse(response);
+            assert.notDeepStrictEqual(cookies.accessToken, undefined);
+            assert.notDeepStrictEqual(cookies.refreshToken, undefined);
+            assert.notDeepStrictEqual(cookies.antiCsrf, undefined);
+            assert.notDeepStrictEqual(cookies.idRefreshTokenFromHeader, undefined);
+            assert.notDeepStrictEqual(cookies.idRefreshTokenFromCookie, undefined);
+            assert.notDeepStrictEqual(cookies.accessTokenExpiry, undefined);
+            assert.notDeepStrictEqual(cookies.refreshTokenExpiry, undefined);
+            assert.notDeepStrictEqual(cookies.idRefreshTokenExpiry, undefined);
+            assert.notDeepStrictEqual(cookies.refreshToken, undefined);
+            assert.deepStrictEqual(cookies.accessTokenDomain, undefined);
+            assert.deepStrictEqual(cookies.refreshTokenDomain, undefined);
+            assert.deepStrictEqual(cookies.idRefreshTokenDomain, undefined);
+            assert.notDeepStrictEqual(cookies.frontToken, undefined);
+        });
+
+        it("test email field validation error returns form field error", async function () {
+            const response = await new Promise((resolve) =>
+                request(app)
+                    .post("/auth/signin")
+                    .send({
+                        formFields: [
+                            {
+                                id: "password",
+                                value: "pwd",
+                            },
+                            {
+                                id: "email",
+                                value: "randomgmail.com",
+                            },
+                        ],
+                    })
+                    .expect(200)
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                        }
+                        resolve(JSON.parse(res.text));
+                    })
+            );
+            assert.deepStrictEqual(response.status, "FIELD_ERROR");
+            assert.deepStrictEqual(response.formFields[0].error, "Email is invalid");
+            assert.deepStrictEqual(response.formFields[0].id, "email");
+        });
+
+        it("test formFields has no email field returns error message", async function () {
+            const response = await new Promise((resolve) =>
+                request(app)
+                    .post("/auth/signin")
+                    .send({
+                        formFields: [
+                            {
+                                id: "password",
+                                value: "validpass123",
+                            },
+                        ],
+                    })
+                    .expect(400)
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                        }
+                        resolve(JSON.parse(res.text));
+                    })
+            );
+            assert.deepStrictEqual(response.message, "Are you sending too many / too few formFields?");
+        });
+
+        it("test input formFields has no password field returns error message", async function () {
+            const response = await new Promise((resolve) =>
+                request(app)
+                    .post("/auth/signin")
+                    .send({
+                        formFields: [
+                            {
+                                id: "email",
+                                value: "random@gmail.com",
+                            },
+                        ],
+                    })
+                    .expect(400)
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                        }
+                        resolve(JSON.parse(res.text));
+                    })
+            );
+            assert.deepStrictEqual(response.message, "Are you sending too many / too few formFields?");
+        });
+
+        // Provide invalid (wrong syntax) email and wrong password, and you should get form field error
+        /*
+        passing email with valid syntax and correct password will cause the test to fail
+        */
+        it("test invalid email and wrong password", async function () {
+            const response = await new Promise((resolve) =>
+                request(app)
+                    .post("/auth/signin")
+                    .send({
+                        formFields: [
+                            {
+                                id: "password",
+                                value: "invalid",
+                            },
+                            {
+                                id: "email",
+                                value: "randomgmail.com",
+                            },
+                        ],
+                    })
+                    .expect(200)
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                        }
+                        resolve(JSON.parse(res.text));
+                    })
+            );
+            assert.deepStrictEqual(response.status, "FIELD_ERROR");
+            assert.deepStrictEqual(response.formFields.length, 1);
+            assert.deepStrictEqual(response.formFields[0].error, "Email is invalid");
+            assert.deepStrictEqual(response.formFields[0].id, "email");
+        });
+
+        it("test getUserByEmail when user does exist/ does not exist", async function () {
+            assert.deepStrictEqual(
+                await EmailPasswordRecipe.getInstanceOrThrowError().getUserByEmail("random2@gmail.com"),
+                undefined
+            );
+            const signUpResponse = await signUPRequest(app, "random2@gmail.com", "validpass123");
+            const signUpUserInfo = JSON.parse(signUpResponse.text).user;
+            const userInfo = await EmailPasswordRecipe.getInstanceOrThrowError().getUserByEmail("random2@gmail.com");
+
+            assert.deepStrictEqual(userInfo.email, signUpUserInfo.email);
+            assert.deepStrictEqual(userInfo.id, signUpUserInfo.id);
+        });
+
+        /*
+         * Test getUserById
+         *        - User does not exist
+         *        - User exists
+         */
+        it("test getUserById when user does not exist", async function () {
+            assert.deepStrictEqual(
+                await EmailPasswordRecipe.getInstanceOrThrowError().getUserById("randomID"),
+                undefined
+            );
+
+            const app = express();
+
+            app.use(STExpress.middleware());
+
+            app.use(STExpress.errorHandler());
+
+            const signUpResponse = await signUPRequest(app, "random3@gmail.com", "validpass123");
+            assert.deepStrictEqual(JSON.parse(signUpResponse.text).status, "OK");
+            assert.deepStrictEqual(signUpResponse.status, 200);
+
+            const signUpUserInfo = JSON.parse(signUpResponse.text).user;
+            const userInfo = await EmailPasswordRecipe.getInstanceOrThrowError().getUserById(signUpUserInfo.id);
+
+            assert.deepStrictEqual(userInfo.email, signUpUserInfo.email);
+            assert.deepStrictEqual(userInfo.id, signUpUserInfo.id);
+        });
     });
 
-    // Test password field validation error. The result should not be a FORM_FIELD_ERROR, but should be WRONG_CREDENTIALS_ERROR
-    /*
-    sending the correct password to the /signin API will cause the test to fail
-    */
-    it("test password field validation error", async function () {
-        await startST();
+    describe("With default implementation disabled", function () {
+        let app;
 
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [EmailPassword.init(), Session.init()],
+        before(async function () {
+            await killAllST();
+            await setupST();
+            await startST();
+            STExpress.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                },
+                appInfo: {
+                    apiDomain: "api.supertokens.io",
+                    appName: "SuperTokens",
+                    websiteDomain: "supertokens.io",
+                },
+                recipeList: [
+                    EmailPassword.init({
+                        signInFeature: {
+                            disableDefaultImplementation: true,
+                        },
+                    }),
+                    Session.init(),
+                ],
+            });
+
+            app = express();
+
+            app.use(STExpress.middleware());
+
+            app.use(STExpress.errorHandler());
+
+            const signUPResponse = await signUPRequest(app, "random@gmail.com", "validpass123");
+            assert.deepStrictEqual(JSON.parse(signUPResponse.text).status, "OK");
+            assert.deepStrictEqual(signUPResponse.status, 200);
         });
-        const app = express();
 
-        app.use(STExpress.middleware());
+        beforeEach(async function () {
+            ProcessState.getInstance().reset();
+        });
 
-        app.use(STExpress.errorHandler());
+        after(async function () {
+            await killAllST();
+            await cleanST();
+        });
 
-        let signUpResponse = await signUPRequest(app, "random@gmail.com", "validpass123");
-        assert(JSON.parse(signUpResponse.text).status === "OK");
-        assert(signUpResponse.status === 200);
-
-        let response = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/signin")
-                .send({
-                    formFields: [
-                        {
-                            id: "password",
-                            value: "invalidpass",
-                        },
-                        {
-                            id: "email",
-                            value: "random@gmail.com",
-                        },
-                    ],
-                })
-                .expect(200)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(undefined);
-                    } else {
-                    }
-                    resolve(JSON.parse(res.text));
-                })
-        );
-        assert(response.status === "WRONG_CREDENTIALS_ERROR");
+        /*
+        Failure condition:
+        Set  disableDefaultImplementation to false in the signInFeature
+        */
+        it("test that disableDefaultImplementation is true, the default signin API does not work", async function () {
+            let response = await new Promise((resolve) =>
+                request(app)
+                    .post("/auth/signin")
+                    .send({
+                        formFields: [
+                            {
+                                id: "password",
+                                value: "validpass123",
+                            },
+                            {
+                                id: "email",
+                                value: "random@gmail.com",
+                            },
+                        ],
+                    })
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                            resolve(res);
+                        }
+                    })
+            );
+            assert.deepStrictEqual(response.status, 404);
+        });
     });
 
-    // Test email field validation error
-    //sending the correct email to the /signin API will cause the test to fail
+    describe("With custom validators", function () {
+        let app;
+        let failsPasswordValidatorCtr = 0;
+        let passesPasswordValidatorCtr = 0;
+        let passesEmailValidatorCtr = 0;
+        let failsEmailValidatorCtr = 0;
 
-    it("test email field validation error", async function () {
-        await startST();
+        before(async function () {
+            await killAllST();
+            await setupST();
+            await startST();
+            STExpress.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                },
+                appInfo: {
+                    apiDomain: "api.supertokens.io",
+                    appName: "SuperTokens",
+                    websiteDomain: "supertokens.io",
+                },
+                recipeList: [
+                    EmailPassword.init({
+                        signUpFeature: {
+                            formFields: [
+                                {
+                                    id: "email",
+                                    validate: (value) => {
+                                        if (value.startsWith("test")) {
+                                            passesEmailValidatorCtr++;
+                                            return undefined;
+                                        }
 
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [EmailPassword.init(), Session.init()],
-        });
-        const app = express();
-
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        let signUpResponse = await signUPRequest(app, "random@gmail.com", "validpass123");
-        assert(JSON.parse(signUpResponse.text).status === "OK");
-        assert(signUpResponse.status === 200);
-
-        let response = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/signin")
-                .send({
-                    formFields: [
-                        {
-                            id: "password",
-                            value: "validpass123",
+                                        failsEmailValidatorCtr++;
+                                        return "email does not start with test";
+                                    },
+                                },
+                                {
+                                    id: "password",
+                                    validate: (value) => {
+                                        if (value.length <= 5) {
+                                            passesPasswordValidatorCtr++;
+                                            return undefined;
+                                        }
+                                        failsPasswordValidatorCtr++;
+                                        return "password is greater than 5 characters";
+                                    },
+                                },
+                            ],
                         },
-                        {
-                            id: "email",
-                            value: "randomgmail.com",
-                        },
-                    ],
-                })
-                .expect(200)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(undefined);
-                    } else {
-                    }
-                    resolve(JSON.parse(res.text));
-                })
-        );
-        assert(response.status === "FIELD_ERROR");
-        assert(response.formFields[0].error === "Email is invalid");
-        assert(response.formFields[0].id === "email");
-    });
+                    }),
+                    Session.init(),
+                ],
+            });
 
-    // Input formFields has no email field
-    //passing the email field in formFields will cause the test to fail
-    it("test formFields has no email field", async function () {
-        await startST();
+            app = express();
 
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [EmailPassword.init(), Session.init()],
-        });
-        const app = express();
+            app.use(STExpress.middleware());
 
-        app.use(STExpress.middleware());
+            app.use(STExpress.errorHandler());
 
-        app.use(STExpress.errorHandler());
-
-        let signUpResponse = await signUPRequest(app, "random@gmail.com", "validpass123");
-        assert(JSON.parse(signUpResponse.text).status === "OK");
-        assert(signUpResponse.status === 200);
-
-        let response = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/signin")
-                .send({
-                    formFields: [
-                        {
-                            id: "password",
-                            value: "validpass123",
-                        },
-                    ],
-                })
-                .expect(400)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(undefined);
-                    } else {
-                    }
-                    resolve(JSON.parse(res.text));
-                })
-        );
-        assert(response.message === "Are you sending too many / too few formFields?");
-    });
-
-    // Input formFields has no password field
-    //passing the password field in formFields will cause the test to fail
-    it("test formFields has no password field", async function () {
-        await startST();
-
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [EmailPassword.init(), Session.init()],
-        });
-        const app = express();
-
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        let signUpResponse = await signUPRequest(app, "random@gmail.com", "validpass123");
-        assert(JSON.parse(signUpResponse.text).status === "OK");
-        assert(signUpResponse.status === 200);
-
-        let response = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/signin")
-                .send({
-                    formFields: [
-                        {
-                            id: "email",
-                            value: "random@gmail.com",
-                        },
-                    ],
-                })
-                .expect(400)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(undefined);
-                    } else {
-                    }
-                    resolve(JSON.parse(res.text));
-                })
-        );
-        assert(response.message === "Are you sending too many / too few formFields?");
-    });
-
-    // Provide invalid (wrong syntax) email and wrong password, and you should get form field error
-    /*
-    passing email with valid syntax and correct password will cause the test to fail
-    */
-    it("test invalid email and wrong password", async function () {
-        await startST();
-
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [EmailPassword.init(), Session.init()],
-        });
-        const app = express();
-
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        let signUpResponse = await signUPRequest(app, "random@gmail.com", "validpass123");
-        assert(JSON.parse(signUpResponse.text).status === "OK");
-        assert(signUpResponse.status === 200);
-
-        let response = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/signin")
-                .send({
-                    formFields: [
-                        {
-                            id: "password",
-                            value: "invalid",
-                        },
-                        {
-                            id: "email",
-                            value: "randomgmail.com",
-                        },
-                    ],
-                })
-                .expect(200)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(undefined);
-                    } else {
-                    }
-                    resolve(JSON.parse(res.text));
-                })
-        );
-        assert(response.status === "FIELD_ERROR");
-        assert(response.formFields.length === 1);
-        assert(response.formFields[0].error === "Email is invalid");
-        assert(response.formFields[0].id === "email");
-    });
-
-    /*
-     * Test getUserByEmail
-     *    - User does not exist
-     *    - User exists
-     */
-    it("test getUserByEmail when user does not exist", async function () {
-        await startST();
-
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [EmailPassword.init(), Session.init()],
+            const signUPResponse = await signUPRequest(app, "testrandom@gmail.com", "pwd");
+            assert.deepStrictEqual(JSON.parse(signUPResponse.text).status, "OK");
+            assert.deepStrictEqual(signUPResponse.status, 200);
         });
 
-        let emailpassword = EmailPasswordRecipe.getInstanceOrThrowError();
-
-        assert((await emailpassword.getUserByEmail("random@gmail.com")) === undefined);
-
-        const app = express();
-
-        app.use(STExpress.middleware());
-
-        app.use(STExpress.errorHandler());
-
-        let signUpResponse = await signUPRequest(app, "random@gmail.com", "validpass123");
-        assert(JSON.parse(signUpResponse.text).status === "OK");
-        assert(signUpResponse.status === 200);
-
-        let signUpUserInfo = JSON.parse(signUpResponse.text).user;
-        let userInfo = await emailpassword.getUserByEmail("random@gmail.com");
-
-        assert(userInfo.email === signUpUserInfo.email);
-        assert(userInfo.id === signUpUserInfo.id);
-    });
-
-    /*
-     * Test getUserById
-     *        - User does not exist
-     *        - User exists
-     */
-    it("test getUserById when user does not exist", async function () {
-        await startST();
-
-        STExpress.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [EmailPassword.init(), Session.init()],
+        beforeEach(async function () {
+            ProcessState.getInstance().reset();
         });
 
-        let emailpassword = EmailPasswordRecipe.getInstanceOrThrowError();
+        after(async function () {
+            await killAllST();
+            await cleanST();
+        });
 
-        assert((await emailpassword.getUserById("randomID")) === undefined);
+        afterEach(async function () {
+            failsPasswordValidatorCtr = 0;
+            passesPasswordValidatorCtr = 0;
+            passesEmailValidatorCtr = 0;
+            failsEmailValidatorCtr = 0;
+        });
 
-        const app = express();
+        /*
+         * formField validation testing:
+         *        - Provide custom email validators to sign up and make sure they are applied to sign in
+         *        - Provide custom password validators to sign up and make sure they are not applied to sign in.
+         *        - Test password field validation error. The result should not be a FORM_FIELD_ERROR, but should be WRONG_CREDENTIALS_ERROR
+         *        - Test email field validation error
+         *        - Input formFields has no email field
+         *        - Input formFields has no password field
+         *        - Provide invalid (wrong syntax) email and wrong password, and you should get form field error
+         */
+        /*
+        having the email start with "test" (requierment of the custom validator) will cause the test to fail
+        */
+        it("test custom email validators to sign up and make sure they are applied to sign in", async function () {
+            const response = await new Promise((resolve) =>
+                request(app)
+                    .post("/auth/signin")
+                    .send({
+                        formFields: [
+                            {
+                                id: "password",
+                                value: "pwd",
+                            },
+                            {
+                                id: "email",
+                                value: "random@gmail.com",
+                            },
+                        ],
+                    })
+                    .expect(200)
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                        }
+                        resolve(JSON.parse(res.text));
+                    })
+            );
+            assert.deepStrictEqual(response.status, "FIELD_ERROR");
+            assert.deepStrictEqual(response.formFields[0].error, "email does not start with test");
+            assert.deepStrictEqual(response.formFields[0].id, "email");
+        });
 
-        app.use(STExpress.middleware());
+        //- Provide custom password validators to sign up and make sure they are not applied to sign in.
+        /*
+        sending the correct password "valid" will cause the test to fail
+        */
+        it("test custom password validators to sign up and make sure they are applied to sign in", async function () {
+            const response = await new Promise((resolve) =>
+                request(app)
+                    .post("/auth/signin")
+                    .send({
+                        formFields: [
+                            {
+                                id: "password",
+                                value: "bad",
+                            },
+                            {
+                                id: "email",
+                                value: "testrandom@gmail.com",
+                            },
+                        ],
+                    })
+                    .expect(200)
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                        }
+                        resolve(JSON.parse(res.text));
+                    })
+            );
 
-        app.use(STExpress.errorHandler());
+            assert.deepStrictEqual(response.status, "WRONG_CREDENTIALS_ERROR");
 
-        let signUpResponse = await signUPRequest(app, "random@gmail.com", "validpass123");
-        assert(JSON.parse(signUpResponse.text).status === "OK");
-        assert(signUpResponse.status === 200);
+            // Email validation on sign in.
+            assert.deepStrictEqual(failsEmailValidatorCtr, 0);
+            assert.deepStrictEqual(passesEmailValidatorCtr, 1);
 
-        let signUpUserInfo = JSON.parse(signUpResponse.text).user;
-        let userInfo = await emailpassword.getUserById(signUpUserInfo.id);
-
-        assert(userInfo.email === signUpUserInfo.email);
-        assert(userInfo.id === signUpUserInfo.id);
+            // No password validation on sign in.
+            assert.deepStrictEqual(failsPasswordValidatorCtr, 0);
+            assert.deepStrictEqual(passesPasswordValidatorCtr, 0);
+        });
     });
 });

--- a/test/faunadb.test.js
+++ b/test/faunadb.test.js
@@ -16,7 +16,6 @@ const {
     printPath,
     setupST,
     startST,
-    stopST,
     killAllST,
     cleanST,
     extractInfoFromResponse,
@@ -449,17 +448,17 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
                     resolve(res);
                 })
         );
-        assert.deepEqual(res3.body.success, true);
+        assert.deepStrictEqual(res3.body.success, true);
 
         let cookies = extractInfoFromResponse(res3);
-        assert.deepEqual(cookies.antiCsrf, undefined);
-        assert.deepEqual(cookies.accessToken, "");
-        assert.deepEqual(cookies.refreshToken, "");
-        assert.deepEqual(cookies.idRefreshTokenFromHeader, "remove");
-        assert.deepEqual(cookies.idRefreshTokenFromCookie, "");
-        assert.deepEqual(cookies.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
-        assert.deepEqual(cookies.idRefreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
-        assert.deepEqual(cookies.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(cookies.antiCsrf, undefined);
+        assert.deepStrictEqual(cookies.accessToken, "");
+        assert.deepStrictEqual(cookies.refreshToken, "");
+        assert.deepStrictEqual(cookies.idRefreshTokenFromHeader, "remove");
+        assert.deepStrictEqual(cookies.idRefreshTokenFromCookie, "");
+        assert.deepStrictEqual(cookies.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(cookies.idRefreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(cookies.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
         let currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
         if (maxVersion(currCDIVersion, "2.1") === "2.1") {
             assert(cookies.accessTokenDomain === "localhost" || cookies.accessTokenDomain === "supertokens.io");
@@ -553,17 +552,17 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
                 })
         );
         assert(res3.status === 401);
-        assert.deepEqual(res3.text, '{"message":"token theft detected"}');
+        assert.deepStrictEqual(res3.text, '{"message":"token theft detected"}');
 
         let cookies = extractInfoFromResponse(res3);
-        assert.deepEqual(cookies.antiCsrf, undefined);
-        assert.deepEqual(cookies.accessToken, "");
-        assert.deepEqual(cookies.refreshToken, "");
-        assert.deepEqual(cookies.idRefreshTokenFromHeader, "remove");
-        assert.deepEqual(cookies.idRefreshTokenFromCookie, "");
-        assert.deepEqual(cookies.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
-        assert.deepEqual(cookies.idRefreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
-        assert.deepEqual(cookies.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(cookies.antiCsrf, undefined);
+        assert.deepStrictEqual(cookies.accessToken, "");
+        assert.deepStrictEqual(cookies.refreshToken, "");
+        assert.deepStrictEqual(cookies.idRefreshTokenFromHeader, "remove");
+        assert.deepStrictEqual(cookies.idRefreshTokenFromCookie, "");
+        assert.deepStrictEqual(cookies.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(cookies.idRefreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(cookies.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
     });
 
     //check basic usage of session

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -297,14 +297,14 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
             )
         );
 
-        assert.deepEqual(res4.antiCsrf, undefined);
-        assert.deepEqual(res4.accessToken, "");
-        assert.deepEqual(res4.refreshToken, "");
-        assert.deepEqual(res4.idRefreshTokenFromHeader, "remove");
-        assert.deepEqual(res4.idRefreshTokenFromCookie, "");
-        assert.deepEqual(res4.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
-        assert.deepEqual(res4.idRefreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
-        assert.deepEqual(res4.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(res4.antiCsrf, undefined);
+        assert.deepStrictEqual(res4.accessToken, "");
+        assert.deepStrictEqual(res4.refreshToken, "");
+        assert.deepStrictEqual(res4.idRefreshTokenFromHeader, "remove");
+        assert.deepStrictEqual(res4.idRefreshTokenFromCookie, "");
+        assert.deepStrictEqual(res4.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(res4.idRefreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(res4.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
 
         let r5 = await new Promise((resolve) =>
             request(app)
@@ -546,14 +546,14 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
             )
         );
 
-        assert.deepEqual(res4.antiCsrf, undefined);
-        assert.deepEqual(res4.accessToken, "");
-        assert.deepEqual(res4.refreshToken, "");
-        assert.deepEqual(res4.idRefreshTokenFromHeader, "remove");
-        assert.deepEqual(res4.idRefreshTokenFromCookie, "");
-        assert.deepEqual(res4.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
-        assert.deepEqual(res4.idRefreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
-        assert.deepEqual(res4.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(res4.antiCsrf, undefined);
+        assert.deepStrictEqual(res4.accessToken, "");
+        assert.deepStrictEqual(res4.refreshToken, "");
+        assert.deepStrictEqual(res4.idRefreshTokenFromHeader, "remove");
+        assert.deepStrictEqual(res4.idRefreshTokenFromCookie, "");
+        assert.deepStrictEqual(res4.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(res4.idRefreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(res4.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
 
         let r5 = await new Promise((resolve) =>
             request(app)
@@ -801,14 +801,14 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
             )
         );
 
-        assert.deepEqual(res4.antiCsrf, undefined);
-        assert.deepEqual(res4.accessToken, "");
-        assert.deepEqual(res4.refreshToken, "");
-        assert.deepEqual(res4.idRefreshTokenFromHeader, "remove");
-        assert.deepEqual(res4.idRefreshTokenFromCookie, "");
-        assert.deepEqual(res4.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
-        assert.deepEqual(res4.idRefreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
-        assert.deepEqual(res4.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(res4.antiCsrf, undefined);
+        assert.deepStrictEqual(res4.accessToken, "");
+        assert.deepStrictEqual(res4.refreshToken, "");
+        assert.deepStrictEqual(res4.idRefreshTokenFromHeader, "remove");
+        assert.deepStrictEqual(res4.idRefreshTokenFromCookie, "");
+        assert.deepStrictEqual(res4.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(res4.idRefreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(res4.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
 
         let r5 = await new Promise((resolve) =>
             request(app)
@@ -1056,14 +1056,14 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
             )
         );
 
-        assert.deepEqual(res4.antiCsrf, undefined);
-        assert.deepEqual(res4.accessToken, "");
-        assert.deepEqual(res4.refreshToken, "");
-        assert.deepEqual(res4.idRefreshTokenFromHeader, "remove");
-        assert.deepEqual(res4.idRefreshTokenFromCookie, "");
-        assert.deepEqual(res4.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
-        assert.deepEqual(res4.idRefreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
-        assert.deepEqual(res4.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(res4.antiCsrf, undefined);
+        assert.deepStrictEqual(res4.accessToken, "");
+        assert.deepStrictEqual(res4.refreshToken, "");
+        assert.deepStrictEqual(res4.idRefreshTokenFromHeader, "remove");
+        assert.deepStrictEqual(res4.idRefreshTokenFromCookie, "");
+        assert.deepStrictEqual(res4.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(res4.idRefreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(res4.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
 
         let r5 = await new Promise((resolve) =>
             request(app)

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -16,7 +16,6 @@ const {
     printPath,
     setupST,
     startST,
-    stopST,
     killAllST,
     cleanST,
     extractInfoFromResponse,
@@ -25,7 +24,6 @@ const {
 let assert = require("assert");
 let { Querier } = require("../lib/build/querier");
 const nock = require("nock");
-let { version } = require("../lib/build/version");
 const express = require("express");
 const request = require("supertest");
 let { ProcessState, PROCESS_STATE } = require("../lib/build/processState");
@@ -41,103 +39,136 @@ let SessionRecipe = require("../lib/build/recipe/session/sessionRecipe").default
 - calling createNewSession in the case of unauthorised error, should create a proper session
 - revoking old session after create new session, should not remove new session's cookies.
 - check that if idRefreshToken is not passed to express, verify throws UNAUTHORISED
-- check that Access-Control-Expose-Headers header is being set properly during create, use and destroy session**** only for express
+- check that Access-Control-Expose-Headers header is being set properly during create, use and destroy session**** for express
 */
 
 describe(`session: ${printPath("[test/session.test.js]")}`, function () {
-    beforeEach(async function () {
-        await killAllST();
-        await setupST();
-        ProcessState.getInstance().reset();
-    });
+    describe("With default config", function () {
+        let app;
 
-    after(async function () {
-        await killAllST();
-        await cleanST();
-    });
+        before(async function () {
+            await killAllST();
+            await setupST();
+            await startST();
+            SuperTokens.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                },
+                appInfo: {
+                    apiDomain: "api.supertokens.io",
+                    appName: "SuperTokens",
+                    websiteDomain: "supertokens.io",
+                },
+                recipeList: [Session.init()],
+            });
 
-    // check if output headers and set cookies for create session is fine
-    it("test that output headers and set cookie for create session is fine", async function () {
-        await startST();
-        SuperTokens.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [Session.init()],
+            app = express();
+
+            app.use(SuperTokens.middleware());
+
+            app.post("/create", async (req, res) => {
+                await Session.createNewSession(res, "", {}, {});
+                res.status(200).send("");
+            });
+
+            app.use(SuperTokens.errorHandler());
         });
 
-        const app = express();
-
-        app.use(SuperTokens.middleware());
-
-        app.post("/create", async (req, res) => {
-            await Session.createNewSession(res, "", {}, {});
-            res.status(200).send("");
+        beforeEach(async function () {
+            ProcessState.getInstance().reset();
         });
 
-        app.use(SuperTokens.errorHandler());
-
-        let res = await new Promise((resolve) =>
-            request(app)
-                .post("/create")
-                .expect(200)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(undefined);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
-        assert(res.header["access-control-expose-headers"] === "front-token, id-refresh-token, anti-csrf");
-
-        let cookies = extractInfoFromResponse(res);
-        assert(cookies.accessToken !== undefined);
-        assert(cookies.refreshToken !== undefined);
-        assert(cookies.antiCsrf !== undefined);
-        assert(cookies.idRefreshTokenFromHeader !== undefined);
-        assert(cookies.idRefreshTokenFromCookie !== undefined);
-        assert(cookies.accessTokenExpiry !== undefined);
-        assert(cookies.refreshTokenExpiry !== undefined);
-        assert(cookies.idRefreshTokenExpiry !== undefined);
-        assert(cookies.refreshToken !== undefined);
-        assert(cookies.accessTokenDomain === undefined);
-        assert(cookies.refreshTokenDomain === undefined);
-        assert(cookies.idRefreshTokenDomain === undefined);
-        assert(cookies.frontToken !== undefined);
-    });
-
-    // check if output headers and set cookies for refresh session is fine
-    it("test that output headers and set cookie for refresh session is fine", async function () {
-        await startST();
-        SuperTokens.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [Session.init()],
+        after(async function () {
+            await killAllST();
+            await cleanST();
         });
 
-        const app = express();
-        app.use(SuperTokens.middleware());
+        it("test that output headers and set cookie for create session is fine", async function () {
+            let res = await new Promise((resolve) =>
+                request(app)
+                    .post("/create")
+                    .expect(200)
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                            resolve(res);
+                        }
+                    })
+            );
+            assert.deepStrictEqual(
+                res.header["access-control-expose-headers"],
+                "front-token, id-refresh-token, anti-csrf"
+            );
 
-        app.post("/create", async (req, res) => {
-            await Session.createNewSession(res, "", {}, {});
-            res.status(200).send("");
+            let cookies = extractInfoFromResponse(res);
+            assert.notDeepStrictEqual(cookies.accessToken, undefined);
+            assert.notDeepStrictEqual(cookies.refreshToken, undefined);
+            assert.notDeepStrictEqual(cookies.antiCsrf, undefined);
+            assert.notDeepStrictEqual(cookies.idRefreshTokenFromHeader, undefined);
+            assert.notDeepStrictEqual(cookies.idRefreshTokenFromCookie, undefined);
+            assert.notDeepStrictEqual(cookies.accessTokenExpiry, undefined);
+            assert.notDeepStrictEqual(cookies.refreshTokenExpiry, undefined);
+            assert.notDeepStrictEqual(cookies.idRefreshTokenExpiry, undefined);
+            assert.notDeepStrictEqual(cookies.refreshToken, undefined);
+            assert.deepStrictEqual(cookies.accessTokenDomain, undefined);
+            assert.deepStrictEqual(cookies.refreshTokenDomain, undefined);
+            assert.deepStrictEqual(cookies.idRefreshTokenDomain, undefined);
+            assert.notDeepStrictEqual(cookies.frontToken, undefined);
         });
 
-        app.use(SuperTokens.errorHandler());
+        it("test that output headers and set cookie for refresh session is fine", async function () {
+            const res = extractInfoFromResponse(
+                await new Promise((resolve) =>
+                    request(app)
+                        .post("/create")
+                        .expect(200)
+                        .end((err, res) => {
+                            if (err) {
+                                resolve(undefined);
+                            } else {
+                                resolve(res);
+                            }
+                        })
+                )
+            );
 
-        let res = extractInfoFromResponse(
+            const res2 = await new Promise((resolve) =>
+                request(app)
+                    .post("/auth/session/refresh")
+                    .set("Cookie", ["sRefreshToken=" + res.refreshToken])
+                    .set("anti-csrf", res.antiCsrf)
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                            resolve(res);
+                        }
+                    })
+            );
+            assert.deepStrictEqual(
+                res2.header["access-control-expose-headers"],
+                "front-token, id-refresh-token, anti-csrf"
+            );
+
+            let cookies = extractInfoFromResponse(res2);
+            assert.notStrictEqual(cookies.accessToken, undefined);
+            assert.notStrictEqual(cookies.refreshToken, undefined);
+            assert.notStrictEqual(cookies.antiCsrf, undefined);
+            assert.notStrictEqual(cookies.idRefreshTokenFromHeader, undefined);
+            assert.notStrictEqual(cookies.idRefreshTokenFromCookie, undefined);
+            assert.notStrictEqual(cookies.accessTokenExpiry, undefined);
+            assert.notStrictEqual(cookies.refreshTokenExpiry, undefined);
+            assert.notStrictEqual(cookies.idRefreshTokenExpiry, undefined);
+            assert.notStrictEqual(cookies.refreshToken, undefined);
+            assert.deepStrictEqual(cookies.accessTokenDomain, undefined);
+            assert.deepStrictEqual(cookies.refreshTokenDomain, undefined);
+            assert.deepStrictEqual(cookies.idRefreshTokenDomain, undefined);
+            assert.notStrictEqual(cookies.frontToken, undefined);
+        });
+
+        // Failure condition: if valid cookies are set in the refresh call the test will fail
+        it("test that if input cookies are missing, an appropriate error is thrown", async function () {
             await new Promise((resolve) =>
                 request(app)
                     .post("/create")
@@ -149,123 +180,11 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
                             resolve(res);
                         }
                     })
-            )
-        );
+            );
 
-        let res2 = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/session/refresh")
-                .set("Cookie", ["sRefreshToken=" + res.refreshToken])
-                .set("anti-csrf", res.antiCsrf)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(undefined);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
-        assert(res2.header["access-control-expose-headers"] === "front-token, id-refresh-token, anti-csrf");
-
-        let cookies = extractInfoFromResponse(res2);
-        assert(cookies.accessToken !== undefined);
-        assert(cookies.refreshToken !== undefined);
-        assert(cookies.antiCsrf !== undefined);
-        assert(cookies.idRefreshTokenFromHeader !== undefined);
-        assert(cookies.idRefreshTokenFromCookie !== undefined);
-        assert(cookies.accessTokenExpiry !== undefined);
-        assert(cookies.refreshTokenExpiry !== undefined);
-        assert(cookies.idRefreshTokenExpiry !== undefined);
-        assert(cookies.refreshToken !== undefined);
-        assert(cookies.accessTokenDomain === undefined);
-        assert(cookies.refreshTokenDomain === undefined);
-        assert(cookies.idRefreshTokenDomain === undefined);
-        assert(cookies.frontToken !== undefined);
-    });
-
-    // check if input cookies are missing, an appropriate error is thrown
-    // Failure condition: if valid cookies are set in the refresh call the test will fail
-    it("test that if input cookies are missing, an appropriate error is thrown", async function () {
-        await startST();
-        SuperTokens.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [Session.init()],
-        });
-
-        const app = express();
-        app.use(SuperTokens.middleware());
-
-        app.post("/create", async (req, res) => {
-            await Session.createNewSession(res, "", {}, {});
-            res.status(200).send("");
-        });
-
-        app.use(SuperTokens.errorHandler());
-
-        await new Promise((resolve) =>
-            request(app)
-                .post("/create")
-                .expect(200)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(undefined);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
-
-        let res2 = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/session/refresh")
-                .end((err, res) => {
-                    if (err) {
-                        resolve(undefined);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
-        assert(res2.status === 401);
-        assert(JSON.parse(res2.text).message === "unauthorised");
-    });
-
-    // check if input cookies are there, no error is thrown
-    // Failure condition: if cookies are no set in the refresh call the test will fail
-    it("test that if input cookies are there, no error is thrown", async function () {
-        await startST();
-        SuperTokens.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [Session.init()],
-        });
-
-        const app = express();
-        app.use(SuperTokens.middleware());
-
-        app.post("/create", async (req, res) => {
-            await Session.createNewSession(res, "", {}, {});
-            res.status(200).send("");
-        });
-
-        let res = extractInfoFromResponse(
-            await new Promise((resolve) =>
+            const refreshSessionResult = await new Promise((resolve) =>
                 request(app)
-                    .post("/create")
-                    .expect(200)
+                    .post("/auth/session/refresh")
                     .end((err, res) => {
                         if (err) {
                             resolve(undefined);
@@ -273,549 +192,644 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
                             resolve(res);
                         }
                     })
-            )
-        );
-
-        let res2 = await new Promise((resolve) =>
-            request(app)
-                .post("/auth/session/refresh")
-                .set("Cookie", ["sRefreshToken=" + res.refreshToken])
-                .set("anti-csrf", res.antiCsrf)
-                .end((err, res) => {
-                    if (err) {
-                        resolve(undefined);
-                    } else {
-                        resolve(res);
-                    }
-                })
-        );
-        assert(res2.status === 200);
-    });
-
-    //- check for token theft detection
-    it("token theft detection", async function () {
-        await startST();
-        SuperTokens.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [Session.init()],
+            );
+            assert.deepStrictEqual(refreshSessionResult.status, 401);
+            assert.deepStrictEqual(JSON.parse(refreshSessionResult.text).message, "unauthorised");
         });
 
-        let response = await SessionFunctions.createNewSession(SessionRecipe.getInstanceOrThrowError(), "", {}, {});
+        // Failure condition: if cookies are no set in the refresh call the test will fail
+        it("test that if input cookies are there, no error is thrown", async function () {
+            const createSessionResponse = extractInfoFromResponse(
+                await new Promise((resolve) =>
+                    request(app)
+                        .post("/create")
+                        .expect(200)
+                        .end((err, res) => {
+                            if (err) {
+                                resolve(undefined);
+                            } else {
+                                resolve(res);
+                            }
+                        })
+                )
+            );
 
-        let response2 = await SessionFunctions.refreshSession(
-            SessionRecipe.getInstanceOrThrowError(),
-            response.refreshToken.token,
-            response.antiCsrfToken
-        );
+            let sessionRefreshResponse = await new Promise((resolve) =>
+                request(app)
+                    .post("/auth/session/refresh")
+                    .set("Cookie", ["sRefreshToken=" + createSessionResponse.refreshToken])
+                    .set("anti-csrf", createSessionResponse.antiCsrf)
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                            resolve(res);
+                        }
+                    })
+            );
+            assert.deepStrictEqual(sessionRefreshResponse.status, 200);
+        });
 
-        await SessionFunctions.getSession(
-            SessionRecipe.getInstanceOrThrowError(),
-            response2.accessToken.token,
-            response2.antiCsrfToken,
-            true,
-            response2.idRefreshToken.token
-        );
+        it("token theft detection", async function () {
+            let response = await SessionFunctions.createNewSession(SessionRecipe.getInstanceOrThrowError(), "", {}, {});
 
-        try {
-            await SessionFunctions.refreshSession(
+            let response2 = await SessionFunctions.refreshSession(
                 SessionRecipe.getInstanceOrThrowError(),
                 response.refreshToken.token,
                 response.antiCsrfToken
             );
-            throw new Error("should not have come here");
-        } catch (err) {
-            if (err.type !== Session.Error.TOKEN_THEFT_DETECTED) {
-                throw err;
-            }
-        }
-    });
 
-    it("token theft detection with API key", async function () {
-        await setKeyValueInConfig("api_keys", "shfo3h98308hOIHoei309saiho");
-        await startST();
-        SuperTokens.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-                apiKey: "shfo3h98308hOIHoei309saiho",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [Session.init()],
+            await SessionFunctions.getSession(
+                SessionRecipe.getInstanceOrThrowError(),
+                response2.accessToken.token,
+                response2.antiCsrfToken,
+                true,
+                response2.idRefreshToken.token
+            );
+
+            try {
+                await SessionFunctions.refreshSession(
+                    SessionRecipe.getInstanceOrThrowError(),
+                    response.refreshToken.token,
+                    response.antiCsrfToken
+                );
+                throw new Error("should not have come here");
+            } catch (err) {
+                if (err.type !== Session.Error.TOKEN_THEFT_DETECTED) {
+                    throw err;
+                }
+            }
         });
 
-        let response = await SessionFunctions.createNewSession(SessionRecipe.getInstanceOrThrowError(), "", {}, {});
+        it("test basic usage of sessions", async function () {
+            const s = SessionRecipe.getInstanceOrThrowError();
 
-        let response2 = await SessionFunctions.refreshSession(
-            SessionRecipe.getInstanceOrThrowError(),
-            response.refreshToken.token,
-            response.antiCsrfToken
-        );
+            let response = await SessionFunctions.createNewSession(s, "", {}, {});
+            assert.notStrictEqual(response.session, undefined);
+            assert.notStrictEqual(response.accessToken, undefined);
+            assert.notStrictEqual(response.refreshToken, undefined);
+            assert.notStrictEqual(response.idRefreshToken, undefined);
+            assert.notStrictEqual(response.antiCsrfToken, undefined);
+            assert.deepStrictEqual(Object.keys(response).length, 5);
 
-        await SessionFunctions.getSession(
-            SessionRecipe.getInstanceOrThrowError(),
-            response2.accessToken.token,
-            response2.antiCsrfToken,
-            true,
-            response2.idRefreshToken.token
-        );
+            await SessionFunctions.getSession(
+                s,
+                response.accessToken.token,
+                response.antiCsrfToken,
+                true,
+                response.idRefreshToken.token
+            );
+            let verifyState3 = await ProcessState.getInstance().waitForEvent(
+                PROCESS_STATE.CALLING_SERVICE_IN_VERIFY,
+                1500
+            );
+            assert.deepStrictEqual(verifyState3, undefined);
 
-        try {
-            await SessionFunctions.refreshSession(
+            let response2 = await SessionFunctions.refreshSession(
+                s,
+                response.refreshToken.token,
+                response.antiCsrfToken
+            );
+            assert.notStrictEqual(response2.session, undefined);
+            assert.notStrictEqual(response2.accessToken, undefined);
+            assert.notStrictEqual(response2.refreshToken, undefined);
+            assert.notStrictEqual(response2.idRefreshToken, undefined);
+            assert.notStrictEqual(response2.antiCsrfToken, undefined);
+            assert.deepStrictEqual(Object.keys(response2).length, 5);
+
+            let response3 = await SessionFunctions.getSession(
+                s,
+                response2.accessToken.token,
+                response2.antiCsrfToken,
+                true,
+                response.idRefreshToken.token
+            );
+            let verifyState = await ProcessState.getInstance().waitForEvent(PROCESS_STATE.CALLING_SERVICE_IN_VERIFY);
+            assert.notStrictEqual(verifyState, undefined);
+            assert.notStrictEqual(response3.session, undefined);
+            assert.notStrictEqual(response3.accessToken, undefined);
+            assert.deepStrictEqual(Object.keys(response3).length, 2);
+
+            ProcessState.getInstance().reset();
+
+            let response4 = await SessionFunctions.getSession(
+                s,
+                response3.accessToken.token,
+                response2.antiCsrfToken,
+                true,
+                response.idRefreshToken.token
+            );
+            let verifyState2 = await ProcessState.getInstance().waitForEvent(
+                PROCESS_STATE.CALLING_SERVICE_IN_VERIFY,
+                1000
+            );
+            assert.deepStrictEqual(verifyState2, undefined);
+            assert.notStrictEqual(response4.session, undefined);
+            assert.deepStrictEqual(response4.accessToken, undefined);
+            assert.deepStrictEqual(Object.keys(response4).length, 1);
+
+            let response5 = await SessionFunctions.revokeSession(s, response4.session.handle);
+            assert.deepStrictEqual(response5, true);
+        });
+
+        //check session verify for with / without anti-csrf present
+        it("test session verify with anti-csrf present", async function () {
+            const s = SessionRecipe.getInstanceOrThrowError();
+
+            let response = await SessionFunctions.createNewSession(s, "", {}, {});
+
+            let response2 = await SessionFunctions.getSession(
+                s,
+                response.accessToken.token,
+                response.antiCsrfToken,
+                true,
+                response.idRefreshToken.token
+            );
+            assert.notDeepStrictEqual(response2.session, undefined);
+            assert.deepStrictEqual(Object.keys(response2.session).length, 3);
+
+            let response3 = await SessionFunctions.getSession(
+                s,
+                response.accessToken.token,
+                response.antiCsrfToken,
+                false,
+                response.idRefreshToken.token
+            );
+            assert.notDeepStrictEqual(response3.session, undefined);
+            assert.deepStrictEqual(Object.keys(response3.session).length, 3);
+        });
+
+        //check session verify for with / without anti-csrf present**
+        it("test session verify without anti-csrf present", async function () {
+            const s = SessionRecipe.getInstanceOrThrowError();
+
+            let response = await SessionFunctions.createNewSession(s, "", {}, {});
+
+            //passing anti-csrf token as undefined and anti-csrf check as false
+            let response2 = await SessionFunctions.getSession(
+                s,
+                response.accessToken.token,
+                undefined,
+                false,
+                response.idRefreshToken
+            );
+            assert.notDeepStrictEqual(response2.session, undefined);
+            assert.deepStrictEqual(Object.keys(response2.session).length, 3);
+
+            //passing anti-csrf token as undefined and anti-csrf check as true
+            try {
+                await SessionFunctions.getSession(
+                    s,
+                    response.accessToken.token,
+                    undefined,
+                    true,
+                    response.idRefreshToken
+                );
+                throw new Error("should not have come here");
+            } catch (err) {
+                if (err.type !== Session.Error.TRY_REFRESH_TOKEN) {
+                    throw err;
+                }
+            }
+        });
+
+        //check revoking session(s)
+        it("test revoking of sessions", async function () {
+            const s = SessionRecipe.getInstanceOrThrowError();
+            //create a single session and  revoke using the session handle
+            let res = await SessionFunctions.createNewSession(s, "someUniqueUserId", {}, {});
+            let res2 = await SessionFunctions.revokeSession(s, res.session.handle);
+            assert.deepStrictEqual(res2, true);
+
+            let res3 = await SessionFunctions.getAllSessionHandlesForUser(s, "someUniqueUserId");
+            assert.deepStrictEqual(res3.length, 0);
+
+            //create multiple sessions with the same userID and use revokeAllSessionsForUser to revoke sessions
+            await SessionFunctions.createNewSession(s, "someUniqueUserId", {}, {});
+            await SessionFunctions.createNewSession(s, "someUniqueUserId", {}, {});
+
+            let sessionIdResponse = await SessionFunctions.getAllSessionHandlesForUser(s, "someUniqueUserId");
+            assert.deepStrictEqual(sessionIdResponse.length, 2);
+
+            let response = await SessionFunctions.revokeAllSessionsForUser(s, "someUniqueUserId");
+            assert.deepStrictEqual(response.length, 2);
+
+            sessionIdResponse = await SessionFunctions.getAllSessionHandlesForUser(s, "someUniqueUserId");
+            assert.deepStrictEqual(sessionIdResponse.length, 0);
+
+            //revoke a session with a session handle that does not exist
+            let resp = await SessionFunctions.revokeSession(s, "");
+            assert.deepStrictEqual(resp, false);
+
+            //revoke a session with a userId that does not exist
+            let resp2 = await SessionFunctions.revokeAllSessionsForUser(s, "random");
+            assert.deepStrictEqual(resp2.length, 0);
+        });
+
+        //check manipulating session data
+        it("test manipulating session data", async function () {
+            const s = SessionRecipe.getInstanceOrThrowError();
+            //adding session data
+            let res = await SessionFunctions.createNewSession(s, "", {}, {});
+            await SessionFunctions.updateSessionData(s, res.session.handle, { key: "value" });
+
+            let res2 = await SessionFunctions.getSessionData(s, res.session.handle);
+            assert.deepStrictEqual(res2, { key: "value" });
+
+            //changing the value of session data with the same key
+            await SessionFunctions.updateSessionData(s, res.session.handle, { key: "value 2" });
+
+            let res3 = await SessionFunctions.getSessionData(s, res.session.handle);
+            assert.deepStrictEqual(res3, { key: "value 2" });
+
+            //passing invalid session handle when updating session data
+            try {
+                await SessionFunctions.updateSessionData(s, "random", { key2: "value2" });
+                assert.deepStrictEqual(false);
+            } catch (error) {
+                if (error.type !== Session.Error.UNAUTHORISED) {
+                    throw error;
+                }
+            }
+        });
+
+        //check manipulating jwt payload
+        it("test manipulating jwt payload", async function () {
+            const s = SessionRecipe.getInstanceOrThrowError();
+            //adding jwt payload
+            let res = await SessionFunctions.createNewSession(s, "", {}, {});
+
+            await SessionFunctions.updateJWTPayload(s, res.session.handle, { key: "value" });
+
+            let res2 = await SessionFunctions.getJWTPayload(s, res.session.handle);
+            assert.deepStrictEqual(res2, { key: "value" });
+
+            //changing the value of jwt payload with the same key
+            await SessionFunctions.updateJWTPayload(s, res.session.handle, { key: "value 2" });
+
+            let res3 = await SessionFunctions.getJWTPayload(s, res.session.handle);
+            assert.deepStrictEqual(res3, { key: "value 2" });
+
+            //passing invalid session handle when updating jwt payload
+            try {
+                await SessionFunctions.updateJWTPayload(s, "random", { key2: "value2" });
+                throw new Error();
+            } catch (error) {
+                if (error.type !== Session.Error.UNAUTHORISED) {
+                    throw error;
+                }
+            }
+        });
+    });
+
+    describe("With API Key", function () {
+        let app;
+
+        before(async function () {
+            const apiKey = "shfo3h98308hOIHoei309saiho";
+            await killAllST();
+            await setupST();
+            await setKeyValueInConfig("api_keys", apiKey);
+            await startST();
+            SuperTokens.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                    apiKey,
+                },
+                appInfo: {
+                    apiDomain: "api.supertokens.io",
+                    appName: "SuperTokens",
+                    websiteDomain: "supertokens.io",
+                },
+                recipeList: [Session.init()],
+            });
+
+            app = express();
+
+            app.use(SuperTokens.middleware());
+
+            app.use(SuperTokens.errorHandler());
+        });
+
+        beforeEach(async function () {
+            ProcessState.getInstance().reset();
+        });
+
+        after(async function () {
+            await killAllST();
+            await cleanST();
+        });
+
+        it("token theft detection with API key", async function () {
+            const response = await SessionFunctions.createNewSession(
+                SessionRecipe.getInstanceOrThrowError(),
+                "",
+                {},
+                {}
+            );
+
+            let response2 = await SessionFunctions.refreshSession(
                 SessionRecipe.getInstanceOrThrowError(),
                 response.refreshToken.token,
                 response.antiCsrfToken
             );
-            throw new Error("should not have come here");
-        } catch (err) {
-            if (err.type !== Session.Error.TOKEN_THEFT_DETECTED) {
-                throw err;
+
+            await SessionFunctions.getSession(
+                SessionRecipe.getInstanceOrThrowError(),
+                response2.accessToken.token,
+                response2.antiCsrfToken,
+                true,
+                response2.idRefreshToken.token
+            );
+
+            try {
+                await SessionFunctions.refreshSession(
+                    SessionRecipe.getInstanceOrThrowError(),
+                    response.refreshToken.token,
+                    response.antiCsrfToken
+                );
+                throw new Error("should not have come here");
+            } catch (err) {
+                if (err.type !== Session.Error.TOKEN_THEFT_DETECTED) {
+                    throw err;
+                }
             }
-        }
+        });
     });
 
-    it("query without API key", async function () {
-        await setKeyValueInConfig("api_keys", "shfo3h98308hOIHoei309saiho");
-        await startST();
-        SuperTokens.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [Session.init()],
+    describe("With API Key in core configs", function () {
+        let app;
+
+        before(async function () {
+            const apiKey = "shfo3h98308hOIHoei309saiho";
+            await killAllST();
+            await setupST();
+            await setKeyValueInConfig("api_keys", apiKey);
+            await startST();
+            SuperTokens.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                },
+                appInfo: {
+                    apiDomain: "api.supertokens.io",
+                    appName: "SuperTokens",
+                    websiteDomain: "supertokens.io",
+                },
+                recipeList: [Session.init()],
+            });
+
+            app = express();
+
+            app.use(SuperTokens.middleware());
+
+            app.use(SuperTokens.errorHandler());
         });
 
-        try {
-            await Querier.getInstanceOrThrowError("").getAPIVersion();
-            throw new Error("should not have come here");
-        } catch (err) {
-            if (
-                err.type !== Session.Error.GENERAL_ERROR ||
-                err.message !==
-                    "SuperTokens core threw an error for a GET request to path: '/apiversion' with status code: 401 and message: Invalid API key\n"
-            ) {
-                throw err;
+        beforeEach(async function () {
+            ProcessState.getInstance().reset();
+        });
+
+        after(async function () {
+            await killAllST();
+            await cleanST();
+        });
+
+        it("query without API key", async function () {
+            try {
+                await Querier.getInstanceOrThrowError("").getAPIVersion();
+                throw new Error("should not have come here");
+            } catch (err) {
+                if (
+                    err.type !== Session.Error.GENERAL_ERROR ||
+                    err.message !==
+                        "SuperTokens core threw an error for a GET request to path: '/apiversion' with status code: 401 and message: Invalid API key\n"
+                ) {
+                    throw err;
+                }
             }
-        }
+        });
     });
 
-    //check basic usage of session
-    it("test basic usage of sessions", async function () {
-        await startST();
-        SuperTokens.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [Session.init()],
+    describe("With CSRF disabled and cookie = sameSite none", function () {
+        let app;
+
+        before(async function () {
+            await killAllST();
+            await setupST();
+            await setKeyValueInConfig("enable_anti_csrf", "false");
+            await startST();
+            SuperTokens.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                },
+                appInfo: {
+                    apiDomain: "api.supertokens.io",
+                    appName: "SuperTokens",
+                    websiteDomain: "supertokens.io",
+                },
+                recipeList: [
+                    Session.init({
+                        cookieSameSite: "none",
+                    }),
+                ],
+            });
+
+            app = express();
+
+            app.use(SuperTokens.middleware());
+
+            app.use(SuperTokens.errorHandler());
         });
 
-        let s = SessionRecipe.getInstanceOrThrowError();
-
-        let response = await SessionFunctions.createNewSession(s, "", {}, {});
-        assert(response.session !== undefined);
-        assert(response.accessToken !== undefined);
-        assert(response.refreshToken !== undefined);
-        assert(response.idRefreshToken !== undefined);
-        assert(response.antiCsrfToken !== undefined);
-        assert(Object.keys(response).length === 5);
-
-        await SessionFunctions.getSession(
-            s,
-            response.accessToken.token,
-            response.antiCsrfToken,
-            true,
-            response.idRefreshToken.token
-        );
-        let verifyState3 = await ProcessState.getInstance().waitForEvent(PROCESS_STATE.CALLING_SERVICE_IN_VERIFY, 1500);
-        assert(verifyState3 === undefined);
-
-        let response2 = await SessionFunctions.refreshSession(s, response.refreshToken.token, response.antiCsrfToken);
-        assert(response2.session !== undefined);
-        assert(response2.accessToken !== undefined);
-        assert(response2.refreshToken !== undefined);
-        assert(response2.idRefreshToken !== undefined);
-        assert(response2.antiCsrfToken !== undefined);
-        assert(Object.keys(response2).length === 5);
-
-        let response3 = await SessionFunctions.getSession(
-            s,
-            response2.accessToken.token,
-            response2.antiCsrfToken,
-            true,
-            response.idRefreshToken.token
-        );
-        let verifyState = await ProcessState.getInstance().waitForEvent(PROCESS_STATE.CALLING_SERVICE_IN_VERIFY);
-        assert(verifyState !== undefined);
-        assert(response3.session !== undefined);
-        assert(response3.accessToken !== undefined);
-        assert(Object.keys(response3).length === 2);
-
-        ProcessState.getInstance().reset();
-
-        let response4 = await SessionFunctions.getSession(
-            s,
-            response3.accessToken.token,
-            response2.antiCsrfToken,
-            true,
-            response.idRefreshToken.token
-        );
-        let verifyState2 = await ProcessState.getInstance().waitForEvent(PROCESS_STATE.CALLING_SERVICE_IN_VERIFY, 1000);
-        assert(verifyState2 === undefined);
-        assert(response4.session !== undefined);
-        assert(response4.accessToken === undefined);
-        assert(Object.keys(response4).length === 1);
-
-        let response5 = await SessionFunctions.revokeSession(s, response4.session.handle);
-        assert(response5 === true);
-    });
-
-    //check session verify for with / without anti-csrf present
-    it("test session verify with anti-csrf present", async function () {
-        await startST();
-        SuperTokens.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [Session.init()],
+        beforeEach(async function () {
+            ProcessState.getInstance().reset();
         });
 
-        let s = SessionRecipe.getInstanceOrThrowError();
-
-        let response = await SessionFunctions.createNewSession(s, "", {}, {});
-
-        let response2 = await SessionFunctions.getSession(
-            s,
-            response.accessToken.token,
-            response.antiCsrfToken,
-            true,
-            response.idRefreshToken.token
-        );
-        assert(response2.session != undefined);
-        assert(Object.keys(response2.session).length === 3);
-
-        let response3 = await SessionFunctions.getSession(
-            s,
-            response.accessToken.token,
-            response.antiCsrfToken,
-            false,
-            response.idRefreshToken.token
-        );
-        assert(response3.session != undefined);
-        assert(Object.keys(response3.session).length === 3);
-    });
-
-    //check session verify for with / without anti-csrf present**
-    it("test session verify without anti-csrf present", async function () {
-        await startST();
-        SuperTokens.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [Session.init()],
+        after(async function () {
+            await killAllST();
+            await cleanST();
         });
 
-        let s = SessionRecipe.getInstanceOrThrowError();
+        it("test that anti-csrf disabled and sameSite none throws an error", async function () {
+            const session = SessionRecipe.getInstanceOrThrowError();
 
-        let response = await SessionFunctions.createNewSession(s, "", {}, {});
-
-        //passing anti-csrf token as undefined and anti-csrf check as false
-        let response2 = await SessionFunctions.getSession(
-            s,
-            response.accessToken.token,
-            undefined,
-            false,
-            response.idRefreshToken
-        );
-        assert(response2.session != undefined);
-        assert(Object.keys(response2.session).length === 3);
-
-        //passing anti-csrf token as undefined and anti-csrf check as true
-        try {
-            await SessionFunctions.getSession(s, response.accessToken.token, undefined, true, response.idRefreshToken);
-            throw new Error("should not have come here");
-        } catch (err) {
-            if (err.type !== Session.Error.TRY_REFRESH_TOKEN) {
-                throw err;
+            try {
+                await SessionFunctions.createNewSession(session, "", {}, {});
+                assert.deepStrictEqual(false);
+            } catch (err) {
+                if (
+                    err.type !== Session.Error.GENERAL_ERROR ||
+                    err.message !==
+                        'Security error: Cookie same site is "none" and anti-CSRF protection is disabled! Please either: \n- Change cookie same site to "lax" or to "strict". or \n- Enable anti-CSRF protection in the core by setting enable_anti_csrf to true.'
+                ) {
+                    throw error;
+                }
             }
-        }
+        });
     });
 
-    //check revoking session(s)
-    it("test revoking of sessions", async function () {
-        await startST();
-        SuperTokens.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [Session.init()],
+    describe("With CSRF disabled and cookie = sameSite none", function () {
+        before(async function () {
+            await killAllST();
+            await setupST();
+            await setKeyValueInConfig("enable_anti_csrf", "false");
+            await startST();
+            SuperTokens.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                },
+                appInfo: {
+                    apiDomain: "api.supertokens.io",
+                    appName: "SuperTokens",
+                    websiteDomain: "supertokens.io",
+                },
+                recipeList: [
+                    Session.init({
+                        cookieSameSite: "none",
+                    }),
+                ],
+            });
         });
 
-        let s = SessionRecipe.getInstanceOrThrowError();
-        //create a single session and  revoke using the session handle
-        let res = await SessionFunctions.createNewSession(s, "someUniqueUserId", {}, {});
-        let res2 = await SessionFunctions.revokeSession(s, res.session.handle);
-        assert(res2 === true);
+        beforeEach(async function () {
+            ProcessState.getInstance().reset();
+        });
 
-        let res3 = await SessionFunctions.getAllSessionHandlesForUser(s, "someUniqueUserId");
-        assert(res3.length === 0);
-
-        //create multiple sessions with the same userID and use revokeAllSessionsForUser to revoke sessions
-        await SessionFunctions.createNewSession(s, "someUniqueUserId", {}, {});
-        await SessionFunctions.createNewSession(s, "someUniqueUserId", {}, {});
-
-        let sessionIdResponse = await SessionFunctions.getAllSessionHandlesForUser(s, "someUniqueUserId");
-        assert(sessionIdResponse.length === 2);
-
-        let response = await SessionFunctions.revokeAllSessionsForUser(s, "someUniqueUserId");
-        assert(response.length === 2);
-
-        sessionIdResponse = await SessionFunctions.getAllSessionHandlesForUser(s, "someUniqueUserId");
-        assert(sessionIdResponse.length === 0);
-
-        //revoke a session with a session handle that does not exist
-        let resp = await SessionFunctions.revokeSession(s, "");
-        assert(resp === false);
-
-        //revoke a session with a userId that does not exist
-        let resp2 = await SessionFunctions.revokeAllSessionsForUser(s, "random");
-        assert(resp2.length === 0);
+        after(async function () {
+            await killAllST();
+            await cleanST();
+        });
     });
 
-    //check manipulating session data
-    it("test manipulating session data", async function () {
-        await startST();
-        SuperTokens.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [Session.init()],
+    describe("With CSRF disabled in the core but default node config", function () {
+        before(async function () {
+            await killAllST();
+            await setupST();
+            await setKeyValueInConfig("enable_anti_csrf", "false");
+            await startST();
+            SuperTokens.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                },
+                appInfo: {
+                    apiDomain: "api.supertokens.io",
+                    appName: "SuperTokens",
+                    websiteDomain: "supertokens.io",
+                },
+                recipeList: [Session.init()],
+            });
         });
 
-        let s = SessionRecipe.getInstanceOrThrowError();
-        //adding session data
-        let res = await SessionFunctions.createNewSession(s, "", {}, {});
-        await SessionFunctions.updateSessionData(s, res.session.handle, { key: "value" });
+        beforeEach(async function () {
+            ProcessState.getInstance().reset();
+        });
 
-        let res2 = await SessionFunctions.getSessionData(s, res.session.handle);
-        assert.deepEqual(res2, { key: "value" });
+        after(async function () {
+            await killAllST();
+            await cleanST();
+        });
 
-        //changing the value of session data with the same key
-        await SessionFunctions.updateSessionData(s, res.session.handle, { key: "value 2" });
+        it("test that when anti-csrf is disabled from ST core not having that in input to verify session is fine", async function () {
+            const s = SessionRecipe.getInstanceOrThrowError();
+            let response = await SessionFunctions.createNewSession(s, "", {}, {});
 
-        let res3 = await SessionFunctions.getSessionData(s, res.session.handle);
-        assert.deepEqual(res3, { key: "value 2" });
+            //passing anti-csrf token as undefined and anti-csrf check as false
+            let response2 = await SessionFunctions.getSession(
+                s,
+                response.accessToken.token,
+                undefined,
+                false,
+                response.idRefreshToken
+            );
+            assert.notDeepStrictEqual(response2.session, undefined);
+            assert.deepStrictEqual(Object.keys(response2.session).length, 3);
 
-        //passing invalid session handle when updating session data
-        try {
-            await SessionFunctions.updateSessionData(s, "random", { key2: "value2" });
-            assert(false);
-        } catch (error) {
-            if (error.type !== Session.Error.UNAUTHORISED) {
-                throw error;
-            }
-        }
+            //passing anti-csrf token as undefined and anti-csrf check as true
+            let response3 = await SessionFunctions.getSession(
+                s,
+                response.accessToken.token,
+                undefined,
+                true,
+                response.idRefreshToken
+            );
+            assert.notDeepStrictEqual(response3.session, undefined);
+            assert.deepStrictEqual(Object.keys(response3.session).length, 3);
+        });
     });
 
-    //check manipulating jwt payload
-    it("test manipulating jwt payload", async function () {
-        await startST();
-        SuperTokens.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [Session.init()],
+    describe("With CSRF disabled in the core and cookieSameSite lax", function () {
+        before(async function () {
+            await killAllST();
+            await setupST();
+            await setKeyValueInConfig("enable_anti_csrf", "false");
+            await startST();
+            SuperTokens.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                },
+                appInfo: {
+                    apiDomain: "api.supertokens.io",
+                    appName: "SuperTokens",
+                    websiteDomain: "supertokens.io",
+                },
+                recipeList: [
+                    Session.init({
+                        cookieSameSite: "lax",
+                    }),
+                ],
+            });
         });
 
-        let s = SessionRecipe.getInstanceOrThrowError();
-        //adding jwt payload
-        let res = await SessionFunctions.createNewSession(s, "", {}, {});
-
-        await SessionFunctions.updateJWTPayload(s, res.session.handle, { key: "value" });
-
-        let res2 = await SessionFunctions.getJWTPayload(s, res.session.handle);
-        assert.deepEqual(res2, { key: "value" });
-
-        //changing the value of jwt payload with the same key
-        await SessionFunctions.updateJWTPayload(s, res.session.handle, { key: "value 2" });
-
-        let res3 = await SessionFunctions.getJWTPayload(s, res.session.handle);
-        assert.deepEqual(res3, { key: "value 2" });
-
-        //passing invalid session handle when updating jwt payload
-        try {
-            await SessionFunctions.updateJWTPayload(s, "random", { key2: "value2" });
-            throw new Error();
-        } catch (error) {
-            if (error.type !== Session.Error.UNAUTHORISED) {
-                throw error;
-            }
-        }
-    });
-
-    //if anti-csrf is disabled from ST core, check that not having that in input to verify session is fine**
-    it("test that when anti-csrf is disabled from ST core not having that in input to verify session is fine", async function () {
-        await setKeyValueInConfig("enable_anti_csrf", "false");
-        await startST();
-        SuperTokens.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [Session.init()],
+        beforeEach(async function () {
+            ProcessState.getInstance().reset();
         });
 
-        let s = SessionRecipe.getInstanceOrThrowError();
-        let response = await SessionFunctions.createNewSession(s, "", {}, {});
-
-        //passing anti-csrf token as undefined and anti-csrf check as false
-        let response2 = await SessionFunctions.getSession(
-            s,
-            response.accessToken.token,
-            undefined,
-            false,
-            response.idRefreshToken
-        );
-        assert(response2.session != undefined);
-        assert(Object.keys(response2.session).length === 3);
-
-        //passing anti-csrf token as undefined and anti-csrf check as true
-        let response3 = await SessionFunctions.getSession(
-            s,
-            response.accessToken.token,
-            undefined,
-            true,
-            response.idRefreshToken
-        );
-        assert(response3.session != undefined);
-        assert(Object.keys(response3.session).length === 3);
-    });
-
-    it("test that anti-csrf disabled and sameSite none throws an error", async function () {
-        await setKeyValueInConfig("enable_anti_csrf", "false");
-        await startST();
-
-        SuperTokens.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [
-                Session.init({
-                    cookieSameSite: "none",
-                }),
-            ],
+        after(async function () {
+            await killAllST();
+            await cleanST();
         });
 
-        let s = SessionRecipe.getInstanceOrThrowError();
-
-        try {
+        it("test that anti-csrf disabled and sameSite lax does now throw an error", async function () {
+            let s = SessionRecipe.getInstanceOrThrowError();
             await SessionFunctions.createNewSession(s, "", {}, {});
-            assert(false);
-        } catch (err) {
-            if (
-                err.type !== Session.Error.GENERAL_ERROR ||
-                err.message !==
-                    'Security error: Cookie same site is "none" and anti-CSRF protection is disabled! Please either: \n- Change cookie same site to "lax" or to "strict". or \n- Enable anti-CSRF protection in the core by setting enable_anti_csrf to true.'
-            ) {
-                throw error;
-            }
-        }
+        });
     });
 
-    it("test that anti-csrf disabled and sameSite lax does now throw an error", async function () {
-        await setKeyValueInConfig("enable_anti_csrf", "false");
-        await startST();
-        SuperTokens.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [
-                Session.init({
-                    cookieSameSite: "lax",
-                }),
-            ],
+    describe("With CSRF disabled in the core and cookieSameSite lax", function () {
+        before(async function () {
+            await killAllST();
+            await setupST();
+            await setKeyValueInConfig("enable_anti_csrf", "false");
+            await startST();
+            SuperTokens.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                },
+                appInfo: {
+                    apiDomain: "api.supertokens.io",
+                    appName: "SuperTokens",
+                    websiteDomain: "supertokens.io",
+                },
+                recipeList: [
+                    Session.init({
+                        cookieSameSite: "strict",
+                    }),
+                ],
+            });
         });
 
-        let s = SessionRecipe.getInstanceOrThrowError();
-        await SessionFunctions.createNewSession(s, "", {}, {});
-    });
-
-    it("test that anti-csrf disabled and sameSite strict does now throw an error", async function () {
-        await setKeyValueInConfig("enable_anti_csrf", "false");
-        await startST();
-        SuperTokens.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [
-                Session.init({
-                    cookieSameSite: "strict",
-                }),
-            ],
+        beforeEach(async function () {
+            ProcessState.getInstance().reset();
         });
 
-        let s = SessionRecipe.getInstanceOrThrowError();
-        await SessionFunctions.createNewSession(s, "", {}, {});
+        after(async function () {
+            await killAllST();
+            await cleanST();
+        });
+
+        it("test that anti-csrf disabled and sameSite strict does now throw an error", async function () {
+            let s = SessionRecipe.getInstanceOrThrowError();
+            await SessionFunctions.createNewSession(s, "", {}, {});
+        });
     });
 });

--- a/test/sessionExpress.test.js
+++ b/test/sessionExpress.test.js
@@ -197,17 +197,17 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                     }
                 })
         );
-        assert.deepEqual(res3.body.success, true);
+        assert.deepStrictEqual(res3.body.success, true);
 
         let cookies = extractInfoFromResponse(res3);
-        assert.deepEqual(cookies.antiCsrf, undefined);
-        assert.deepEqual(cookies.accessToken, "");
-        assert.deepEqual(cookies.refreshToken, "");
-        assert.deepEqual(cookies.idRefreshTokenFromHeader, "remove");
-        assert.deepEqual(cookies.idRefreshTokenFromCookie, "");
-        assert.deepEqual(cookies.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
-        assert.deepEqual(cookies.idRefreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
-        assert.deepEqual(cookies.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(cookies.antiCsrf, undefined);
+        assert.deepStrictEqual(cookies.accessToken, "");
+        assert.deepStrictEqual(cookies.refreshToken, "");
+        assert.deepStrictEqual(cookies.idRefreshTokenFromHeader, "remove");
+        assert.deepStrictEqual(cookies.idRefreshTokenFromCookie, "");
+        assert.deepStrictEqual(cookies.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(cookies.idRefreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(cookies.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
         assert(cookies.accessTokenDomain === undefined);
         assert(cookies.refreshTokenDomain === undefined);
         assert(cookies.idRefreshTokenDomain === undefined);
@@ -300,17 +300,17 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                 })
         );
         assert(res3.status === 401);
-        assert.deepEqual(res3.text, '{"message":"token theft detected"}');
+        assert.deepStrictEqual(res3.text, '{"message":"token theft detected"}');
 
         let cookies = extractInfoFromResponse(res3);
-        assert.deepEqual(cookies.antiCsrf, undefined);
-        assert.deepEqual(cookies.accessToken, "");
-        assert.deepEqual(cookies.refreshToken, "");
-        assert.deepEqual(cookies.idRefreshTokenFromHeader, "remove");
-        assert.deepEqual(cookies.idRefreshTokenFromCookie, "");
-        assert.deepEqual(cookies.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
-        assert.deepEqual(cookies.idRefreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
-        assert.deepEqual(cookies.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(cookies.antiCsrf, undefined);
+        assert.deepStrictEqual(cookies.accessToken, "");
+        assert.deepStrictEqual(cookies.refreshToken, "");
+        assert.deepStrictEqual(cookies.idRefreshTokenFromHeader, "remove");
+        assert.deepStrictEqual(cookies.idRefreshTokenFromCookie, "");
+        assert.deepStrictEqual(cookies.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(cookies.idRefreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert.deepStrictEqual(cookies.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
     });
 
     //check basic usage of session
@@ -700,7 +700,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                     }
                 })
         );
-        assert.deepEqual(res2.body.userId, "id1");
+        assert.deepStrictEqual(res2.body.userId, "id1");
 
         let res3 = await new Promise((resolve) =>
             request(app)
@@ -715,7 +715,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                     }
                 })
         );
-        assert.deepEqual(res3.body.userId, "id1");
+        assert.deepStrictEqual(res3.body.userId, "id1");
     });
 
     // check session verify for with / without anti-csrf present
@@ -783,7 +783,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                     }
                 })
         );
-        assert.deepEqual(response2.body.userId, "id1");
+        assert.deepStrictEqual(response2.body.userId, "id1");
 
         let response = await new Promise((resolve) =>
             request(app)
@@ -797,7 +797,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                     }
                 })
         );
-        assert.deepEqual(response.body.success, true);
+        assert.deepStrictEqual(response.body.success, true);
     });
 
     //check revoking session(s)**
@@ -1042,7 +1042,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
         );
 
         //check that the session data returned is valid
-        assert.deepEqual(response2.body.key, "value");
+        assert.deepStrictEqual(response2.body.key, "value");
 
         // change the value of the inserted session data
         await new Promise((resolve) =>
@@ -1080,7 +1080,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
         );
 
         //check the value of the retrieved
-        assert.deepEqual(response2.body.key, "value2");
+        assert.deepStrictEqual(response2.body.key, "value2");
 
         //invalid session handle when updating the session data
         let invalidSessionResponse = await new Promise((resolve) =>
@@ -1099,7 +1099,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                     }
                 })
         );
-        assert.deepEqual(invalidSessionResponse.body.success, true);
+        assert.deepStrictEqual(invalidSessionResponse.body.success, true);
     });
 
     //check manipulating jwt payload
@@ -1173,7 +1173,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
 
         let frontendInfo = JSON.parse(new Buffer.from(response.frontToken, "base64").toString());
         assert(frontendInfo.uid === "user1");
-        assert.deepEqual(frontendInfo.up, {});
+        assert.deepStrictEqual(frontendInfo.up, {});
 
         //call the updateJWTPayload api to add jwt payload
         let updatedResponse = extractInfoFromResponse(
@@ -1200,7 +1200,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
 
         frontendInfo = JSON.parse(new Buffer.from(updatedResponse.frontToken, "base64").toString());
         assert(frontendInfo.uid === "user1");
-        assert.deepEqual(frontendInfo.up, { key: "value" });
+        assert.deepStrictEqual(frontendInfo.up, { key: "value" });
 
         //call the getJWTPayload api to get jwt payload
         let response2 = await new Promise((resolve) =>
@@ -1223,7 +1223,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                 })
         );
         //check that the jwt payload returned is valid
-        assert.deepEqual(response2.body.key, "value");
+        assert.deepStrictEqual(response2.body.key, "value");
 
         // refresh session
         response2 = extractInfoFromResponse(
@@ -1250,7 +1250,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
 
         frontendInfo = JSON.parse(new Buffer.from(response2.frontToken, "base64").toString());
         assert(frontendInfo.uid === "user1");
-        assert.deepEqual(frontendInfo.up, { key: "value" });
+        assert.deepStrictEqual(frontendInfo.up, { key: "value" });
 
         // change the value of the inserted jwt payload
         let updatedResponse2 = extractInfoFromResponse(
@@ -1277,7 +1277,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
 
         frontendInfo = JSON.parse(new Buffer.from(updatedResponse2.frontToken, "base64").toString());
         assert(frontendInfo.uid === "user1");
-        assert.deepEqual(frontendInfo.up, { key: "value2" });
+        assert.deepStrictEqual(frontendInfo.up, { key: "value2" });
 
         //retrieve the changed jwt payload
         response2 = await new Promise((resolve) =>
@@ -1301,7 +1301,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
         );
 
         //check the value of the retrieved
-        assert.deepEqual(response2.body.key, "value2");
+        assert.deepStrictEqual(response2.body.key, "value2");
         //invalid session handle when updating the jwt payload
         let invalidSessionResponse = await new Promise((resolve) =>
             request(app)
@@ -1322,7 +1322,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                     }
                 })
         );
-        assert.deepEqual(invalidSessionResponse.body.success, true);
+        assert.deepStrictEqual(invalidSessionResponse.body.success, true);
     });
 
     // test with existing header params being there and that the lib appends to those and not overrides those
@@ -1361,8 +1361,8 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                     }
                 })
         );
-        assert.deepEqual(response.headers.testheader, "testValue");
-        assert.deepEqual(
+        assert.deepStrictEqual(response.headers.testheader, "testValue");
+        assert.deepStrictEqual(
             response.headers["access-control-expose-headers"],
             "customValue, front-token, id-refresh-token, anti-csrf"
         );
@@ -1434,7 +1434,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                     }
                 })
         );
-        assert.deepEqual(res2.body.userId, "id1");
+        assert.deepStrictEqual(res2.body.userId, "id1");
 
         let res3 = await new Promise((resolve) =>
             request(app)
@@ -1448,7 +1448,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                     }
                 })
         );
-        assert.deepEqual(res3.body.userId, "id1");
+        assert.deepStrictEqual(res3.body.userId, "id1");
     });
 
     it("test that getSession does not clear cookies if a session does not exist in the first place", async function () {
@@ -1491,17 +1491,17 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                 })
         );
 
-        assert.deepEqual(res.body.success, true);
+        assert.deepStrictEqual(res.body.success, true);
 
         let cookies = extractInfoFromResponse(res);
-        assert.deepEqual(cookies.antiCsrf, undefined);
-        assert.deepEqual(cookies.accessToken, undefined);
-        assert.deepEqual(cookies.refreshToken, undefined);
-        assert.deepEqual(cookies.idRefreshTokenFromHeader, undefined);
-        assert.deepEqual(cookies.idRefreshTokenFromCookie, undefined);
-        assert.deepEqual(cookies.accessTokenExpiry, undefined);
-        assert.deepEqual(cookies.idRefreshTokenExpiry, undefined);
-        assert.deepEqual(cookies.refreshTokenExpiry, undefined);
+        assert.deepStrictEqual(cookies.antiCsrf, undefined);
+        assert.deepStrictEqual(cookies.accessToken, undefined);
+        assert.deepStrictEqual(cookies.refreshToken, undefined);
+        assert.deepStrictEqual(cookies.idRefreshTokenFromHeader, undefined);
+        assert.deepStrictEqual(cookies.idRefreshTokenFromCookie, undefined);
+        assert.deepStrictEqual(cookies.accessTokenExpiry, undefined);
+        assert.deepStrictEqual(cookies.idRefreshTokenExpiry, undefined);
+        assert.deepStrictEqual(cookies.refreshTokenExpiry, undefined);
     });
 
     it("test that refreshSession does not clear cookies if a session does not exist in the first place", async function () {
@@ -1544,16 +1544,16 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                 })
         );
 
-        assert.deepEqual(res.body.success, true);
+        assert.deepStrictEqual(res.body.success, true);
 
         let cookies = extractInfoFromResponse(res);
-        assert.deepEqual(cookies.antiCsrf, undefined);
-        assert.deepEqual(cookies.accessToken, undefined);
-        assert.deepEqual(cookies.refreshToken, undefined);
-        assert.deepEqual(cookies.idRefreshTokenFromHeader, undefined);
-        assert.deepEqual(cookies.idRefreshTokenFromCookie, undefined);
-        assert.deepEqual(cookies.accessTokenExpiry, undefined);
-        assert.deepEqual(cookies.idRefreshTokenExpiry, undefined);
-        assert.deepEqual(cookies.refreshTokenExpiry, undefined);
+        assert.deepStrictEqual(cookies.antiCsrf, undefined);
+        assert.deepStrictEqual(cookies.accessToken, undefined);
+        assert.deepStrictEqual(cookies.refreshToken, undefined);
+        assert.deepStrictEqual(cookies.idRefreshTokenFromHeader, undefined);
+        assert.deepStrictEqual(cookies.idRefreshTokenFromCookie, undefined);
+        assert.deepStrictEqual(cookies.accessTokenExpiry, undefined);
+        assert.deepStrictEqual(cookies.idRefreshTokenExpiry, undefined);
+        assert.deepStrictEqual(cookies.refreshTokenExpiry, undefined);
     });
 });


### PR DESCRIPTION
Increase test speeds (decreasing the load on the system and cpu at the same time)

**configTest: [test/emailpassword/config.test.js]**
    Before: 19.84s user 3.75s system 207% cpu 11.357 total
    After: 4.39s user 0.61s system 172% cpu 2.901 total

**emailExists: [test/emailpassword/emailExists.test.js]**
    Before: 47.98s user 12.08s system 238% cpu 25.165 total
    After: 14.46s user 2.81s system 185% cpu 9.302 total

**emailverify: [test/emailpassword/emailverify.test.js]**
    Before: 83.59s user 29.88s system 238% cpu 47.573 total
    After: 13.66s user 3.63s system 177% cpu 9.731 total

**passwordreset: [test/emailpassword/passwordreset.test.js]**
    Before: 33.52s user 7.35s system 234% cpu 17.437 total
    After:  6.18s user 1.18s system 162% cpu 4.525 total

**signinFeature: [test/emailpassword/signinFeature.test.js]**
    Before: 105.94s user 31.13s system 248% cpu 55.140 total
    After: 16.30s user 3.32s system 193% cpu 10.119 total

**signoutFeature: [test/emailpassword/signoutFeature.test.js]**
    Before: 23.56s user 8.84s system 207% cpu 15.584 total
    After: 10.06s user 1.89s system 168% cpu 7.099 total

**signupFeature: [test/emailpassword/signupFeature.test.js]**
    Before: 143.97s user 44.51s system 236% cpu 1:19.53 total
    After: 25.77s user 5.42s system 196% cpu 15.882 total

**usersTest: [test/emailpassword/users.test.js]**
    Before: 19.02s user 4.51s system 218% cpu 10.751 total
    After: 7.03s user 1.19s system 188% cpu 4.350 total

**session: [test/session.test.js]**
    Before: 103.11s user 29.74s system 236% cpu 56.177 total
    After: 39.03s user 8.25s system 206% cpu 22.869 total


Total:
     Before: Unknown, I have stopped it before the end, it was consuming too many resources on my machine.
     After:  485.18s user 202.40s system 201% cpu 5:41.66 total

We can easily go down to 300sec ( < 5mins),  which is still somewhat reasonable, by refactoring the list below using the same technique as in this PR

  - sessionExpress: [test/sessionExpress.test.js]
  - faunadb: [test/faunadb.test.js]
  - handshake: [test/handshake.test.js]
  - middleware: [test/middleware.test.js]
  - recipeModuleManager: [test/recipeModuleManager.test.js]
  - config: [test/config.test.js]
  - querier: [test/querier.test.js]
  
 The main idea here is that I identified tests that needed same configs for the core and for the init, and moved all the setup (starting the core and the express app mainly) to a `before` instead of a `beforeEach`. Since for each tests setup is what consumes the most time, any time we have two tests that can run in sequence we are almost dividing the time it takes by a factor of 2.

