### PR TITLE
Changes related to core v3.2.0 and CDI v2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0] - 2021-01-28
+### Changed
+- enableAntiCsrf as config parameter in session recipe
+- enableAntiCsrf boolean in session create,verify and refresh APIs if CDI version is 2.6
+- cookieSecure to true by default if the apiDomain has https
+- if the apiDomain and websiteDomain values are different (no common top level domain), then cookieSameSite will be set to none by default, else set it to lax
+
 ## [3.3.1] - 2021-01-20
 ### Changed
 - Update superTokensNextWrapper to add a return value.

--- a/coreDriverInterfaceSupported.json
+++ b/coreDriverInterfaceSupported.json
@@ -2,6 +2,7 @@
     "_comment": "contains a list of core-driver interfaces branch names that this core supports",
     "versions": [
         "2.4",
-        "2.5"
+        "2.5",
+        "2.6"
     ]
 }

--- a/lib/build/normalisedURLDomain.js
+++ b/lib/build/normalisedURLDomain.js
@@ -16,6 +16,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const url_1 = require("url");
 const error_1 = require("./error");
+const utils_1 = require("./utils");
 class NormalisedURLDomain {
     constructor(rId, url) {
         this.getAsStringDangerous = () => {
@@ -26,11 +27,6 @@ class NormalisedURLDomain {
 }
 exports.default = NormalisedURLDomain;
 function normaliseURLDomainOrThrowError(rId, input, ignoreProtocol = false) {
-    function isAnIpAddress(ipaddress) {
-        return /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(
-            ipaddress
-        );
-    }
     input = input.trim().toLowerCase();
     try {
         if (!input.startsWith("http://") && !input.startsWith("https://") && !input.startsWith("supertokens://")) {
@@ -38,7 +34,7 @@ function normaliseURLDomainOrThrowError(rId, input, ignoreProtocol = false) {
         }
         let urlObj = new url_1.URL(input);
         if (ignoreProtocol) {
-            if (urlObj.hostname.startsWith("localhost") || isAnIpAddress(urlObj.hostname)) {
+            if (urlObj.hostname.startsWith("localhost") || utils_1.isAnIpAddress(urlObj.hostname)) {
                 input = "http://" + urlObj.host;
             } else {
                 input = "https://" + urlObj.host;

--- a/lib/build/recipe/session/sessionFunctions.js
+++ b/lib/build/recipe/session/sessionFunctions.js
@@ -49,7 +49,6 @@ const accessToken_1 = require("./accessToken");
 const error_1 = require("./error");
 const processState_1 = require("../../processState");
 const normalisedURLPath_1 = require("../../normalisedURLPath");
-const utils_1 = require("./utils");
 /**
  * @description call this to "login" a user.
  * @throws GENERAL_ERROR in case anything fails.
@@ -99,12 +98,12 @@ function getSession(recipeInstance, accessToken, antiCsrfToken, doAntiCsrfCheck)
                     recipeInstance,
                     accessToken,
                     handShakeInfo.jwtSigningPublicKey,
-                    (yield utils_1.getEnableAntiCsrfBoolean(recipeInstance)) && doAntiCsrfCheck
+                    handShakeInfo.enableAntiCsrf && doAntiCsrfCheck
                 );
                 let sessionHandle = accessTokenInfo.sessionHandle;
                 // anti-csrf check
                 if (
-                    (yield utils_1.getEnableAntiCsrfBoolean(recipeInstance)) &&
+                    handShakeInfo.enableAntiCsrf &&
                     doAntiCsrfCheck &&
                     (antiCsrfToken === undefined || antiCsrfToken !== accessTokenInfo.antiCsrfToken)
                 ) {

--- a/lib/build/recipe/session/sessionFunctions.js
+++ b/lib/build/recipe/session/sessionFunctions.js
@@ -79,18 +79,6 @@ function createNewSession(recipeInstance, userId, jwtPayload = {}, sessionData =
         delete response.status;
         delete response.jwtSigningPublicKey;
         delete response.jwtSigningPublicKeyExpiryTime;
-        // we check if sameSite is none, antiCsrfTokens is being sent - this is a security check
-        if (recipeInstance.config.cookieSameSite === "none" && response.antiCsrfToken === undefined) {
-            throw new error_1.default(
-                {
-                    type: error_1.default.GENERAL_ERROR,
-                    payload: new Error(
-                        'Security error: Cookie same site is "none" and anti-CSRF protection is disabled! Please either: \n- Change cookie same site to "lax" or to "strict". or \n- Enable anti-CSRF protection in the core by setting enable_anti_csrf to true.'
-                    ),
-                },
-                recipeInstance.getRecipeId()
-            );
-        }
         return response;
     });
 }

--- a/lib/build/recipe/session/sessionFunctions.js
+++ b/lib/build/recipe/session/sessionFunctions.js
@@ -49,19 +49,29 @@ const accessToken_1 = require("./accessToken");
 const error_1 = require("./error");
 const processState_1 = require("../../processState");
 const normalisedURLPath_1 = require("../../normalisedURLPath");
+const utils_1 = require("../../utils");
 /**
  * @description call this to "login" a user.
  * @throws GENERAL_ERROR in case anything fails.
  */
 function createNewSession(recipeInstance, userId, jwtPayload = {}, sessionData = {}) {
     return __awaiter(this, void 0, void 0, function* () {
+        let requestBody = {
+            userId,
+            userDataInJWT: jwtPayload,
+            userDataInDatabase: sessionData,
+        };
+        let cdiVersion = yield recipeInstance.getQuerier().getAPIVersion();
+        if (utils_1.maxVersion(cdiVersion, "2.6") === cdiVersion) {
+            let handShakeInfo = yield recipeInstance.getHandshakeInfo();
+            requestBody.enableAntiCsrf = handShakeInfo.enableAntiCsrf;
+        }
         let response = yield recipeInstance
             .getQuerier()
-            .sendPostRequest(new normalisedURLPath_1.default(recipeInstance.getRecipeId(), "/recipe/session"), {
-                userId,
-                userDataInJWT: jwtPayload,
-                userDataInDatabase: sessionData,
-            });
+            .sendPostRequest(
+                new normalisedURLPath_1.default(recipeInstance.getRecipeId(), "/recipe/session"),
+                requestBody
+            );
         recipeInstance.updateJwtSigningPublicKeyInfo(
             response.jwtSigningPublicKey,
             response.jwtSigningPublicKeyExpiryTime
@@ -146,14 +156,22 @@ function getSession(recipeInstance, accessToken, antiCsrfToken, doAntiCsrfCheck)
             }
         }
         processState_1.ProcessState.getInstance().addState(processState_1.PROCESS_STATE.CALLING_SERVICE_IN_VERIFY);
+        let requestBody = {
+            accessToken,
+            antiCsrfToken,
+            doAntiCsrfCheck,
+        };
+        let cdiVersion = yield recipeInstance.getQuerier().getAPIVersion();
+        if (utils_1.maxVersion(cdiVersion, "2.6") === cdiVersion) {
+            requestBody.enableAntiCsrf = handShakeInfo.enableAntiCsrf;
+        }
         let response = yield recipeInstance
             .getQuerier()
-            .sendPostRequest(new normalisedURLPath_1.default(recipeInstance.getRecipeId(), "/recipe/session/verify"), {
-                accessToken,
-                antiCsrfToken,
-                doAntiCsrfCheck,
-            });
-        if (response.status == "OK") {
+            .sendPostRequest(
+                new normalisedURLPath_1.default(recipeInstance.getRecipeId(), "/recipe/session/verify"),
+                requestBody
+            );
+        if (response.status === "OK") {
             recipeInstance.updateJwtSigningPublicKeyInfo(
                 response.jwtSigningPublicKey,
                 response.jwtSigningPublicKeyExpiryTime
@@ -162,7 +180,7 @@ function getSession(recipeInstance, accessToken, antiCsrfToken, doAntiCsrfCheck)
             delete response.jwtSigningPublicKey;
             delete response.jwtSigningPublicKeyExpiryTime;
             return response;
-        } else if (response.status == "UNAUTHORISED") {
+        } else if (response.status === "UNAUTHORISED") {
             throw new error_1.default(
                 {
                     message: response.message,
@@ -189,16 +207,25 @@ exports.getSession = getSession;
  */
 function refreshSession(recipeInstance, refreshToken, antiCsrfToken) {
     return __awaiter(this, void 0, void 0, function* () {
+        let requestBody = {
+            refreshToken,
+            antiCsrfToken,
+        };
+        let cdiVersion = yield recipeInstance.getQuerier().getAPIVersion();
+        if (utils_1.maxVersion(cdiVersion, "2.6") === cdiVersion) {
+            let handShakeInfo = yield recipeInstance.getHandshakeInfo();
+            requestBody.enableAntiCsrf = handShakeInfo.enableAntiCsrf;
+        }
         let response = yield recipeInstance
             .getQuerier()
-            .sendPostRequest(new normalisedURLPath_1.default(recipeInstance.getRecipeId(), "/recipe/session/refresh"), {
-                refreshToken,
-                antiCsrfToken,
-            });
-        if (response.status == "OK") {
+            .sendPostRequest(
+                new normalisedURLPath_1.default(recipeInstance.getRecipeId(), "/recipe/session/refresh"),
+                requestBody
+            );
+        if (response.status === "OK") {
             delete response.status;
             return response;
-        } else if (response.status == "UNAUTHORISED") {
+        } else if (response.status === "UNAUTHORISED") {
             throw new error_1.default(
                 {
                     message: response.message,

--- a/lib/build/recipe/session/sessionFunctions.js
+++ b/lib/build/recipe/session/sessionFunctions.js
@@ -49,6 +49,7 @@ const accessToken_1 = require("./accessToken");
 const error_1 = require("./error");
 const processState_1 = require("../../processState");
 const normalisedURLPath_1 = require("../../normalisedURLPath");
+const utils_1 = require("./utils");
 /**
  * @description call this to "login" a user.
  * @throws GENERAL_ERROR in case anything fails.
@@ -98,12 +99,12 @@ function getSession(recipeInstance, accessToken, antiCsrfToken, doAntiCsrfCheck)
                     recipeInstance,
                     accessToken,
                     handShakeInfo.jwtSigningPublicKey,
-                    handShakeInfo.enableAntiCsrf && doAntiCsrfCheck
+                    (yield utils_1.getEnableAntiCsrfBoolean(recipeInstance)) && doAntiCsrfCheck
                 );
                 let sessionHandle = accessTokenInfo.sessionHandle;
                 // anti-csrf check
                 if (
-                    handShakeInfo.enableAntiCsrf &&
+                    (yield utils_1.getEnableAntiCsrfBoolean(recipeInstance)) &&
                     doAntiCsrfCheck &&
                     (antiCsrfToken === undefined || antiCsrfToken !== accessTokenInfo.antiCsrfToken)
                 ) {

--- a/lib/build/recipe/session/sessionRecipe.js
+++ b/lib/build/recipe/session/sessionRecipe.js
@@ -110,9 +110,14 @@ class SessionRecipe extends recipeModule_1.default {
                         new normalisedURLPath_1.default(this.getRecipeId(), "/recipe/handshake"),
                         {}
                     );
+                    let enableAntiCsrf = response.enableAntiCsrf;
+                    let cdiVersion = yield this.getQuerier().getAPIVersion();
+                    if (utils_2.maxVersion(cdiVersion, "2.6") === cdiVersion) {
+                        enableAntiCsrf = this.config.enableAntiCsrf;
+                    }
                     this.handshakeInfo = {
                         jwtSigningPublicKey: response.jwtSigningPublicKey,
-                        enableAntiCsrf: response.enableAntiCsrf,
+                        enableAntiCsrf,
                         accessTokenBlacklistingEnabled: response.accessTokenBlacklistingEnabled,
                         jwtSigningPublicKeyExpiryTime: response.jwtSigningPublicKeyExpiryTime,
                         accessTokenValidity: response.accessTokenValidity,

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -41,6 +41,7 @@ export declare type TypeInput = {
         disableDefaultImplementation?: boolean;
     };
     errorHandlers?: ErrorHandlers;
+    enableAntiCsrf?: boolean;
 };
 export declare type TypeNormalisedInput = {
     refreshTokenPath: NormalisedURLPath;
@@ -52,6 +53,7 @@ export declare type TypeNormalisedInput = {
         disableDefaultImplementation: boolean;
     };
     errorHandlers: NormalisedErrorHandlers;
+    enableAntiCsrf: boolean;
 };
 export interface SessionRequest extends Request {
     session: Session;

--- a/lib/build/recipe/session/utils.d.ts
+++ b/lib/build/recipe/session/utils.d.ts
@@ -3,7 +3,7 @@ import * as express from "express";
 import SessionRecipe from "./sessionRecipe";
 import { NormalisedAppinfo } from "../../types";
 export declare function normaliseSessionScopeOrThrowError(rId: string, sessionScope: string): string;
-export declare function getTopLevelDomain(url: string): string | null;
+export declare function getTopLevelDomain(url: string, recipeInstance: SessionRecipe): string;
 export declare function validateAndNormaliseUserInput(recipeInstance: SessionRecipe, appInfo: NormalisedAppinfo, config?: TypeInput): TypeNormalisedInput;
 export declare function normaliseSameSiteOrThrowError(rId: string, sameSite: string): "strict" | "lax" | "none";
 export declare function attachCreateOrRefreshSessionResponseToExpressRes(recipeInstance: SessionRecipe, res: express.Response, response: CreateOrRefreshAPIResponse): void;

--- a/lib/build/recipe/session/utils.d.ts
+++ b/lib/build/recipe/session/utils.d.ts
@@ -6,3 +6,4 @@ export declare function normaliseSessionScopeOrThrowError(rId: string, sessionSc
 export declare function validateAndNormaliseUserInput(recipeInstance: SessionRecipe, appInfo: NormalisedAppinfo, config?: TypeInput): TypeNormalisedInput;
 export declare function normaliseSameSiteOrThrowError(rId: string, sameSite: string): "strict" | "lax" | "none";
 export declare function attachCreateOrRefreshSessionResponseToExpressRes(recipeInstance: SessionRecipe, res: express.Response, response: CreateOrRefreshAPIResponse): void;
+export declare function getEnableAntiCsrfBoolean(recipeInstance: SessionRecipe): Promise<boolean>;

--- a/lib/build/recipe/session/utils.d.ts
+++ b/lib/build/recipe/session/utils.d.ts
@@ -6,4 +6,3 @@ export declare function normaliseSessionScopeOrThrowError(rId: string, sessionSc
 export declare function validateAndNormaliseUserInput(recipeInstance: SessionRecipe, appInfo: NormalisedAppinfo, config?: TypeInput): TypeNormalisedInput;
 export declare function normaliseSameSiteOrThrowError(rId: string, sameSite: string): "strict" | "lax" | "none";
 export declare function attachCreateOrRefreshSessionResponseToExpressRes(recipeInstance: SessionRecipe, res: express.Response, response: CreateOrRefreshAPIResponse): void;
-export declare function getEnableAntiCsrfBoolean(recipeInstance: SessionRecipe): Promise<boolean>;

--- a/lib/build/recipe/session/utils.d.ts
+++ b/lib/build/recipe/session/utils.d.ts
@@ -3,6 +3,7 @@ import * as express from "express";
 import SessionRecipe from "./sessionRecipe";
 import { NormalisedAppinfo } from "../../types";
 export declare function normaliseSessionScopeOrThrowError(rId: string, sessionScope: string): string;
+export declare function getTopLevelDomain(url: string): string | null;
 export declare function validateAndNormaliseUserInput(recipeInstance: SessionRecipe, appInfo: NormalisedAppinfo, config?: TypeInput): TypeNormalisedInput;
 export declare function normaliseSameSiteOrThrowError(rId: string, sameSite: string): "strict" | "lax" | "none";
 export declare function attachCreateOrRefreshSessionResponseToExpressRes(recipeInstance: SessionRecipe, res: express.Response, response: CreateOrRefreshAPIResponse): void;

--- a/lib/build/recipe/session/utils.js
+++ b/lib/build/recipe/session/utils.js
@@ -13,37 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-var __awaiter =
-    (this && this.__awaiter) ||
-    function (thisArg, _arguments, P, generator) {
-        function adopt(value) {
-            return value instanceof P
-                ? value
-                : new P(function (resolve) {
-                      resolve(value);
-                  });
-        }
-        return new (P || (P = Promise))(function (resolve, reject) {
-            function fulfilled(value) {
-                try {
-                    step(generator.next(value));
-                } catch (e) {
-                    reject(e);
-                }
-            }
-            function rejected(value) {
-                try {
-                    step(generator["throw"](value));
-                } catch (e) {
-                    reject(e);
-                }
-            }
-            function step(result) {
-                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-            }
-            step((generator = generator.apply(thisArg, _arguments || [])).next());
-        });
-    };
 Object.defineProperty(exports, "__esModule", { value: true });
 const cookieAndHeaders_1 = require("./cookieAndHeaders");
 const url_1 = require("url");
@@ -51,7 +20,6 @@ const error_1 = require("./error");
 const middleware_1 = require("./middleware");
 const constants_1 = require("./constants");
 const normalisedURLPath_1 = require("../../normalisedURLPath");
-const utils_1 = require("../../utils");
 function normaliseSessionScopeOrThrowError(rId, sessionScope) {
     function helper(sessionScope) {
         sessionScope = sessionScope.trim().toLowerCase();
@@ -198,15 +166,4 @@ function attachCreateOrRefreshSessionResponseToExpressRes(recipeInstance, res, r
     }
 }
 exports.attachCreateOrRefreshSessionResponseToExpressRes = attachCreateOrRefreshSessionResponseToExpressRes;
-function getEnableAntiCsrfBoolean(recipeInstance) {
-    return __awaiter(this, void 0, void 0, function* () {
-        let handShakeInfo = yield recipeInstance.getHandshakeInfo();
-        let cdiVersion = yield recipeInstance.getQuerier().getAPIVersion();
-        if (utils_1.maxVersion(cdiVersion, "2.6") === cdiVersion) {
-            return recipeInstance.config.enableAntiCsrf;
-        }
-        return handShakeInfo.enableAntiCsrf;
-    });
-}
-exports.getEnableAntiCsrfBoolean = getEnableAntiCsrfBoolean;
 //# sourceMappingURL=utils.js.map

--- a/lib/build/recipe/session/utils.js
+++ b/lib/build/recipe/session/utils.js
@@ -13,6 +13,37 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 const cookieAndHeaders_1 = require("./cookieAndHeaders");
 const url_1 = require("url");
@@ -20,6 +51,7 @@ const error_1 = require("./error");
 const middleware_1 = require("./middleware");
 const constants_1 = require("./constants");
 const normalisedURLPath_1 = require("../../normalisedURLPath");
+const utils_1 = require("../../utils");
 function normaliseSessionScopeOrThrowError(rId, sessionScope) {
     function helper(sessionScope) {
         sessionScope = sessionScope.trim().toLowerCase();
@@ -166,4 +198,15 @@ function attachCreateOrRefreshSessionResponseToExpressRes(recipeInstance, res, r
     }
 }
 exports.attachCreateOrRefreshSessionResponseToExpressRes = attachCreateOrRefreshSessionResponseToExpressRes;
+function getEnableAntiCsrfBoolean(recipeInstance) {
+    return __awaiter(this, void 0, void 0, function* () {
+        let handShakeInfo = yield recipeInstance.getHandshakeInfo();
+        let cdiVersion = yield recipeInstance.getQuerier().getAPIVersion();
+        if (utils_1.maxVersion(cdiVersion, "2.6") === cdiVersion) {
+            return recipeInstance.config.enableAntiCsrf;
+        }
+        return handShakeInfo.enableAntiCsrf;
+    });
+}
+exports.getEnableAntiCsrfBoolean = getEnableAntiCsrfBoolean;
 //# sourceMappingURL=utils.js.map

--- a/lib/build/recipe/session/utils.js
+++ b/lib/build/recipe/session/utils.js
@@ -21,6 +21,7 @@ const middleware_1 = require("./middleware");
 const constants_1 = require("./constants");
 const normalisedURLPath_1 = require("../../normalisedURLPath");
 const psl = require("psl");
+const utils_1 = require("../../utils");
 function normaliseSessionScopeOrThrowError(rId, sessionScope) {
     function helper(sessionScope) {
         sessionScope = sessionScope.trim().toLowerCase();
@@ -49,13 +50,8 @@ function normaliseSessionScopeOrThrowError(rId, sessionScope) {
             );
         }
     }
-    function isAnIpAddress(ipaddress) {
-        return /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(
-            ipaddress
-        );
-    }
     let noDotNormalised = helper(sessionScope);
-    if (noDotNormalised === "localhost" || isAnIpAddress(noDotNormalised)) {
+    if (noDotNormalised === "localhost" || utils_1.isAnIpAddress(noDotNormalised)) {
         return noDotNormalised;
     }
     if (sessionScope.startsWith(".")) {
@@ -64,17 +60,22 @@ function normaliseSessionScopeOrThrowError(rId, sessionScope) {
     return noDotNormalised;
 }
 exports.normaliseSessionScopeOrThrowError = normaliseSessionScopeOrThrowError;
-function getTopLevelDomain(url) {
-    function isAnIpAddress(ipaddress) {
-        return /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(
-            ipaddress
+function getTopLevelDomain(url, recipeInstance) {
+    let urlObj = new url_1.URL(url);
+    let hostname = urlObj.hostname;
+    if (hostname.startsWith("localhost") || utils_1.isAnIpAddress(hostname)) {
+        return hostname;
+    }
+    let parsedURL = psl.parse(hostname);
+    if (parsedURL.domain === null) {
+        throw new error_1.default(
+            {
+                type: error_1.default.GENERAL_ERROR,
+                payload: new Error("Please make sure that the apiDomain and websiteDomain have correct values"),
+            },
+            recipeInstance.getRecipeId()
         );
     }
-    let urlObj = new url_1.URL(url);
-    if (urlObj.hostname.startsWith("localhost") || isAnIpAddress(urlObj.hostname)) {
-        return urlObj.hostname;
-    }
-    let parsedURL = psl.parse(urlObj.hostname);
     return parsedURL.domain;
 }
 exports.getTopLevelDomain = getTopLevelDomain;
@@ -83,9 +84,9 @@ function validateAndNormaliseUserInput(recipeInstance, appInfo, config) {
         config === undefined || config.cookieDomain === undefined
             ? undefined
             : normaliseSessionScopeOrThrowError(recipeInstance.getRecipeId(), config.cookieDomain);
-    let topLevelAPIDomain = getTopLevelDomain(appInfo.apiDomain.getAsStringDangerous());
-    let topLevelWebsiteDomain = getTopLevelDomain(appInfo.websiteDomain.getAsStringDangerous());
-    let cookieSameSite = topLevelAPIDomain !== null && topLevelAPIDomain !== topLevelWebsiteDomain ? "none" : "lax";
+    let topLevelAPIDomain = getTopLevelDomain(appInfo.apiDomain.getAsStringDangerous(), recipeInstance);
+    let topLevelWebsiteDomain = getTopLevelDomain(appInfo.websiteDomain.getAsStringDangerous(), recipeInstance);
+    let cookieSameSite = topLevelAPIDomain !== topLevelWebsiteDomain ? "none" : "lax";
     cookieSameSite =
         config === undefined || config.cookieSameSite === undefined
             ? cookieSameSite
@@ -138,7 +139,9 @@ function validateAndNormaliseUserInput(recipeInstance, appInfo, config) {
         throw new error_1.default(
             {
                 type: error_1.default.GENERAL_ERROR,
-                payload: new Error('enableAntiCsrf can\'t be set to false if cookieSameSite value is "none".'),
+                payload: new Error(
+                    'Security error: enableAntiCsrf can\'t be set to false if cookieSameSite value is "none".'
+                ),
             },
             recipeInstance.getRecipeId()
         );

--- a/lib/build/recipe/session/utils.js
+++ b/lib/build/recipe/session/utils.js
@@ -20,6 +20,7 @@ const error_1 = require("./error");
 const middleware_1 = require("./middleware");
 const constants_1 = require("./constants");
 const normalisedURLPath_1 = require("../../normalisedURLPath");
+const psl = require("psl");
 function normaliseSessionScopeOrThrowError(rId, sessionScope) {
     function helper(sessionScope) {
         sessionScope = sessionScope.trim().toLowerCase();
@@ -63,14 +64,31 @@ function normaliseSessionScopeOrThrowError(rId, sessionScope) {
     return noDotNormalised;
 }
 exports.normaliseSessionScopeOrThrowError = normaliseSessionScopeOrThrowError;
+function getTopLevelDomain(url) {
+    function isAnIpAddress(ipaddress) {
+        return /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(
+            ipaddress
+        );
+    }
+    let urlObj = new url_1.URL(url);
+    if (urlObj.hostname.startsWith("localhost") || isAnIpAddress(urlObj.hostname)) {
+        return urlObj.hostname;
+    }
+    let parsedURL = psl.parse(urlObj.hostname);
+    return parsedURL.domain;
+}
+exports.getTopLevelDomain = getTopLevelDomain;
 function validateAndNormaliseUserInput(recipeInstance, appInfo, config) {
     let cookieDomain =
         config === undefined || config.cookieDomain === undefined
             ? undefined
             : normaliseSessionScopeOrThrowError(recipeInstance.getRecipeId(), config.cookieDomain);
-    let cookieSameSite =
+    let topLevelAPIDomain = getTopLevelDomain(appInfo.apiDomain.getAsStringDangerous());
+    let topLevelWebsiteDomain = getTopLevelDomain(appInfo.websiteDomain.getAsStringDangerous());
+    let cookieSameSite = topLevelAPIDomain !== null && topLevelAPIDomain !== topLevelWebsiteDomain ? "none" : "lax";
+    cookieSameSite =
         config === undefined || config.cookieSameSite === undefined
-            ? "lax"
+            ? cookieSameSite
             : normaliseSameSiteOrThrowError(recipeInstance.getRecipeId(), config.cookieSameSite);
     let cookieSecure = appInfo.apiDomain.getAsStringDangerous().startsWith("https") ? true : false;
     cookieSecure = config === undefined || config.cookieSecure === undefined ? cookieSecure : config.cookieSecure;
@@ -86,7 +104,9 @@ function validateAndNormaliseUserInput(recipeInstance, appInfo, config) {
     ) {
         sessionRefreshFeature.disableDefaultImplementation = config.sessionRefreshFeature.disableDefaultImplementation;
     }
-    let enableAntiCsrf = config === undefined || config.enableAntiCsrf === undefined ? false : config.enableAntiCsrf;
+    let enableAntiCsrf = cookieSameSite === "none" ? true : false;
+    enableAntiCsrf =
+        config === undefined || config.enableAntiCsrf === undefined ? enableAntiCsrf : config.enableAntiCsrf;
     let errorHandlers = {
         onTokenTheftDetected: (sessionHandle, userId, request, response, next) => {
             return middleware_1.sendTokenTheftDetectedResponse(
@@ -112,6 +132,15 @@ function validateAndNormaliseUserInput(recipeInstance, appInfo, config) {
         if (config.errorHandlers.onUnauthorised !== undefined) {
             errorHandlers.onUnauthorised = config.errorHandlers.onUnauthorised;
         }
+    }
+    if (cookieSameSite === "none" && !enableAntiCsrf) {
+        throw new error_1.default(
+            {
+                type: error_1.default.GENERAL_ERROR,
+                payload: new Error('enableAntiCsrf can\'t be set to false if cookieSameSite value is "none".'),
+            },
+            recipeInstance.getRecipeId()
+        );
     }
     return {
         refreshTokenPath: appInfo.apiBasePath.appendPath(

--- a/lib/build/recipe/session/utils.js
+++ b/lib/build/recipe/session/utils.js
@@ -72,7 +72,8 @@ function validateAndNormaliseUserInput(recipeInstance, appInfo, config) {
         config === undefined || config.cookieSameSite === undefined
             ? "lax"
             : normaliseSameSiteOrThrowError(recipeInstance.getRecipeId(), config.cookieSameSite);
-    let cookieSecure = config === undefined || config.cookieSecure === undefined ? false : config.cookieSecure;
+    let cookieSecure = appInfo.apiDomain.getAsStringDangerous().startsWith("https") ? true : false;
+    cookieSecure = config === undefined || config.cookieSecure === undefined ? cookieSecure : config.cookieSecure;
     let sessionExpiredStatusCode =
         config === undefined || config.sessionExpiredStatusCode === undefined ? 401 : config.sessionExpiredStatusCode;
     let sessionRefreshFeature = {

--- a/lib/build/recipe/session/utils.js
+++ b/lib/build/recipe/session/utils.js
@@ -85,6 +85,7 @@ function validateAndNormaliseUserInput(recipeInstance, appInfo, config) {
     ) {
         sessionRefreshFeature.disableDefaultImplementation = config.sessionRefreshFeature.disableDefaultImplementation;
     }
+    let enableAntiCsrf = config === undefined || config.enableAntiCsrf === undefined ? false : config.enableAntiCsrf;
     let errorHandlers = {
         onTokenTheftDetected: (sessionHandle, userId, request, response, next) => {
             return middleware_1.sendTokenTheftDetectedResponse(
@@ -122,6 +123,7 @@ function validateAndNormaliseUserInput(recipeInstance, appInfo, config) {
         sessionExpiredStatusCode,
         sessionRefreshFeature,
         errorHandlers,
+        enableAntiCsrf,
     };
 }
 exports.validateAndNormaliseUserInput = validateAndNormaliseUserInput;

--- a/lib/build/utils.d.ts
+++ b/lib/build/utils.d.ts
@@ -9,3 +9,4 @@ export declare function getHeader(req: express.Request, key: string): string | u
 export declare function sendNon200Response(rId: string, res: express.Response, message: string, statusCode: number): void;
 export declare function send200Response(res: express.Response, responseJson: any): void;
 export declare function assertThatBodyParserHasBeenUsed(rId: string, req: express.Request, res: express.Response): Promise<void>;
+export declare function isAnIpAddress(ipaddress: string): boolean;

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -186,4 +186,10 @@ function assertThatBodyParserHasBeenUsed(rId, req, res) {
     });
 }
 exports.assertThatBodyParserHasBeenUsed = assertThatBodyParserHasBeenUsed;
+function isAnIpAddress(ipaddress) {
+    return /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(
+        ipaddress
+    );
+}
+exports.isAnIpAddress = isAnIpAddress;
 //# sourceMappingURL=utils.js.map

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,2 +1,2 @@
-export declare const version = "3.3.1";
+export declare const version = "3.4.0";
 export declare const cdiSupported: string[];

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -14,6 +14,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "3.3.1";
-exports.cdiSupported = ["2.4", "2.5"];
+exports.version = "3.4.0";
+exports.cdiSupported = ["2.4", "2.5", "2.6"];
 //# sourceMappingURL=version.js.map

--- a/lib/ts/normalisedURLDomain.ts
+++ b/lib/ts/normalisedURLDomain.ts
@@ -15,6 +15,7 @@
 
 import { URL } from "url";
 import STError from "./error";
+import { isAnIpAddress } from "./utils";
 
 export default class NormalisedURLDomain {
     private value: string;
@@ -29,12 +30,6 @@ export default class NormalisedURLDomain {
 }
 
 export function normaliseURLDomainOrThrowError(rId: string, input: string, ignoreProtocol = false): string {
-    function isAnIpAddress(ipaddress: string) {
-        return /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(
-            ipaddress
-        );
-    }
-
     input = input.trim().toLowerCase();
 
     try {

--- a/lib/ts/recipe/session/sessionFunctions.ts
+++ b/lib/ts/recipe/session/sessionFunctions.ts
@@ -18,7 +18,6 @@ import { PROCESS_STATE, ProcessState } from "../../processState";
 import { CreateOrRefreshAPIResponse } from "./types";
 import SessionRecipe from "./sessionRecipe";
 import NormalisedURLPath from "../../normalisedURLPath";
-import { getEnableAntiCsrfBoolean } from "./utils";
 
 /**
  * @description call this to "login" a user.
@@ -85,13 +84,13 @@ export async function getSession(
                 recipeInstance,
                 accessToken,
                 handShakeInfo.jwtSigningPublicKey,
-                (await getEnableAntiCsrfBoolean(recipeInstance)) && doAntiCsrfCheck
+                handShakeInfo.enableAntiCsrf && doAntiCsrfCheck
             );
             let sessionHandle = accessTokenInfo.sessionHandle;
 
             // anti-csrf check
             if (
-                (await getEnableAntiCsrfBoolean(recipeInstance)) &&
+                handShakeInfo.enableAntiCsrf &&
                 doAntiCsrfCheck &&
                 (antiCsrfToken === undefined || antiCsrfToken !== accessTokenInfo.antiCsrfToken)
             ) {

--- a/lib/ts/recipe/session/sessionFunctions.ts
+++ b/lib/ts/recipe/session/sessionFunctions.ts
@@ -18,6 +18,7 @@ import { PROCESS_STATE, ProcessState } from "../../processState";
 import { CreateOrRefreshAPIResponse } from "./types";
 import SessionRecipe from "./sessionRecipe";
 import NormalisedURLPath from "../../normalisedURLPath";
+import { getEnableAntiCsrfBoolean } from "./utils";
 
 /**
  * @description call this to "login" a user.
@@ -84,13 +85,13 @@ export async function getSession(
                 recipeInstance,
                 accessToken,
                 handShakeInfo.jwtSigningPublicKey,
-                handShakeInfo.enableAntiCsrf && doAntiCsrfCheck
+                (await getEnableAntiCsrfBoolean(recipeInstance)) && doAntiCsrfCheck
             );
             let sessionHandle = accessTokenInfo.sessionHandle;
 
             // anti-csrf check
             if (
-                handShakeInfo.enableAntiCsrf &&
+                (await getEnableAntiCsrfBoolean(recipeInstance)) &&
                 doAntiCsrfCheck &&
                 (antiCsrfToken === undefined || antiCsrfToken !== accessTokenInfo.antiCsrfToken)
             ) {

--- a/lib/ts/recipe/session/sessionFunctions.ts
+++ b/lib/ts/recipe/session/sessionFunctions.ts
@@ -53,18 +53,7 @@ export async function createNewSession(
     delete response.status;
     delete response.jwtSigningPublicKey;
     delete response.jwtSigningPublicKeyExpiryTime;
-    // we check if sameSite is none, antiCsrfTokens is being sent - this is a security check
-    if (recipeInstance.config.cookieSameSite === "none" && response.antiCsrfToken === undefined) {
-        throw new STError(
-            {
-                type: STError.GENERAL_ERROR,
-                payload: new Error(
-                    'Security error: Cookie same site is "none" and anti-CSRF protection is disabled! Please either: \n- Change cookie same site to "lax" or to "strict". or \n- Enable anti-CSRF protection in the core by setting enable_anti_csrf to true.'
-                ),
-            },
-            recipeInstance.getRecipeId()
-        );
-    }
+
     return response;
 }
 

--- a/lib/ts/recipe/session/sessionRecipe.ts
+++ b/lib/ts/recipe/session/sessionRecipe.ts
@@ -35,7 +35,7 @@ import { NormalisedAppinfo, RecipeListFunction, APIHandled } from "../../types";
 import { handleRefreshAPI } from "./api";
 import { REFRESH_API_PATH } from "./constants";
 import NormalisedURLPath from "../../normalisedURLPath";
-import { normaliseHttpMethod } from "../../utils";
+import { maxVersion, normaliseHttpMethod } from "../../utils";
 import { PROCESS_STATE, ProcessState } from "../../processState";
 
 // For Express
@@ -150,9 +150,14 @@ export default class SessionRecipe extends RecipeModule {
                 new NormalisedURLPath(this.getRecipeId(), "/recipe/handshake"),
                 {}
             );
+            let enableAntiCsrf = response.enableAntiCsrf;
+            let cdiVersion = await this.getQuerier().getAPIVersion();
+            if (maxVersion(cdiVersion, "2.6") === cdiVersion) {
+                enableAntiCsrf = this.config.enableAntiCsrf;
+            }
             this.handshakeInfo = {
                 jwtSigningPublicKey: response.jwtSigningPublicKey,
-                enableAntiCsrf: response.enableAntiCsrf,
+                enableAntiCsrf,
                 accessTokenBlacklistingEnabled: response.accessTokenBlacklistingEnabled,
                 jwtSigningPublicKeyExpiryTime: response.jwtSigningPublicKeyExpiryTime,
                 accessTokenValidity: response.accessTokenValidity,

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -58,6 +58,7 @@ export type TypeInput = {
         disableDefaultImplementation?: boolean;
     };
     errorHandlers?: ErrorHandlers;
+    enableAntiCsrf?: boolean;
 };
 
 export type TypeNormalisedInput = {
@@ -70,6 +71,7 @@ export type TypeNormalisedInput = {
         disableDefaultImplementation: boolean;
     };
     errorHandlers: NormalisedErrorHandlers;
+    enableAntiCsrf: boolean;
 };
 
 export interface SessionRequest extends Request {

--- a/lib/ts/recipe/session/utils.ts
+++ b/lib/ts/recipe/session/utils.ts
@@ -29,6 +29,7 @@ import { sendTryRefreshTokenResponse, sendTokenTheftDetectedResponse, sendUnauth
 import { REFRESH_API_PATH } from "./constants";
 import NormalisedURLPath from "../../normalisedURLPath";
 import { NormalisedAppinfo } from "../../types";
+import { maxVersion } from "../../utils";
 
 export function normaliseSessionScopeOrThrowError(rId: string, sessionScope: string): string {
     function helper(sessionScope: string): string {
@@ -203,4 +204,13 @@ export function attachCreateOrRefreshSessionResponseToExpressRes(
     if (response.antiCsrfToken !== undefined) {
         setAntiCsrfTokenInHeaders(recipeInstance, res, response.antiCsrfToken);
     }
+}
+
+export async function getEnableAntiCsrfBoolean(recipeInstance: SessionRecipe): Promise<boolean> {
+    let handShakeInfo = await recipeInstance.getHandshakeInfo();
+    let cdiVersion = await recipeInstance.getQuerier().getAPIVersion();
+    if (maxVersion(cdiVersion, "2.6") === cdiVersion) {
+        return recipeInstance.config.enableAntiCsrf;
+    }
+    return handShakeInfo.enableAntiCsrf;
 }

--- a/lib/ts/recipe/session/utils.ts
+++ b/lib/ts/recipe/session/utils.ts
@@ -114,6 +114,8 @@ export function validateAndNormaliseUserInput(
         sessionRefreshFeature.disableDefaultImplementation = config.sessionRefreshFeature.disableDefaultImplementation;
     }
 
+    let enableAntiCsrf = config === undefined || config.enableAntiCsrf === undefined ? false : config.enableAntiCsrf;
+
     let errorHandlers: NormalisedErrorHandlers = {
         onTokenTheftDetected: (
             sessionHandle: string,
@@ -161,6 +163,7 @@ export function validateAndNormaliseUserInput(
         sessionExpiredStatusCode,
         sessionRefreshFeature,
         errorHandlers,
+        enableAntiCsrf,
     };
 }
 

--- a/lib/ts/recipe/session/utils.ts
+++ b/lib/ts/recipe/session/utils.ts
@@ -99,7 +99,8 @@ export function validateAndNormaliseUserInput(
             ? "lax"
             : normaliseSameSiteOrThrowError(recipeInstance.getRecipeId(), config.cookieSameSite);
 
-    let cookieSecure = config === undefined || config.cookieSecure === undefined ? false : config.cookieSecure;
+    let cookieSecure = appInfo.apiDomain.getAsStringDangerous().startsWith("https") ? true : false;
+    cookieSecure = config === undefined || config.cookieSecure === undefined ? cookieSecure : config.cookieSecure;
 
     let sessionExpiredStatusCode =
         config === undefined || config.sessionExpiredStatusCode === undefined ? 401 : config.sessionExpiredStatusCode;

--- a/lib/ts/recipe/session/utils.ts
+++ b/lib/ts/recipe/session/utils.ts
@@ -205,12 +205,3 @@ export function attachCreateOrRefreshSessionResponseToExpressRes(
         setAntiCsrfTokenInHeaders(recipeInstance, res, response.antiCsrfToken);
     }
 }
-
-export async function getEnableAntiCsrfBoolean(recipeInstance: SessionRecipe): Promise<boolean> {
-    let handShakeInfo = await recipeInstance.getHandshakeInfo();
-    let cdiVersion = await recipeInstance.getQuerier().getAPIVersion();
-    if (maxVersion(cdiVersion, "2.6") === cdiVersion) {
-        return recipeInstance.config.enableAntiCsrf;
-    }
-    return handShakeInfo.enableAntiCsrf;
-}

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -153,3 +153,9 @@ export async function assertThatBodyParserHasBeenUsed(rId: string, req: express.
         }
     }
 }
+
+export function isAnIpAddress(ipaddress: string) {
+    return /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(
+        ipaddress
+    );
+}

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,6 +12,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "3.3.1";
+export const version = "3.4.0";
 
-export const cdiSupported = ["2.4", "2.5"];
+export const cdiSupported = ["2.4", "2.5", "2.6"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,12 @@
       "integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A==",
       "dev": true
     },
+    "@types/psl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/psl/-/psl-1.1.0.tgz",
+      "integrity": "sha512-HhZnoLAvI2koev3czVPzBNRYvdrzJGLjQbWZhqFmS9Q6a0yumc5qtfSahBGb5g+6qWvA8iiQktqGkwoIXa/BNQ==",
+      "dev": true
+    },
     "@types/qs": {
       "version": "6.9.5",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
@@ -1471,6 +1477,11 @@
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "pump": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "supertokens-node",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supertokens-node",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "NodeJS driver for SuperTokens core",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -35,21 +35,23 @@
     "axios": "0.21.1",
     "body-parser": "1.19.0",
     "cookie": "0.4.0",
-    "jsonwebtoken": "8.5.1"
+    "jsonwebtoken": "8.5.1",
+    "psl": "1.8.0"
   },
   "devDependencies": {
-    "cookie-parser": "^1.4.5",
     "@types/cookie": "0.3.3",
-    "@types/jsonwebtoken": "8.5.0",
-    "@types/validator": "10.11.0",
     "@types/express": "4.16.1",
+    "@types/jsonwebtoken": "8.5.0",
+    "@types/psl": "1.1.0",
+    "@types/validator": "10.11.0",
+    "cookie-parser": "^1.4.5",
     "express": "4.17.1",
+    "faunadb": "^3.0.1",
     "mocha": "6.1.4",
     "nock": "11.7.0",
     "node-mocks-http": "^1.9.0",
     "prettier": "2.0.5",
     "supertest": "4.0.2",
-    "typescript": "3.8.3",
-    "faunadb": "^3.0.1"
+    "typescript": "3.8.3"
   }
 }

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -939,7 +939,10 @@ describe(`configTest: ${printPath("[test/config.test.js]")}`, function () {
                 });
                 assert(false);
             } catch (err) {
-                if (err.message !== 'enableAntiCsrf can\'t be set to false if cookieSameSite value is "none".') {
+                if (
+                    err.message !==
+                    'Security error: enableAntiCsrf can\'t be set to false if cookieSameSite value is "none"'
+                ) {
                     throw err;
                 }
             }
@@ -962,7 +965,7 @@ describe(`configTest: ${printPath("[test/config.test.js]")}`, function () {
         });
         assert.equal(SessionRecipe.getInstanceOrThrowError().config.cookieDomain, undefined);
         assert.equal(SessionRecipe.getInstanceOrThrowError().config.cookieSameSite, "lax");
-        assert.equal(SessionRecipe.getInstanceOrThrowError().config.cookieSecure, false);
+        assert.equal(SessionRecipe.getInstanceOrThrowError().config.cookieSecure, true);
         assert.equal(
             SessionRecipe.getInstanceOrThrowError().config.refreshTokenPath.getAsStringDangerous(),
             "/auth/session/refresh"

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -739,6 +739,27 @@ describe(`configTest: ${printPath("[test/config.test.js]")}`, function () {
             assert(hosts[3].getAsStringDangerous() === "http://localhost:90");
             resetAll();
         }
+
+        {
+            STExpress.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                },
+                appInfo: {
+                    apiDomain: "api.supertokens.io",
+                    appName: "SuperTokens",
+                    websiteDomain: "supertokens.io",
+                    apiBasePath: "/",
+                },
+                recipeList: [
+                    Session.init({
+                        enableAntiCsrf: true,
+                    }),
+                ],
+            });
+            assert(SessionRecipe.getInstanceOrThrowError().config.enableAntiCsrf === true);
+            resetAll();
+        }
     });
 
     it("checking for default cookie config", async function () {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -760,6 +760,46 @@ describe(`configTest: ${printPath("[test/config.test.js]")}`, function () {
             assert(SessionRecipe.getInstanceOrThrowError().config.enableAntiCsrf === true);
             resetAll();
         }
+
+        {
+            STExpress.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                },
+                appInfo: {
+                    apiDomain: "https://api.supertokens.io",
+                    appName: "SuperTokens",
+                    websiteDomain: "supertokens.io",
+                    apiBasePath: "test/",
+                    websiteBasePath: "test1/",
+                },
+                recipeList: [Session.init()],
+            });
+
+            assert(SessionRecipe.getInstanceOrThrowError().config.cookieSecure === true);
+
+            resetAll();
+        }
+
+        {
+            STExpress.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                },
+                appInfo: {
+                    apiDomain: "http://api.supertokens.io",
+                    appName: "SuperTokens",
+                    websiteDomain: "supertokens.io",
+                    apiBasePath: "test/",
+                    websiteBasePath: "test1/",
+                },
+                recipeList: [Session.init()],
+            });
+
+            assert(SessionRecipe.getInstanceOrThrowError().config.cookieSecure === false);
+
+            resetAll();
+        }
     });
 
     it("checking for default cookie config", async function () {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -759,6 +759,8 @@ describe(`configTest: ${printPath("[test/config.test.js]")}`, function () {
                 ],
             });
             assert(SessionRecipe.getInstanceOrThrowError().config.enableAntiCsrf === true);
+            assert(SessionRecipe.getInstanceOrThrowError().config.cookieSameSite === "lax");
+            assert(SessionRecipe.getInstanceOrThrowError().config.cookieSecure === true);
             resetAll();
         }
 
@@ -777,6 +779,8 @@ describe(`configTest: ${printPath("[test/config.test.js]")}`, function () {
                 recipeList: [Session.init()],
             });
 
+            assert(SessionRecipe.getInstanceOrThrowError().config.enableAntiCsrf === false);
+            assert(SessionRecipe.getInstanceOrThrowError().config.cookieSameSite === "lax");
             assert(SessionRecipe.getInstanceOrThrowError().config.cookieSecure === true);
 
             resetAll();
@@ -797,8 +801,9 @@ describe(`configTest: ${printPath("[test/config.test.js]")}`, function () {
                 recipeList: [Session.init()],
             });
 
+            assert(SessionRecipe.getInstanceOrThrowError().config.enableAntiCsrf === false);
+            assert(SessionRecipe.getInstanceOrThrowError().config.cookieSameSite === "lax");
             assert(SessionRecipe.getInstanceOrThrowError().config.cookieSecure === false);
-
             resetAll();
         }
 
@@ -817,7 +822,9 @@ describe(`configTest: ${printPath("[test/config.test.js]")}`, function () {
                 recipeList: [Session.init()],
             });
 
-            assert.strictEqual(SessionRecipe.getInstanceOrThrowError().config.cookieSameSite, "lax");
+            assert(SessionRecipe.getInstanceOrThrowError().config.enableAntiCsrf === false);
+            assert(SessionRecipe.getInstanceOrThrowError().config.cookieSameSite === "lax");
+            assert(SessionRecipe.getInstanceOrThrowError().config.cookieSecure === true);
             resetAll();
         }
 
@@ -836,7 +843,9 @@ describe(`configTest: ${printPath("[test/config.test.js]")}`, function () {
                 recipeList: [Session.init()],
             });
 
-            assert.strictEqual(SessionRecipe.getInstanceOrThrowError().config.cookieSameSite, "none");
+            assert(SessionRecipe.getInstanceOrThrowError().config.enableAntiCsrf === true);
+            assert(SessionRecipe.getInstanceOrThrowError().config.cookieSameSite === "none");
+            assert(SessionRecipe.getInstanceOrThrowError().config.cookieSecure === true);
             resetAll();
         }
 
@@ -855,7 +864,9 @@ describe(`configTest: ${printPath("[test/config.test.js]")}`, function () {
                 recipeList: [Session.init()],
             });
 
-            assert.strictEqual(SessionRecipe.getInstanceOrThrowError().config.cookieSameSite, "lax");
+            assert(SessionRecipe.getInstanceOrThrowError().config.enableAntiCsrf === false);
+            assert(SessionRecipe.getInstanceOrThrowError().config.cookieSameSite === "lax");
+            assert(SessionRecipe.getInstanceOrThrowError().config.cookieSecure === true);
             resetAll();
         }
 
@@ -874,7 +885,9 @@ describe(`configTest: ${printPath("[test/config.test.js]")}`, function () {
                 recipeList: [Session.init()],
             });
 
-            assert.strictEqual(SessionRecipe.getInstanceOrThrowError().config.cookieSameSite, "lax");
+            assert(SessionRecipe.getInstanceOrThrowError().config.enableAntiCsrf === false);
+            assert(SessionRecipe.getInstanceOrThrowError().config.cookieSameSite === "lax");
+            assert(SessionRecipe.getInstanceOrThrowError().config.cookieSecure === false);
             resetAll();
         }
 
@@ -897,6 +910,8 @@ describe(`configTest: ${printPath("[test/config.test.js]")}`, function () {
                 ],
             });
             assert(SessionRecipe.getInstanceOrThrowError().config.enableAntiCsrf === true);
+            assert(SessionRecipe.getInstanceOrThrowError().config.cookieSameSite === "lax");
+            assert(SessionRecipe.getInstanceOrThrowError().config.cookieSecure === false);
             resetAll();
         }
 
@@ -915,6 +930,8 @@ describe(`configTest: ${printPath("[test/config.test.js]")}`, function () {
                 recipeList: [Session.init()],
             });
             assert(SessionRecipe.getInstanceOrThrowError().config.enableAntiCsrf === false);
+            assert(SessionRecipe.getInstanceOrThrowError().config.cookieSameSite === "lax");
+            assert(SessionRecipe.getInstanceOrThrowError().config.cookieSecure === false);
             resetAll();
         }
 
@@ -941,7 +958,7 @@ describe(`configTest: ${printPath("[test/config.test.js]")}`, function () {
             } catch (err) {
                 if (
                     err.message !==
-                    'Security error: enableAntiCsrf can\'t be set to false if cookieSameSite value is "none"'
+                    'Security error: enableAntiCsrf can\'t be set to false if cookieSameSite value is "none".'
                 ) {
                     throw err;
                 }

--- a/test/emailpassword/emailverify.test.js
+++ b/test/emailpassword/emailverify.test.js
@@ -75,7 +75,12 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [EmailPassword.init(), Session.init()],
+            recipeList: [
+                EmailPassword.init(),
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         let currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
@@ -120,7 +125,12 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [EmailPassword.init(), Session.init()],
+            recipeList: [
+                EmailPassword.init(),
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         let currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
@@ -169,7 +179,12 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [EmailPassword.init(), Session.init()],
+            recipeList: [
+                EmailPassword.init(),
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         let currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
@@ -214,7 +229,12 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [EmailPassword.init(), Session.init()],
+            recipeList: [
+                EmailPassword.init(),
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         let currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
@@ -305,7 +325,9 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                         },
                     },
                 }),
-                Session.init(),
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
             ],
         });
 
@@ -378,7 +400,9 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                         },
                     },
                 }),
-                Session.init(),
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
             ],
         });
 
@@ -444,7 +468,12 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [EmailPassword.init(), Session.init()],
+            recipeList: [
+                EmailPassword.init(),
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         let currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
@@ -491,7 +520,12 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [EmailPassword.init(), Session.init()],
+            recipeList: [
+                EmailPassword.init(),
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         let currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
@@ -552,7 +586,9 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                         },
                     },
                 }),
-                Session.init(),
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
             ],
         });
 
@@ -630,7 +666,9 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                         },
                     },
                 }),
-                Session.init(),
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
             ],
         });
 
@@ -717,7 +755,12 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [EmailPassword.init(), Session.init()],
+            recipeList: [
+                EmailPassword.init(),
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         let currCDIVersion = await Querier.getInstanceOrThrowError().getAPIVersion();
@@ -772,7 +815,9 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                         },
                     },
                 }),
-                Session.init(),
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
             ],
         });
 

--- a/test/emailpassword/signinFeature.test.js
+++ b/test/emailpassword/signinFeature.test.js
@@ -436,7 +436,12 @@ describe(`signinFeature: ${printPath("[test/emailpassword/signinFeature.test.js]
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [EmailPassword.init(), Session.init()],
+            recipeList: [
+                EmailPassword.init(),
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
         const app = express();
 

--- a/test/emailpassword/signoutFeature.test.js
+++ b/test/emailpassword/signoutFeature.test.js
@@ -66,7 +66,12 @@ describe(`signoutFeature: ${printPath("[test/emailpassword/signoutFeature.test.j
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [EmailPassword.init(), Session.init()],
+            recipeList: [
+                EmailPassword.init(),
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         const app = express();
@@ -210,7 +215,12 @@ describe(`signoutFeature: ${printPath("[test/emailpassword/signoutFeature.test.j
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [EmailPassword.init(), Session.init()],
+            recipeList: [
+                EmailPassword.init(),
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         const app = express();

--- a/test/emailpassword/signupFeature.test.js
+++ b/test/emailpassword/signupFeature.test.js
@@ -412,7 +412,12 @@ describe(`signupFeature: ${printPath("[test/emailpassword/signupFeature.test.js]
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [EmailPassword.init(), Session.init()],
+            recipeList: [
+                EmailPassword.init(),
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
         const app = express();
 

--- a/test/faunadb.test.js
+++ b/test/faunadb.test.js
@@ -63,6 +63,7 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
                     faunadbSecret: "fnAD2HH-Q6ACBSJxMjwU5YT7hvkaVo6Te8PJWqsT",
                     userCollectionName: "users",
                     accessFaunadbTokenFromFrontend: true,
+                    enableAntiCsrf: true,
                 }),
             ],
         });
@@ -179,6 +180,7 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
                     faunadbSecret: "fnAD2HH-Q6ACBSJxMjwU5YT7hvkaVo6Te8PJWqsT",
                     userCollectionName: "users",
                     accessFaunadbTokenFromFrontend: true,
+                    enableAntiCsrf: true,
                 }),
             ],
         });
@@ -298,6 +300,7 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
                 Session.init({
                     faunadbSecret: "fnAD2HH-Q6ACBSJxMjwU5YT7hvkaVo6Te8PJWqsT",
                     userCollectionName: "users",
+                    enableAntiCsrf: true,
                 }),
             ],
         });
@@ -379,6 +382,7 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
                 Session.init({
                     faunadbSecret: "fnAD2HH-Q6ACBSJxMjwU5YT7hvkaVo6Te8PJWqsT",
                     userCollectionName: "users",
+                    enableAntiCsrf: true,
                 }),
             ],
         });
@@ -491,6 +495,7 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
                     faunadbSecret: "fnAD2HH-Q6ACBSJxMjwU5YT7hvkaVo6Te8PJWqsT",
                     userCollectionName: "users",
                     accessFaunadbTokenFromFrontend: true,
+                    enableAntiCsrf: true,
                 }),
             ],
         });
@@ -583,6 +588,7 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
                     faunadbSecret: "fnAD2HH-Q6ACBSJxMjwU5YT7hvkaVo6Te8PJWqsT",
                     userCollectionName: "users",
                     accessFaunadbTokenFromFrontend: true,
+                    enableAntiCsrf: true,
                 }),
             ],
         });
@@ -730,6 +736,7 @@ describe(`faunaDB: ${printPath("[test/faunadb.test.js]")}`, function () {
                 Session.init({
                     faunadbSecret: "fnAD2HH-Q6ACBSJxMjwU5YT7hvkaVo6Te8PJWqsT",
                     userCollectionName: "users",
+                    enableAntiCsrf: true,
                 }),
             ],
         });

--- a/test/handshake.test.js
+++ b/test/handshake.test.js
@@ -18,6 +18,7 @@ let Session = require("../recipe/session");
 let SessionRecipe = require("../lib/build/recipe/session/sessionRecipe").default;
 let assert = require("assert");
 let { ProcessState, PROCESS_STATE } = require("../lib/build/processState");
+const { maxVersion } = require("../lib/build/utils");
 
 describe(`Handshake: ${printPath("[test/handshake.test.js]")}`, function () {
     beforeEach(async function () {
@@ -101,7 +102,10 @@ describe(`Handshake: ${printPath("[test/handshake.test.js]")}`, function () {
         });
         let info = await SessionRecipe.getInstanceOrThrowError().getHandshakeInfo();
         assert.equal(typeof info.jwtSigningPublicKey, "string");
-        assert.equal(info.enableAntiCsrf, true);
+        let cdiVersion = await SessionRecipe.getInstanceOrThrowError().getQuerier().getAPIVersion();
+        if (maxVersion(cdiVersion, "2.6") !== cdiVersion) {
+            assert.strictEqual(info.enableAntiCsrf, true);
+        }
         assert.equal(info.accessTokenBlacklistingEnabled, false);
         assert.equal(typeof info.jwtSigningPublicKeyExpiryTime, "number");
         assert.equal(info.accessTokenValidity, 3600 * 1000);

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -55,6 +55,7 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
                 Session.init({
                     sessionRefreshFeature: {
                         disableDefaultImplementation: true,
+                        enableAntiCsrf: true,
                     },
                 }),
             ],
@@ -100,6 +101,7 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
                             });
                         },
                     },
+                    enableAntiCsrf: true,
                 }),
             ],
         });
@@ -337,6 +339,7 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
             },
             recipeList: [
                 Session.init({
+                    enableAntiCsrf: true,
                     errorHandlers: {
                         onTokenTheftDetected: (sessionHandle, userId, req, res, next) => {
                             res.statusCode = 403;
@@ -598,6 +601,7 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
                             });
                         },
                     },
+                    enableAntiCsrf: true,
                 }),
             ],
         });
@@ -854,6 +858,7 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
                             });
                         },
                     },
+                    enableAntiCsrf: true,
                 }),
             ],
         });

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -902,6 +902,10 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
             )
         );
 
+        assert(res1.accessTokenHttpOnly);
+        assert(res1.idRefreshTokenHttpOnly);
+        assert(res1.refreshTokenHttpOnly);
+
         let r1 = await new Promise((resolve) =>
             request(app)
                 .get("/custom/user/id")

--- a/test/nextjs.test.js
+++ b/test/nextjs.test.js
@@ -40,7 +40,12 @@ describe(`NextJS Middleware Test: ${printPath("[test/helpers/nextjs/index.test.j
                     apiBasePath: "/api/auth",
                     websiteDomain: "supertokens.io",
                 },
-                recipeList: [EmailPassword.init(), Session.init()],
+                recipeList: [
+                    EmailPassword.init(),
+                    Session.init({
+                        enableAntiCsrf: true,
+                    }),
+                ],
             });
         });
 

--- a/test/querier.test.js
+++ b/test/querier.test.js
@@ -47,7 +47,12 @@ describe(`Querier: ${printPath("[test/querier.test.js]")}`, function () {
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init(), EmailPassword.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+                EmailPassword.init(),
+            ],
         });
         try {
             await Session.getAllSessionHandlesForUser();
@@ -80,7 +85,11 @@ describe(`Querier: ${printPath("[test/querier.test.js]")}`, function () {
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
         let q = Querier.getInstanceOrThrowError("");
         await q.getAPIVersion();
@@ -113,7 +122,11 @@ describe(`Querier: ${printPath("[test/querier.test.js]")}`, function () {
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         let querier = Querier.getInstanceOrThrowError("test");
@@ -162,7 +175,11 @@ describe(`Querier: ${printPath("[test/querier.test.js]")}`, function () {
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
         try {
             let q = Querier.getInstanceOrThrowError("");
@@ -188,7 +205,11 @@ describe(`Querier: ${printPath("[test/querier.test.js]")}`, function () {
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
         let q = Querier.getInstanceOrThrowError("");
         assert.equal(await q.sendGetRequest(new NormalisedURLPath("", "/hello"), {}), "Hello\n");
@@ -215,7 +236,11 @@ describe(`Querier: ${printPath("[test/querier.test.js]")}`, function () {
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
         let q = Querier.getInstanceOrThrowError("");
         assert.equal(await q.sendGetRequest(new NormalisedURLPath("", "/hello"), {}), "Hello\n");

--- a/test/recipeModuleManager.test.js
+++ b/test/recipeModuleManager.test.js
@@ -59,7 +59,12 @@ describe(`recipeModuleManagerTest: ${printPath("[test/recipeModuleManager.test.j
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init(), EmailPassword.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+                EmailPassword.init(),
+            ],
         });
 
         ST.init({
@@ -71,7 +76,12 @@ describe(`recipeModuleManagerTest: ${printPath("[test/recipeModuleManager.test.j
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init(), EmailPassword.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+                EmailPassword.init(),
+            ],
         });
     });
 
@@ -98,7 +108,11 @@ describe(`recipeModuleManagerTest: ${printPath("[test/recipeModuleManager.test.j
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         await Querier.getInstanceOrThrowError();
@@ -136,7 +150,12 @@ describe(`recipeModuleManagerTest: ${printPath("[test/recipeModuleManager.test.j
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init(), EmailPassword.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+                EmailPassword.init(),
+            ],
         });
         await SessionRecipe.getInstanceOrThrowError();
         await EmailPasswordRecipe.getInstanceOrThrowError();

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -68,7 +68,11 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         const app = express();
@@ -124,7 +128,11 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         const app = express();
@@ -196,7 +204,11 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         const app = express();
@@ -250,7 +262,11 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         const app = express();
@@ -304,7 +320,11 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         let response = await SessionFunctions.createNewSession(SessionRecipe.getInstanceOrThrowError(), "", {}, {});
@@ -350,7 +370,11 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         let response = await SessionFunctions.createNewSession(SessionRecipe.getInstanceOrThrowError(), "", {}, {});
@@ -395,7 +419,11 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         try {
@@ -424,7 +452,11 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         let s = SessionRecipe.getInstanceOrThrowError();
@@ -499,7 +531,11 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         let s = SessionRecipe.getInstanceOrThrowError();
@@ -539,7 +575,11 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         let s = SessionRecipe.getInstanceOrThrowError();
@@ -580,7 +620,11 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         let s = SessionRecipe.getInstanceOrThrowError();
@@ -626,7 +670,11 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         let s = SessionRecipe.getInstanceOrThrowError();
@@ -666,7 +714,11 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         let s = SessionRecipe.getInstanceOrThrowError();
@@ -708,7 +760,11 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: false,
+                }),
+            ],
         });
 
         let s = SessionRecipe.getInstanceOrThrowError();
@@ -753,6 +809,7 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
             recipeList: [
                 Session.init({
                     cookieSameSite: "none",
+                    enableAntiCsrf: false,
                 }),
             ],
         });
@@ -788,6 +845,7 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
             recipeList: [
                 Session.init({
                     cookieSameSite: "lax",
+                    enableAntiCsrf: false,
                 }),
             ],
         });
@@ -811,6 +869,7 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
             recipeList: [
                 Session.init({
                     cookieSameSite: "strict",
+                    enableAntiCsrf: false,
                 }),
             ],
         });

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -797,22 +797,25 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
         await setKeyValueInConfig("enable_anti_csrf", "false");
         await startST();
 
-        SuperTokens.init({
-            supertokens: {
-                connectionURI: "http://localhost:8080",
-            },
-            appInfo: {
-                apiDomain: "api.supertokens.io",
-                appName: "SuperTokens",
-                websiteDomain: "supertokens.io",
-            },
-            recipeList: [
-                Session.init({
-                    cookieSameSite: "none",
-                    enableAntiCsrf: false,
-                }),
-            ],
-        });
+        try {
+            SuperTokens.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                },
+                appInfo: {
+                    apiDomain: "api.supertokens.io",
+                    appName: "SuperTokens",
+                    websiteDomain: "supertokens.io",
+                },
+                recipeList: [
+                    Session.init({
+                        cookieSameSite: "none",
+                        enableAntiCsrf: false,
+                    }),
+                ],
+            });
+            assert(false);
+        } catch (err) {}
 
         let s = SessionRecipe.getInstanceOrThrowError();
 
@@ -823,9 +826,9 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
             if (
                 err.type !== Session.Error.GENERAL_ERROR ||
                 err.message !==
-                    'Security error: Cookie same site is "none" and anti-CSRF protection is disabled! Please either: \n- Change cookie same site to "lax" or to "strict". or \n- Enable anti-CSRF protection in the core by setting enable_anti_csrf to true.'
+                    'Security error: enableAntiCsrf can\'t be set to false if cookieSameSite value is "none"'
             ) {
-                throw error;
+                throw err;
             }
         }
     });

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -815,18 +815,11 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
                 ],
             });
             assert(false);
-        } catch (err) {}
-
-        let s = SessionRecipe.getInstanceOrThrowError();
-
-        try {
-            await SessionFunctions.createNewSession(s, "", {}, {});
-            assert(false);
         } catch (err) {
             if (
                 err.type !== Session.Error.GENERAL_ERROR ||
                 err.message !==
-                    'Security error: enableAntiCsrf can\'t be set to false if cookieSameSite value is "none"'
+                    'Security error: enableAntiCsrf can\'t be set to false if cookieSameSite value is "none".'
             ) {
                 throw err;
             }

--- a/test/sessionExpress.test.js
+++ b/test/sessionExpress.test.js
@@ -61,6 +61,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                     sessionRefreshFeature: {
                         disableDefaultImplementation: true,
                     },
+                    enableAntiCsrf: true,
                 }),
             ],
         });
@@ -116,7 +117,11 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         const app = express();
@@ -225,7 +230,11 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         const app = express();
@@ -325,7 +334,11 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         const app = express();
@@ -490,7 +503,11 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                 websiteDomain: "supertokens.io",
                 apiBasePath: "/",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         const app = express();
@@ -653,7 +670,11 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         const app = express();
@@ -730,7 +751,11 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         const app = express();
@@ -812,7 +837,11 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
         const app = express();
         app.post("/create", async (req, res) => {
@@ -953,7 +982,11 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         const app = express();
@@ -1114,7 +1147,11 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
         const app = express();
         app.post("/create", async (req, res) => {
@@ -1337,7 +1374,11 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
         const app = express();
         app.post("/create", async (req, res) => {
@@ -1389,7 +1430,11 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: false,
+                }),
+            ],
         });
 
         const app = express();
@@ -1462,7 +1507,11 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         const app = express();
@@ -1515,7 +1564,11 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
                 appName: "SuperTokens",
                 websiteDomain: "supertokens.io",
             },
-            recipeList: [Session.init()],
+            recipeList: [
+                Session.init({
+                    enableAntiCsrf: true,
+                }),
+            ],
         });
 
         const app = express();

--- a/test/utils.js
+++ b/test/utils.js
@@ -74,6 +74,9 @@ module.exports.extractInfoFromResponse = function (res) {
     let accessTokenDomain = undefined;
     let refreshTokenDomain = undefined;
     let idRefreshTokenDomain = undefined;
+    let accessTokenHttpOnly = false;
+    let idRefreshTokenHttpOnly = false;
+    let refreshTokenHttpOnly = false;
     let frontToken = res.headers["front-token"];
     let cookies = res.headers["set-cookie"];
     cookies = cookies === undefined ? [] : cookies;
@@ -88,6 +91,7 @@ module.exports.extractInfoFromResponse = function (res) {
             if (i.split(";")[1].includes("Domain=")) {
                 accessTokenDomain = i.split(";")[1].split("=")[1];
             }
+            accessTokenHttpOnly = i.split(";").findIndex((j) => j.includes("HttpOnly")) !== -1;
         } else if (i.split(";")[0].split("=")[0] === "sRefreshToken") {
             refreshToken = i.split(";")[0].split("=")[1];
             if (i.split(";")[2].includes("Expires=")) {
@@ -98,6 +102,7 @@ module.exports.extractInfoFromResponse = function (res) {
             if (i.split(";")[1].includes("Domain=")) {
                 refreshTokenDomain = i.split(";")[1].split("=")[1];
             }
+            refreshTokenHttpOnly = i.split(";").findIndex((j) => j.includes("HttpOnly")) !== -1;
         } else {
             idRefreshTokenFromCookie = i.split(";")[0].split("=")[1];
             if (i.split(";")[2].includes("Expires=")) {
@@ -108,6 +113,7 @@ module.exports.extractInfoFromResponse = function (res) {
             if (i.split(";")[1].includes("Domain=")) {
                 idRefreshTokenDomain = i.split(";")[1].split("=")[1];
             }
+            idRefreshTokenHttpOnly = i.split(";").findIndex((j) => j.includes("HttpOnly")) !== -1;
         }
     });
     return {
@@ -123,6 +129,9 @@ module.exports.extractInfoFromResponse = function (res) {
         refreshTokenDomain,
         idRefreshTokenDomain,
         frontToken,
+        accessTokenHttpOnly,
+        refreshTokenHttpOnly,
+        idRefreshTokenHttpOnly,
     };
 };
 


### PR DESCRIPTION
## Related issue:
- https://github.com/supertokens/supertokens-node/issues/63

## Changes
- [x] accept `enableAntiCsrf` as config parameter in session recipe
- [x] changes in code to use `enableAntiCsrf` value based on the CDI version
- [x] passing `enableAntiCsrf` boolean in session create API if CDI version is 2.6
- [x] passing `enableAntiCsrf` boolean in session verify API if CDI version is 2.6
- [x] passing `enableAntiCsrf` boolean in session refresh API if CDI version is 2.6
- [x] set `cookieSecure` to true by default if the `apiDomain` has **https**
- [x] if the `apiDomain` and `websiteDomain` values are different (no common top level domain), then set `cookieSameSite` to `none` by default, else set it to `lax`.
- [x] if `cookieSameSite` is set to `none`, make sure `enableAntiCsrf` value is `true`. if not, throw error
- [x] changelog updates
- [x] Changes to CDI json and CDI array in version file
- [x] Change to SDK version in package.json, package-lock.json and version file

## Migration:
- update core to version >= 3.2
- if `enable_anti_csrf` is specified in core config, use `enableAntiCsrf` in session config in the driver instead