### PR TITLE
changes to make sure response from provider is of type json

### DIFF
--- a/lib/build/recipe/thirdParty/api/signinup.js
+++ b/lib/build/recipe/thirdParty/api/signinup.js
@@ -106,6 +106,7 @@ function signInUpAPI(recipeInstance, req, res, next) {
                 data: qs.stringify(providerInfo.accessTokenAPI.params),
                 headers: {
                     "content-type": "application/x-www-form-urlencoded",
+                    accept: "application/json", // few providers like github don't send back json response by default
                 },
             });
             userInfo = yield providerInfo.getProfileInfo(accessTokenAPIResponse.data);

--- a/lib/build/recipe/thirdParty/providers/github.js
+++ b/lib/build/recipe/thirdParty/providers/github.js
@@ -119,18 +119,20 @@ function Github(config) {
                     let userInfo = response.data;
                     let emailsInfo = emailsInfoResponse.data;
                     let id = userInfo.id;
-                    let email = userInfo.email;
-                    if (email === undefined || email === null) {
+                    // if user has choosen not to show their email publicly, userInfo here will
+                    // have email as null. So we instead get the info from the emails api and
+                    // use the email which is maked as primary one.
+                    let emailInfo = emailsInfo.find((e) => e.primary);
+                    if (emailInfo === undefined) {
                         return {
                             id,
                         };
                     }
-                    let emailInfo = emailsInfo.find((e) => e.email === email);
                     let isVerified = emailInfo !== undefined ? emailInfo.verified : false;
                     return {
                         id,
                         email: {
-                            id: email,
+                            id: emailInfo.email,
                             isVerified,
                         },
                     };

--- a/lib/ts/recipe/thirdParty/api/signinup.ts
+++ b/lib/ts/recipe/thirdParty/api/signinup.ts
@@ -82,6 +82,7 @@ export default async function signInUpAPI(recipeInstance: Recipe, req: Request, 
             data: qs.stringify(providerInfo.accessTokenAPI.params),
             headers: {
                 "content-type": "application/x-www-form-urlencoded",
+                accept: "application/json", // few providers like github don't send back json response by default
             },
         });
         userInfo = await providerInfo.getProfileInfo(accessTokenAPIResponse.data);

--- a/lib/ts/recipe/thirdParty/providers/github.ts
+++ b/lib/ts/recipe/thirdParty/providers/github.ts
@@ -120,18 +120,20 @@ export default function Github(config: TypeThirdPartyProviderGithubConfig): Type
             let userInfo = response.data;
             let emailsInfo = emailsInfoResponse.data;
             let id = userInfo.id;
-            let email = userInfo.email;
-            if (email === undefined || email === null) {
+            // if user has choosen not to show their email publicly, userInfo here will
+            // have email as null. So we instead get the info from the emails api and
+            // use the email which is maked as primary one.
+            let emailInfo = emailsInfo.find((e: any) => e.primary);
+            if (emailInfo === undefined) {
                 return {
                     id,
                 };
             }
-            let emailInfo = emailsInfo.find((e: any) => e.email === email);
             let isVerified = emailInfo !== undefined ? emailInfo.verified : false;
             return {
                 id,
                 email: {
-                    id: email,
+                    id: emailInfo.email,
                     isVerified,
                 },
             };


### PR DESCRIPTION
- adding headers in signinup api to make sure response from provider is of type json
- using emails api to get primary email of user (provider: github)