### PR TITLE
Accept dynamic params via function for authorisation url

### DIFF
--- a/lib/build/recipe/thirdparty/api/authorisationUrl.js
+++ b/lib/build/recipe/thirdparty/api/authorisationUrl.js
@@ -86,7 +86,11 @@ function authorisationUrlAPI(recipeInstance, req, res, next) {
                 recipeInstance.getRecipeId()
             );
         }
-        let paramsString = new url_1.URLSearchParams(providerInfo.authorisationRedirect.params).toString();
+        const params = Object.entries(providerInfo.authorisationRedirect.params).reduce((acc, [key, value]) => {
+            console.log(key, typeof value);
+            return Object.assign(Object.assign({}, acc), { [key]: typeof value === "function" ? value(req) : value });
+        }, {});
+        let paramsString = new url_1.URLSearchParams(params).toString();
         let url = `${providerInfo.authorisationRedirect.url}?${paramsString}`;
         return utils_1.send200Response(res, {
             status: "OK",

--- a/lib/build/recipe/thirdparty/types.d.ts
+++ b/lib/build/recipe/thirdparty/types.d.ts
@@ -1,3 +1,4 @@
+import { Request } from "express";
 import { TypeInput as TypeNormalisedInputEmailVerification } from "../emailverification/types";
 export declare type UserInfo = {
     id: string;
@@ -16,7 +17,7 @@ export declare type TypeProviderGetResponse = {
     authorisationRedirect: {
         url: string;
         params: {
-            [key: string]: string;
+            [key: string]: string | ((request: Request) => string);
         };
     };
     getProfileInfo: (authCodeResponse: any) => Promise<UserInfo>;

--- a/lib/ts/recipe/thirdparty/api/authorisationUrl.ts
+++ b/lib/ts/recipe/thirdparty/api/authorisationUrl.ts
@@ -65,7 +65,16 @@ export default async function authorisationUrlAPI(
             recipeInstance.getRecipeId()
         );
     }
-    let paramsString = new URLSearchParams(providerInfo.authorisationRedirect.params).toString();
+
+    const params = Object.entries(providerInfo.authorisationRedirect.params).reduce(
+        (acc, [key, value]) => ({
+            ...acc,
+            [key]: typeof value === "function" ? value(req) : value,
+        }),
+        {}
+    );
+
+    let paramsString = new URLSearchParams(params).toString();
 
     let url = `${providerInfo.authorisationRedirect.url}?${paramsString}`;
 

--- a/lib/ts/recipe/thirdparty/types.ts
+++ b/lib/ts/recipe/thirdparty/types.ts
@@ -13,6 +13,7 @@
  * under the License.
  */
 
+import { Request } from "express";
 import { TypeInput as TypeNormalisedInputEmailVerification } from "../emailverification/types";
 
 const TypeBoolean = {
@@ -32,7 +33,7 @@ export type TypeProviderGetResponse = {
     };
     authorisationRedirect: {
         url: string;
-        params: { [key: string]: string };
+        params: { [key: string]: string | ((request: Request) => string) };
     };
     getProfileInfo: (authCodeResponse: any) => Promise<UserInfo>;
 };

--- a/test/thirdparty/authorisationUrlFeature.test.js
+++ b/test/thirdparty/authorisationUrlFeature.test.js
@@ -23,7 +23,7 @@ const express = require("express");
 const request = require("supertest");
 let Session = require("../../recipe/session");
 
-describe(`authorisationTest: ${printPath("[test/thirdparty/authorisationFeature.test.js]")}`, function () {
+describe.only(`authorisationTest: ${printPath("[test/thirdparty/authorisationFeature.test.js]")}`, function () {
     before(function () {
         this.customProvider1 = {
             id: "custom",
@@ -37,6 +37,9 @@ describe(`authorisationTest: ${printPath("[test/thirdparty/authorisationFeature.
                         params: {
                             scope: "test",
                             client_id: "supertokens",
+                            dynamic: function dynamicParam(request) {
+                                return request.query.dynamic;
+                            },
                         },
                     },
                     getProfileInfo: async (authCodeResponse) => {
@@ -101,7 +104,7 @@ describe(`authorisationTest: ${printPath("[test/thirdparty/authorisationFeature.
 
         let response1 = await new Promise((resolve) =>
             request(app)
-                .get("/auth/authorisationurl?thirdPartyId=custom")
+                .get("/auth/authorisationurl?thirdPartyId=custom&dynamic=example.com")
                 .end((err, res) => {
                     if (err) {
                         resolve(undefined);
@@ -112,7 +115,10 @@ describe(`authorisationTest: ${printPath("[test/thirdparty/authorisationFeature.
         );
         assert.notStrictEqual(response1, undefined);
         assert.strictEqual(response1.body.status, "OK");
-        assert.strictEqual(response1.body.url, "https://test.com/oauth/auth?scope=test&client_id=supertokens");
+        assert.strictEqual(
+            response1.body.url,
+            "https://test.com/oauth/auth?scope=test&client_id=supertokens&dynamic=example.com"
+        );
     });
 
     it("test provider get function throws error", async function () {

--- a/test/thirdparty/authorisationUrlFeature.test.js
+++ b/test/thirdparty/authorisationUrlFeature.test.js
@@ -23,7 +23,7 @@ const express = require("express");
 const request = require("supertest");
 let Session = require("../../recipe/session");
 
-describe.only(`authorisationTest: ${printPath("[test/thirdparty/authorisationFeature.test.js]")}`, function () {
+describe(`authorisationTest: ${printPath("[test/thirdparty/authorisationFeature.test.js]")}`, function () {
     before(function () {
         this.customProvider1 = {
             id: "custom",


### PR DESCRIPTION
per #94 this allows thirdparty providers to include dynamic params when constructing an authorisation url.

The params value type on the thirdparty now accepts a string or a function, where the function is provided the request object in order to read params, locales, etc.

This can be used for example to collect a user's domain, and use that in the `hd` parameter for google oauth.

Also updates a test.