### PR TITLE
Fix email sending in serverless env

### DIFF
--- a/lib/build/recipe/emailpassword/api/generatePasswordResetToken.js
+++ b/lib/build/recipe/emailpassword/api/generatePasswordResetToken.js
@@ -85,10 +85,13 @@ function generatePasswordResetToken(recipeInstance, req, res, _) {
             token +
             "&rid=" +
             recipeInstance.getRecipeId();
-        // step 5
-        utils_1.send200Response(res, {
-            status: "OK",
-        });
+        // step 5 - respond before email sending if not in a serverless environment
+        const isInServerlessEnv = recipeInstance.checkIfInServerlessEnv();
+        if (!isInServerlessEnv) {
+            utils_1.send200Response(res, {
+                status: "OK",
+            });
+        }
         // step 6 & 7
         try {
             yield recipeInstance.config.resetPasswordUsingTokenFeature.createAndSendCustomEmail(
@@ -96,6 +99,13 @@ function generatePasswordResetToken(recipeInstance, req, res, _) {
                 passwordResetLink
             );
         } catch (ignored) {}
+        // step 8 - respond after email sending in a serverless environment
+        // This ensures the program does not exist prior to the email being sent
+        if (isInServerlessEnv) {
+            utils_1.send200Response(res, {
+                status: "OK",
+            });
+        }
     });
 }
 exports.default = generatePasswordResetToken;

--- a/lib/build/recipe/emailverification/api/generateEmailVerifyToken.js
+++ b/lib/build/recipe/emailverification/api/generateEmailVerifyToken.js
@@ -82,14 +82,24 @@ function generateEmailVerifyToken(recipeInstance, req, res, _) {
             token +
             "&rid=" +
             recipeInstance.getRecipeId();
-        // step 4
-        utils_1.send200Response(res, {
-            status: "OK",
-        });
+        // step 4 - respond before email sending if not in a serverless environment
+        const isInServerlessEnv = recipeInstance.checkIfInServerlessEnv();
+        if (!isInServerlessEnv) {
+            utils_1.send200Response(res, {
+                status: "OK",
+            });
+        }
         // step 5 & 6
         try {
             yield recipeInstance.config.createAndSendCustomEmail({ id: userId, email }, emailVerifyLink);
         } catch (ignored) {}
+        // step 7 - respond after email sending in a serverless environment
+        // This ensures the program does not exist prior to the email being sent
+        if (isInServerlessEnv) {
+            utils_1.send200Response(res, {
+                status: "OK",
+            });
+        }
     });
 }
 exports.default = generateEmailVerifyToken;

--- a/lib/ts/recipe/emailpassword/api/generatePasswordResetToken.ts
+++ b/lib/ts/recipe/emailpassword/api/generatePasswordResetToken.ts
@@ -69,13 +69,24 @@ export default async function generatePasswordResetToken(
         "&rid=" +
         recipeInstance.getRecipeId();
 
-    // step 5
-    send200Response(res, {
-        status: "OK",
-    });
+    // step 5 - respond before email sending if not in a serverless environment
+    const isInServerlessEnv = recipeInstance.checkIfInServerlessEnv();
+    if (!isInServerlessEnv) {
+        send200Response(res, {
+            status: "OK",
+        });
+    }
 
     // step 6 & 7
     try {
         await recipeInstance.config.resetPasswordUsingTokenFeature.createAndSendCustomEmail(user, passwordResetLink);
     } catch (ignored) {}
+
+    // step 8 - respond after email sending in a serverless environment
+    // This ensures the program does not exist prior to the email being sent
+    if (isInServerlessEnv) {
+        send200Response(res, {
+            status: "OK",
+        });
+    }
 }

--- a/lib/ts/recipe/emailverification/api/generateEmailVerifyToken.ts
+++ b/lib/ts/recipe/emailverification/api/generateEmailVerifyToken.ts
@@ -64,13 +64,24 @@ export default async function generateEmailVerifyToken(
         "&rid=" +
         recipeInstance.getRecipeId();
 
-    // step 4
-    send200Response(res, {
-        status: "OK",
-    });
+    // step 4 - respond before email sending if not in a serverless environment
+    const isInServerlessEnv = recipeInstance.checkIfInServerlessEnv();
+    if (!isInServerlessEnv) {
+        send200Response(res, {
+            status: "OK",
+        });
+    }
 
     // step 5 & 6
     try {
         await recipeInstance.config.createAndSendCustomEmail({ id: userId, email }, emailVerifyLink);
     } catch (ignored) {}
+
+    // step 7 - respond after email sending in a serverless environment
+    // This ensures the program does not exist prior to the email being sent
+    if (isInServerlessEnv) {
+        send200Response(res, {
+            status: "OK",
+        });
+    }
 }


### PR DESCRIPTION
## Issue

In a serverless environment (specifically Vercel functions), the function program seems to stop shortly after a response is sent. This means that `createAndSendCustomEmail` does not always finish even though it is awaited. So usually an email is never sent even though the API responds "ok".

## Reproduction

1. Define a custom async `createAndSendCustomEmail` for either password reset or email verify. In it, wait some (5?) seconds before resolving, and log something after waiting.
2. Deploy to Vercel
3. Open the realtime functions log in Vercel dashboard
4. Hit the API route to verify email or reset password. Note that the API response is "ok" but note in Vercel logs that your final log message after waiting is never printed.

## Solution

I am not sure if this is a Vercel issue, lambda issue, or something else. Supposedly lambda functions do wait for the promise to resolve, but Vercel may be overriding this somehow. The solution in this PR does fix it for me and it seems fine to do this, but it may be considered more of a workaround than a fix.

The change is to check whether `isInServerlessEnv`, and if so, do not send the response until after awaiting `createAndSendCustomEmail`.