### PR TITLE
Add ability to fetch all session info from database using a session handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     -   `ThirdParty.getUserCount()`, `ThirdParty.getUsersNewestFirst()`, `ThirdParty.getUsersOldestFirst`
     -   `EmailPassword.getUserCount()`, `EmailPassword.getUsersNewestFirst()`, `EmailPassword.getUsersOldestFirst`
     -   `ThirdPartyEmailPassword.getUserCount()`, `ThirdPartyEmailPassword.getUsersNewestFirst()`, `ThirdPartyEmailPassword.getUsersOldestFirst`
+-   Deprecates (instead use `Session.getSessionInformation()`)
+    -   `Session.getSessionData()`, `Session.getJWTPayload()`
 
 ## [6.0.3] - 2021-07-08
 

--- a/lib/build/recipe/session/faunadb/recipeImplementation.d.ts
+++ b/lib/build/recipe/session/faunadb/recipeImplementation.d.ts
@@ -39,7 +39,7 @@ export default class RecipeImplementation implements RecipeInterface {
         res: express.Response;
         options?: VerifySessionOptions | undefined;
     }) => Promise<FaunaDBSessionContainer | undefined>;
-    getSessionDetails: ({ sessionHandle }: { sessionHandle: string }) => Promise<any>;
+    getSessionInformation: ({ sessionHandle }: { sessionHandle: string }) => Promise<any>;
     refreshSession: ({ req, res }: { req: express.Request; res: express.Response }) => Promise<FaunaDBSessionContainer>;
     revokeAllSessionsForUser: ({ userId }: { userId: string }) => Promise<string[]>;
     getAllSessionHandlesForUser: ({ userId }: { userId: string }) => Promise<string[]>;

--- a/lib/build/recipe/session/faunadb/recipeImplementation.d.ts
+++ b/lib/build/recipe/session/faunadb/recipeImplementation.d.ts
@@ -39,6 +39,7 @@ export default class RecipeImplementation implements RecipeInterface {
         res: express.Response;
         options?: VerifySessionOptions | undefined;
     }) => Promise<FaunaDBSessionContainer | undefined>;
+    getSessionDetails: ({ sessionHandle }: { sessionHandle: string }) => Promise<any>;
     refreshSession: ({ req, res }: { req: express.Request; res: express.Response }) => Promise<FaunaDBSessionContainer>;
     revokeAllSessionsForUser: ({ userId }: { userId: string }) => Promise<string[]>;
     getAllSessionHandlesForUser: ({ userId }: { userId: string }) => Promise<string[]>;

--- a/lib/build/recipe/session/faunadb/recipeImplementation.d.ts
+++ b/lib/build/recipe/session/faunadb/recipeImplementation.d.ts
@@ -2,6 +2,7 @@ import { VerifySessionOptions, RecipeInterface } from "../";
 import * as express from "express";
 import * as faunadb from "faunadb";
 import { Session as FaunaDBSessionContainer } from "./types";
+import { SessionInformation } from "../types";
 export default class RecipeImplementation implements RecipeInterface {
     config: {
         accessFaunadbTokenFromFrontend: boolean;
@@ -39,7 +40,7 @@ export default class RecipeImplementation implements RecipeInterface {
         res: express.Response;
         options?: VerifySessionOptions | undefined;
     }) => Promise<FaunaDBSessionContainer | undefined>;
-    getSessionInformation: ({ sessionHandle }: { sessionHandle: string }) => Promise<any>;
+    getSessionInformation: ({ sessionHandle }: { sessionHandle: string }) => Promise<SessionInformation>;
     refreshSession: ({ req, res }: { req: express.Request; res: express.Response }) => Promise<FaunaDBSessionContainer>;
     revokeAllSessionsForUser: ({ userId }: { userId: string }) => Promise<string[]>;
     getAllSessionHandlesForUser: ({ userId }: { userId: string }) => Promise<string[]>;

--- a/lib/build/recipe/session/faunadb/recipeImplementation.js
+++ b/lib/build/recipe/session/faunadb/recipeImplementation.js
@@ -80,6 +80,9 @@ class RecipeImplementation {
                 }
                 return getModifiedSession(originalSession);
             });
+        this.getSessionDetails = ({ sessionHandle }) => {
+            return this.originalImplementation.getSessionDetails({ sessionHandle });
+        };
         this.refreshSession = ({ req, res }) =>
             __awaiter(this, void 0, void 0, function* () {
                 let originalSession = yield this.originalImplementation.refreshSession({ req, res });

--- a/lib/build/recipe/session/faunadb/recipeImplementation.js
+++ b/lib/build/recipe/session/faunadb/recipeImplementation.js
@@ -80,8 +80,8 @@ class RecipeImplementation {
                 }
                 return getModifiedSession(originalSession);
             });
-        this.getSessionDetails = ({ sessionHandle }) => {
-            return this.originalImplementation.getSessionDetails({ sessionHandle });
+        this.getSessionInformation = ({ sessionHandle }) => {
+            return this.originalImplementation.getSessionInformation({ sessionHandle });
         };
         this.refreshSession = ({ req, res }) =>
             __awaiter(this, void 0, void 0, function* () {

--- a/lib/build/recipe/session/index.d.ts
+++ b/lib/build/recipe/session/index.d.ts
@@ -4,6 +4,7 @@ import {
     VerifySessionOptions,
     RecipeInterface,
     SessionContainerInterface as SessionContainer,
+    SessionInformation,
     SessionRequest,
     APIInterface,
     APIOptions,
@@ -23,7 +24,7 @@ export default class SessionWrapper {
         res: express.Response,
         options?: VerifySessionOptions
     ): Promise<SessionContainer | undefined>;
-    static getSessionInformation(sessionHandle: string): Promise<any>;
+    static getSessionInformation(sessionHandle: string): Promise<SessionInformation>;
     static refreshSession(req: express.Request, res: express.Response): Promise<SessionContainer>;
     static revokeAllSessionsForUser(userId: string): Promise<string[]>;
     static getAllSessionHandlesForUser(userId: string): Promise<string[]>;
@@ -54,4 +55,12 @@ export declare let verifySession: (
     options?: VerifySessionOptions | undefined
 ) => (req: express.Request, res: express.Response, next: express.NextFunction) => Promise<void>;
 export declare let Error: typeof SuperTokensError;
-export type { VerifySessionOptions, RecipeInterface, SessionContainer, SessionRequest, APIInterface, APIOptions };
+export type {
+    VerifySessionOptions,
+    RecipeInterface,
+    SessionContainer,
+    SessionRequest,
+    APIInterface,
+    APIOptions,
+    SessionInformation,
+};

--- a/lib/build/recipe/session/index.d.ts
+++ b/lib/build/recipe/session/index.d.ts
@@ -23,7 +23,7 @@ export default class SessionWrapper {
         res: express.Response,
         options?: VerifySessionOptions
     ): Promise<SessionContainer | undefined>;
-    static getSessionDetails(sessionHandle: string): Promise<any>;
+    static getSessionInformation(sessionHandle: string): Promise<any>;
     static refreshSession(req: express.Request, res: express.Response): Promise<SessionContainer>;
     static revokeAllSessionsForUser(userId: string): Promise<string[]>;
     static getAllSessionHandlesForUser(userId: string): Promise<string[]>;
@@ -40,7 +40,7 @@ export default class SessionWrapper {
 export declare let init: typeof Recipe.init;
 export declare let createNewSession: typeof SessionWrapper.createNewSession;
 export declare let getSession: typeof SessionWrapper.getSession;
-export declare let getSessionDetails: typeof SessionWrapper.getSessionDetails;
+export declare let getSessionInformation: typeof SessionWrapper.getSessionInformation;
 export declare let refreshSession: typeof SessionWrapper.refreshSession;
 export declare let revokeAllSessionsForUser: typeof SessionWrapper.revokeAllSessionsForUser;
 export declare let getAllSessionHandlesForUser: typeof SessionWrapper.getAllSessionHandlesForUser;

--- a/lib/build/recipe/session/index.d.ts
+++ b/lib/build/recipe/session/index.d.ts
@@ -23,6 +23,7 @@ export default class SessionWrapper {
         res: express.Response,
         options?: VerifySessionOptions
     ): Promise<SessionContainer | undefined>;
+    static getSessionDetails(sessionHandle: string): Promise<any>;
     static refreshSession(req: express.Request, res: express.Response): Promise<SessionContainer>;
     static revokeAllSessionsForUser(userId: string): Promise<string[]>;
     static getAllSessionHandlesForUser(userId: string): Promise<string[]>;
@@ -39,6 +40,7 @@ export default class SessionWrapper {
 export declare let init: typeof Recipe.init;
 export declare let createNewSession: typeof SessionWrapper.createNewSession;
 export declare let getSession: typeof SessionWrapper.getSession;
+export declare let getSessionDetails: typeof SessionWrapper.getSessionDetails;
 export declare let refreshSession: typeof SessionWrapper.refreshSession;
 export declare let revokeAllSessionsForUser: typeof SessionWrapper.revokeAllSessionsForUser;
 export declare let getAllSessionHandlesForUser: typeof SessionWrapper.getAllSessionHandlesForUser;

--- a/lib/build/recipe/session/index.js
+++ b/lib/build/recipe/session/index.js
@@ -30,6 +30,9 @@ class SessionWrapper {
     static getSession(req, res, options) {
         return recipe_1.default.getInstanceOrThrowError().recipeInterfaceImpl.getSession({ req, res, options });
     }
+    static getSessionDetails(sessionHandle) {
+        return recipe_1.default.getInstanceOrThrowError().recipeInterfaceImpl.getSessionDetails({ sessionHandle });
+    }
     static refreshSession(req, res) {
         return recipe_1.default.getInstanceOrThrowError().recipeInterfaceImpl.refreshSession({ req, res });
     }
@@ -77,6 +80,7 @@ SessionWrapper.verifySession = (options) => {
 exports.init = SessionWrapper.init;
 exports.createNewSession = SessionWrapper.createNewSession;
 exports.getSession = SessionWrapper.getSession;
+exports.getSessionDetails = SessionWrapper.getSessionDetails;
 exports.refreshSession = SessionWrapper.refreshSession;
 exports.revokeAllSessionsForUser = SessionWrapper.revokeAllSessionsForUser;
 exports.getAllSessionHandlesForUser = SessionWrapper.getAllSessionHandlesForUser;

--- a/lib/build/recipe/session/index.js
+++ b/lib/build/recipe/session/index.js
@@ -30,8 +30,8 @@ class SessionWrapper {
     static getSession(req, res, options) {
         return recipe_1.default.getInstanceOrThrowError().recipeInterfaceImpl.getSession({ req, res, options });
     }
-    static getSessionDetails(sessionHandle) {
-        return recipe_1.default.getInstanceOrThrowError().recipeInterfaceImpl.getSessionDetails({ sessionHandle });
+    static getSessionInformation(sessionHandle) {
+        return recipe_1.default.getInstanceOrThrowError().recipeInterfaceImpl.getSessionInformation({ sessionHandle });
     }
     static refreshSession(req, res) {
         return recipe_1.default.getInstanceOrThrowError().recipeInterfaceImpl.refreshSession({ req, res });
@@ -80,7 +80,7 @@ SessionWrapper.verifySession = (options) => {
 exports.init = SessionWrapper.init;
 exports.createNewSession = SessionWrapper.createNewSession;
 exports.getSession = SessionWrapper.getSession;
-exports.getSessionDetails = SessionWrapper.getSessionDetails;
+exports.getSessionInformation = SessionWrapper.getSessionInformation;
 exports.refreshSession = SessionWrapper.refreshSession;
 exports.revokeAllSessionsForUser = SessionWrapper.revokeAllSessionsForUser;
 exports.getAllSessionHandlesForUser = SessionWrapper.getAllSessionHandlesForUser;

--- a/lib/build/recipe/session/recipeImplementation.d.ts
+++ b/lib/build/recipe/session/recipeImplementation.d.ts
@@ -28,6 +28,7 @@ export default class RecipeImplementation implements RecipeInterface {
         res: express.Response;
         options?: VerifySessionOptions | undefined;
     }) => Promise<Session | undefined>;
+    getSessionDetails: ({ sessionHandle }: { sessionHandle: string }) => Promise<any>;
     refreshSession: ({ req, res }: { req: express.Request; res: express.Response }) => Promise<Session>;
     revokeAllSessionsForUser: ({ userId }: { userId: string }) => Promise<string[]>;
     getAllSessionHandlesForUser: ({ userId }: { userId: string }) => Promise<string[]>;

--- a/lib/build/recipe/session/recipeImplementation.d.ts
+++ b/lib/build/recipe/session/recipeImplementation.d.ts
@@ -28,7 +28,7 @@ export default class RecipeImplementation implements RecipeInterface {
         res: express.Response;
         options?: VerifySessionOptions | undefined;
     }) => Promise<Session | undefined>;
-    getSessionDetails: ({ sessionHandle }: { sessionHandle: string }) => Promise<any>;
+    getSessionInformation: ({ sessionHandle }: { sessionHandle: string }) => Promise<any>;
     refreshSession: ({ req, res }: { req: express.Request; res: express.Response }) => Promise<Session>;
     revokeAllSessionsForUser: ({ userId }: { userId: string }) => Promise<string[]>;
     getAllSessionHandlesForUser: ({ userId }: { userId: string }) => Promise<string[]>;

--- a/lib/build/recipe/session/recipeImplementation.d.ts
+++ b/lib/build/recipe/session/recipeImplementation.d.ts
@@ -1,4 +1,4 @@
-import { RecipeInterface, VerifySessionOptions, TypeNormalisedInput, HandshakeInfo } from "./types";
+import { RecipeInterface, VerifySessionOptions, TypeNormalisedInput, HandshakeInfo, SessionInformation } from "./types";
 import * as express from "express";
 import Session from "./sessionClass";
 import { Querier } from "../../querier";
@@ -28,7 +28,7 @@ export default class RecipeImplementation implements RecipeInterface {
         res: express.Response;
         options?: VerifySessionOptions | undefined;
     }) => Promise<Session | undefined>;
-    getSessionInformation: ({ sessionHandle }: { sessionHandle: string }) => Promise<any>;
+    getSessionInformation: ({ sessionHandle }: { sessionHandle: string }) => Promise<SessionInformation>;
     refreshSession: ({ req, res }: { req: express.Request; res: express.Response }) => Promise<Session>;
     revokeAllSessionsForUser: ({ userId }: { userId: string }) => Promise<string[]>;
     getAllSessionHandlesForUser: ({ userId }: { userId: string }) => Promise<string[]>;

--- a/lib/build/recipe/session/recipeImplementation.js
+++ b/lib/build/recipe/session/recipeImplementation.js
@@ -125,9 +125,9 @@ class RecipeImplementation {
                     throw err;
                 }
             });
-        this.getSessionDetails = ({ sessionHandle }) =>
+        this.getSessionInformation = ({ sessionHandle }) =>
             __awaiter(this, void 0, void 0, function* () {
-                return SessionFunctions.getSessionDetails(this, sessionHandle);
+                return SessionFunctions.getSessionInformation(this, sessionHandle);
             });
         this.refreshSession = ({ req, res }) =>
             __awaiter(this, void 0, void 0, function* () {

--- a/lib/build/recipe/session/recipeImplementation.js
+++ b/lib/build/recipe/session/recipeImplementation.js
@@ -125,6 +125,10 @@ class RecipeImplementation {
                     throw err;
                 }
             });
+        this.getSessionDetails = ({ sessionHandle }) =>
+            __awaiter(this, void 0, void 0, function* () {
+                return SessionFunctions.getSessionDetails(this, sessionHandle);
+            });
         this.refreshSession = ({ req, res }) =>
             __awaiter(this, void 0, void 0, function* () {
                 let inputIdRefreshToken = cookieAndHeaders_1.getIdRefreshTokenFromCookie(req);

--- a/lib/build/recipe/session/sessionClass.d.ts
+++ b/lib/build/recipe/session/sessionClass.d.ts
@@ -24,4 +24,6 @@ export default class Session implements SessionContainerInterface {
     getHandle: () => string;
     getAccessToken: () => string;
     updateJWTPayload: (newJWTPayload: any) => Promise<void>;
+    getTimeCreated: () => Promise<number>;
+    getExpiry: () => Promise<number>;
 }

--- a/lib/build/recipe/session/sessionClass.js
+++ b/lib/build/recipe/session/sessionClass.js
@@ -35,9 +35,6 @@ const SessionFunctions = require("./sessionFunctions");
 const cookieAndHeaders_1 = require("./cookieAndHeaders");
 const error_1 = require("./error");
 const normalisedURLPath_1 = require("../../normalisedURLPath");
-const querier_1 = require("../../querier");
-const supertokens_1 = require("../../supertokens");
-const utils_1 = require("../../utils");
 class Session {
     constructor(recipeImplementation, accessToken, sessionHandle, userId, userDataInJWT, res) {
         this.revokeSession = () =>
@@ -49,19 +46,7 @@ class Session {
         this.getSessionData = () =>
             __awaiter(this, void 0, void 0, function* () {
                 try {
-                    let querier = querier_1.Querier.getNewInstanceOrThrowError(
-                        supertokens_1.default.getInstanceOrThrowError().isInServerlessEnv
-                    );
-                    let apiVersion = yield querier.getAPIVersion();
-                    // Call older function for < 2.8
-                    if (utils_1.maxVersion(apiVersion, "2.7") === "2.7") {
-                        return yield SessionFunctions.getSessionData(this.recipeImplementation, this.sessionHandle);
-                    } else {
-                        return yield (yield SessionFunctions.getSessionInformation(
-                            this.recipeImplementation,
-                            this.sessionHandle
-                        )).userDataInDatabase;
-                    }
+                    return yield SessionFunctions.getSessionData(this.recipeImplementation, this.sessionHandle);
                 } catch (err) {
                     if (err.type === error_1.default.UNAUTHORISED) {
                         cookieAndHeaders_1.clearSessionFromCookie(this.recipeImplementation.config, this.res);
@@ -133,13 +118,6 @@ class Session {
         this.getTimeCreated = () =>
             __awaiter(this, void 0, void 0, function* () {
                 try {
-                    let querier = querier_1.Querier.getNewInstanceOrThrowError(
-                        supertokens_1.default.getInstanceOrThrowError().isInServerlessEnv
-                    );
-                    let apiVersion = yield querier.getAPIVersion();
-                    if (utils_1.maxVersion(apiVersion, "2.7") === "2.7") {
-                        throw new Error("Please use core version >= 3.5 to call this function.");
-                    }
                     return (yield SessionFunctions.getSessionInformation(
                         this.recipeImplementation,
                         this.sessionHandle
@@ -154,13 +132,6 @@ class Session {
         this.getExpiry = () =>
             __awaiter(this, void 0, void 0, function* () {
                 try {
-                    let querier = querier_1.Querier.getNewInstanceOrThrowError(
-                        supertokens_1.default.getInstanceOrThrowError().isInServerlessEnv
-                    );
-                    let apiVersion = yield querier.getAPIVersion();
-                    if (utils_1.maxVersion(apiVersion, "2.7") === "2.7") {
-                        throw new Error("Please use core version >= 3.5 to call this function.");
-                    }
                     return (yield SessionFunctions.getSessionInformation(
                         this.recipeImplementation,
                         this.sessionHandle

--- a/lib/build/recipe/session/sessionClass.js
+++ b/lib/build/recipe/session/sessionClass.js
@@ -35,6 +35,9 @@ const SessionFunctions = require("./sessionFunctions");
 const cookieAndHeaders_1 = require("./cookieAndHeaders");
 const error_1 = require("./error");
 const normalisedURLPath_1 = require("../../normalisedURLPath");
+const querier_1 = require("../../querier");
+const supertokens_1 = require("../../supertokens");
+const utils_1 = require("../../utils");
 class Session {
     constructor(recipeImplementation, accessToken, sessionHandle, userId, userDataInJWT, res) {
         this.revokeSession = () =>
@@ -46,7 +49,19 @@ class Session {
         this.getSessionData = () =>
             __awaiter(this, void 0, void 0, function* () {
                 try {
-                    return yield SessionFunctions.getSessionData(this.recipeImplementation, this.sessionHandle);
+                    let querier = querier_1.Querier.getNewInstanceOrThrowError(
+                        supertokens_1.default.getInstanceOrThrowError().isInServerlessEnv
+                    );
+                    let apiVersion = yield querier.getAPIVersion();
+                    // Call older function for < 2.8
+                    if (utils_1.maxVersion(apiVersion, "2.7") === "2.7") {
+                        return yield SessionFunctions.getSessionData(this.recipeImplementation, this.sessionHandle);
+                    } else {
+                        return yield (yield SessionFunctions.getSessionInformation(
+                            this.recipeImplementation,
+                            this.sessionHandle
+                        )).userDataInDatabase;
+                    }
                 } catch (err) {
                     if (err.type === error_1.default.UNAUTHORISED) {
                         cookieAndHeaders_1.clearSessionFromCookie(this.recipeImplementation.config, this.res);
@@ -113,6 +128,48 @@ class Session {
                         response.accessToken.token,
                         response.accessToken.expiry
                     );
+                }
+            });
+        this.getTimeCreated = () =>
+            __awaiter(this, void 0, void 0, function* () {
+                try {
+                    let querier = querier_1.Querier.getNewInstanceOrThrowError(
+                        supertokens_1.default.getInstanceOrThrowError().isInServerlessEnv
+                    );
+                    let apiVersion = yield querier.getAPIVersion();
+                    if (utils_1.maxVersion(apiVersion, "2.7") === "2.7") {
+                        throw new Error("Please use core version >= 3.5 to call this function.");
+                    }
+                    return (yield SessionFunctions.getSessionInformation(
+                        this.recipeImplementation,
+                        this.sessionHandle
+                    )).timeCreated;
+                } catch (err) {
+                    if (err.type === error_1.default.UNAUTHORISED) {
+                        cookieAndHeaders_1.clearSessionFromCookie(this.recipeImplementation.config, this.res);
+                    }
+                    throw err;
+                }
+            });
+        this.getExpiry = () =>
+            __awaiter(this, void 0, void 0, function* () {
+                try {
+                    let querier = querier_1.Querier.getNewInstanceOrThrowError(
+                        supertokens_1.default.getInstanceOrThrowError().isInServerlessEnv
+                    );
+                    let apiVersion = yield querier.getAPIVersion();
+                    if (utils_1.maxVersion(apiVersion, "2.7") === "2.7") {
+                        throw new Error("Please use core version >= 3.5 to call this function.");
+                    }
+                    return (yield SessionFunctions.getSessionInformation(
+                        this.recipeImplementation,
+                        this.sessionHandle
+                    )).expiry;
+                } catch (err) {
+                    if (err.type === error_1.default.UNAUTHORISED) {
+                        cookieAndHeaders_1.clearSessionFromCookie(this.recipeImplementation.config, this.res);
+                    }
+                    throw err;
                 }
             });
         this.sessionHandle = sessionHandle;

--- a/lib/build/recipe/session/sessionFunctions.d.ts
+++ b/lib/build/recipe/session/sessionFunctions.d.ts
@@ -31,6 +31,14 @@ export declare function getSession(
     };
 }>;
 /**
+ * @description Retrieves session information from storage for a given session handle
+ * @returns session data stored in the database, including userData and JWT payload
+ */
+export declare function getSessionDetails(
+    recipeImplementation: RecipeImplementation,
+    sessionHandle: string
+): Promise<any>;
+/**
  * @description generates new access and refresh tokens for a given refresh token. Called when client's access token has expired.
  * @sideEffects calls onTokenTheftDetection if token theft is detected.
  */

--- a/lib/build/recipe/session/sessionFunctions.d.ts
+++ b/lib/build/recipe/session/sessionFunctions.d.ts
@@ -1,4 +1,4 @@
-import { CreateOrRefreshAPIResponse } from "./types";
+import { CreateOrRefreshAPIResponse, SessionInformation } from "./types";
 import RecipeImplementation from "./recipeImplementation";
 /**
  * @description call this to "login" a user.
@@ -37,7 +37,7 @@ export declare function getSession(
 export declare function getSessionInformation(
     recipeImplementation: RecipeImplementation,
     sessionHandle: string
-): Promise<any>;
+): Promise<SessionInformation>;
 /**
  * @description generates new access and refresh tokens for a given refresh token. Called when client's access token has expired.
  * @sideEffects calls onTokenTheftDetection if token theft is detected.

--- a/lib/build/recipe/session/sessionFunctions.d.ts
+++ b/lib/build/recipe/session/sessionFunctions.d.ts
@@ -34,7 +34,7 @@ export declare function getSession(
  * @description Retrieves session information from storage for a given session handle
  * @returns session data stored in the database, including userData and JWT payload
  */
-export declare function getSessionDetails(
+export declare function getSessionInformation(
     recipeImplementation: RecipeImplementation,
     sessionHandle: string
 ): Promise<any>;
@@ -80,7 +80,7 @@ export declare function revokeMultipleSessions(
     sessionHandles: string[]
 ): Promise<string[]>;
 /**
- * @deprecated use getSessionDetails() instead
+ * @deprecated use getSessionInformation() instead
  * @description: this function reads from the database every time. It provides no locking mechanism in case other processes are updating session data for this session as well, so please take of that by yourself.
  * @returns session data as provided by the user earlier
  */
@@ -94,7 +94,7 @@ export declare function updateSessionData(
     newSessionData: any
 ): Promise<void>;
 /**
- * @deprecated use getSessionDetails() instead
+ * @deprecated use getSessionInformation() instead
  * @returns jwt payload as provided by the user earlier
  */
 export declare function getJWTPayload(recipeImplementation: RecipeImplementation, sessionHandle: string): Promise<any>;

--- a/lib/build/recipe/session/sessionFunctions.d.ts
+++ b/lib/build/recipe/session/sessionFunctions.d.ts
@@ -80,6 +80,7 @@ export declare function revokeMultipleSessions(
     sessionHandles: string[]
 ): Promise<string[]>;
 /**
+ * @deprecated use getSessionDetails() instead
  * @description: this function reads from the database every time. It provides no locking mechanism in case other processes are updating session data for this session as well, so please take of that by yourself.
  * @returns session data as provided by the user earlier
  */
@@ -93,6 +94,7 @@ export declare function updateSessionData(
     newSessionData: any
 ): Promise<void>;
 /**
+ * @deprecated use getSessionDetails() instead
  * @returns jwt payload as provided by the user earlier
  */
 export declare function getJWTPayload(recipeImplementation: RecipeImplementation, sessionHandle: string): Promise<any>;

--- a/lib/build/recipe/session/sessionFunctions.js
+++ b/lib/build/recipe/session/sessionFunctions.js
@@ -367,6 +367,7 @@ function revokeMultipleSessions(recipeImplementation, sessionHandles) {
 }
 exports.revokeMultipleSessions = revokeMultipleSessions;
 /**
+ * @deprecated use getSessionDetails() instead
  * @description: this function reads from the database every time. It provides no locking mechanism in case other processes are updating session data for this session as well, so please take of that by yourself.
  * @returns session data as provided by the user earlier
  */
@@ -412,6 +413,7 @@ function updateSessionData(recipeImplementation, sessionHandle, newSessionData) 
 }
 exports.updateSessionData = updateSessionData;
 /**
+ * @deprecated use getSessionDetails() instead
  * @returns jwt payload as provided by the user earlier
  */
 function getJWTPayload(recipeImplementation, sessionHandle) {

--- a/lib/build/recipe/session/sessionFunctions.js
+++ b/lib/build/recipe/session/sessionFunctions.js
@@ -236,7 +236,7 @@ exports.getSession = getSession;
  * @description Retrieves session information from storage for a given session handle
  * @returns session data stored in the database, including userData and JWT payload
  */
-function getSessionDetails(recipeImplementation, sessionHandle) {
+function getSessionInformation(recipeImplementation, sessionHandle) {
     return __awaiter(this, void 0, void 0, function* () {
         let response = yield recipeImplementation.querier.sendGetRequest(
             new normalisedURLPath_1.default("/recipe/session"),
@@ -254,7 +254,7 @@ function getSessionDetails(recipeImplementation, sessionHandle) {
         }
     });
 }
-exports.getSessionDetails = getSessionDetails;
+exports.getSessionInformation = getSessionInformation;
 /**
  * @description generates new access and refresh tokens for a given refresh token. Called when client's access token has expired.
  * @sideEffects calls onTokenTheftDetection if token theft is detected.
@@ -367,7 +367,7 @@ function revokeMultipleSessions(recipeImplementation, sessionHandles) {
 }
 exports.revokeMultipleSessions = revokeMultipleSessions;
 /**
- * @deprecated use getSessionDetails() instead
+ * @deprecated use getSessionInformation() instead
  * @description: this function reads from the database every time. It provides no locking mechanism in case other processes are updating session data for this session as well, so please take of that by yourself.
  * @returns session data as provided by the user earlier
  */
@@ -413,7 +413,7 @@ function updateSessionData(recipeImplementation, sessionHandle, newSessionData) 
 }
 exports.updateSessionData = updateSessionData;
 /**
- * @deprecated use getSessionDetails() instead
+ * @deprecated use getSessionInformation() instead
  * @returns jwt payload as provided by the user earlier
  */
 function getJWTPayload(recipeImplementation, sessionHandle) {

--- a/lib/build/recipe/session/sessionFunctions.js
+++ b/lib/build/recipe/session/sessionFunctions.js
@@ -50,6 +50,9 @@ const jwt_1 = require("./jwt");
 const error_1 = require("./error");
 const processState_1 = require("../../processState");
 const normalisedURLPath_1 = require("../../normalisedURLPath");
+const utils_1 = require("../../utils");
+const querier_1 = require("../../querier");
+const supertokens_1 = require("../../supertokens");
 /**
  * @description call this to "login" a user.
  */
@@ -238,6 +241,13 @@ exports.getSession = getSession;
  */
 function getSessionInformation(recipeImplementation, sessionHandle) {
     return __awaiter(this, void 0, void 0, function* () {
+        let querier = querier_1.Querier.getNewInstanceOrThrowError(
+            supertokens_1.default.getInstanceOrThrowError().isInServerlessEnv
+        );
+        let apiVersion = yield querier.getAPIVersion();
+        if (utils_1.maxVersion(apiVersion, "2.7") === "2.7") {
+            throw new Error("Please use core version >= 3.5 to call this function.");
+        }
         let response = yield recipeImplementation.querier.sendGetRequest(
             new normalisedURLPath_1.default("/recipe/session"),
             {
@@ -380,7 +390,16 @@ function getSessionData(recipeImplementation, sessionHandle) {
             }
         );
         if (response.status === "OK") {
-            return response.userDataInDatabase;
+            let querier = querier_1.Querier.getNewInstanceOrThrowError(
+                supertokens_1.default.getInstanceOrThrowError().isInServerlessEnv
+            );
+            let apiVersion = yield querier.getAPIVersion();
+            // Call new function for >= 2.8
+            if (utils_1.maxVersion(apiVersion, "2.7") === "2.7") {
+                return response.userDataInDatabase;
+            } else {
+                return yield (yield getSessionInformation(recipeImplementation, sessionHandle)).userDataInDatabase;
+            }
         } else {
             throw new error_1.default({
                 message: response.message,

--- a/lib/build/recipe/session/sessionFunctions.js
+++ b/lib/build/recipe/session/sessionFunctions.js
@@ -51,8 +51,6 @@ const error_1 = require("./error");
 const processState_1 = require("../../processState");
 const normalisedURLPath_1 = require("../../normalisedURLPath");
 const utils_1 = require("../../utils");
-const querier_1 = require("../../querier");
-const supertokens_1 = require("../../supertokens");
 /**
  * @description call this to "login" a user.
  */
@@ -241,10 +239,7 @@ exports.getSession = getSession;
  */
 function getSessionInformation(recipeImplementation, sessionHandle) {
     return __awaiter(this, void 0, void 0, function* () {
-        let querier = querier_1.Querier.getNewInstanceOrThrowError(
-            supertokens_1.default.getInstanceOrThrowError().isInServerlessEnv
-        );
-        let apiVersion = yield querier.getAPIVersion();
+        let apiVersion = yield recipeImplementation.querier.getAPIVersion();
         if (utils_1.maxVersion(apiVersion, "2.7") === "2.7") {
             throw new Error("Please use core version >= 3.5 to call this function.");
         }
@@ -383,6 +378,11 @@ exports.revokeMultipleSessions = revokeMultipleSessions;
  */
 function getSessionData(recipeImplementation, sessionHandle) {
     return __awaiter(this, void 0, void 0, function* () {
+        let apiVersion = yield recipeImplementation.querier.getAPIVersion();
+        // Call new method for >= 2.8
+        if (utils_1.maxVersion(apiVersion, "2.7") !== "2.7") {
+            return (yield getSessionInformation(recipeImplementation, sessionHandle)).userDataInDatabase;
+        }
         let response = yield recipeImplementation.querier.sendGetRequest(
             new normalisedURLPath_1.default("/recipe/session/data"),
             {
@@ -390,16 +390,7 @@ function getSessionData(recipeImplementation, sessionHandle) {
             }
         );
         if (response.status === "OK") {
-            let querier = querier_1.Querier.getNewInstanceOrThrowError(
-                supertokens_1.default.getInstanceOrThrowError().isInServerlessEnv
-            );
-            let apiVersion = yield querier.getAPIVersion();
-            // Call new function for >= 2.8
-            if (utils_1.maxVersion(apiVersion, "2.7") === "2.7") {
-                return response.userDataInDatabase;
-            } else {
-                return yield (yield getSessionInformation(recipeImplementation, sessionHandle)).userDataInDatabase;
-            }
+            return response.userDataInDatabase;
         } else {
             throw new error_1.default({
                 message: response.message,

--- a/lib/build/recipe/session/sessionFunctions.js
+++ b/lib/build/recipe/session/sessionFunctions.js
@@ -233,6 +233,29 @@ function getSession(recipeImplementation, accessToken, antiCsrfToken, doAntiCsrf
 }
 exports.getSession = getSession;
 /**
+ * @description Retrieves session information from storage for a given session handle
+ * @returns session data stored in the database, including userData and JWT payload
+ */
+function getSessionDetails(recipeImplementation, sessionHandle) {
+    return __awaiter(this, void 0, void 0, function* () {
+        let response = yield recipeImplementation.querier.sendGetRequest(
+            new normalisedURLPath_1.default("/recipe/session"),
+            {
+                sessionHandle,
+            }
+        );
+        if (response.status === "OK") {
+            return response;
+        } else {
+            throw new error_1.default({
+                message: response.message,
+                type: error_1.default.UNAUTHORISED,
+            });
+        }
+    });
+}
+exports.getSessionDetails = getSessionDetails;
+/**
  * @description generates new access and refresh tokens for a given refresh token. Called when client's access token has expired.
  * @sideEffects calls onTokenTheftDetection if token theft is detected.
  */

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -140,6 +140,12 @@ export interface RecipeInterface {
         res: express.Response;
         options?: VerifySessionOptions;
     }): Promise<SessionContainerInterface | undefined>;
+    /**
+     * Used to retrieve all session information for a given session handle. Can be used in place of:
+     * - getSessionData
+     * - getJWTPayload
+     */
+    getSessionDetails(input: { sessionHandle: string }): Promise<any>;
     refreshSession(input: { req: express.Request; res: express.Response }): Promise<SessionContainerInterface>;
     revokeAllSessionsForUser(input: { userId: string }): Promise<string[]>;
     getAllSessionHandlesForUser(input: { userId: string }): Promise<string[]>;

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -196,8 +196,8 @@ export interface APIInterface {
 export declare type SessionInformation = {
     sessionHandle: string;
     userId: string;
-    userDataInDatabase: Object;
+    userDataInDatabase: any;
     expiry: number;
-    userDataInJWT: Object;
+    userDataInJWT: any;
     timeCreated: number;
 };

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -145,7 +145,7 @@ export interface RecipeInterface {
      * - getSessionData
      * - getJWTPayload
      */
-    getSessionInformation(input: { sessionHandle: string }): Promise<any>;
+    getSessionInformation(input: { sessionHandle: string }): Promise<SessionInformation>;
     refreshSession(input: { req: express.Request; res: express.Response }): Promise<SessionContainerInterface>;
     revokeAllSessionsForUser(input: { userId: string }): Promise<string[]>;
     getAllSessionHandlesForUser(input: { userId: string }): Promise<string[]>;
@@ -193,3 +193,11 @@ export interface APIInterface {
         options: APIOptions;
     }): Promise<void>;
 }
+export declare type SessionInformation = {
+    sessionHandle: string;
+    userId: string;
+    userDataInDatabase: Object;
+    expiry: number;
+    userDataInJWT: Object;
+    timeCreated: number;
+};

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -151,8 +151,10 @@ export interface RecipeInterface {
     getAllSessionHandlesForUser(input: { userId: string }): Promise<string[]>;
     revokeSession(input: { sessionHandle: string }): Promise<boolean>;
     revokeMultipleSessions(input: { sessionHandles: string[] }): Promise<string[]>;
+    /** @deprecated Use getSessionDetails() instead **/
     getSessionData(input: { sessionHandle: string }): Promise<any>;
     updateSessionData(input: { sessionHandle: string; newSessionData: any }): Promise<void>;
+    /** @deprecated Use getSessionDetails() instead **/
     getJWTPayload(input: { sessionHandle: string }): Promise<any>;
     updateJWTPayload(input: { sessionHandle: string; newJWTPayload: any }): Promise<void>;
     getAccessTokenLifeTimeMS(): Promise<number>;

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -145,16 +145,16 @@ export interface RecipeInterface {
      * - getSessionData
      * - getJWTPayload
      */
-    getSessionDetails(input: { sessionHandle: string }): Promise<any>;
+    getSessionInformation(input: { sessionHandle: string }): Promise<any>;
     refreshSession(input: { req: express.Request; res: express.Response }): Promise<SessionContainerInterface>;
     revokeAllSessionsForUser(input: { userId: string }): Promise<string[]>;
     getAllSessionHandlesForUser(input: { userId: string }): Promise<string[]>;
     revokeSession(input: { sessionHandle: string }): Promise<boolean>;
     revokeMultipleSessions(input: { sessionHandles: string[] }): Promise<string[]>;
-    /** @deprecated Use getSessionDetails() instead **/
+    /** @deprecated Use getSessionInformation() instead **/
     getSessionData(input: { sessionHandle: string }): Promise<any>;
     updateSessionData(input: { sessionHandle: string; newSessionData: any }): Promise<void>;
-    /** @deprecated Use getSessionDetails() instead **/
+    /** @deprecated Use getSessionInformation() instead **/
     getJWTPayload(input: { sessionHandle: string }): Promise<any>;
     updateJWTPayload(input: { sessionHandle: string; newJWTPayload: any }): Promise<void>;
     getAccessTokenLifeTimeMS(): Promise<number>;

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -169,6 +169,8 @@ export interface SessionContainerInterface {
     getHandle(): string;
     getAccessToken(): string;
     updateJWTPayload(newJWTPayload: any): Promise<void>;
+    getTimeCreated(): Promise<number>;
+    getExpiry(): Promise<number>;
 }
 export declare type APIOptions = {
     recipeImplementation: RecipeInterface;

--- a/lib/ts/recipe/session/faunadb/recipeImplementation.ts
+++ b/lib/ts/recipe/session/faunadb/recipeImplementation.ts
@@ -97,6 +97,10 @@ export default class RecipeImplementation implements RecipeInterface {
         return getModifiedSession(originalSession);
     };
 
+    getSessionDetails = ({ sessionHandle }: { sessionHandle: string }): Promise<any> => {
+        return this.originalImplementation.getSessionDetails({ sessionHandle });
+    };
+
     refreshSession = async ({
         req,
         res,

--- a/lib/ts/recipe/session/faunadb/recipeImplementation.ts
+++ b/lib/ts/recipe/session/faunadb/recipeImplementation.ts
@@ -4,6 +4,7 @@ import { SessionContainer } from "../";
 import * as faunadb from "faunadb";
 import { FAUNADB_SESSION_KEY, FAUNADB_TOKEN_TIME_LAG_MILLI } from "./constants";
 import { Session as FaunaDBSessionContainer } from "./types";
+import { SessionInformation } from "../types";
 
 export default class RecipeImplementation implements RecipeInterface {
     config: {
@@ -97,7 +98,7 @@ export default class RecipeImplementation implements RecipeInterface {
         return getModifiedSession(originalSession);
     };
 
-    getSessionInformation = ({ sessionHandle }: { sessionHandle: string }): Promise<any> => {
+    getSessionInformation = ({ sessionHandle }: { sessionHandle: string }): Promise<SessionInformation> => {
         return this.originalImplementation.getSessionInformation({ sessionHandle });
     };
 

--- a/lib/ts/recipe/session/faunadb/recipeImplementation.ts
+++ b/lib/ts/recipe/session/faunadb/recipeImplementation.ts
@@ -97,8 +97,8 @@ export default class RecipeImplementation implements RecipeInterface {
         return getModifiedSession(originalSession);
     };
 
-    getSessionDetails = ({ sessionHandle }: { sessionHandle: string }): Promise<any> => {
-        return this.originalImplementation.getSessionDetails({ sessionHandle });
+    getSessionInformation = ({ sessionHandle }: { sessionHandle: string }): Promise<any> => {
+        return this.originalImplementation.getSessionInformation({ sessionHandle });
     };
 
     refreshSession = async ({

--- a/lib/ts/recipe/session/index.ts
+++ b/lib/ts/recipe/session/index.ts
@@ -45,6 +45,10 @@ export default class SessionWrapper {
         return Recipe.getInstanceOrThrowError().recipeInterfaceImpl.getSession({ req, res, options });
     }
 
+    static getSessionDetails(sessionHandle: string) {
+        return Recipe.getInstanceOrThrowError().recipeInterfaceImpl.getSessionDetails({ sessionHandle });
+    }
+
     static refreshSession(req: express.Request, res: express.Response) {
         return Recipe.getInstanceOrThrowError().recipeInterfaceImpl.refreshSession({ req, res });
     }
@@ -98,6 +102,8 @@ export let init = SessionWrapper.init;
 export let createNewSession = SessionWrapper.createNewSession;
 
 export let getSession = SessionWrapper.getSession;
+
+export let getSessionDetails = SessionWrapper.getSessionDetails;
 
 export let refreshSession = SessionWrapper.refreshSession;
 

--- a/lib/ts/recipe/session/index.ts
+++ b/lib/ts/recipe/session/index.ts
@@ -45,8 +45,8 @@ export default class SessionWrapper {
         return Recipe.getInstanceOrThrowError().recipeInterfaceImpl.getSession({ req, res, options });
     }
 
-    static getSessionDetails(sessionHandle: string) {
-        return Recipe.getInstanceOrThrowError().recipeInterfaceImpl.getSessionDetails({ sessionHandle });
+    static getSessionInformation(sessionHandle: string) {
+        return Recipe.getInstanceOrThrowError().recipeInterfaceImpl.getSessionInformation({ sessionHandle });
     }
 
     static refreshSession(req: express.Request, res: express.Response) {
@@ -103,7 +103,7 @@ export let createNewSession = SessionWrapper.createNewSession;
 
 export let getSession = SessionWrapper.getSession;
 
-export let getSessionDetails = SessionWrapper.getSessionDetails;
+export let getSessionInformation = SessionWrapper.getSessionInformation;
 
 export let refreshSession = SessionWrapper.refreshSession;
 

--- a/lib/ts/recipe/session/index.ts
+++ b/lib/ts/recipe/session/index.ts
@@ -20,6 +20,7 @@ import {
     VerifySessionOptions,
     RecipeInterface,
     SessionContainerInterface as SessionContainer,
+    SessionInformation,
     SessionRequest,
     APIInterface,
     APIOptions,
@@ -127,4 +128,12 @@ export let verifySession = SessionWrapper.verifySession;
 
 export let Error = SessionWrapper.Error;
 
-export type { VerifySessionOptions, RecipeInterface, SessionContainer, SessionRequest, APIInterface, APIOptions };
+export type {
+    VerifySessionOptions,
+    RecipeInterface,
+    SessionContainer,
+    SessionRequest,
+    APIInterface,
+    APIOptions,
+    SessionInformation,
+};

--- a/lib/ts/recipe/session/recipeImplementation.ts
+++ b/lib/ts/recipe/session/recipeImplementation.ts
@@ -136,8 +136,8 @@ export default class RecipeImplementation implements RecipeInterface {
         }
     };
 
-    getSessionDetails = async ({ sessionHandle }: { sessionHandle: string }): Promise<any> => {
-        return SessionFunctions.getSessionDetails(this, sessionHandle);
+    getSessionInformation = async ({ sessionHandle }: { sessionHandle: string }): Promise<any> => {
+        return SessionFunctions.getSessionInformation(this, sessionHandle);
     };
 
     refreshSession = async ({ req, res }: { req: express.Request; res: express.Response }): Promise<Session> => {

--- a/lib/ts/recipe/session/recipeImplementation.ts
+++ b/lib/ts/recipe/session/recipeImplementation.ts
@@ -136,6 +136,10 @@ export default class RecipeImplementation implements RecipeInterface {
         }
     };
 
+    getSessionDetails = async ({ sessionHandle }: { sessionHandle: string }): Promise<any> => {
+        return SessionFunctions.getSessionDetails(this, sessionHandle);
+    };
+
     refreshSession = async ({ req, res }: { req: express.Request; res: express.Response }): Promise<Session> => {
         let inputIdRefreshToken = getIdRefreshTokenFromCookie(req);
         if (inputIdRefreshToken === undefined) {

--- a/lib/ts/recipe/session/recipeImplementation.ts
+++ b/lib/ts/recipe/session/recipeImplementation.ts
@@ -1,4 +1,4 @@
-import { RecipeInterface, VerifySessionOptions, TypeNormalisedInput, HandshakeInfo } from "./types";
+import { RecipeInterface, VerifySessionOptions, TypeNormalisedInput, HandshakeInfo, SessionInformation } from "./types";
 import * as SessionFunctions from "./sessionFunctions";
 import {
     attachAccessTokenToCookie,
@@ -136,7 +136,7 @@ export default class RecipeImplementation implements RecipeInterface {
         }
     };
 
-    getSessionInformation = async ({ sessionHandle }: { sessionHandle: string }): Promise<any> => {
+    getSessionInformation = async ({ sessionHandle }: { sessionHandle: string }): Promise<SessionInformation> => {
         return SessionFunctions.getSessionInformation(this, sessionHandle);
     };
 

--- a/lib/ts/recipe/session/sessionClass.ts
+++ b/lib/ts/recipe/session/sessionClass.ts
@@ -19,9 +19,6 @@ import STError from "./error";
 import NormalisedURLPath from "../../normalisedURLPath";
 import { SessionContainerInterface } from "./types";
 import RecipeImplementation from "./recipeImplementation";
-import { Querier } from "../../querier";
-import SuperTokens from "../../supertokens";
-import { maxVersion } from "../../utils";
 
 export default class Session implements SessionContainerInterface {
     private sessionHandle: string;
@@ -55,17 +52,7 @@ export default class Session implements SessionContainerInterface {
 
     getSessionData = async (): Promise<any> => {
         try {
-            let querier = Querier.getNewInstanceOrThrowError(SuperTokens.getInstanceOrThrowError().isInServerlessEnv);
-            let apiVersion = await querier.getAPIVersion();
-
-            // Call older function for < 2.8
-            if (maxVersion(apiVersion, "2.7") === "2.7") {
-                return await SessionFunctions.getSessionData(this.recipeImplementation, this.sessionHandle);
-            } else {
-                return await (
-                    await SessionFunctions.getSessionInformation(this.recipeImplementation, this.sessionHandle)
-                ).userDataInDatabase;
-            }
+            return await SessionFunctions.getSessionData(this.recipeImplementation, this.sessionHandle);
         } catch (err) {
             if (err.type === STError.UNAUTHORISED) {
                 clearSessionFromCookie(this.recipeImplementation.config, this.res);
@@ -137,13 +124,6 @@ export default class Session implements SessionContainerInterface {
 
     getTimeCreated = async (): Promise<number> => {
         try {
-            let querier = Querier.getNewInstanceOrThrowError(SuperTokens.getInstanceOrThrowError().isInServerlessEnv);
-            let apiVersion = await querier.getAPIVersion();
-
-            if (maxVersion(apiVersion, "2.7") === "2.7") {
-                throw new Error("Please use core version >= 3.5 to call this function.");
-            }
-
             return (await SessionFunctions.getSessionInformation(this.recipeImplementation, this.sessionHandle))
                 .timeCreated;
         } catch (err) {
@@ -156,13 +136,6 @@ export default class Session implements SessionContainerInterface {
 
     getExpiry = async (): Promise<number> => {
         try {
-            let querier = Querier.getNewInstanceOrThrowError(SuperTokens.getInstanceOrThrowError().isInServerlessEnv);
-            let apiVersion = await querier.getAPIVersion();
-
-            if (maxVersion(apiVersion, "2.7") === "2.7") {
-                throw new Error("Please use core version >= 3.5 to call this function.");
-            }
-
             return (await SessionFunctions.getSessionInformation(this.recipeImplementation, this.sessionHandle)).expiry;
         } catch (err) {
             if (err.type === STError.UNAUTHORISED) {

--- a/lib/ts/recipe/session/sessionFunctions.ts
+++ b/lib/ts/recipe/session/sessionFunctions.ts
@@ -16,7 +16,7 @@ import { getInfoFromAccessToken, sanitizeNumberInput } from "./accessToken";
 import { getPayloadWithoutVerifiying } from "./jwt";
 import STError from "./error";
 import { PROCESS_STATE, ProcessState } from "../../processState";
-import { CreateOrRefreshAPIResponse } from "./types";
+import { CreateOrRefreshAPIResponse, SessionInformation } from "./types";
 import NormalisedURLPath from "../../normalisedURLPath";
 import RecipeImplementation from "./recipeImplementation";
 
@@ -243,7 +243,7 @@ export async function getSession(
 export async function getSessionInformation(
     recipeImplementation: RecipeImplementation,
     sessionHandle: string
-): Promise<any> {
+): Promise<SessionInformation> {
     let response = await recipeImplementation.querier.sendGetRequest(new NormalisedURLPath("/recipe/session"), {
         sessionHandle,
     });

--- a/lib/ts/recipe/session/sessionFunctions.ts
+++ b/lib/ts/recipe/session/sessionFunctions.ts
@@ -237,6 +237,28 @@ export async function getSession(
 }
 
 /**
+ * @description Retrieves session information from storage for a given session handle
+ * @returns session data stored in the database, including userData and JWT payload
+ */
+export async function getSessionDetails(
+    recipeImplementation: RecipeImplementation,
+    sessionHandle: string
+): Promise<any> {
+    let response = await recipeImplementation.querier.sendGetRequest(new NormalisedURLPath("/recipe/session"), {
+        sessionHandle,
+    });
+
+    if (response.status === "OK") {
+        return response;
+    } else {
+        throw new STError({
+            message: response.message,
+            type: STError.UNAUTHORISED,
+        });
+    }
+}
+
+/**
  * @description generates new access and refresh tokens for a given refresh token. Called when client's access token has expired.
  * @sideEffects calls onTokenTheftDetection if token theft is detected.
  */

--- a/lib/ts/recipe/session/sessionFunctions.ts
+++ b/lib/ts/recipe/session/sessionFunctions.ts
@@ -240,7 +240,7 @@ export async function getSession(
  * @description Retrieves session information from storage for a given session handle
  * @returns session data stored in the database, including userData and JWT payload
  */
-export async function getSessionDetails(
+export async function getSessionInformation(
     recipeImplementation: RecipeImplementation,
     sessionHandle: string
 ): Promise<any> {
@@ -372,7 +372,7 @@ export async function revokeMultipleSessions(
 }
 
 /**
- * @deprecated use getSessionDetails() instead
+ * @deprecated use getSessionInformation() instead
  * @description: this function reads from the database every time. It provides no locking mechanism in case other processes are updating session data for this session as well, so please take of that by yourself.
  * @returns session data as provided by the user earlier
  */
@@ -412,7 +412,7 @@ export async function updateSessionData(
 }
 
 /**
- * @deprecated use getSessionDetails() instead
+ * @deprecated use getSessionInformation() instead
  * @returns jwt payload as provided by the user earlier
  */
 export async function getJWTPayload(recipeImplementation: RecipeImplementation, sessionHandle: string): Promise<any> {

--- a/lib/ts/recipe/session/sessionFunctions.ts
+++ b/lib/ts/recipe/session/sessionFunctions.ts
@@ -372,6 +372,7 @@ export async function revokeMultipleSessions(
 }
 
 /**
+ * @deprecated use getSessionDetails() instead
  * @description: this function reads from the database every time. It provides no locking mechanism in case other processes are updating session data for this session as well, so please take of that by yourself.
  * @returns session data as provided by the user earlier
  */
@@ -411,6 +412,7 @@ export async function updateSessionData(
 }
 
 /**
+ * @deprecated use getSessionDetails() instead
  * @returns jwt payload as provided by the user earlier
  */
 export async function getJWTPayload(recipeImplementation: RecipeImplementation, sessionHandle: string): Promise<any> {

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -206,6 +206,10 @@ export interface SessionContainerInterface {
     getAccessToken(): string;
 
     updateJWTPayload(newJWTPayload: any): Promise<void>;
+
+    getTimeCreated(): Promise<number>;
+
+    getExpiry(): Promise<number>;
 }
 
 export type APIOptions = {

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -175,10 +175,12 @@ export interface RecipeInterface {
 
     revokeMultipleSessions(input: { sessionHandles: string[] }): Promise<string[]>;
 
+    /** @deprecated Use getSessionDetails() instead **/
     getSessionData(input: { sessionHandle: string }): Promise<any>;
 
     updateSessionData(input: { sessionHandle: string; newSessionData: any }): Promise<void>;
 
+    /** @deprecated Use getSessionDetails() instead **/
     getJWTPayload(input: { sessionHandle: string }): Promise<any>;
 
     updateJWTPayload(input: { sessionHandle: string; newJWTPayload: any }): Promise<void>;

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -163,7 +163,7 @@ export interface RecipeInterface {
      * - getSessionData
      * - getJWTPayload
      */
-    getSessionInformation(input: { sessionHandle: string }): Promise<any>;
+    getSessionInformation(input: { sessionHandle: string }): Promise<SessionInformation>;
 
     refreshSession(input: { req: express.Request; res: express.Response }): Promise<SessionContainerInterface>;
 
@@ -234,3 +234,12 @@ export interface APIInterface {
         options: APIOptions;
     }): Promise<void>;
 }
+
+export type SessionInformation = {
+    sessionHandle: string;
+    userId: string;
+    userDataInDatabase: Object;
+    expiry: number;
+    userDataInJWT: Object;
+    timeCreated: number;
+};

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -238,8 +238,8 @@ export interface APIInterface {
 export type SessionInformation = {
     sessionHandle: string;
     userId: string;
-    userDataInDatabase: Object;
+    userDataInDatabase: any;
     expiry: number;
-    userDataInJWT: Object;
+    userDataInJWT: any;
     timeCreated: number;
 };

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -163,7 +163,7 @@ export interface RecipeInterface {
      * - getSessionData
      * - getJWTPayload
      */
-    getSessionDetails(input: { sessionHandle: string }): Promise<any>;
+    getSessionInformation(input: { sessionHandle: string }): Promise<any>;
 
     refreshSession(input: { req: express.Request; res: express.Response }): Promise<SessionContainerInterface>;
 
@@ -175,12 +175,12 @@ export interface RecipeInterface {
 
     revokeMultipleSessions(input: { sessionHandles: string[] }): Promise<string[]>;
 
-    /** @deprecated Use getSessionDetails() instead **/
+    /** @deprecated Use getSessionInformation() instead **/
     getSessionData(input: { sessionHandle: string }): Promise<any>;
 
     updateSessionData(input: { sessionHandle: string; newSessionData: any }): Promise<void>;
 
-    /** @deprecated Use getSessionDetails() instead **/
+    /** @deprecated Use getSessionInformation() instead **/
     getJWTPayload(input: { sessionHandle: string }): Promise<any>;
 
     updateJWTPayload(input: { sessionHandle: string; newJWTPayload: any }): Promise<void>;

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -158,6 +158,13 @@ export interface RecipeInterface {
         options?: VerifySessionOptions;
     }): Promise<SessionContainerInterface | undefined>;
 
+    /**
+     * Used to retrieve all session information for a given session handle. Can be used in place of:
+     * - getSessionData
+     * - getJWTPayload
+     */
+    getSessionDetails(input: { sessionHandle: string }): Promise<any>;
+
     refreshSession(input: { req: express.Request; res: express.Response }): Promise<SessionContainerInterface>;
 
     revokeAllSessionsForUser(input: { userId: string }): Promise<string[]>;

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -722,6 +722,49 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
         }
     });
 
+    it("test manipulating session data with new get session function", async function () {
+        await startST();
+        SuperTokens.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                Session.init({
+                    antiCsrf: "VIA_TOKEN",
+                }),
+            ],
+        });
+
+        let s = SessionRecipe.getInstanceOrThrowError().recipeInterfaceImpl;
+        //adding session data
+        let res = await SessionFunctions.createNewSession(s, "", {}, {});
+        await SessionFunctions.updateSessionData(s, res.session.handle, { key: "value" });
+
+        let res2 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        assert.deepEqual(res2.userDataInDatabase, { key: "value" });
+
+        //changing the value of session data with the same key
+        await SessionFunctions.updateSessionData(s, res.session.handle, { key: "value 2" });
+
+        let res3 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        assert.deepEqual(res3.userDataInDatabase, { key: "value 2" });
+
+        //passing invalid session handle when updating session data
+        try {
+            await SessionFunctions.updateSessionData(s, "random", { key2: "value2" });
+            assert(false);
+        } catch (error) {
+            if (error.type !== Session.Error.UNAUTHORISED) {
+                throw error;
+            }
+        }
+    });
+
     it("test null and undefined values passed for session data", async function () {
         await startST();
         SuperTokens.init({
@@ -768,6 +811,52 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
         assert.deepStrictEqual(res6, {});
     });
 
+    it("test null and undefined values passed for session data with new get session method", async function () {
+        await startST();
+        SuperTokens.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                Session.init({
+                    antiCsrf: "VIA_TOKEN",
+                }),
+            ],
+        });
+
+        let s = SessionRecipe.getInstanceOrThrowError().recipeInterfaceImpl;
+        //adding session data
+        let res = await SessionFunctions.createNewSession(s, "", {}, null);
+
+        let res2 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        assert.deepStrictEqual(res2.userDataInDatabase, {});
+
+        await SessionFunctions.updateSessionData(s, res.session.handle, { key: "value" });
+
+        let res3 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        assert.deepStrictEqual(res3.userDataInDatabase, { key: "value" });
+
+        await SessionFunctions.updateSessionData(s, res.session.handle, undefined);
+
+        let res4 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        assert.deepStrictEqual(res4.userDataInDatabase, {});
+
+        await SessionFunctions.updateSessionData(s, res.session.handle, { key: "value 2" });
+
+        let res5 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        assert.deepStrictEqual(res5.userDataInDatabase, { key: "value 2" });
+
+        await SessionFunctions.updateSessionData(s, res.session.handle, null);
+
+        let res6 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        assert.deepStrictEqual(res6.userDataInDatabase, {});
+    });
+
     //check manipulating jwt payload
     it("test manipulating jwt payload", async function () {
         await startST();
@@ -801,6 +890,50 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
 
         let res3 = await SessionFunctions.getJWTPayload(s, res.session.handle);
         assert.deepEqual(res3, { key: "value 2" });
+
+        //passing invalid session handle when updating jwt payload
+        try {
+            await SessionFunctions.updateJWTPayload(s, "random", { key2: "value2" });
+            throw new Error();
+        } catch (error) {
+            if (error.type !== Session.Error.UNAUTHORISED) {
+                throw error;
+            }
+        }
+    });
+
+    it("test manipulating jwt payload with new get session method", async function () {
+        await startST();
+        SuperTokens.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                Session.init({
+                    antiCsrf: "VIA_TOKEN",
+                }),
+            ],
+        });
+
+        let s = SessionRecipe.getInstanceOrThrowError().recipeInterfaceImpl;
+        //adding jwt payload
+        let res = await SessionFunctions.createNewSession(s, "", {}, {});
+
+        await SessionFunctions.updateJWTPayload(s, res.session.handle, { key: "value" });
+
+        let res2 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        assert.deepEqual(res2.userDataInJWT, { key: "value" });
+
+        //changing the value of jwt payload with the same key
+        await SessionFunctions.updateJWTPayload(s, res.session.handle, { key: "value 2" });
+
+        let res3 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        assert.deepEqual(res3.userDataInJWT, { key: "value 2" });
 
         //passing invalid session handle when updating jwt payload
         try {
@@ -857,6 +990,52 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
 
         let res6 = await SessionFunctions.getJWTPayload(s, res.session.handle);
         assert.deepStrictEqual(res6, {});
+    });
+
+    it("test null and undefined values passed for jwt payload with new get session method", async function () {
+        await startST();
+        SuperTokens.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                Session.init({
+                    antiCsrf: "VIA_TOKEN",
+                }),
+            ],
+        });
+
+        let s = SessionRecipe.getInstanceOrThrowError().recipeInterfaceImpl;
+        //adding jwt payload
+        let res = await SessionFunctions.createNewSession(s, "", null, {});
+
+        let res2 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        assert.deepStrictEqual(res2.userDataInJWT, {});
+
+        await SessionFunctions.updateJWTPayload(s, res.session.handle, { key: "value" });
+
+        let res3 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        assert.deepStrictEqual(res3.userDataInJWT, { key: "value" });
+
+        await SessionFunctions.updateJWTPayload(s, res.session.handle);
+
+        let res4 = await SessionFunctions.getSessionDetails(s, res.session.handle, undefined);
+        assert.deepStrictEqual(res4.userDataInJWT, {});
+
+        await SessionFunctions.updateJWTPayload(s, res.session.handle, { key: "value 2" });
+
+        let res5 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        assert.deepStrictEqual(res5.userDataInJWT, { key: "value 2" });
+
+        await SessionFunctions.updateJWTPayload(s, res.session.handle, null);
+
+        let res6 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        assert.deepStrictEqual(res6.userDataInJWT, {});
     });
 
     //if anti-csrf is disabled from ST core, check that not having that in input to verify session is fine**

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -745,13 +745,13 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
         let res = await SessionFunctions.createNewSession(s, "", {}, {});
         await SessionFunctions.updateSessionData(s, res.session.handle, { key: "value" });
 
-        let res2 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        let res2 = await SessionFunctions.getSessionInformation(s, res.session.handle);
         assert.deepEqual(res2.userDataInDatabase, { key: "value" });
 
         //changing the value of session data with the same key
         await SessionFunctions.updateSessionData(s, res.session.handle, { key: "value 2" });
 
-        let res3 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        let res3 = await SessionFunctions.getSessionInformation(s, res.session.handle);
         assert.deepEqual(res3.userDataInDatabase, { key: "value 2" });
 
         //passing invalid session handle when updating session data
@@ -833,27 +833,27 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
         //adding session data
         let res = await SessionFunctions.createNewSession(s, "", {}, null);
 
-        let res2 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        let res2 = await SessionFunctions.getSessionInformation(s, res.session.handle);
         assert.deepStrictEqual(res2.userDataInDatabase, {});
 
         await SessionFunctions.updateSessionData(s, res.session.handle, { key: "value" });
 
-        let res3 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        let res3 = await SessionFunctions.getSessionInformation(s, res.session.handle);
         assert.deepStrictEqual(res3.userDataInDatabase, { key: "value" });
 
         await SessionFunctions.updateSessionData(s, res.session.handle, undefined);
 
-        let res4 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        let res4 = await SessionFunctions.getSessionInformation(s, res.session.handle);
         assert.deepStrictEqual(res4.userDataInDatabase, {});
 
         await SessionFunctions.updateSessionData(s, res.session.handle, { key: "value 2" });
 
-        let res5 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        let res5 = await SessionFunctions.getSessionInformation(s, res.session.handle);
         assert.deepStrictEqual(res5.userDataInDatabase, { key: "value 2" });
 
         await SessionFunctions.updateSessionData(s, res.session.handle, null);
 
-        let res6 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        let res6 = await SessionFunctions.getSessionInformation(s, res.session.handle);
         assert.deepStrictEqual(res6.userDataInDatabase, {});
     });
 
@@ -926,13 +926,13 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
 
         await SessionFunctions.updateJWTPayload(s, res.session.handle, { key: "value" });
 
-        let res2 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        let res2 = await SessionFunctions.getSessionInformation(s, res.session.handle);
         assert.deepEqual(res2.userDataInJWT, { key: "value" });
 
         //changing the value of jwt payload with the same key
         await SessionFunctions.updateJWTPayload(s, res.session.handle, { key: "value 2" });
 
-        let res3 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        let res3 = await SessionFunctions.getSessionInformation(s, res.session.handle);
         assert.deepEqual(res3.userDataInJWT, { key: "value 2" });
 
         //passing invalid session handle when updating jwt payload
@@ -1014,27 +1014,27 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
         //adding jwt payload
         let res = await SessionFunctions.createNewSession(s, "", null, {});
 
-        let res2 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        let res2 = await SessionFunctions.getSessionInformation(s, res.session.handle);
         assert.deepStrictEqual(res2.userDataInJWT, {});
 
         await SessionFunctions.updateJWTPayload(s, res.session.handle, { key: "value" });
 
-        let res3 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        let res3 = await SessionFunctions.getSessionInformation(s, res.session.handle);
         assert.deepStrictEqual(res3.userDataInJWT, { key: "value" });
 
         await SessionFunctions.updateJWTPayload(s, res.session.handle);
 
-        let res4 = await SessionFunctions.getSessionDetails(s, res.session.handle, undefined);
+        let res4 = await SessionFunctions.getSessionInformation(s, res.session.handle, undefined);
         assert.deepStrictEqual(res4.userDataInJWT, {});
 
         await SessionFunctions.updateJWTPayload(s, res.session.handle, { key: "value 2" });
 
-        let res5 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        let res5 = await SessionFunctions.getSessionInformation(s, res.session.handle);
         assert.deepStrictEqual(res5.userDataInJWT, { key: "value 2" });
 
         await SessionFunctions.updateJWTPayload(s, res.session.handle, null);
 
-        let res6 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        let res6 = await SessionFunctions.getSessionInformation(s, res.session.handle);
         assert.deepStrictEqual(res6.userDataInJWT, {});
     });
 
@@ -1530,7 +1530,7 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
         //adding session data
         let res = await SessionFunctions.createNewSession(s, "customuserid", {}, null);
 
-        let res2 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        let res2 = await SessionFunctions.getSessionInformation(s, res.session.handle);
 
         assert.strictEqual(res2.userId, "customuserid");
     });
@@ -1556,7 +1556,7 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
         let s = SessionRecipe.getInstanceOrThrowError().recipeInterfaceImpl;
         //adding session data
         let res = await SessionFunctions.createNewSession(s, "", {}, null);
-        let res2 = await SessionFunctions.getSessionDetails(s, res.session.handle);
+        let res2 = await SessionFunctions.getSessionInformation(s, res.session.handle);
 
         assert(typeof res2.status === "string");
         assert(res2.status === "OK");
@@ -1593,7 +1593,7 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
         assert(response.length === 1);
 
         try {
-            await SessionFunctions.getSessionDetails(s, res.session.handle);
+            await SessionFunctions.getSessionInformation(s, res.session.handle);
             assert(false);
         } catch (e) {
             if (e.type !== Session.Error.UNAUTHORISED) {

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -32,7 +32,7 @@ let SuperTokens = require("../");
 let Session = require("../recipe/session");
 let SessionFunctions = require("../lib/build/recipe/session/sessionFunctions");
 let SessionRecipe = require("../lib/build/recipe/session/recipe").default;
-const { removeServerlessCache } = require("../lib/build/utils");
+const { removeServerlessCache, maxVersion } = require("../lib/build/utils");
 
 /* TODO:
 - the opposite of the above (check that if signing key changes, things are still fine) condition
@@ -740,6 +740,14 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
             ],
         });
 
+        let q = Querier.getNewInstanceOrThrowError(false, undefined);
+        let apiVersion = await q.getAPIVersion();
+
+        // Only run test for >= 2.8
+        if (maxVersion(apiVersion, "2.7") === "2.7") {
+            return;
+        }
+
         let s = SessionRecipe.getInstanceOrThrowError().recipeInterfaceImpl;
         //adding session data
         let res = await SessionFunctions.createNewSession(s, "", {}, {});
@@ -828,6 +836,14 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
                 }),
             ],
         });
+
+        let q = Querier.getNewInstanceOrThrowError(false, undefined);
+        let apiVersion = await q.getAPIVersion();
+
+        // Only run test for >= 2.8
+        if (maxVersion(apiVersion, "2.7") === "2.7") {
+            return;
+        }
 
         let s = SessionRecipe.getInstanceOrThrowError().recipeInterfaceImpl;
         //adding session data
@@ -920,6 +936,14 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
             ],
         });
 
+        let q = Querier.getNewInstanceOrThrowError(false, undefined);
+        let apiVersion = await q.getAPIVersion();
+
+        // Only run test for >= 2.8
+        if (maxVersion(apiVersion, "2.7") === "2.7") {
+            return;
+        }
+
         let s = SessionRecipe.getInstanceOrThrowError().recipeInterfaceImpl;
         //adding jwt payload
         let res = await SessionFunctions.createNewSession(s, "", {}, {});
@@ -1009,6 +1033,14 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
                 }),
             ],
         });
+
+        let q = Querier.getNewInstanceOrThrowError(false, undefined);
+        let apiVersion = await q.getAPIVersion();
+
+        // Only run test for >= 2.8
+        if (maxVersion(apiVersion, "2.7") === "2.7") {
+            return;
+        }
 
         let s = SessionRecipe.getInstanceOrThrowError().recipeInterfaceImpl;
         //adding jwt payload
@@ -1526,6 +1558,14 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
             ],
         });
 
+        let q = Querier.getNewInstanceOrThrowError(false, undefined);
+        let apiVersion = await q.getAPIVersion();
+
+        // Only run test for >= 2.8
+        if (maxVersion(apiVersion, "2.7") === "2.7") {
+            return;
+        }
+
         let s = SessionRecipe.getInstanceOrThrowError().recipeInterfaceImpl;
         //adding session data
         let res = await SessionFunctions.createNewSession(s, "customuserid", {}, null);
@@ -1552,6 +1592,14 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
                 }),
             ],
         });
+
+        let q = Querier.getNewInstanceOrThrowError(false, undefined);
+        let apiVersion = await q.getAPIVersion();
+
+        // Only run test for >= 2.8
+        if (maxVersion(apiVersion, "2.7") === "2.7") {
+            return;
+        }
 
         let s = SessionRecipe.getInstanceOrThrowError().recipeInterfaceImpl;
         //adding session data
@@ -1584,6 +1632,14 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
                 }),
             ],
         });
+
+        let q = Querier.getNewInstanceOrThrowError(false, undefined);
+        let apiVersion = await q.getAPIVersion();
+
+        // Only run test for >= 2.8
+        if (maxVersion(apiVersion, "2.7") === "2.7") {
+            return;
+        }
 
         let s = SessionRecipe.getInstanceOrThrowError().recipeInterfaceImpl;
         //adding session data


### PR DESCRIPTION
### Summary
- Adds a new method to fetch all session info stored in the database for a given session handle
- Marks existing methods to fetch JWT and session data individually by session handle as deprecated

### Related issues
https://github.com/supertokens/supertokens-core/issues/255