### PR TITLE
fixes ts issue with default imports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
     slack: circleci/slack@3.4.2
+    jq: circleci/jq@2.2.0
 jobs:
     publish:
         docker:
@@ -8,7 +9,11 @@ jobs:
         steps:
             - checkout
             - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-            - run: npm publish
+            - run:
+                  name: Publish
+                  command: |
+                      cd .circleci
+                      ./publish.sh
             - slack/status
     test:
         docker:

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -1,0 +1,12 @@
+version=$(cat ../package.json | jq .version | tr -d '"')
+isLatest=`curl -s -X GET \
+"https://api.supertokens.io/0/driver/latest/check?password=$SUPERTOKENS_API_KEY&version=$version&name=node" \
+-H 'api-version: 0'`
+if [[ `echo $isLatest | jq .isLatest` == "true" ]]
+then
+    cd ..
+    npm publish --tag latest
+else
+    cd ..
+    npm publish --tag version-$version
+fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.4] - 2021-07-29
+
+## Fixes
+
+-   Fixes typescript issue with default imports. (Related to https://github.com/supertokens/supertokens-auth-react/issues/297)
+
 ## [6.0.3] - 2021-07-08
 
 ## Fixes

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,10 @@
 export * from "./lib/build";
+/**
+ * 'export *' does not re-export a default.
+ * import SuperTokens from "supertokens-node";
+ * the above import statement won't be possible unless either
+ * - user add "esModuleInterop": true in their tsconfig.json file
+ * - we do the following change:
+ */
+import * as _default from "./lib/build";
+export default _default;

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,2 +1,2 @@
-export declare const version = "6.0.3";
+export declare const version = "6.0.4";
 export declare const cdiSupported: string[];

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -14,6 +14,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "6.0.3";
+exports.version = "6.0.4";
 exports.cdiSupported = ["2.7"];
 //# sourceMappingURL=version.js.map

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,6 +12,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "6.0.3";
+export const version = "6.0.4";
 
 export const cdiSupported = ["2.7"];

--- a/nextjs/index.d.ts
+++ b/nextjs/index.d.ts
@@ -1,1 +1,11 @@
 export * from "../lib/build/nextjs";
+/**
+ * 'export *' does not re-export a default.
+ * import NextJS from "supertokens-node/nextjs";
+ * the above import statement won't be possible unless either
+ * - user add "esModuleInterop": true in their tsconfig.json file
+ * - we do the following change:
+ */
+
+import * as _default from "../lib/build/nextjs";
+export default _default;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "6.0.3",
+    "version": "6.0.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "6.0.3",
+    "version": "6.0.4",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {
         "test": "TEST_MODE=testing SERVERLESS_CACHE_BASE_FILE_PATH=./.tmp npx mocha --timeout 500000",
-        "build-check": "cd lib && npx tsc -p tsconfig.json --noEmit",
-        "build": "cd lib && rm -rf build && npx tsc -p tsconfig.json",
+        "build-check": "cd lib && npx tsc -p tsconfig.json --noEmit && cd ../test/with-typescript && npx tsc -p tsconfig.json --noEmit",
+        "build": "cd lib && rm -rf build && npx tsc -p tsconfig.json && cd ../test/with-typescript && npx tsc -p tsconfig.json --noEmit",
         "pretty": "npx pretty-quick .",
         "build-pretty": "npm run build && npm run pretty",
         "pretty-check": "npx pretty-quick --check .",

--- a/recipe/emailpassword/index.d.ts
+++ b/recipe/emailpassword/index.d.ts
@@ -1,1 +1,10 @@
 export * from "../../lib/build/recipe/emailpassword";
+/**
+ * 'export *' does not re-export a default.
+ * import NextJS from "supertokens-node/nextjs";
+ * the above import statement won't be possible unless either
+ * - user add "esModuleInterop": true in their tsconfig.json file
+ * - we do the following change:
+ */
+import * as _default from "../../lib/build/recipe/emailpassword";
+export default _default;

--- a/recipe/emailverification/index.d.ts
+++ b/recipe/emailverification/index.d.ts
@@ -1,1 +1,10 @@
 export * from "../../lib/build/recipe/emailverification";
+/**
+ * 'export *' does not re-export a default.
+ * import NextJS from "supertokens-node/nextjs";
+ * the above import statement won't be possible unless either
+ * - user add "esModuleInterop": true in their tsconfig.json file
+ * - we do the following change:
+ */
+import * as _default from "../../lib/build/recipe/emailverification";
+export default _default;

--- a/recipe/session/faunadb/index.d.ts
+++ b/recipe/session/faunadb/index.d.ts
@@ -1,1 +1,10 @@
 export * from "../../../lib/build/recipe/session/faunadb";
+/**
+ * 'export *' does not re-export a default.
+ * import NextJS from "supertokens-node/nextjs";
+ * the above import statement won't be possible unless either
+ * - user add "esModuleInterop": true in their tsconfig.json file
+ * - we do the following change:
+ */
+import * as _default from "../../../lib/build/recipe/session/faunadb";
+export default _default;

--- a/recipe/session/index.d.ts
+++ b/recipe/session/index.d.ts
@@ -1,1 +1,10 @@
 export * from "../../lib/build/recipe/session";
+/**
+ * 'export *' does not re-export a default.
+ * import NextJS from "supertokens-node/nextjs";
+ * the above import statement won't be possible unless either
+ * - user add "esModuleInterop": true in their tsconfig.json file
+ * - we do the following change:
+ */
+import * as _default from "../../lib/build/recipe/session";
+export default _default;

--- a/recipe/thirdparty/index.d.ts
+++ b/recipe/thirdparty/index.d.ts
@@ -1,1 +1,10 @@
 export * from "../../lib/build/recipe/thirdparty";
+/**
+ * 'export *' does not re-export a default.
+ * import NextJS from "supertokens-node/nextjs";
+ * the above import statement won't be possible unless either
+ * - user add "esModuleInterop": true in their tsconfig.json file
+ * - we do the following change:
+ */
+import * as _default from "../../lib/build/recipe/thirdparty";
+export default _default;

--- a/recipe/thirdpartyemailpassword/index.d.ts
+++ b/recipe/thirdpartyemailpassword/index.d.ts
@@ -1,1 +1,10 @@
 export * from "../../lib/build/recipe/thirdpartyemailpassword";
+/**
+ * 'export *' does not re-export a default.
+ * import NextJS from "supertokens-node/nextjs";
+ * the above import statement won't be possible unless either
+ * - user add "esModuleInterop": true in their tsconfig.json file
+ * - we do the following change:
+ */
+import * as _default from "../../lib/build/recipe/thirdpartyemailpassword";
+export default _default;

--- a/redwood/index.d.ts
+++ b/redwood/index.d.ts
@@ -1,1 +1,10 @@
 export * from "../lib/build/redwood";
+/**
+ * 'export *' does not re-export a default.
+ * import NextJS from "supertokens-node/nextjs";
+ * the above import statement won't be possible unless either
+ * - user add "esModuleInterop": true in their tsconfig.json file
+ * - we do the following change:
+ */
+import * as _default from "../lib/build/redwood";
+export default _default;

--- a/test/with-typescript/tsconfig.json
+++ b/test/with-typescript/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "target": "ES2016",
+        "strictNullChecks": true,
+        "declaration": true,
+        "module": "commonJS",
+        "moduleResolution": "Node",
+        "sourceMap": true,
+        "skipLibCheck": true,
+        "noFallthroughCasesInSwitch": true,
+        "lib": ["ES2017"],
+        "noEmit": true
+    },
+    "include": ["./**/*"],
+    "exclude": ["build"],
+    "compileOnSave": true
+}

--- a/test/with-typescript/tslint.json
+++ b/test/with-typescript/tslint.json
@@ -1,0 +1,43 @@
+{
+    "jsRules": {
+        "class-name": true,
+        "comment-format": [true, "check-space"],
+        "indent": [true, "spaces"],
+        "no-duplicate-variable": true,
+        "no-eval": true,
+        "no-trailing-whitespace": true,
+        "no-unsafe-finally": true,
+        "one-line": [true, "check-open-brace", "check-whitespace"],
+        "quotemark": [true, "double"],
+        "semicolon": [true, "always"],
+        "triple-equals": [true, "allow-null-check"],
+        "variable-name": [true, "ban-keywords"],
+        "whitespace": [true, "check-branch", "check-decl", "check-operator", "check-separator", "check-type"]
+    },
+    "rules": {
+        "class-name": true,
+        "comment-format": [true, "check-space"],
+        "indent": [true, "spaces"],
+        "no-eval": true,
+        "no-internal-module": true,
+        "no-trailing-whitespace": true,
+        "no-unsafe-finally": true,
+        "no-var-keyword": true,
+        "one-line": [true, "check-open-brace", "check-whitespace"],
+        "quotemark": [true, "double"],
+        "semicolon": [true, "always"],
+        "triple-equals": [true, "allow-null-check"],
+        "typedef-whitespace": [
+            true,
+            {
+                "call-signature": "nospace",
+                "index-signature": "nospace",
+                "parameter": "nospace",
+                "property-declaration": "nospace",
+                "variable-declaration": "nospace"
+            }
+        ],
+        "variable-name": [true, "ban-keywords"],
+        "whitespace": [true, "check-branch", "check-decl", "check-operator", "check-separator", "check-type"]
+    }
+}


### PR DESCRIPTION
## Summary of change
imports like:
```ts
import SuperTokens from 'supertokens-node';
```
throws the error `export * from "./lib/build" doesn't re-export the default export` . So for all the user facing  *.d.ts files, added:
```ts
import * as _default from "...";
export default _default;
```

## Related issues
- https://github.com/su…pertokens/supertokens-auth-react/issues/297

## Test Plan
- updated `package.json` to try to build `test/with-typescript/index.ts` everytime after the source code is rebuild. If there is any issue with the default import statement, an error will be thrown.

## Documentation changes
- None

## Checklist for important updates
- [x] Changelog has been updated
- [x] Changes to the version if needed
   - In `package.json`
   - In `package-lock.json`
   - In `lib/ts/version.ts`
- [x] Had run `npm run build-pretty`
- [x] Had installed and ran the pre-commit hook
- [x] Issue this PR against the latest non released version branch.