### PR TITLE
Rename properties of getSessionInformation response

### DIFF
--- a/lib/build/recipe/session/sessionFunctions.js
+++ b/lib/build/recipe/session/sessionFunctions.js
@@ -250,6 +250,11 @@ function getSessionInformation(recipeImplementation, sessionHandle) {
             }
         );
         if (response.status === "OK") {
+            // Change keys to make them more readable
+            response["sessionData"] = response.userDataInDatabase;
+            response["jwtPayload"] = response.userDataInJWT;
+            delete response.userDataInJWT;
+            delete response.userDataInJWT;
             return response;
         } else {
             throw new error_1.default({
@@ -381,7 +386,7 @@ function getSessionData(recipeImplementation, sessionHandle) {
         let apiVersion = yield recipeImplementation.querier.getAPIVersion();
         // Call new method for >= 2.8
         if (utils_1.maxVersion(apiVersion, "2.7") !== "2.7") {
-            return (yield getSessionInformation(recipeImplementation, sessionHandle)).userDataInDatabase;
+            return (yield getSessionInformation(recipeImplementation, sessionHandle)).sessionData;
         }
         let response = yield recipeImplementation.querier.sendGetRequest(
             new normalisedURLPath_1.default("/recipe/session/data"),

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -198,8 +198,8 @@ export interface APIInterface {
 export declare type SessionInformation = {
     sessionHandle: string;
     userId: string;
-    userDataInDatabase: any;
+    sessionData: any;
     expiry: number;
-    userDataInJWT: any;
+    jwtPayload: any;
     timeCreated: number;
 };

--- a/lib/ts/recipe/session/sessionFunctions.ts
+++ b/lib/ts/recipe/session/sessionFunctions.ts
@@ -256,6 +256,13 @@ export async function getSessionInformation(
     });
 
     if (response.status === "OK") {
+        // Change keys to make them more readable
+        response["sessionData"] = response.userDataInDatabase;
+        response["jwtPayload"] = response.userDataInJWT;
+
+        delete response.userDataInJWT;
+        delete response.userDataInJWT;
+
         return response;
     } else {
         throw new STError({
@@ -388,7 +395,7 @@ export async function getSessionData(recipeImplementation: RecipeImplementation,
 
     // Call new method for >= 2.8
     if (maxVersion(apiVersion, "2.7") !== "2.7") {
-        return (await getSessionInformation(recipeImplementation, sessionHandle)).userDataInDatabase;
+        return (await getSessionInformation(recipeImplementation, sessionHandle)).sessionData;
     }
 
     let response = await recipeImplementation.querier.sendGetRequest(new NormalisedURLPath("/recipe/session/data"), {

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -242,8 +242,8 @@ export interface APIInterface {
 export type SessionInformation = {
     sessionHandle: string;
     userId: string;
-    userDataInDatabase: any;
+    sessionData: any;
     expiry: number;
-    userDataInJWT: any;
+    jwtPayload: any;
     timeCreated: number;
 };

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -754,13 +754,13 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
         await SessionFunctions.updateSessionData(s, res.session.handle, { key: "value" });
 
         let res2 = await SessionFunctions.getSessionInformation(s, res.session.handle);
-        assert.deepEqual(res2.userDataInDatabase, { key: "value" });
+        assert.deepEqual(res2.sessionData, { key: "value" });
 
         //changing the value of session data with the same key
         await SessionFunctions.updateSessionData(s, res.session.handle, { key: "value 2" });
 
         let res3 = await SessionFunctions.getSessionInformation(s, res.session.handle);
-        assert.deepEqual(res3.userDataInDatabase, { key: "value 2" });
+        assert.deepEqual(res3.sessionData, { key: "value 2" });
 
         //passing invalid session handle when updating session data
         try {
@@ -850,27 +850,27 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
         let res = await SessionFunctions.createNewSession(s, "", {}, null);
 
         let res2 = await SessionFunctions.getSessionInformation(s, res.session.handle);
-        assert.deepStrictEqual(res2.userDataInDatabase, {});
+        assert.deepStrictEqual(res2.sessionData, {});
 
         await SessionFunctions.updateSessionData(s, res.session.handle, { key: "value" });
 
         let res3 = await SessionFunctions.getSessionInformation(s, res.session.handle);
-        assert.deepStrictEqual(res3.userDataInDatabase, { key: "value" });
+        assert.deepStrictEqual(res3.sessionData, { key: "value" });
 
         await SessionFunctions.updateSessionData(s, res.session.handle, undefined);
 
         let res4 = await SessionFunctions.getSessionInformation(s, res.session.handle);
-        assert.deepStrictEqual(res4.userDataInDatabase, {});
+        assert.deepStrictEqual(res4.sessionData, {});
 
         await SessionFunctions.updateSessionData(s, res.session.handle, { key: "value 2" });
 
         let res5 = await SessionFunctions.getSessionInformation(s, res.session.handle);
-        assert.deepStrictEqual(res5.userDataInDatabase, { key: "value 2" });
+        assert.deepStrictEqual(res5.sessionData, { key: "value 2" });
 
         await SessionFunctions.updateSessionData(s, res.session.handle, null);
 
         let res6 = await SessionFunctions.getSessionInformation(s, res.session.handle);
-        assert.deepStrictEqual(res6.userDataInDatabase, {});
+        assert.deepStrictEqual(res6.sessionData, {});
     });
 
     //check manipulating jwt payload
@@ -951,13 +951,13 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
         await SessionFunctions.updateJWTPayload(s, res.session.handle, { key: "value" });
 
         let res2 = await SessionFunctions.getSessionInformation(s, res.session.handle);
-        assert.deepEqual(res2.userDataInJWT, { key: "value" });
+        assert.deepEqual(res2.jwtPayload, { key: "value" });
 
         //changing the value of jwt payload with the same key
         await SessionFunctions.updateJWTPayload(s, res.session.handle, { key: "value 2" });
 
         let res3 = await SessionFunctions.getSessionInformation(s, res.session.handle);
-        assert.deepEqual(res3.userDataInJWT, { key: "value 2" });
+        assert.deepEqual(res3.jwtPayload, { key: "value 2" });
 
         //passing invalid session handle when updating jwt payload
         try {
@@ -1047,27 +1047,27 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
         let res = await SessionFunctions.createNewSession(s, "", null, {});
 
         let res2 = await SessionFunctions.getSessionInformation(s, res.session.handle);
-        assert.deepStrictEqual(res2.userDataInJWT, {});
+        assert.deepStrictEqual(res2.jwtPayload, {});
 
         await SessionFunctions.updateJWTPayload(s, res.session.handle, { key: "value" });
 
         let res3 = await SessionFunctions.getSessionInformation(s, res.session.handle);
-        assert.deepStrictEqual(res3.userDataInJWT, { key: "value" });
+        assert.deepStrictEqual(res3.jwtPayload, { key: "value" });
 
         await SessionFunctions.updateJWTPayload(s, res.session.handle);
 
         let res4 = await SessionFunctions.getSessionInformation(s, res.session.handle, undefined);
-        assert.deepStrictEqual(res4.userDataInJWT, {});
+        assert.deepStrictEqual(res4.jwtPayload, {});
 
         await SessionFunctions.updateJWTPayload(s, res.session.handle, { key: "value 2" });
 
         let res5 = await SessionFunctions.getSessionInformation(s, res.session.handle);
-        assert.deepStrictEqual(res5.userDataInJWT, { key: "value 2" });
+        assert.deepStrictEqual(res5.jwtPayload, { key: "value 2" });
 
         await SessionFunctions.updateJWTPayload(s, res.session.handle, null);
 
         let res6 = await SessionFunctions.getSessionInformation(s, res.session.handle);
-        assert.deepStrictEqual(res6.userDataInJWT, {});
+        assert.deepStrictEqual(res6.jwtPayload, {});
     });
 
     //if anti-csrf is disabled from ST core, check that not having that in input to verify session is fine**
@@ -1609,9 +1609,9 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
         assert(typeof res2.status === "string");
         assert(res2.status === "OK");
         assert(typeof res2.userId === "string");
-        assert(typeof res2.userDataInDatabase === "object");
+        assert(typeof res2.sessionData === "object");
         assert(typeof res2.expiry === "number");
-        assert(typeof res2.userDataInJWT === "object");
+        assert(typeof res2.jwtPayload === "object");
         assert(typeof res2.timeCreated === "number");
     });
 


### PR DESCRIPTION
## Summary of change
Changes the response properties of getSessionInformation to be more readable and easy to understand:
- userDataInDatabase -> sessionData
- userDataInJWT -> jwtPayload

## Related issues/Pull Requests
https://github.com/supertokens/docs/pull/80

## Test Plan
Modified existing test cases to accommodate for the key changes, no new test cases needed. All existing tests pass (tested against core 3.5 and plugin-interface 2.8)

## Documentation changes
Documentation changes that are part of https://github.com/supertokens/docs/pull/80 will be modified to reflect these changes after this pull request is merged

## Checklist for important updates
- [ ] Changelog has been updated
- [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `lib/ts/version.ts`
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
   - In `package.json`
   - In `package-lock.json`
   - In `lib/ts/version.ts`
- [x] Had run `npm run build-pretty`
- [x] Had installed and ran the pre-commit hook
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
None