### PR TITLE
Thirdparty emailverification sign up change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     -   `ThirdPartyEmailPassword.getUserCount()`, `ThirdPartyEmailPassword.getUsersNewestFirst()`, `ThirdPartyEmailPassword.getUsersOldestFirst`
 -   Deprecates (instead use `Session.getSessionInformation()`)
     -   `Session.getSessionData()`, `Session.getJWTPayload()`
+-   Adds email verification function calls in thirdparty sign in up API as per https://github.com/supertokens/supertokens-core/issues/295
+-   Adds `emailVerificationRecipeImplementation` in all auth recipe `APIOptions` so that APIs can access the email verification implementation.
 
 ## [6.0.4] - 2021-07-29
 

--- a/lib/build/recipe/emailpassword/recipe.js
+++ b/lib/build/recipe/emailpassword/recipe.js
@@ -109,6 +109,7 @@ class Recipe extends recipeModule_1.default {
                     recipeId: this.getRecipeId(),
                     isInServerlessEnv: this.isInServerlessEnv,
                     recipeImplementation: this.recipeInterfaceImpl,
+                    emailVerificationRecipeImplementation: this.emailVerificationRecipe.recipeInterfaceImpl,
                     req,
                     res,
                 };

--- a/lib/build/recipe/emailpassword/types.d.ts
+++ b/lib/build/recipe/emailpassword/types.d.ts
@@ -262,6 +262,7 @@ export interface RecipeInterface {
 }
 export declare type APIOptions = {
     recipeImplementation: RecipeInterface;
+    emailVerificationRecipeImplementation: EmailVerificationRecipeInterface;
     config: TypeNormalisedInput;
     recipeId: string;
     isInServerlessEnv: boolean;

--- a/lib/build/recipe/thirdparty/api/implementation.js
+++ b/lib/build/recipe/thirdparty/api/implementation.js
@@ -83,6 +83,21 @@ class APIImplementation {
                 if (response.status === "FIELD_ERROR") {
                     return response;
                 }
+                // we set the email as verified if already verified by the OAuth provider.
+                // This block was added because of https://github.com/supertokens/supertokens-core/issues/295
+                if (emailInfo.isVerified) {
+                    const tokenResponse = yield options.emailVerificationRecipeImplementation.createEmailVerificationToken(
+                        {
+                            userId: response.user.id,
+                            email: response.user.email,
+                        }
+                    );
+                    if (tokenResponse.status === "OK") {
+                        yield options.emailVerificationRecipeImplementation.verifyEmailUsingToken({
+                            token: tokenResponse.token,
+                        });
+                    }
+                }
                 let action = response.createdNewUser ? "signup" : "signin";
                 let jwtPayloadPromise = options.config.sessionFeature.setJwtPayload(
                     response.user,

--- a/lib/build/recipe/thirdparty/recipe.js
+++ b/lib/build/recipe/thirdparty/recipe.js
@@ -84,6 +84,7 @@ class Recipe extends recipeModule_1.default {
                     recipeId: this.getRecipeId(),
                     isInServerlessEnv: this.isInServerlessEnv,
                     recipeImplementation: this.recipeInterfaceImpl,
+                    emailVerificationRecipeImplementation: this.emailVerificationRecipe.recipeInterfaceImpl,
                     providers: this.providers,
                     req,
                     res,

--- a/lib/build/recipe/thirdparty/types.d.ts
+++ b/lib/build/recipe/thirdparty/types.d.ts
@@ -201,6 +201,7 @@ export interface RecipeInterface {
 }
 export declare type APIOptions = {
     recipeImplementation: RecipeInterface;
+    emailVerificationRecipeImplementation: EmailVerificationRecipeInterface;
     config: TypeNormalisedInput;
     recipeId: string;
     isInServerlessEnv: boolean;

--- a/lib/ts/recipe/emailpassword/recipe.ts
+++ b/lib/ts/recipe/emailpassword/recipe.ts
@@ -155,6 +155,7 @@ export default class Recipe extends RecipeModule {
             recipeId: this.getRecipeId(),
             isInServerlessEnv: this.isInServerlessEnv,
             recipeImplementation: this.recipeInterfaceImpl,
+            emailVerificationRecipeImplementation: this.emailVerificationRecipe.recipeInterfaceImpl,
             req,
             res,
         };

--- a/lib/ts/recipe/emailpassword/types.ts
+++ b/lib/ts/recipe/emailpassword/types.ts
@@ -254,6 +254,7 @@ export interface RecipeInterface {
 
 export type APIOptions = {
     recipeImplementation: RecipeInterface;
+    emailVerificationRecipeImplementation: EmailVerificationRecipeInterface;
     config: TypeNormalisedInput;
     recipeId: string;
     isInServerlessEnv: boolean;

--- a/lib/ts/recipe/thirdparty/api/implementation.ts
+++ b/lib/ts/recipe/thirdparty/api/implementation.ts
@@ -88,6 +88,21 @@ export default class APIImplementation implements APIInterface {
             return response;
         }
 
+        // we set the email as verified if already verified by the OAuth provider.
+        // This block was added because of https://github.com/supertokens/supertokens-core/issues/295
+        if (emailInfo.isVerified) {
+            const tokenResponse = await options.emailVerificationRecipeImplementation.createEmailVerificationToken({
+                userId: response.user.id,
+                email: response.user.email,
+            });
+
+            if (tokenResponse.status === "OK") {
+                await options.emailVerificationRecipeImplementation.verifyEmailUsingToken({
+                    token: tokenResponse.token,
+                });
+            }
+        }
+
         let action: "signup" | "signin" = response.createdNewUser ? "signup" : "signin";
         let jwtPayloadPromise = options.config.sessionFeature.setJwtPayload(
             response.user,

--- a/lib/ts/recipe/thirdparty/recipe.ts
+++ b/lib/ts/recipe/thirdparty/recipe.ts
@@ -130,6 +130,7 @@ export default class Recipe extends RecipeModule {
             recipeId: this.getRecipeId(),
             isInServerlessEnv: this.isInServerlessEnv,
             recipeImplementation: this.recipeInterfaceImpl,
+            emailVerificationRecipeImplementation: this.emailVerificationRecipe.recipeInterfaceImpl,
             providers: this.providers,
             req,
             res,

--- a/lib/ts/recipe/thirdparty/types.ts
+++ b/lib/ts/recipe/thirdparty/types.ts
@@ -215,6 +215,7 @@ export interface RecipeInterface {
 
 export type APIOptions = {
     recipeImplementation: RecipeInterface;
+    emailVerificationRecipeImplementation: EmailVerificationRecipeInterface;
     config: TypeNormalisedInput;
     recipeId: string;
     isInServerlessEnv: boolean;


### PR DESCRIPTION
## Summary of change
We verify the email in the thirdparty sign in / up API if it is verified by the OAuth provider. Previously, this used to happen in the core itself, but that is going to be removed (see related issue). So we need to do it in the API.

## Related issues
- https://github.com/supertokens/supertokens-core/issues/295

## Test Plan
The test for this is already done in one of the previous tests. Furthermore, I have confirmed that if the email verification code is missing in the sign in up API, the associated tests fail.

## Documentation changes
None

## Checklist for important updates
- [x] Changelog has been updated
- [x] Had run `npm run build-pretty`
- [x] Had installed and ran the pre-commit hook
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.