### PR TITLE
Thirdparty fetch email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     -   `Session.getSessionData()`, `Session.getJWTPayload()`
 -   Adds email verification function calls in thirdparty sign in up API as per https://github.com/supertokens/supertokens-core/issues/295
 -   Adds `emailVerificationRecipeImplementation` in all auth recipe `APIOptions` so that APIs can access the email verification implementation.
+-   Add recipe function to fetch third party users https://github.com/supertokens/supertokens-core/issues/277
+-   Deprecates `getUserByEmail` in thirdpartyemailpassword and replaces it with `getUsersByEmail`.
 
 ## [6.0.4] - 2021-07-29
 

--- a/lib/build/recipe/thirdparty/index.d.ts
+++ b/lib/build/recipe/thirdparty/index.d.ts
@@ -16,6 +16,7 @@ export default class Wrapper {
         user: User;
     }>;
     static getUserById(userId: string): Promise<User | undefined>;
+    static getUsersByEmail(email: string): Promise<User[]>;
     static getUserByThirdPartyInfo(thirdPartyId: string, thirdPartyUserId: string): Promise<User | undefined>;
     /**
      * @deprecated Use supertokens.getUsersOldestFirst(...) function instead IF using core version >= 3.5
@@ -53,6 +54,7 @@ export declare let init: typeof Recipe.init;
 export declare let Error: typeof SuperTokensError;
 export declare let signInUp: typeof Wrapper.signInUp;
 export declare let getUserById: typeof Wrapper.getUserById;
+export declare let getUsersByEmail: typeof Wrapper.getUsersByEmail;
 export declare let getUserByThirdPartyInfo: typeof Wrapper.getUserByThirdPartyInfo;
 export declare let createEmailVerificationToken: typeof Wrapper.createEmailVerificationToken;
 export declare let verifyEmailUsingToken: typeof Wrapper.verifyEmailUsingToken;

--- a/lib/build/recipe/thirdparty/index.js
+++ b/lib/build/recipe/thirdparty/index.js
@@ -66,6 +66,9 @@ class Wrapper {
     static getUserById(userId) {
         return recipe_1.default.getInstanceOrThrowError().recipeInterfaceImpl.getUserById({ userId });
     }
+    static getUsersByEmail(email) {
+        return recipe_1.default.getInstanceOrThrowError().recipeInterfaceImpl.getUsersByEmail({ email });
+    }
     static getUserByThirdPartyInfo(thirdPartyId, thirdPartyUserId) {
         return recipe_1.default.getInstanceOrThrowError().recipeInterfaceImpl.getUserByThirdPartyInfo({
             thirdPartyId,
@@ -117,6 +120,7 @@ exports.init = Wrapper.init;
 exports.Error = Wrapper.Error;
 exports.signInUp = Wrapper.signInUp;
 exports.getUserById = Wrapper.getUserById;
+exports.getUsersByEmail = Wrapper.getUsersByEmail;
 exports.getUserByThirdPartyInfo = Wrapper.getUserByThirdPartyInfo;
 exports.createEmailVerificationToken = Wrapper.createEmailVerificationToken;
 exports.verifyEmailUsingToken = Wrapper.verifyEmailUsingToken;

--- a/lib/build/recipe/thirdparty/recipeImplementation.d.ts
+++ b/lib/build/recipe/thirdparty/recipeImplementation.d.ts
@@ -64,6 +64,7 @@ export default class RecipeImplementation implements RecipeInterface {
           }
     >;
     getUserById: ({ userId }: { userId: string }) => Promise<User | undefined>;
+    getUsersByEmail: ({ email }: { email: string }) => Promise<User[]>;
     getUserByThirdPartyInfo: ({
         thirdPartyId,
         thirdPartyUserId,

--- a/lib/build/recipe/thirdparty/recipeImplementation.js
+++ b/lib/build/recipe/thirdparty/recipeImplementation.js
@@ -95,6 +95,16 @@ class RecipeImplementation {
                     return undefined;
                 }
             });
+        this.getUsersByEmail = ({ email }) =>
+            __awaiter(this, void 0, void 0, function* () {
+                const { users } = yield this.querier.sendGetRequest(
+                    new normalisedURLPath_1.default("/recipe/users/by-email"),
+                    {
+                        email,
+                    }
+                );
+                return users;
+            });
         this.getUserByThirdPartyInfo = ({ thirdPartyId, thirdPartyUserId }) =>
             __awaiter(this, void 0, void 0, function* () {
                 let response = yield this.querier.sendGetRequest(new normalisedURLPath_1.default("/recipe/user"), {

--- a/lib/build/recipe/thirdparty/types.d.ts
+++ b/lib/build/recipe/thirdparty/types.d.ts
@@ -155,6 +155,7 @@ export declare type TypeNormalisedInput = {
 };
 export interface RecipeInterface {
     getUserById(input: { userId: string }): Promise<User | undefined>;
+    getUsersByEmail(input: { email: string }): Promise<User[]>;
     getUserByThirdPartyInfo(input: { thirdPartyId: string; thirdPartyUserId: string }): Promise<User | undefined>;
     /**
      * @deprecated Please do not override this function

--- a/lib/build/recipe/thirdpartyemailpassword/index.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/index.d.ts
@@ -57,6 +57,10 @@ export default class Wrapper {
           }
     >;
     static getUserById(userId: string): Promise<User | undefined>;
+    static getUsersByEmail(email: string): Promise<User[]>;
+    /**
+     * @deprecated Use supertokens.getUsersByEmail(...) function instead IF using core version >= 3.5
+     *   */
     static getUserByEmail(email: string): Promise<User | undefined>;
     static createResetPasswordToken(
         userId: string
@@ -114,7 +118,11 @@ export declare let signIn: typeof Wrapper.signIn;
 export declare let signInUp: typeof Wrapper.signInUp;
 export declare let getUserById: typeof Wrapper.getUserById;
 export declare let getUserByThirdPartyInfo: typeof Wrapper.getUserByThirdPartyInfo;
+/**
+ * @deprecated Use supertokens.getUsersByEmail(...) function instead IF using core version >= 3.5
+ *   */
 export declare let getUserByEmail: typeof Wrapper.getUserByEmail;
+export declare let getUsersByEmail: typeof Wrapper.getUsersByEmail;
 export declare let createResetPasswordToken: typeof Wrapper.createResetPasswordToken;
 export declare let resetPasswordUsingToken: typeof Wrapper.resetPasswordUsingToken;
 export declare let createEmailVerificationToken: typeof Wrapper.createEmailVerificationToken;

--- a/lib/build/recipe/thirdpartyemailpassword/index.js
+++ b/lib/build/recipe/thirdpartyemailpassword/index.js
@@ -39,6 +39,12 @@ class Wrapper {
     static getUserById(userId) {
         return recipe_1.default.getInstanceOrThrowError().recipeInterfaceImpl.getUserById({ userId });
     }
+    static getUsersByEmail(email) {
+        return recipe_1.default.getInstanceOrThrowError().recipeInterfaceImpl.getUsersByEmail({ email });
+    }
+    /**
+     * @deprecated Use supertokens.getUsersByEmail(...) function instead IF using core version >= 3.5
+     *   */
     static getUserByEmail(email) {
         return recipe_1.default.getInstanceOrThrowError().recipeInterfaceImpl.getUserByEmail({ email });
     }
@@ -96,7 +102,11 @@ exports.signIn = Wrapper.signIn;
 exports.signInUp = Wrapper.signInUp;
 exports.getUserById = Wrapper.getUserById;
 exports.getUserByThirdPartyInfo = Wrapper.getUserByThirdPartyInfo;
+/**
+ * @deprecated Use supertokens.getUsersByEmail(...) function instead IF using core version >= 3.5
+ *   */
 exports.getUserByEmail = Wrapper.getUserByEmail;
+exports.getUsersByEmail = Wrapper.getUsersByEmail;
 exports.createResetPasswordToken = Wrapper.createResetPasswordToken;
 exports.resetPasswordUsingToken = Wrapper.resetPasswordUsingToken;
 exports.createEmailVerificationToken = Wrapper.createEmailVerificationToken;

--- a/lib/build/recipe/thirdpartyemailpassword/recipeImplementation/index.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/recipeImplementation/index.d.ts
@@ -84,6 +84,9 @@ export default class RecipeImplementation implements RecipeInterface {
         nextPaginationTokenString?: string | undefined;
     }) => Promise<{
         users: User[];
+        /**
+         * @deprecated Please do not override this function
+         *   */
         nextPaginationToken?: string | undefined;
     }>;
     /**
@@ -97,6 +100,9 @@ export default class RecipeImplementation implements RecipeInterface {
         nextPaginationTokenString?: string | undefined;
     }) => Promise<{
         users: User[];
+        /**
+         * @deprecated Please do not override this function
+         *   */
         nextPaginationToken?: string | undefined;
     }>;
     /**

--- a/lib/build/recipe/thirdpartyemailpassword/recipeImplementation/index.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/recipeImplementation/index.d.ts
@@ -49,8 +49,12 @@ export default class RecipeImplementation implements RecipeInterface {
           }
     >;
     getUserById: (input: { userId: string }) => Promise<User | undefined>;
+    getUsersByEmail: ({ email }: { email: string }) => Promise<User[]>;
     getUserByThirdPartyInfo: (input: { thirdPartyId: string; thirdPartyUserId: string }) => Promise<User | undefined>;
     getEmailForUserId: (input: { userId: string }) => Promise<string>;
+    /**
+     * @deprecated Please do not override this function
+     *   */
     getUserByEmail: (input: { email: string }) => Promise<User | undefined>;
     createResetPasswordToken: (input: {
         userId: string;

--- a/lib/build/recipe/thirdpartyemailpassword/recipeImplementation/index.js
+++ b/lib/build/recipe/thirdpartyemailpassword/recipeImplementation/index.js
@@ -62,6 +62,18 @@ class RecipeImplementation {
                 }
                 return yield this.thirdPartyImplementation.getUserById(input);
             });
+        this.getUsersByEmail = ({ email }) =>
+            __awaiter(this, void 0, void 0, function* () {
+                let userFromEmailPass = yield this.emailPasswordImplementation.getUserByEmail({ email });
+                if (this.thirdPartyImplementation === undefined) {
+                    return userFromEmailPass === undefined ? [] : [userFromEmailPass];
+                }
+                let usersFromThirdParty = yield this.thirdPartyImplementation.getUsersByEmail({ email });
+                if (userFromEmailPass !== undefined) {
+                    return [...usersFromThirdParty, userFromEmailPass];
+                }
+                return usersFromThirdParty;
+            });
         this.getUserByThirdPartyInfo = (input) =>
             __awaiter(this, void 0, void 0, function* () {
                 if (this.thirdPartyImplementation === undefined) {
@@ -77,6 +89,9 @@ class RecipeImplementation {
                 }
                 return userInfo.email;
             });
+        /**
+         * @deprecated Please do not override this function
+         *   */
         this.getUserByEmail = (input) =>
             __awaiter(this, void 0, void 0, function* () {
                 return this.emailPasswordImplementation.getUserByEmail(input);

--- a/lib/build/recipe/thirdpartyemailpassword/recipeImplementation/thirdPartyRecipeImplementation.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/recipeImplementation/thirdPartyRecipeImplementation.d.ts
@@ -23,6 +23,7 @@ export default class RecipeImplementation implements RecipeInterface {
           }
     >;
     getUserById: (input: { userId: string }) => Promise<User | undefined>;
+    getUsersByEmail: ({ email }: { email: string }) => Promise<User[]>;
     /**
      * @deprecated
      *   */

--- a/lib/build/recipe/thirdpartyemailpassword/recipeImplementation/thirdPartyRecipeImplementation.js
+++ b/lib/build/recipe/thirdpartyemailpassword/recipeImplementation/thirdPartyRecipeImplementation.js
@@ -80,6 +80,14 @@ class RecipeImplementation {
                     thirdParty: user.thirdParty,
                 };
             });
+        this.getUsersByEmail = ({ email }) =>
+            __awaiter(this, void 0, void 0, function* () {
+                let users = yield this.recipeImplementation.getUsersByEmail({ email });
+                // we filter out all non thirdparty users.
+                return users.filter((u) => {
+                    return u.thirdParty !== undefined;
+                });
+            });
         /**
          * @deprecated
          *   */

--- a/lib/build/recipe/thirdpartyemailpassword/types.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/types.d.ts
@@ -180,6 +180,7 @@ export declare type TypeNormalisedInput = {
 };
 export interface RecipeInterface {
     getUserById(input: { userId: string }): Promise<User | undefined>;
+    getUsersByEmail(input: { email: string }): Promise<User[]>;
     getUserByThirdPartyInfo(input: { thirdPartyId: string; thirdPartyUserId: string }): Promise<User | undefined>;
     /**
      * @deprecated Please do not override this function
@@ -247,6 +248,9 @@ export interface RecipeInterface {
               status: "WRONG_CREDENTIALS_ERROR";
           }
     >;
+    /**
+     * @deprecated Please do not override this function
+     *   */
     getUserByEmail(input: { email: string }): Promise<User | undefined>;
     createResetPasswordToken(input: {
         userId: string;

--- a/lib/ts/recipe/thirdparty/index.ts
+++ b/lib/ts/recipe/thirdparty/index.ts
@@ -47,6 +47,10 @@ export default class Wrapper {
         return Recipe.getInstanceOrThrowError().recipeInterfaceImpl.getUserById({ userId });
     }
 
+    static getUsersByEmail(email: string): Promise<User[]> {
+        return Recipe.getInstanceOrThrowError().recipeInterfaceImpl.getUsersByEmail({ email });
+    }
+
     static getUserByThirdPartyInfo(thirdPartyId: string, thirdPartyUserId: string): Promise<User | undefined> {
         return Recipe.getInstanceOrThrowError().recipeInterfaceImpl.getUserByThirdPartyInfo({
             thirdPartyId,
@@ -121,6 +125,8 @@ export let Error = Wrapper.Error;
 export let signInUp = Wrapper.signInUp;
 
 export let getUserById = Wrapper.getUserById;
+
+export let getUsersByEmail = Wrapper.getUsersByEmail;
 
 export let getUserByThirdPartyInfo = Wrapper.getUserByThirdPartyInfo;
 

--- a/lib/ts/recipe/thirdparty/recipeImplementation.ts
+++ b/lib/ts/recipe/thirdparty/recipeImplementation.ts
@@ -92,6 +92,14 @@ export default class RecipeImplementation implements RecipeInterface {
         }
     };
 
+    getUsersByEmail = async ({ email }: { email: string }): Promise<User[]> => {
+        const { users } = await this.querier.sendGetRequest(new NormalisedURLPath("/recipe/users/by-email"), {
+            email,
+        });
+
+        return users;
+    };
+
     getUserByThirdPartyInfo = async ({
         thirdPartyId,
         thirdPartyUserId,

--- a/lib/ts/recipe/thirdparty/types.ts
+++ b/lib/ts/recipe/thirdparty/types.ts
@@ -168,6 +168,8 @@ export type TypeNormalisedInput = {
 export interface RecipeInterface {
     getUserById(input: { userId: string }): Promise<User | undefined>;
 
+    getUsersByEmail(input: { email: string }): Promise<User[]>;
+
     getUserByThirdPartyInfo(input: { thirdPartyId: string; thirdPartyUserId: string }): Promise<User | undefined>;
 
     /**

--- a/lib/ts/recipe/thirdpartyemailpassword/index.ts
+++ b/lib/ts/recipe/thirdpartyemailpassword/index.ts
@@ -63,6 +63,13 @@ export default class Wrapper {
         return Recipe.getInstanceOrThrowError().recipeInterfaceImpl.getUserById({ userId });
     }
 
+    static getUsersByEmail(email: string) {
+        return Recipe.getInstanceOrThrowError().recipeInterfaceImpl.getUsersByEmail({ email });
+    }
+
+    /**
+     * @deprecated Use supertokens.getUsersByEmail(...) function instead IF using core version >= 3.5
+     *   */
     static getUserByEmail(email: string) {
         return Recipe.getInstanceOrThrowError().recipeInterfaceImpl.getUserByEmail({ email });
     }
@@ -131,7 +138,12 @@ export let getUserById = Wrapper.getUserById;
 
 export let getUserByThirdPartyInfo = Wrapper.getUserByThirdPartyInfo;
 
+/**
+ * @deprecated Use supertokens.getUsersByEmail(...) function instead IF using core version >= 3.5
+ *   */
 export let getUserByEmail = Wrapper.getUserByEmail;
+
+export let getUsersByEmail = Wrapper.getUsersByEmail;
 
 export let createResetPasswordToken = Wrapper.createResetPasswordToken;
 

--- a/lib/ts/recipe/thirdpartyemailpassword/recipeImplementation/index.ts
+++ b/lib/ts/recipe/thirdpartyemailpassword/recipeImplementation/index.ts
@@ -61,6 +61,20 @@ export default class RecipeImplementation implements RecipeInterface {
         return await this.thirdPartyImplementation.getUserById(input);
     };
 
+    getUsersByEmail = async ({ email }: { email: string }): Promise<User[]> => {
+        let userFromEmailPass: User | undefined = await this.emailPasswordImplementation.getUserByEmail({ email });
+
+        if (this.thirdPartyImplementation === undefined) {
+            return userFromEmailPass === undefined ? [] : [userFromEmailPass];
+        }
+        let usersFromThirdParty: User[] = await this.thirdPartyImplementation.getUsersByEmail({ email });
+
+        if (userFromEmailPass !== undefined) {
+            return [...usersFromThirdParty, userFromEmailPass];
+        }
+        return usersFromThirdParty;
+    };
+
     getUserByThirdPartyInfo = async (input: {
         thirdPartyId: string;
         thirdPartyUserId: string;
@@ -79,6 +93,9 @@ export default class RecipeImplementation implements RecipeInterface {
         return userInfo.email;
     };
 
+    /**
+     * @deprecated Please do not override this function
+     *   */
     getUserByEmail = async (input: { email: string }): Promise<User | undefined> => {
         return this.emailPasswordImplementation.getUserByEmail(input);
     };

--- a/lib/ts/recipe/thirdpartyemailpassword/recipeImplementation/thirdPartyRecipeImplementation.ts
+++ b/lib/ts/recipe/thirdpartyemailpassword/recipeImplementation/thirdPartyRecipeImplementation.ts
@@ -71,6 +71,15 @@ export default class RecipeImplementation implements RecipeInterface {
         };
     };
 
+    getUsersByEmail = async ({ email }: { email: string }): Promise<User[]> => {
+        let users = await this.recipeImplementation.getUsersByEmail({ email });
+
+        // we filter out all non thirdparty users.
+        return users.filter((u) => {
+            return u.thirdParty !== undefined;
+        }) as User[];
+    };
+
     /**
      * @deprecated
      *   */

--- a/lib/ts/recipe/thirdpartyemailpassword/types.ts
+++ b/lib/ts/recipe/thirdpartyemailpassword/types.ts
@@ -196,6 +196,8 @@ export type TypeNormalisedInput = {
 export interface RecipeInterface {
     getUserById(input: { userId: string }): Promise<User | undefined>;
 
+    getUsersByEmail(input: { email: string }): Promise<User[]>;
+
     getUserByThirdPartyInfo(input: { thirdPartyId: string; thirdPartyUserId: string }): Promise<User | undefined>;
 
     /**
@@ -250,6 +252,9 @@ export interface RecipeInterface {
         password: string;
     }): Promise<{ status: "OK"; user: User } | { status: "WRONG_CREDENTIALS_ERROR" }>;
 
+    /**
+     * @deprecated Please do not override this function
+     *   */
     getUserByEmail(input: { email: string }): Promise<User | undefined>;
 
     createResetPasswordToken(input: {

--- a/test/thirdparty/getUsersByEmailFeature.test.js
+++ b/test/thirdparty/getUsersByEmailFeature.test.js
@@ -1,0 +1,90 @@
+const { printPath, setupST, startST, killAllST, cleanST, createServerlessCacheForTesting } = require("../utils");
+let STExpress = require("../../");
+let assert = require("assert");
+let { ProcessState } = require("../../lib/build/processState");
+let ThirdPartyRecipe = require("../../lib/build/recipe/thirdparty/recipe").default;
+const { signInUp } = require("../../lib/build/recipe/thirdparty");
+const { getUsersByEmail } = require("../../lib/build/recipe/thirdparty");
+const { removeServerlessCache } = require("../../lib/build/utils");
+
+describe(`getUsersByEmail: ${printPath("[test/thirdparty/getUsersByEmailFeature.test.js]")}`, function () {
+    const MockThirdPartyProvider = {
+        id: "mock",
+    };
+
+    const MockThirdPartyProvider2 = {
+        id: "mock2",
+    };
+
+    const testSTConfig = {
+        supertokens: {
+            connectionURI: "http://localhost:8080",
+        },
+        appInfo: {
+            apiDomain: "api.supertokens.io",
+            appName: "SuperTokens",
+            websiteDomain: "supertokens.io",
+        },
+        recipeList: [
+            ThirdPartyRecipe.init({
+                signInAndUpFeature: {
+                    providers: [MockThirdPartyProvider],
+                },
+            }),
+        ],
+    };
+
+    beforeEach(async function () {
+        await killAllST();
+        await setupST();
+        await createServerlessCacheForTesting();
+        await removeServerlessCache();
+        ProcessState.getInstance().reset();
+    });
+
+    after(async function () {
+        await killAllST();
+        await cleanST();
+    });
+
+    it("invalid email yields empty users array", async function () {
+        await startST();
+        STExpress.init(testSTConfig);
+
+        // given there are no users
+
+        // when
+        const thirdPartyUsers = await getUsersByEmail("john.doe@example.com");
+
+        // then
+        assert.strictEqual(thirdPartyUsers.length, 0);
+    });
+
+    it("valid email yields third party users", async function () {
+        await startST();
+        STExpress.init({
+            ...testSTConfig,
+            recipeList: [
+                ThirdPartyRecipe.init({
+                    signInAndUpFeature: {
+                        providers: [MockThirdPartyProvider, MockThirdPartyProvider2],
+                    },
+                }),
+            ],
+        });
+
+        await signInUp("mock", "thirdPartyJohnDoe", { id: "john.doe@example.com", isVerified: true });
+        await signInUp("mock2", "thirdPartyDaveDoe", { id: "john.doe@example.com", isVerified: false });
+
+        const thirdPartyUsers = await getUsersByEmail("john.doe@example.com");
+
+        assert.strictEqual(thirdPartyUsers.length, 2);
+
+        thirdPartyUsers.forEach((user) => {
+            assert.notStrictEqual(user.thirdParty.id, undefined);
+            assert.notStrictEqual(user.id, undefined);
+            assert.notStrictEqual(user.timeJoined, undefined);
+            assert.strictEqual(user.email, "john.doe@example.com");
+        });
+    });
+});

--- a/test/thirdpartyemailpassword/getUsersByEmailFeature.test.js
+++ b/test/thirdpartyemailpassword/getUsersByEmailFeature.test.js
@@ -1,0 +1,87 @@
+const { printPath, setupST, startST, killAllST, cleanST, createServerlessCacheForTesting } = require("../utils");
+let STExpress = require("../../");
+let assert = require("assert");
+let { ProcessState } = require("../../lib/build/processState");
+let ThirdPartyEmailPassword = require("../../recipe/thirdpartyemailpassword");
+const { signInUp, getUsersByEmail, signUp } = require("../../lib/build/recipe/thirdpartyemailpassword");
+const { removeServerlessCache } = require("../../lib/build/utils");
+
+describe(`getUsersByEmail: ${printPath("[test/thirdpartyemailpassword/getUsersByEmailFeature.test.js]")}`, function () {
+    const MockThirdPartyProvider = {
+        id: "mock",
+    };
+
+    const MockThirdPartyProvider2 = {
+        id: "mock2",
+    };
+
+    const testSTConfig = {
+        supertokens: {
+            connectionURI: "http://localhost:8080",
+        },
+        appInfo: {
+            apiDomain: "api.supertokens.io",
+            appName: "SuperTokens",
+            websiteDomain: "supertokens.io",
+        },
+        recipeList: [
+            ThirdPartyEmailPassword.init({
+                signInAndUpFeature: {
+                    providers: [MockThirdPartyProvider],
+                },
+            }),
+        ],
+    };
+
+    beforeEach(async function () {
+        await killAllST();
+        await setupST();
+        await createServerlessCacheForTesting();
+        await removeServerlessCache();
+        ProcessState.getInstance().reset();
+    });
+
+    after(async function () {
+        await killAllST();
+        await cleanST();
+    });
+
+    it("invalid email yields empty users array", async function () {
+        await startST();
+        STExpress.init(testSTConfig);
+
+        // given there are no users
+
+        // when
+        const thirdPartyUsers = await getUsersByEmail("john.doe@example.com");
+
+        // then
+        assert.strictEqual(thirdPartyUsers.length, 0);
+    });
+
+    it("valid email yields third party users", async function () {
+        await startST();
+        STExpress.init({
+            ...testSTConfig,
+            recipeList: [
+                ThirdPartyEmailPassword.init({
+                    signInAndUpFeature: {
+                        providers: [MockThirdPartyProvider, MockThirdPartyProvider2],
+                    },
+                }),
+            ],
+        });
+
+        await signUp("john.doe@example.com", "somePass");
+        await signInUp("mock", "thirdPartyJohnDoe", { id: "john.doe@example.com", isVerified: true });
+        await signInUp("mock2", "thirdPartyDaveDoe", { id: "john.doe@example.com", isVerified: false });
+
+        const thirdPartyUsers = await getUsersByEmail("john.doe@example.com");
+
+        assert.strictEqual(thirdPartyUsers.length, 3);
+
+        thirdPartyUsers.forEach((user) => {
+            assert.strictEqual(user.email, "john.doe@example.com");
+        });
+    });
+});


### PR DESCRIPTION
## Summary of change
Changes recipe interface for thirdparty and thirdpartyemailpassword to fetch users based on email.

## Related issues
- https://github.com/supertokens/supertokens-core/issues/277

## Test Plan
- Fetched users based on email if none exist and check that the array length is 0
- Signed up users and checked that the users returned this time were correct.

## Documentation changes
- Deprecatation of `getUserByEmail` in thirdpartyemailpassword
- Addition of `getUsersByEmail` in thirdpartyemailpassword and thirdparty.

## Checklist for important updates
- [x] Changelog has been updated
- [x] Had run `npm run build-pretty`
- [x] Had installed and ran the pre-commit hook
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.