### PR TITLE
adds emailverification recipe functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Add recipe function to fetch third party users https://github.com/supertokens/supertokens-core/issues/277
 -   Deprecates `getUserByEmail` in thirdpartyemailpassword and replaces it with `getUsersByEmail`.
 -   Adds `updateEmailOrPassword` recipe function to emailpassword and thirdpartyemailpassword recipes: https://github.com/supertokens/supertokens-core/issues/275
+-   Adds emailverification recipe functions to all recipes: https://github.com/supertokens/supertokens-core/issues/270
 
 ## [6.0.4] - 2021-07-29
 

--- a/lib/build/recipe/emailpassword/index.d.ts
+++ b/lib/build/recipe/emailpassword/index.d.ts
@@ -38,8 +38,8 @@ export default class Wrapper {
     static createEmailVerificationToken(userId: string): Promise<string>;
     static verifyEmailUsingToken(token: string): Promise<User>;
     static isEmailVerified(userId: string): Promise<boolean>;
-    static revokeEmailVerificationTokens(userId: string, email: string): Promise<void>;
-    static unverifyEmail(userId: string, email: string): Promise<void>;
+    static revokeEmailVerificationTokens(userId: string): Promise<void>;
+    static unverifyEmail(userId: string): Promise<void>;
 }
 export declare let init: typeof Recipe.init;
 export declare let Error: typeof SuperTokensError;

--- a/lib/build/recipe/emailpassword/index.d.ts
+++ b/lib/build/recipe/emailpassword/index.d.ts
@@ -38,6 +38,8 @@ export default class Wrapper {
     static createEmailVerificationToken(userId: string): Promise<string>;
     static verifyEmailUsingToken(token: string): Promise<User>;
     static isEmailVerified(userId: string): Promise<boolean>;
+    static revokeEmailVerificationTokens(userId: string, email: string): Promise<void>;
+    static unverifyEmail(userId: string, email: string): Promise<void>;
 }
 export declare let init: typeof Recipe.init;
 export declare let Error: typeof SuperTokensError;
@@ -50,6 +52,8 @@ export declare let resetPasswordUsingToken: typeof Wrapper.resetPasswordUsingTok
 export declare let createEmailVerificationToken: typeof Wrapper.createEmailVerificationToken;
 export declare let verifyEmailUsingToken: typeof Wrapper.verifyEmailUsingToken;
 export declare let isEmailVerified: typeof Wrapper.isEmailVerified;
+export declare let revokeEmailVerificationTokens: typeof Wrapper.revokeEmailVerificationTokens;
+export declare let unverifyEmail: typeof Wrapper.unverifyEmail;
 /**
  * @deprecated Use supertokens.getUsersOldestFirst(...) function instead IF using core version >= 3.5
  *   */

--- a/lib/build/recipe/emailpassword/index.js
+++ b/lib/build/recipe/emailpassword/index.js
@@ -110,9 +110,10 @@ class Wrapper {
     }
     static unverifyEmail(userId, email) {
         return __awaiter(this, void 0, void 0, function* () {
-            yield recipe_1.default
-                .getInstanceOrThrowError()
-                .emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({ userId, email });
+            yield recipe_1.default.getInstanceOrThrowError().emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({
+                userId,
+                email,
+            });
         });
     }
 }

--- a/lib/build/recipe/emailpassword/index.js
+++ b/lib/build/recipe/emailpassword/index.js
@@ -101,19 +101,14 @@ class Wrapper {
     static isEmailVerified(userId) {
         return recipe_1.default.getInstanceOrThrowError().isEmailVerified(userId);
     }
-    static revokeEmailVerificationTokens(userId, email) {
+    static revokeEmailVerificationTokens(userId) {
         return __awaiter(this, void 0, void 0, function* () {
-            yield recipe_1.default
-                .getInstanceOrThrowError()
-                .emailVerificationRecipe.recipeInterfaceImpl.revokeEmailVerificationTokens({ userId, email });
+            yield recipe_1.default.getInstanceOrThrowError().revokeEmailVerificationTokens(userId);
         });
     }
-    static unverifyEmail(userId, email) {
+    static unverifyEmail(userId) {
         return __awaiter(this, void 0, void 0, function* () {
-            yield recipe_1.default.getInstanceOrThrowError().emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({
-                userId,
-                email,
-            });
+            yield recipe_1.default.getInstanceOrThrowError().unverifyEmail(userId);
         });
     }
 }

--- a/lib/build/recipe/emailpassword/index.js
+++ b/lib/build/recipe/emailpassword/index.js
@@ -13,6 +13,37 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 const recipe_1 = require("./recipe");
 const error_1 = require("./error");
@@ -70,6 +101,20 @@ class Wrapper {
     static isEmailVerified(userId) {
         return recipe_1.default.getInstanceOrThrowError().isEmailVerified(userId);
     }
+    static revokeEmailVerificationTokens(userId, email) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield recipe_1.default
+                .getInstanceOrThrowError()
+                .emailVerificationRecipe.recipeInterfaceImpl.revokeEmailVerificationTokens({ userId, email });
+        });
+    }
+    static unverifyEmail(userId, email) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield recipe_1.default
+                .getInstanceOrThrowError()
+                .emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({ userId, email });
+        });
+    }
 }
 exports.default = Wrapper;
 Wrapper.init = recipe_1.default.init;
@@ -85,6 +130,8 @@ exports.resetPasswordUsingToken = Wrapper.resetPasswordUsingToken;
 exports.createEmailVerificationToken = Wrapper.createEmailVerificationToken;
 exports.verifyEmailUsingToken = Wrapper.verifyEmailUsingToken;
 exports.isEmailVerified = Wrapper.isEmailVerified;
+exports.revokeEmailVerificationTokens = Wrapper.revokeEmailVerificationTokens;
+exports.unverifyEmail = Wrapper.unverifyEmail;
 /**
  * @deprecated Use supertokens.getUsersOldestFirst(...) function instead IF using core version >= 3.5
  *   */

--- a/lib/build/recipe/emailpassword/recipe.d.ts
+++ b/lib/build/recipe/emailpassword/recipe.d.ts
@@ -46,6 +46,8 @@ export default class Recipe extends RecipeModule {
     createEmailVerificationToken: (userId: string) => Promise<string>;
     verifyEmailUsingToken: (token: string) => Promise<import("./types").User>;
     isEmailVerified: (userId: string) => Promise<boolean>;
+    revokeEmailVerificationTokens: (userId: string) => Promise<void>;
+    unverifyEmail: (userId: string) => Promise<void>;
     signUp: (email: string, password: string) => Promise<import("./types").User>;
     signIn: (email: string, password: string) => Promise<import("./types").User>;
     createResetPasswordToken: (userId: string) => Promise<string>;

--- a/lib/build/recipe/emailpassword/recipe.js
+++ b/lib/build/recipe/emailpassword/recipe.js
@@ -182,6 +182,20 @@ class Recipe extends recipeModule_1.default {
                     email: yield this.getEmailForUserId(userId),
                 });
             });
+        this.revokeEmailVerificationTokens = (userId) =>
+            __awaiter(this, void 0, void 0, function* () {
+                yield this.emailVerificationRecipe.recipeInterfaceImpl.revokeEmailVerificationTokens({
+                    userId,
+                    email: yield this.getEmailForUserId(userId),
+                });
+            });
+        this.unverifyEmail = (userId) =>
+            __awaiter(this, void 0, void 0, function* () {
+                yield this.emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({
+                    userId,
+                    email: yield this.getEmailForUserId(userId),
+                });
+            });
         this.signUp = (email, password) =>
             __awaiter(this, void 0, void 0, function* () {
                 let response = yield this.recipeInterfaceImpl.signUp({ email, password });

--- a/lib/build/recipe/emailverification/index.d.ts
+++ b/lib/build/recipe/emailverification/index.d.ts
@@ -7,10 +7,14 @@ export default class Wrapper {
     static createEmailVerificationToken(userId: string, email: string): Promise<string>;
     static verifyEmailUsingToken(token: string): Promise<User>;
     static isEmailVerified(userId: string, email: string): Promise<boolean>;
+    static revokeEmailVerificationTokens(userId: string, email: string): Promise<void>;
+    static unverifyEmail(userId: string, email: string): Promise<void>;
 }
 export declare let init: typeof Recipe.init;
 export declare let Error: typeof SuperTokensError;
 export declare let createEmailVerificationToken: typeof Wrapper.createEmailVerificationToken;
 export declare let verifyEmailUsingToken: typeof Wrapper.verifyEmailUsingToken;
 export declare let isEmailVerified: typeof Wrapper.isEmailVerified;
+export declare let revokeEmailVerificationTokens: typeof Wrapper.revokeEmailVerificationTokens;
+export declare let unverifyEmail: typeof Wrapper.unverifyEmail;
 export type { RecipeInterface, APIOptions, APIInterface, User };

--- a/lib/build/recipe/emailverification/index.js
+++ b/lib/build/recipe/emailverification/index.js
@@ -65,6 +65,18 @@ class Wrapper {
                 .recipeInterfaceImpl.isEmailVerified({ userId, email });
         });
     }
+    static revokeEmailVerificationTokens(userId, email) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield recipe_1.default
+                .getInstanceOrThrowError()
+                .recipeInterfaceImpl.revokeEmailVerificationTokens({ userId, email });
+        });
+    }
+    static unverifyEmail(userId, email) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield recipe_1.default.getInstanceOrThrowError().recipeInterfaceImpl.unverifyEmail({ userId, email });
+        });
+    }
 }
 exports.default = Wrapper;
 Wrapper.init = recipe_1.default.init;
@@ -74,4 +86,6 @@ exports.Error = Wrapper.Error;
 exports.createEmailVerificationToken = Wrapper.createEmailVerificationToken;
 exports.verifyEmailUsingToken = Wrapper.verifyEmailUsingToken;
 exports.isEmailVerified = Wrapper.isEmailVerified;
+exports.revokeEmailVerificationTokens = Wrapper.revokeEmailVerificationTokens;
+exports.unverifyEmail = Wrapper.unverifyEmail;
 //# sourceMappingURL=index.js.map

--- a/lib/build/recipe/emailverification/recipeImplementation.d.ts
+++ b/lib/build/recipe/emailverification/recipeImplementation.d.ts
@@ -32,4 +32,16 @@ export default class RecipeImplementation implements RecipeInterface {
           }
     >;
     isEmailVerified: ({ userId, email }: { userId: string; email: string }) => Promise<boolean>;
+    revokeEmailVerificationTokens: (input: {
+        userId: string;
+        email: string;
+    }) => Promise<{
+        status: "OK";
+    }>;
+    unverifyEmail: (input: {
+        userId: string;
+        email: string;
+    }) => Promise<{
+        status: "OK";
+    }>;
 }

--- a/lib/build/recipe/emailverification/recipeImplementation.js
+++ b/lib/build/recipe/emailverification/recipeImplementation.js
@@ -88,6 +88,28 @@ class RecipeImplementation {
                 );
                 return response.isVerified;
             });
+        this.revokeEmailVerificationTokens = (input) =>
+            __awaiter(this, void 0, void 0, function* () {
+                yield this.querier.sendPostRequest(
+                    new normalisedURLPath_1.default("/recipe/user/email/verify/token/remove"),
+                    {
+                        userId: input.userId,
+                        email: input.email,
+                    }
+                );
+                return { status: "OK" };
+            });
+        this.unverifyEmail = (input) =>
+            __awaiter(this, void 0, void 0, function* () {
+                yield this.querier.sendPostRequest(
+                    new normalisedURLPath_1.default("/recipe/user/email/verify/remove"),
+                    {
+                        userId: input.userId,
+                        email: input.email,
+                    }
+                );
+                return { status: "OK" };
+            });
         this.querier = querier;
     }
 }

--- a/lib/build/recipe/emailverification/types.d.ts
+++ b/lib/build/recipe/emailverification/types.d.ts
@@ -46,6 +46,18 @@ export interface RecipeInterface {
           }
     >;
     isEmailVerified(input: { userId: string; email: string }): Promise<boolean>;
+    revokeEmailVerificationTokens(input: {
+        userId: string;
+        email: string;
+    }): Promise<{
+        status: "OK";
+    }>;
+    unverifyEmail(input: {
+        userId: string;
+        email: string;
+    }): Promise<{
+        status: "OK";
+    }>;
 }
 export declare type APIOptions = {
     recipeImplementation: RecipeInterface;

--- a/lib/build/recipe/emailverification/types.js
+++ b/lib/build/recipe/emailverification/types.js
@@ -1,3 +1,17 @@
 "use strict";
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 Object.defineProperty(exports, "__esModule", { value: true });
 //# sourceMappingURL=types.js.map

--- a/lib/build/recipe/thirdparty/index.d.ts
+++ b/lib/build/recipe/thirdparty/index.d.ts
@@ -45,6 +45,8 @@ export default class Wrapper {
     static createEmailVerificationToken(userId: string): Promise<string>;
     static verifyEmailUsingToken(token: string): Promise<User>;
     static isEmailVerified(userId: string): Promise<boolean>;
+    static revokeEmailVerificationTokens(userId: string, email: string): Promise<void>;
+    static unverifyEmail(userId: string, email: string): Promise<void>;
     static Google: typeof import("./providers/google").default;
     static Github: typeof import("./providers/github").default;
     static Facebook: typeof import("./providers/facebook").default;
@@ -59,6 +61,8 @@ export declare let getUserByThirdPartyInfo: typeof Wrapper.getUserByThirdPartyIn
 export declare let createEmailVerificationToken: typeof Wrapper.createEmailVerificationToken;
 export declare let verifyEmailUsingToken: typeof Wrapper.verifyEmailUsingToken;
 export declare let isEmailVerified: typeof Wrapper.isEmailVerified;
+export declare let revokeEmailVerificationTokens: typeof Wrapper.revokeEmailVerificationTokens;
+export declare let unverifyEmail: typeof Wrapper.unverifyEmail;
 /**
  * @deprecated Use supertokens.getUsersOldestFirst(...) function instead IF using core version >= 3.5
  *   */

--- a/lib/build/recipe/thirdparty/index.d.ts
+++ b/lib/build/recipe/thirdparty/index.d.ts
@@ -45,8 +45,8 @@ export default class Wrapper {
     static createEmailVerificationToken(userId: string): Promise<string>;
     static verifyEmailUsingToken(token: string): Promise<User>;
     static isEmailVerified(userId: string): Promise<boolean>;
-    static revokeEmailVerificationTokens(userId: string, email: string): Promise<void>;
-    static unverifyEmail(userId: string, email: string): Promise<void>;
+    static revokeEmailVerificationTokens(userId: string): Promise<void>;
+    static unverifyEmail(userId: string): Promise<void>;
     static Google: typeof import("./providers/google").default;
     static Github: typeof import("./providers/github").default;
     static Facebook: typeof import("./providers/facebook").default;

--- a/lib/build/recipe/thirdparty/index.js
+++ b/lib/build/recipe/thirdparty/index.js
@@ -108,19 +108,14 @@ class Wrapper {
     static isEmailVerified(userId) {
         return recipe_1.default.getInstanceOrThrowError().isEmailVerified(userId);
     }
-    static revokeEmailVerificationTokens(userId, email) {
+    static revokeEmailVerificationTokens(userId) {
         return __awaiter(this, void 0, void 0, function* () {
-            yield recipe_1.default
-                .getInstanceOrThrowError()
-                .emailVerificationRecipe.recipeInterfaceImpl.revokeEmailVerificationTokens({ userId, email });
+            yield recipe_1.default.getInstanceOrThrowError().revokeEmailVerificationTokens(userId);
         });
     }
-    static unverifyEmail(userId, email) {
+    static unverifyEmail(userId) {
         return __awaiter(this, void 0, void 0, function* () {
-            yield recipe_1.default.getInstanceOrThrowError().emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({
-                userId,
-                email,
-            });
+            yield recipe_1.default.getInstanceOrThrowError().unverifyEmail(userId);
         });
     }
 }

--- a/lib/build/recipe/thirdparty/index.js
+++ b/lib/build/recipe/thirdparty/index.js
@@ -117,9 +117,10 @@ class Wrapper {
     }
     static unverifyEmail(userId, email) {
         return __awaiter(this, void 0, void 0, function* () {
-            yield recipe_1.default
-                .getInstanceOrThrowError()
-                .emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({ userId, email });
+            yield recipe_1.default.getInstanceOrThrowError().emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({
+                userId,
+                email,
+            });
         });
     }
 }

--- a/lib/build/recipe/thirdparty/index.js
+++ b/lib/build/recipe/thirdparty/index.js
@@ -108,6 +108,20 @@ class Wrapper {
     static isEmailVerified(userId) {
         return recipe_1.default.getInstanceOrThrowError().isEmailVerified(userId);
     }
+    static revokeEmailVerificationTokens(userId, email) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield recipe_1.default
+                .getInstanceOrThrowError()
+                .emailVerificationRecipe.recipeInterfaceImpl.revokeEmailVerificationTokens({ userId, email });
+        });
+    }
+    static unverifyEmail(userId, email) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield recipe_1.default
+                .getInstanceOrThrowError()
+                .emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({ userId, email });
+        });
+    }
 }
 exports.default = Wrapper;
 Wrapper.init = recipe_1.default.init;
@@ -125,6 +139,8 @@ exports.getUserByThirdPartyInfo = Wrapper.getUserByThirdPartyInfo;
 exports.createEmailVerificationToken = Wrapper.createEmailVerificationToken;
 exports.verifyEmailUsingToken = Wrapper.verifyEmailUsingToken;
 exports.isEmailVerified = Wrapper.isEmailVerified;
+exports.revokeEmailVerificationTokens = Wrapper.revokeEmailVerificationTokens;
+exports.unverifyEmail = Wrapper.unverifyEmail;
 /**
  * @deprecated Use supertokens.getUsersOldestFirst(...) function instead IF using core version >= 3.5
  *   */

--- a/lib/build/recipe/thirdparty/recipe.d.ts
+++ b/lib/build/recipe/thirdparty/recipe.d.ts
@@ -47,4 +47,6 @@ export default class Recipe extends RecipeModule {
     createEmailVerificationToken: (userId: string) => Promise<string>;
     verifyEmailUsingToken: (token: string) => Promise<User>;
     isEmailVerified: (userId: string) => Promise<boolean>;
+    revokeEmailVerificationTokens: (userId: string) => Promise<void>;
+    unverifyEmail: (userId: string) => Promise<void>;
 }

--- a/lib/build/recipe/thirdparty/recipe.js
+++ b/lib/build/recipe/thirdparty/recipe.js
@@ -145,6 +145,20 @@ class Recipe extends recipeModule_1.default {
                     email: yield this.getEmailForUserId(userId),
                 });
             });
+        this.revokeEmailVerificationTokens = (userId) =>
+            __awaiter(this, void 0, void 0, function* () {
+                yield this.emailVerificationRecipe.recipeInterfaceImpl.revokeEmailVerificationTokens({
+                    userId,
+                    email: yield this.getEmailForUserId(userId),
+                });
+            });
+        this.unverifyEmail = (userId) =>
+            __awaiter(this, void 0, void 0, function* () {
+                yield this.emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({
+                    userId,
+                    email: yield this.getEmailForUserId(userId),
+                });
+            });
         this.config = utils_1.validateAndNormaliseUserInput(this, appInfo, config);
         this.isInServerlessEnv = isInServerlessEnv;
         this.emailVerificationRecipe =

--- a/lib/build/recipe/thirdpartyemailpassword/index.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/index.d.ts
@@ -113,6 +113,8 @@ export default class Wrapper {
     static createEmailVerificationToken(userId: string): Promise<string>;
     static verifyEmailUsingToken(token: string): Promise<User>;
     static isEmailVerified(userId: string): Promise<boolean>;
+    static revokeEmailVerificationTokens(userId: string, email: string): Promise<void>;
+    static unverifyEmail(userId: string, email: string): Promise<void>;
     static Google: typeof import("../thirdparty/providers/google").default;
     static Github: typeof import("../thirdparty/providers/github").default;
     static Facebook: typeof import("../thirdparty/providers/facebook").default;
@@ -135,6 +137,8 @@ export declare let resetPasswordUsingToken: typeof Wrapper.resetPasswordUsingTok
 export declare let createEmailVerificationToken: typeof Wrapper.createEmailVerificationToken;
 export declare let verifyEmailUsingToken: typeof Wrapper.verifyEmailUsingToken;
 export declare let isEmailVerified: typeof Wrapper.isEmailVerified;
+export declare let revokeEmailVerificationTokens: typeof Wrapper.revokeEmailVerificationTokens;
+export declare let unverifyEmail: typeof Wrapper.unverifyEmail;
 /**
  * @deprecated Use supertokens.getUsersOldestFirst(...) function instead IF using core version >= 3.5
  *   */

--- a/lib/build/recipe/thirdpartyemailpassword/index.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/index.d.ts
@@ -113,8 +113,8 @@ export default class Wrapper {
     static createEmailVerificationToken(userId: string): Promise<string>;
     static verifyEmailUsingToken(token: string): Promise<User>;
     static isEmailVerified(userId: string): Promise<boolean>;
-    static revokeEmailVerificationTokens(userId: string, email: string): Promise<void>;
-    static unverifyEmail(userId: string, email: string): Promise<void>;
+    static revokeEmailVerificationTokens(userId: string): Promise<void>;
+    static unverifyEmail(userId: string): Promise<void>;
     static Google: typeof import("../thirdparty/providers/google").default;
     static Github: typeof import("../thirdparty/providers/github").default;
     static Facebook: typeof import("../thirdparty/providers/facebook").default;

--- a/lib/build/recipe/thirdpartyemailpassword/index.js
+++ b/lib/build/recipe/thirdpartyemailpassword/index.js
@@ -130,9 +130,10 @@ class Wrapper {
     }
     static unverifyEmail(userId, email) {
         return __awaiter(this, void 0, void 0, function* () {
-            yield recipe_1.default
-                .getInstanceOrThrowError()
-                .emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({ userId, email });
+            yield recipe_1.default.getInstanceOrThrowError().emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({
+                userId,
+                email,
+            });
         });
     }
 }

--- a/lib/build/recipe/thirdpartyemailpassword/index.js
+++ b/lib/build/recipe/thirdpartyemailpassword/index.js
@@ -13,6 +13,37 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 const recipe_1 = require("./recipe");
 const error_1 = require("./error");
@@ -90,6 +121,20 @@ class Wrapper {
     static isEmailVerified(userId) {
         return recipe_1.default.getInstanceOrThrowError().isEmailVerified(userId);
     }
+    static revokeEmailVerificationTokens(userId, email) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield recipe_1.default
+                .getInstanceOrThrowError()
+                .emailVerificationRecipe.recipeInterfaceImpl.revokeEmailVerificationTokens({ userId, email });
+        });
+    }
+    static unverifyEmail(userId, email) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield recipe_1.default
+                .getInstanceOrThrowError()
+                .emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({ userId, email });
+        });
+    }
 }
 exports.default = Wrapper;
 Wrapper.init = recipe_1.default.init;
@@ -115,6 +160,8 @@ exports.resetPasswordUsingToken = Wrapper.resetPasswordUsingToken;
 exports.createEmailVerificationToken = Wrapper.createEmailVerificationToken;
 exports.verifyEmailUsingToken = Wrapper.verifyEmailUsingToken;
 exports.isEmailVerified = Wrapper.isEmailVerified;
+exports.revokeEmailVerificationTokens = Wrapper.revokeEmailVerificationTokens;
+exports.unverifyEmail = Wrapper.unverifyEmail;
 /**
  * @deprecated Use supertokens.getUsersOldestFirst(...) function instead IF using core version >= 3.5
  *   */

--- a/lib/build/recipe/thirdpartyemailpassword/index.js
+++ b/lib/build/recipe/thirdpartyemailpassword/index.js
@@ -121,19 +121,14 @@ class Wrapper {
     static isEmailVerified(userId) {
         return recipe_1.default.getInstanceOrThrowError().isEmailVerified(userId);
     }
-    static revokeEmailVerificationTokens(userId, email) {
+    static revokeEmailVerificationTokens(userId) {
         return __awaiter(this, void 0, void 0, function* () {
-            yield recipe_1.default
-                .getInstanceOrThrowError()
-                .emailVerificationRecipe.recipeInterfaceImpl.revokeEmailVerificationTokens({ userId, email });
+            yield recipe_1.default.getInstanceOrThrowError().revokeEmailVerificationTokens(userId);
         });
     }
-    static unverifyEmail(userId, email) {
+    static unverifyEmail(userId) {
         return __awaiter(this, void 0, void 0, function* () {
-            yield recipe_1.default.getInstanceOrThrowError().emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({
-                userId,
-                email,
-            });
+            yield recipe_1.default.getInstanceOrThrowError().unverifyEmail(userId);
         });
     }
 }

--- a/lib/build/recipe/thirdpartyemailpassword/recipe.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/recipe.d.ts
@@ -53,4 +53,6 @@ export default class Recipe extends RecipeModule {
     createEmailVerificationToken: (userId: string) => Promise<string>;
     verifyEmailUsingToken: (token: string) => Promise<User>;
     isEmailVerified: (userId: string) => Promise<boolean>;
+    revokeEmailVerificationTokens: (userId: string) => Promise<void>;
+    unverifyEmail: (userId: string) => Promise<void>;
 }

--- a/lib/build/recipe/thirdpartyemailpassword/recipe.js
+++ b/lib/build/recipe/thirdpartyemailpassword/recipe.js
@@ -147,6 +147,20 @@ class Recipe extends recipeModule_1.default {
                     email: yield this.getEmailForUserId(userId),
                 });
             });
+        this.revokeEmailVerificationTokens = (userId) =>
+            __awaiter(this, void 0, void 0, function* () {
+                yield this.emailVerificationRecipe.recipeInterfaceImpl.revokeEmailVerificationTokens({
+                    userId,
+                    email: yield this.getEmailForUserId(userId),
+                });
+            });
+        this.unverifyEmail = (userId) =>
+            __awaiter(this, void 0, void 0, function* () {
+                yield this.emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({
+                    userId,
+                    email: yield this.getEmailForUserId(userId),
+                });
+            });
         this.config = utils_1.validateAndNormaliseUserInput(this, appInfo, config);
         this.recipeInterfaceImpl = this.config.override.functions(
             new recipeImplementation_1.default(

--- a/lib/build/recipe/thirdpartyemailpassword/recipeImplementation/index.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/recipeImplementation/index.d.ts
@@ -84,6 +84,9 @@ export default class RecipeImplementation implements RecipeInterface {
         nextPaginationTokenString?: string | undefined;
     }) => Promise<{
         users: User[];
+        /**
+         * @deprecated Please do not override this function
+         *   */
         nextPaginationToken?: string | undefined;
     }>;
     /**
@@ -97,6 +100,9 @@ export default class RecipeImplementation implements RecipeInterface {
         nextPaginationTokenString?: string | undefined;
     }) => Promise<{
         users: User[];
+        /**
+         * @deprecated Please do not override this function
+         *   */
         nextPaginationToken?: string | undefined;
     }>;
     /**

--- a/lib/ts/recipe/emailpassword/index.ts
+++ b/lib/ts/recipe/emailpassword/index.ts
@@ -95,6 +95,19 @@ export default class Wrapper {
     static isEmailVerified(userId: string): Promise<boolean> {
         return Recipe.getInstanceOrThrowError().isEmailVerified(userId);
     }
+
+    static async revokeEmailVerificationTokens(userId: string, email: string): Promise<void> {
+        await Recipe.getInstanceOrThrowError().emailVerificationRecipe.recipeInterfaceImpl.revokeEmailVerificationTokens(
+            { userId, email }
+        );
+    }
+
+    static async unverifyEmail(userId: string, email: string): Promise<void> {
+        await Recipe.getInstanceOrThrowError().emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({
+            userId,
+            email,
+        });
+    }
 }
 
 export let init = Wrapper.init;
@@ -118,6 +131,10 @@ export let createEmailVerificationToken = Wrapper.createEmailVerificationToken;
 export let verifyEmailUsingToken = Wrapper.verifyEmailUsingToken;
 
 export let isEmailVerified = Wrapper.isEmailVerified;
+
+export let revokeEmailVerificationTokens = Wrapper.revokeEmailVerificationTokens;
+
+export let unverifyEmail = Wrapper.unverifyEmail;
 
 /**
  * @deprecated Use supertokens.getUsersOldestFirst(...) function instead IF using core version >= 3.5

--- a/lib/ts/recipe/emailpassword/index.ts
+++ b/lib/ts/recipe/emailpassword/index.ts
@@ -96,17 +96,12 @@ export default class Wrapper {
         return Recipe.getInstanceOrThrowError().isEmailVerified(userId);
     }
 
-    static async revokeEmailVerificationTokens(userId: string, email: string): Promise<void> {
-        await Recipe.getInstanceOrThrowError().emailVerificationRecipe.recipeInterfaceImpl.revokeEmailVerificationTokens(
-            { userId, email }
-        );
+    static async revokeEmailVerificationTokens(userId: string): Promise<void> {
+        await Recipe.getInstanceOrThrowError().revokeEmailVerificationTokens(userId);
     }
 
-    static async unverifyEmail(userId: string, email: string): Promise<void> {
-        await Recipe.getInstanceOrThrowError().emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({
-            userId,
-            email,
-        });
+    static async unverifyEmail(userId: string): Promise<void> {
+        await Recipe.getInstanceOrThrowError().unverifyEmail(userId);
     }
 }
 

--- a/lib/ts/recipe/emailpassword/recipe.ts
+++ b/lib/ts/recipe/emailpassword/recipe.ts
@@ -235,6 +235,20 @@ export default class Recipe extends RecipeModule {
         });
     };
 
+    revokeEmailVerificationTokens = async (userId: string): Promise<void> => {
+        await this.emailVerificationRecipe.recipeInterfaceImpl.revokeEmailVerificationTokens({
+            userId,
+            email: await this.getEmailForUserId(userId),
+        });
+    };
+
+    unverifyEmail = async (userId: string): Promise<void> => {
+        await this.emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({
+            userId,
+            email: await this.getEmailForUserId(userId),
+        });
+    };
+
     signUp = async (email: string, password: string) => {
         let response = await this.recipeInterfaceImpl.signUp({ email, password });
         if (response.status === "OK") {

--- a/lib/ts/recipe/emailverification/index.ts
+++ b/lib/ts/recipe/emailverification/index.ts
@@ -33,6 +33,14 @@ export default class Wrapper {
     static async isEmailVerified(userId: string, email: string): Promise<boolean> {
         return await Recipe.getInstanceOrThrowError().recipeInterfaceImpl.isEmailVerified({ userId, email });
     }
+
+    static async revokeEmailVerificationTokens(userId: string, email: string): Promise<void> {
+        await Recipe.getInstanceOrThrowError().recipeInterfaceImpl.revokeEmailVerificationTokens({ userId, email });
+    }
+
+    static async unverifyEmail(userId: string, email: string): Promise<void> {
+        await Recipe.getInstanceOrThrowError().recipeInterfaceImpl.unverifyEmail({ userId, email });
+    }
 }
 
 export let init = Wrapper.init;
@@ -44,5 +52,9 @@ export let createEmailVerificationToken = Wrapper.createEmailVerificationToken;
 export let verifyEmailUsingToken = Wrapper.verifyEmailUsingToken;
 
 export let isEmailVerified = Wrapper.isEmailVerified;
+
+export let revokeEmailVerificationTokens = Wrapper.revokeEmailVerificationTokens;
+
+export let unverifyEmail = Wrapper.unverifyEmail;
 
 export type { RecipeInterface, APIOptions, APIInterface, User };

--- a/lib/ts/recipe/emailverification/recipeImplementation.ts
+++ b/lib/ts/recipe/emailverification/recipeImplementation.ts
@@ -68,4 +68,20 @@ export default class RecipeImplementation implements RecipeInterface {
         });
         return response.isVerified;
     };
+
+    revokeEmailVerificationTokens = async (input: { userId: string; email: string }): Promise<{ status: "OK" }> => {
+        await this.querier.sendPostRequest(new NormalisedURLPath("/recipe/user/email/verify/token/remove"), {
+            userId: input.userId,
+            email: input.email,
+        });
+        return { status: "OK" };
+    };
+
+    unverifyEmail = async (input: { userId: string; email: string }): Promise<{ status: "OK" }> => {
+        await this.querier.sendPostRequest(new NormalisedURLPath("/recipe/user/email/verify/remove"), {
+            userId: input.userId,
+            email: input.email,
+        });
+        return { status: "OK" };
+    };
 }

--- a/lib/ts/recipe/emailverification/types.ts
+++ b/lib/ts/recipe/emailverification/types.ts
@@ -1,4 +1,3 @@
-import { Request, Response, NextFunction } from "express";
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
  * This software is licensed under the Apache License, Version 2.0 (the
@@ -13,6 +12,8 @@ import { Request, Response, NextFunction } from "express";
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
+import { Request, Response, NextFunction } from "express";
 
 export type TypeInput = {
     getEmailForUserId: (userId: string) => Promise<string>;
@@ -56,6 +57,10 @@ export interface RecipeInterface {
     }): Promise<{ status: "OK"; user: User } | { status: "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR" }>;
 
     isEmailVerified(input: { userId: string; email: string }): Promise<boolean>;
+
+    revokeEmailVerificationTokens(input: { userId: string; email: string }): Promise<{ status: "OK" }>;
+
+    unverifyEmail(input: { userId: string; email: string }): Promise<{ status: "OK" }>;
 }
 
 export type APIOptions = {

--- a/lib/ts/recipe/thirdparty/index.ts
+++ b/lib/ts/recipe/thirdparty/index.ts
@@ -109,6 +109,19 @@ export default class Wrapper {
         return Recipe.getInstanceOrThrowError().isEmailVerified(userId);
     }
 
+    static async revokeEmailVerificationTokens(userId: string, email: string): Promise<void> {
+        await Recipe.getInstanceOrThrowError().emailVerificationRecipe.recipeInterfaceImpl.revokeEmailVerificationTokens(
+            { userId, email }
+        );
+    }
+
+    static async unverifyEmail(userId: string, email: string): Promise<void> {
+        await Recipe.getInstanceOrThrowError().emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({
+            userId,
+            email,
+        });
+    }
+
     static Google = thirdPartyProviders.Google;
 
     static Github = thirdPartyProviders.Github;
@@ -135,6 +148,10 @@ export let createEmailVerificationToken = Wrapper.createEmailVerificationToken;
 export let verifyEmailUsingToken = Wrapper.verifyEmailUsingToken;
 
 export let isEmailVerified = Wrapper.isEmailVerified;
+
+export let revokeEmailVerificationTokens = Wrapper.revokeEmailVerificationTokens;
+
+export let unverifyEmail = Wrapper.unverifyEmail;
 
 /**
  * @deprecated Use supertokens.getUsersOldestFirst(...) function instead IF using core version >= 3.5

--- a/lib/ts/recipe/thirdparty/index.ts
+++ b/lib/ts/recipe/thirdparty/index.ts
@@ -109,17 +109,12 @@ export default class Wrapper {
         return Recipe.getInstanceOrThrowError().isEmailVerified(userId);
     }
 
-    static async revokeEmailVerificationTokens(userId: string, email: string): Promise<void> {
-        await Recipe.getInstanceOrThrowError().emailVerificationRecipe.recipeInterfaceImpl.revokeEmailVerificationTokens(
-            { userId, email }
-        );
+    static async revokeEmailVerificationTokens(userId: string): Promise<void> {
+        await Recipe.getInstanceOrThrowError().revokeEmailVerificationTokens(userId);
     }
 
-    static async unverifyEmail(userId: string, email: string): Promise<void> {
-        await Recipe.getInstanceOrThrowError().emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({
-            userId,
-            email,
-        });
+    static async unverifyEmail(userId: string): Promise<void> {
+        await Recipe.getInstanceOrThrowError().unverifyEmail(userId);
     }
 
     static Google = thirdPartyProviders.Google;

--- a/lib/ts/recipe/thirdparty/recipe.ts
+++ b/lib/ts/recipe/thirdparty/recipe.ts
@@ -197,4 +197,18 @@ export default class Recipe extends RecipeModule {
             email: await this.getEmailForUserId(userId),
         });
     };
+
+    revokeEmailVerificationTokens = async (userId: string): Promise<void> => {
+        await this.emailVerificationRecipe.recipeInterfaceImpl.revokeEmailVerificationTokens({
+            userId,
+            email: await this.getEmailForUserId(userId),
+        });
+    };
+
+    unverifyEmail = async (userId: string): Promise<void> => {
+        await this.emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({
+            userId,
+            email: await this.getEmailForUserId(userId),
+        });
+    };
 }

--- a/lib/ts/recipe/thirdpartyemailpassword/index.ts
+++ b/lib/ts/recipe/thirdpartyemailpassword/index.ts
@@ -119,6 +119,19 @@ export default class Wrapper {
         return Recipe.getInstanceOrThrowError().isEmailVerified(userId);
     }
 
+    static async revokeEmailVerificationTokens(userId: string, email: string): Promise<void> {
+        await Recipe.getInstanceOrThrowError().emailVerificationRecipe.recipeInterfaceImpl.revokeEmailVerificationTokens(
+            { userId, email }
+        );
+    }
+
+    static async unverifyEmail(userId: string, email: string): Promise<void> {
+        await Recipe.getInstanceOrThrowError().emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({
+            userId,
+            email,
+        });
+    }
+
     static Google = thirdPartyProviders.Google;
 
     static Github = thirdPartyProviders.Github;
@@ -158,6 +171,10 @@ export let createEmailVerificationToken = Wrapper.createEmailVerificationToken;
 export let verifyEmailUsingToken = Wrapper.verifyEmailUsingToken;
 
 export let isEmailVerified = Wrapper.isEmailVerified;
+
+export let revokeEmailVerificationTokens = Wrapper.revokeEmailVerificationTokens;
+
+export let unverifyEmail = Wrapper.unverifyEmail;
 
 /**
  * @deprecated Use supertokens.getUsersOldestFirst(...) function instead IF using core version >= 3.5

--- a/lib/ts/recipe/thirdpartyemailpassword/index.ts
+++ b/lib/ts/recipe/thirdpartyemailpassword/index.ts
@@ -119,17 +119,12 @@ export default class Wrapper {
         return Recipe.getInstanceOrThrowError().isEmailVerified(userId);
     }
 
-    static async revokeEmailVerificationTokens(userId: string, email: string): Promise<void> {
-        await Recipe.getInstanceOrThrowError().emailVerificationRecipe.recipeInterfaceImpl.revokeEmailVerificationTokens(
-            { userId, email }
-        );
+    static async revokeEmailVerificationTokens(userId: string): Promise<void> {
+        await Recipe.getInstanceOrThrowError().revokeEmailVerificationTokens(userId);
     }
 
-    static async unverifyEmail(userId: string, email: string): Promise<void> {
-        await Recipe.getInstanceOrThrowError().emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({
-            userId,
-            email,
-        });
+    static async unverifyEmail(userId: string): Promise<void> {
+        await Recipe.getInstanceOrThrowError().unverifyEmail(userId);
     }
 
     static Google = thirdPartyProviders.Google;

--- a/lib/ts/recipe/thirdpartyemailpassword/recipe.ts
+++ b/lib/ts/recipe/thirdpartyemailpassword/recipe.ts
@@ -304,4 +304,18 @@ export default class Recipe extends RecipeModule {
             email: await this.getEmailForUserId(userId),
         });
     };
+
+    revokeEmailVerificationTokens = async (userId: string): Promise<void> => {
+        await this.emailVerificationRecipe.recipeInterfaceImpl.revokeEmailVerificationTokens({
+            userId,
+            email: await this.getEmailForUserId(userId),
+        });
+    };
+
+    unverifyEmail = async (userId: string): Promise<void> => {
+        await this.emailVerificationRecipe.recipeInterfaceImpl.unverifyEmail({
+            userId,
+            email: await this.getEmailForUserId(userId),
+        });
+    };
 }

--- a/test/emailpassword/emailverify.test.js
+++ b/test/emailpassword/emailverify.test.js
@@ -1266,4 +1266,91 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         assert.strictEqual(user.id, userId);
         assert.strictEqual(user.email, "test@gmail.com");
     });
+
+    it("test the generate token api with valid input, and then remove token", async function () {
+        await startST();
+        STExpress.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                EmailPassword.init(),
+                Session.init({
+                    antiCsrf: "VIA_TOKEN",
+                }),
+            ],
+        });
+
+        const app = express();
+
+        app.use(STExpress.middleware());
+
+        app.use(STExpress.errorHandler());
+
+        let response = await signUPRequest(app, "test@gmail.com", "testPass123");
+        assert(JSON.parse(response.text).status === "OK");
+        assert(response.status === 200);
+
+        let userId = JSON.parse(response.text).user.id;
+        let infoFromResponse = extractInfoFromResponse(response);
+
+        let verifyToken = await EmailPassword.createEmailVerificationToken(userId);
+
+        await EmailPassword.revokeEmailVerificationTokens(userId);
+
+        try {
+            await EmailPassword.verifyEmailUsingToken(verifyToken);
+            throw new Error("should never come here");
+        } catch (err) {
+            assert(err.message === "Invalid token");
+        }
+    });
+
+    it("test the generate token api with valid input, verify and then unverify email", async function () {
+        await startST();
+        STExpress.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                EmailPassword.init(),
+                Session.init({
+                    antiCsrf: "VIA_TOKEN",
+                }),
+            ],
+        });
+
+        const app = express();
+
+        app.use(STExpress.middleware());
+
+        app.use(STExpress.errorHandler());
+
+        let response = await signUPRequest(app, "test@gmail.com", "testPass123");
+        assert(JSON.parse(response.text).status === "OK");
+        assert(response.status === 200);
+
+        let userId = JSON.parse(response.text).user.id;
+        let infoFromResponse = extractInfoFromResponse(response);
+
+        let verifyToken = await EmailPassword.createEmailVerificationToken(userId);
+
+        await EmailPassword.verifyEmailUsingToken(verifyToken);
+
+        assert(await EmailPassword.isEmailVerified(userId));
+
+        await EmailPassword.unverifyEmail(userId);
+
+        assert(!(await EmailPassword.isEmailVerified(userId)));
+    });
 });


### PR DESCRIPTION
## Summary of change
Adds email verification recipe functions for revoking tokens and for unverifying email

## Related issues
- https://github.com/supertokens/supertokens-core/issues/270

## Test Plan
- Generate tokens, remove them, and try to verify yields error
- Verify and then unverify and check that email is unverified

## Documentation changes
- Recipe function changes
- About `unverifyEmail` and `revokeEmailVerificationTokens`

## Checklist for important updates
- [x] Changelog has been updated
- [x] Had run `npm run build-pretty`
- [x] Had installed and ran the pre-commit hook
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [ ] Tests