### PR TITLE
fixes #175

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.1] - 2021-09-10
+
+### Fixes
+
+-   fixes issue #175 regarding making error handlers async, session error callabacks async and making VerifySessionOptions optional for verifySession middleware.
+
 ## [7.0.0] - 2021-07-31
 
 ### Added

--- a/lib/build/framework/awsLambda/framework.js
+++ b/lib/build/framework/awsLambda/framework.js
@@ -239,7 +239,7 @@ exports.middleware = (handler) => {
                 }
                 return response.sendResponse({});
             } catch (err) {
-                supertokens.errorHandler(err, request, response);
+                yield supertokens.errorHandler(err, request, response);
                 if (response.responseSet) {
                     return response.sendResponse({});
                 }

--- a/lib/build/framework/express/framework.js
+++ b/lib/build/framework/express/framework.js
@@ -148,7 +148,7 @@ exports.errorHandler = () => {
             let request = new ExpressRequest(req);
             let response = new ExpressResponse(res);
             try {
-                supertokens.errorHandler(err, request, response);
+                yield supertokens.errorHandler(err, request, response);
             } catch (err) {
                 return next(err);
             }

--- a/lib/build/framework/fastify/framework.js
+++ b/lib/build/framework/fastify/framework.js
@@ -159,7 +159,7 @@ exports.errorHandler = () => {
             let supertokens = supertokens_1.default.getInstanceOrThrowError();
             let request = new FastifyRequest(req);
             let response = new FastifyResponse(res);
-            supertokens.errorHandler(err, request, response);
+            yield supertokens.errorHandler(err, request, response);
         });
 };
 exports.FastifyWrapper = {

--- a/lib/build/framework/koa/framework.js
+++ b/lib/build/framework/koa/framework.js
@@ -149,7 +149,7 @@ exports.middleware = () => {
                     return yield next();
                 }
             } catch (err) {
-                return supertokens.errorHandler(err, request, response);
+                return yield supertokens.errorHandler(err, request, response);
             }
         });
 };

--- a/lib/build/framework/loopback/framework.js
+++ b/lib/build/framework/loopback/framework.js
@@ -134,7 +134,7 @@ exports.middleware = (ctx, next) =>
             }
             return;
         } catch (err) {
-            return supertokens.errorHandler(err, request, response);
+            return yield supertokens.errorHandler(err, request, response);
         }
     });
 exports.LoopbackWrapper = {

--- a/lib/build/recipe/emailpassword/recipe.d.ts
+++ b/lib/build/recipe/emailpassword/recipe.d.ts
@@ -33,7 +33,7 @@ export default class Recipe extends RecipeModule {
         path: NormalisedURLPath,
         method: HTTPMethod
     ) => Promise<boolean>;
-    handleError: (err: STError, request: BaseRequest, response: BaseResponse) => void;
+    handleError: (err: STError, request: BaseRequest, response: BaseResponse) => Promise<void>;
     getAllCORSHeaders: () => string[];
     isErrorFromThisRecipe: (err: any) => err is STError;
     getEmailForUserId: (userId: string) => Promise<string>;

--- a/lib/build/recipe/emailpassword/recipe.js
+++ b/lib/build/recipe/emailpassword/recipe.js
@@ -126,20 +126,21 @@ class Recipe extends recipeModule_1.default {
                     return yield this.emailVerificationRecipe.handleAPIRequest(id, req, res, path, method);
                 }
             });
-        this.handleError = (err, request, response) => {
-            if (err.fromRecipe === Recipe.RECIPE_ID) {
-                if (err.type === error_1.default.FIELD_ERROR) {
-                    return utils_2.send200Response(response, {
-                        status: "FIELD_ERROR",
-                        formFields: err.payload,
-                    });
+        this.handleError = (err, request, response) =>
+            __awaiter(this, void 0, void 0, function* () {
+                if (err.fromRecipe === Recipe.RECIPE_ID) {
+                    if (err.type === error_1.default.FIELD_ERROR) {
+                        return utils_2.send200Response(response, {
+                            status: "FIELD_ERROR",
+                            formFields: err.payload,
+                        });
+                    } else {
+                        throw err;
+                    }
                 } else {
-                    throw err;
+                    return yield this.emailVerificationRecipe.handleError(err, request, response);
                 }
-            } else {
-                return this.emailVerificationRecipe.handleError(err, request, response);
-            }
-        };
+            });
         this.getAllCORSHeaders = () => {
             return [...this.emailVerificationRecipe.getAllCORSHeaders()];
         };

--- a/lib/build/recipe/emailverification/recipe.d.ts
+++ b/lib/build/recipe/emailverification/recipe.d.ts
@@ -23,7 +23,7 @@ export default class Recipe extends RecipeModule {
         _: NormalisedURLPath,
         __: HTTPMethod
     ) => Promise<boolean>;
-    handleError: (err: STError, _: BaseRequest, __: BaseResponse) => void;
+    handleError: (err: STError, _: BaseRequest, __: BaseResponse) => Promise<void>;
     getAllCORSHeaders: () => string[];
     isErrorFromThisRecipe: (err: any) => err is STError;
 }

--- a/lib/build/recipe/emailverification/recipe.js
+++ b/lib/build/recipe/emailverification/recipe.js
@@ -99,9 +99,10 @@ class Recipe extends recipeModule_1.default {
                     return yield emailVerify_1.default(this.apiImpl, options);
                 }
             });
-        this.handleError = (err, _, __) => {
-            throw err;
-        };
+        this.handleError = (err, _, __) =>
+            __awaiter(this, void 0, void 0, function* () {
+                throw err;
+            });
         this.getAllCORSHeaders = () => {
             return [];
         };

--- a/lib/build/recipe/session/framework/express.d.ts
+++ b/lib/build/recipe/session/framework/express.d.ts
@@ -2,5 +2,5 @@ import type { VerifySessionOptions } from "..";
 import type { SessionRequest } from "../../../framework/express/framework";
 import type { NextFunction, Response } from "express";
 export declare function verifySession(
-    options: VerifySessionOptions | undefined
+    options?: VerifySessionOptions
 ): (req: SessionRequest, res: Response, next: NextFunction) => Promise<void>;

--- a/lib/build/recipe/session/framework/fastify.d.ts
+++ b/lib/build/recipe/session/framework/fastify.d.ts
@@ -3,7 +3,7 @@ import { VerifySessionOptions } from "..";
 import { SessionRequest } from "../../../framework/fastify/framework";
 import { FastifyReply } from "fastify";
 export declare function verifySession(
-    options: VerifySessionOptions | undefined
+    options?: VerifySessionOptions
 ): (
     req: SessionRequest,
     res: FastifyReply<

--- a/lib/build/recipe/session/framework/hapi.d.ts
+++ b/lib/build/recipe/session/framework/hapi.d.ts
@@ -1,5 +1,5 @@
 import { VerifySessionOptions } from "..";
 import { ExtendedResponseToolkit, SessionRequest } from "../../../framework/hapi/framework";
 export declare function verifySession(
-    options: VerifySessionOptions | undefined
+    options?: VerifySessionOptions
 ): (req: SessionRequest, h: ExtendedResponseToolkit) => Promise<symbol>;

--- a/lib/build/recipe/session/framework/koa.d.ts
+++ b/lib/build/recipe/session/framework/koa.d.ts
@@ -2,5 +2,5 @@ import type { VerifySessionOptions } from "..";
 import type { Next } from "koa";
 import type { SessionContext } from "../../../framework/koa/framework";
 export declare function verifySession(
-    options: VerifySessionOptions | undefined
+    options?: VerifySessionOptions
 ): (ctx: SessionContext, next: Next) => Promise<void>;

--- a/lib/build/recipe/session/recipe.d.ts
+++ b/lib/build/recipe/session/recipe.d.ts
@@ -23,7 +23,7 @@ export default class SessionRecipe extends RecipeModule {
         __: NormalisedURLPath,
         ___: HTTPMethod
     ) => Promise<boolean>;
-    handleError: (err: STError, request: BaseRequest, response: BaseResponse) => void;
+    handleError: (err: STError, request: BaseRequest, response: BaseResponse) => Promise<void>;
     getAllCORSHeaders: () => string[];
     isErrorFromThisRecipe: (err: any) => err is STError;
     verifySession: (

--- a/lib/build/recipe/session/recipe.js
+++ b/lib/build/recipe/session/recipe.js
@@ -93,26 +93,27 @@ class SessionRecipe extends recipeModule_1.default {
                     return yield signout_1.default(this.apiImpl, options);
                 }
             });
-        this.handleError = (err, request, response) => {
-            if (err.fromRecipe === SessionRecipe.RECIPE_ID) {
-                if (err.type === error_1.default.UNAUTHORISED) {
-                    return this.config.errorHandlers.onUnauthorised(err.message, request, response);
-                } else if (err.type === error_1.default.TRY_REFRESH_TOKEN) {
-                    return this.config.errorHandlers.onTryRefreshToken(err.message, request, response);
-                } else if (err.type === error_1.default.TOKEN_THEFT_DETECTED) {
-                    return this.config.errorHandlers.onTokenTheftDetected(
-                        err.payload.sessionHandle,
-                        err.payload.userId,
-                        request,
-                        response
-                    );
+        this.handleError = (err, request, response) =>
+            __awaiter(this, void 0, void 0, function* () {
+                if (err.fromRecipe === SessionRecipe.RECIPE_ID) {
+                    if (err.type === error_1.default.UNAUTHORISED) {
+                        return yield this.config.errorHandlers.onUnauthorised(err.message, request, response);
+                    } else if (err.type === error_1.default.TRY_REFRESH_TOKEN) {
+                        return yield this.config.errorHandlers.onTryRefreshToken(err.message, request, response);
+                    } else if (err.type === error_1.default.TOKEN_THEFT_DETECTED) {
+                        return yield this.config.errorHandlers.onTokenTheftDetected(
+                            err.payload.sessionHandle,
+                            err.payload.userId,
+                            request,
+                            response
+                        );
+                    } else {
+                        throw err;
+                    }
                 } else {
                     throw err;
                 }
-            } else {
-                throw err;
-            }
-        };
+            });
         this.getAllCORSHeaders = () => {
             return cookieAndHeaders_1.getCORSAllowedHeaders();
         };

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -113,10 +113,10 @@ export interface SessionRequest extends BaseRequest {
     session?: SessionContainerInterface;
 }
 export interface ErrorHandlerMiddleware {
-    (message: string, request: BaseRequest, response: BaseResponse): void;
+    (message: string, request: BaseRequest, response: BaseResponse): Promise<void>;
 }
 export interface TokenTheftErrorHandlerMiddleware {
-    (sessionHandle: string, userId: string, request: BaseRequest, response: BaseResponse): void;
+    (sessionHandle: string, userId: string, request: BaseRequest, response: BaseResponse): Promise<void>;
 }
 export interface NormalisedErrorHandlers {
     onUnauthorised: ErrorHandlerMiddleware;

--- a/lib/build/recipe/session/utils.js
+++ b/lib/build/recipe/session/utils.js
@@ -149,15 +149,18 @@ function validateAndNormaliseUserInput(recipeInstance, appInfo, config) {
                 : "NONE"
             : config.antiCsrf;
     let errorHandlers = {
-        onTokenTheftDetected: (sessionHandle, userId, request, response) => {
-            return sendTokenTheftDetectedResponse(recipeInstance, sessionHandle, userId, request, response);
-        },
-        onTryRefreshToken: (message, request, response) => {
-            return sendTryRefreshTokenResponse(recipeInstance, message, request, response);
-        },
-        onUnauthorised: (message, request, response) => {
-            return sendUnauthorisedResponse(recipeInstance, message, request, response);
-        },
+        onTokenTheftDetected: (sessionHandle, userId, request, response) =>
+            __awaiter(this, void 0, void 0, function* () {
+                return yield sendTokenTheftDetectedResponse(recipeInstance, sessionHandle, userId, request, response);
+            }),
+        onTryRefreshToken: (message, request, response) =>
+            __awaiter(this, void 0, void 0, function* () {
+                return yield sendTryRefreshTokenResponse(recipeInstance, message, request, response);
+            }),
+        onUnauthorised: (message, request, response) =>
+            __awaiter(this, void 0, void 0, function* () {
+                return yield sendUnauthorisedResponse(recipeInstance, message, request, response);
+            }),
     };
     if (config !== undefined && config.errorHandlers !== undefined) {
         if (config.errorHandlers.onTokenTheftDetected !== undefined) {

--- a/lib/build/recipe/thirdparty/recipe.d.ts
+++ b/lib/build/recipe/thirdparty/recipe.d.ts
@@ -34,7 +34,7 @@ export default class Recipe extends RecipeModule {
         path: NormalisedURLPath,
         method: HTTPMethod
     ) => Promise<boolean>;
-    handleError: (err: STError, request: BaseRequest, response: BaseResponse) => void;
+    handleError: (err: STError, request: BaseRequest, response: BaseResponse) => Promise<void>;
     getAllCORSHeaders: () => string[];
     isErrorFromThisRecipe: (err: any) => err is STError;
     getEmailForUserId: (userId: string) => Promise<string>;

--- a/lib/build/recipe/thirdparty/recipe.js
+++ b/lib/build/recipe/thirdparty/recipe.js
@@ -96,13 +96,14 @@ class Recipe extends recipeModule_1.default {
                     return yield this.emailVerificationRecipe.handleAPIRequest(id, req, res, path, method);
                 }
             });
-        this.handleError = (err, request, response) => {
-            if (err.fromRecipe === Recipe.RECIPE_ID) {
-                throw err;
-            } else {
-                return this.emailVerificationRecipe.handleError(err, request, response);
-            }
-        };
+        this.handleError = (err, request, response) =>
+            __awaiter(this, void 0, void 0, function* () {
+                if (err.fromRecipe === Recipe.RECIPE_ID) {
+                    throw err;
+                } else {
+                    return yield this.emailVerificationRecipe.handleError(err, request, response);
+                }
+            });
         this.getAllCORSHeaders = () => {
             return [...this.emailVerificationRecipe.getAllCORSHeaders()];
         };

--- a/lib/build/recipe/thirdpartyemailpassword/recipe.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/recipe.d.ts
@@ -40,7 +40,11 @@ export default class Recipe extends RecipeModule {
         path: NormalisedURLPath,
         method: HTTPMethod
     ) => Promise<boolean>;
-    handleError: (err: STErrorEmailPassword | STErrorThirdParty, request: BaseRequest, response: BaseResponse) => void;
+    handleError: (
+        err: STErrorEmailPassword | STErrorThirdParty,
+        request: BaseRequest,
+        response: BaseResponse
+    ) => Promise<void>;
     getAllCORSHeaders: () => string[];
     isErrorFromThisRecipe: (err: any) => err is STError;
     getEmailForUserId: (userId: string) => Promise<string>;

--- a/lib/build/recipe/thirdpartyemailpassword/recipe.js
+++ b/lib/build/recipe/thirdpartyemailpassword/recipe.js
@@ -84,18 +84,22 @@ class Recipe extends recipeModule_1.default {
                 }
                 return yield this.emailVerificationRecipe.handleAPIRequest(id, req, res, path, method);
             });
-        this.handleError = (err, request, response) => {
-            if (err.fromRecipe === Recipe.RECIPE_ID) {
-                throw err;
-            } else {
-                if (this.emailPasswordRecipe.isErrorFromThisRecipe(err)) {
-                    return this.emailPasswordRecipe.handleError(err, request, response);
-                } else if (this.thirdPartyRecipe !== undefined && this.thirdPartyRecipe.isErrorFromThisRecipe(err)) {
-                    return this.thirdPartyRecipe.handleError(err, request, response);
+        this.handleError = (err, request, response) =>
+            __awaiter(this, void 0, void 0, function* () {
+                if (err.fromRecipe === Recipe.RECIPE_ID) {
+                    throw err;
+                } else {
+                    if (this.emailPasswordRecipe.isErrorFromThisRecipe(err)) {
+                        return yield this.emailPasswordRecipe.handleError(err, request, response);
+                    } else if (
+                        this.thirdPartyRecipe !== undefined &&
+                        this.thirdPartyRecipe.isErrorFromThisRecipe(err)
+                    ) {
+                        return yield this.thirdPartyRecipe.handleError(err, request, response);
+                    }
+                    return yield this.emailVerificationRecipe.handleError(err, request, response);
                 }
-                return this.emailVerificationRecipe.handleError(err, request, response);
-            }
-        };
+            });
         this.getAllCORSHeaders = () => {
             let corsHeaders = [
                 ...this.emailVerificationRecipe.getAllCORSHeaders(),

--- a/lib/build/recipeModule.d.ts
+++ b/lib/build/recipeModule.d.ts
@@ -17,7 +17,7 @@ export default abstract class RecipeModule {
         path: NormalisedURLPath,
         method: HTTPMethod
     ): Promise<boolean>;
-    abstract handleError(error: STError, request: BaseRequest, response: BaseResponse): void;
+    abstract handleError(error: STError, request: BaseRequest, response: BaseResponse): Promise<void>;
     abstract getAllCORSHeaders(): string[];
     abstract isErrorFromThisRecipe(err: any): err is STError;
 }

--- a/lib/build/supertokens.d.ts
+++ b/lib/build/supertokens.d.ts
@@ -37,5 +37,5 @@ export default class SuperTokens {
         nextPaginationToken?: string | undefined;
     }>;
     middleware: (request: BaseRequest, response: BaseResponse) => Promise<boolean>;
-    errorHandler: (err: any, request: BaseRequest, response: BaseResponse) => void;
+    errorHandler: (err: any, request: BaseRequest, response: BaseResponse) => Promise<void>;
 }

--- a/lib/build/supertokens.js
+++ b/lib/build/supertokens.js
@@ -193,19 +193,20 @@ class SuperTokens {
                     return false;
                 }
             });
-        this.errorHandler = (err, request, response) => {
-            if (error_1.default.isErrorFromSuperTokens(err)) {
-                if (err.type === error_1.default.BAD_INPUT_ERROR) {
-                    return utils_1.sendNon200Response(response, err.message, 400);
-                }
-                for (let i = 0; i < this.recipeModules.length; i++) {
-                    if (this.recipeModules[i].isErrorFromThisRecipe(err)) {
-                        return this.recipeModules[i].handleError(err, request, response);
+        this.errorHandler = (err, request, response) =>
+            __awaiter(this, void 0, void 0, function* () {
+                if (error_1.default.isErrorFromSuperTokens(err)) {
+                    if (err.type === error_1.default.BAD_INPUT_ERROR) {
+                        return utils_1.sendNon200Response(response, err.message, 400);
+                    }
+                    for (let i = 0; i < this.recipeModules.length; i++) {
+                        if (this.recipeModules[i].isErrorFromThisRecipe(err)) {
+                            return yield this.recipeModules[i].handleError(err, request, response);
+                        }
                     }
                 }
-            }
-            throw err;
-        };
+                throw err;
+            });
         utils_1.validateTheStructureOfUserInput(config, types_1.InputSchema, "init function");
         this.framework = config.framework !== undefined ? config.framework : "express";
         this.appInfo = utils_1.normaliseInputAppInfoOrThrowError(config.appInfo);

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,2 +1,2 @@
-export declare const version = "7.0.0";
+export declare const version = "7.0.1";
 export declare const cdiSupported: string[];

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -14,6 +14,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "7.0.0";
+exports.version = "7.0.1";
 exports.cdiSupported = ["2.7", "2.8"];
 //# sourceMappingURL=version.js.map

--- a/lib/ts/framework/awsLambda/framework.ts
+++ b/lib/ts/framework/awsLambda/framework.ts
@@ -286,7 +286,7 @@ export const middleware = (handler?: Handler): Handler => {
             }
             return response.sendResponse({});
         } catch (err) {
-            supertokens.errorHandler(err, request, response);
+            await supertokens.errorHandler(err, request, response);
             if (response.responseSet) {
                 return response.sendResponse({});
             }

--- a/lib/ts/framework/express/framework.ts
+++ b/lib/ts/framework/express/framework.ts
@@ -143,7 +143,7 @@ export const errorHandler = () => {
         let request = new ExpressRequest(req);
         let response = new ExpressResponse(res);
         try {
-            supertokens.errorHandler(err, request, response);
+            await supertokens.errorHandler(err, request, response);
         } catch (err) {
             return next(err);
         }

--- a/lib/ts/framework/fastify/framework.ts
+++ b/lib/ts/framework/fastify/framework.ts
@@ -167,7 +167,7 @@ export const errorHandler = () => {
         let supertokens = SuperTokens.getInstanceOrThrowError();
         let request = new FastifyRequest(req);
         let response = new FastifyResponse(res);
-        supertokens.errorHandler(err, request, response);
+        await supertokens.errorHandler(err, request, response);
     };
 };
 

--- a/lib/ts/framework/koa/framework.ts
+++ b/lib/ts/framework/koa/framework.ts
@@ -148,7 +148,7 @@ export const middleware = () => {
                 return await next();
             }
         } catch (err) {
-            return supertokens.errorHandler(err, request, response);
+            return await supertokens.errorHandler(err, request, response);
         }
     };
 };

--- a/lib/ts/framework/loopback/framework.ts
+++ b/lib/ts/framework/loopback/framework.ts
@@ -133,7 +133,7 @@ export const middleware: Middleware = async (ctx: MiddlewareContext, next: Next)
         }
         return;
     } catch (err) {
-        return supertokens.errorHandler(err, request, response);
+        return await supertokens.errorHandler(err, request, response);
     }
 };
 

--- a/lib/ts/recipe/emailpassword/recipe.ts
+++ b/lib/ts/recipe/emailpassword/recipe.ts
@@ -172,7 +172,7 @@ export default class Recipe extends RecipeModule {
         }
     };
 
-    handleError = (err: STError, request: BaseRequest, response: BaseResponse): void => {
+    handleError = async (err: STError, request: BaseRequest, response: BaseResponse): Promise<void> => {
         if (err.fromRecipe === Recipe.RECIPE_ID) {
             if (err.type === STError.FIELD_ERROR) {
                 return send200Response(response, {
@@ -183,7 +183,7 @@ export default class Recipe extends RecipeModule {
                 throw err;
             }
         } else {
-            return this.emailVerificationRecipe.handleError(err, request, response);
+            return await this.emailVerificationRecipe.handleError(err, request, response);
         }
     };
 

--- a/lib/ts/recipe/emailverification/recipe.ts
+++ b/lib/ts/recipe/emailverification/recipe.ts
@@ -123,7 +123,7 @@ export default class Recipe extends RecipeModule {
         }
     };
 
-    handleError = (err: STError, _: BaseRequest, __: BaseResponse): void => {
+    handleError = async (err: STError, _: BaseRequest, __: BaseResponse): Promise<void> => {
         throw err;
     };
 

--- a/lib/ts/recipe/session/framework/express.ts
+++ b/lib/ts/recipe/session/framework/express.ts
@@ -18,7 +18,7 @@ import type { SessionRequest } from "../../../framework/express/framework";
 import { ExpressRequest, ExpressResponse } from "../../../framework/express/framework";
 import type { NextFunction, Response } from "express";
 
-export function verifySession(options: VerifySessionOptions | undefined) {
+export function verifySession(options?: VerifySessionOptions) {
     return async (req: SessionRequest, res: Response, next: NextFunction) => {
         try {
             let sessionRecipe = Session.getInstanceOrThrowError();

--- a/lib/ts/recipe/session/framework/fastify.ts
+++ b/lib/ts/recipe/session/framework/fastify.ts
@@ -17,7 +17,7 @@ import { VerifySessionOptions } from "..";
 import { FastifyRequest, FastifyResponse, SessionRequest } from "../../../framework/fastify/framework";
 import { FastifyReply } from "fastify";
 
-export function verifySession(options: VerifySessionOptions | undefined) {
+export function verifySession(options?: VerifySessionOptions) {
     return async (req: SessionRequest, res: FastifyReply) => {
         let sessionRecipe = Session.getInstanceOrThrowError();
         let request = new FastifyRequest(req);

--- a/lib/ts/recipe/session/framework/hapi.ts
+++ b/lib/ts/recipe/session/framework/hapi.ts
@@ -16,7 +16,7 @@ import Session from "../recipe";
 import { VerifySessionOptions } from "..";
 import { ExtendedResponseToolkit, HapiRequest, HapiResponse, SessionRequest } from "../../../framework/hapi/framework";
 
-export function verifySession(options: VerifySessionOptions | undefined) {
+export function verifySession(options?: VerifySessionOptions) {
     return async (req: SessionRequest, h: ExtendedResponseToolkit) => {
         let sessionRecipe = Session.getInstanceOrThrowError();
         let request = new HapiRequest(req);

--- a/lib/ts/recipe/session/framework/koa.ts
+++ b/lib/ts/recipe/session/framework/koa.ts
@@ -18,7 +18,7 @@ import type { Next } from "koa";
 import { KoaRequest, KoaResponse } from "../../../framework/koa/framework";
 import type { SessionContext } from "../../../framework/koa/framework";
 
-export function verifySession(options: VerifySessionOptions | undefined) {
+export function verifySession(options?: VerifySessionOptions) {
     return async (ctx: SessionContext, next: Next) => {
         let sessionRecipe = Session.getInstanceOrThrowError();
         let request = new KoaRequest(ctx);

--- a/lib/ts/recipe/session/recipe.ts
+++ b/lib/ts/recipe/session/recipe.ts
@@ -121,14 +121,14 @@ export default class SessionRecipe extends RecipeModule {
         }
     };
 
-    handleError = (err: STError, request: BaseRequest, response: BaseResponse) => {
+    handleError = async (err: STError, request: BaseRequest, response: BaseResponse) => {
         if (err.fromRecipe === SessionRecipe.RECIPE_ID) {
             if (err.type === STError.UNAUTHORISED) {
-                return this.config.errorHandlers.onUnauthorised(err.message, request, response);
+                return await this.config.errorHandlers.onUnauthorised(err.message, request, response);
             } else if (err.type === STError.TRY_REFRESH_TOKEN) {
-                return this.config.errorHandlers.onTryRefreshToken(err.message, request, response);
+                return await this.config.errorHandlers.onTryRefreshToken(err.message, request, response);
             } else if (err.type === STError.TOKEN_THEFT_DETECTED) {
-                return this.config.errorHandlers.onTokenTheftDetected(
+                return await this.config.errorHandlers.onTokenTheftDetected(
                     err.payload.sessionHandle,
                     err.payload.userId,
                     request,

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -125,11 +125,11 @@ export interface SessionRequest extends BaseRequest {
 }
 
 export interface ErrorHandlerMiddleware {
-    (message: string, request: BaseRequest, response: BaseResponse): void;
+    (message: string, request: BaseRequest, response: BaseResponse): Promise<void>;
 }
 
 export interface TokenTheftErrorHandlerMiddleware {
-    (sessionHandle: string, userId: string, request: BaseRequest, response: BaseResponse): void;
+    (sessionHandle: string, userId: string, request: BaseRequest, response: BaseResponse): Promise<void>;
 }
 
 export interface NormalisedErrorHandlers {

--- a/lib/ts/recipe/session/utils.ts
+++ b/lib/ts/recipe/session/utils.ts
@@ -164,14 +164,19 @@ export function validateAndNormaliseUserInput(
             : config.antiCsrf;
 
     let errorHandlers: NormalisedErrorHandlers = {
-        onTokenTheftDetected: (sessionHandle: string, userId: string, request: BaseRequest, response: BaseResponse) => {
-            return sendTokenTheftDetectedResponse(recipeInstance, sessionHandle, userId, request, response);
+        onTokenTheftDetected: async (
+            sessionHandle: string,
+            userId: string,
+            request: BaseRequest,
+            response: BaseResponse
+        ) => {
+            return await sendTokenTheftDetectedResponse(recipeInstance, sessionHandle, userId, request, response);
         },
-        onTryRefreshToken: (message: string, request: BaseRequest, response: BaseResponse) => {
-            return sendTryRefreshTokenResponse(recipeInstance, message, request, response);
+        onTryRefreshToken: async (message: string, request: BaseRequest, response: BaseResponse) => {
+            return await sendTryRefreshTokenResponse(recipeInstance, message, request, response);
         },
-        onUnauthorised: (message: string, request: BaseRequest, response: BaseResponse) => {
-            return sendUnauthorisedResponse(recipeInstance, message, request, response);
+        onUnauthorised: async (message: string, request: BaseRequest, response: BaseResponse) => {
+            return await sendUnauthorisedResponse(recipeInstance, message, request, response);
         },
     };
     if (config !== undefined && config.errorHandlers !== undefined) {

--- a/lib/ts/recipe/thirdparty/recipe.ts
+++ b/lib/ts/recipe/thirdparty/recipe.ts
@@ -142,11 +142,11 @@ export default class Recipe extends RecipeModule {
         }
     };
 
-    handleError = (err: STError, request: BaseRequest, response: BaseResponse): void => {
+    handleError = async (err: STError, request: BaseRequest, response: BaseResponse): Promise<void> => {
         if (err.fromRecipe === Recipe.RECIPE_ID) {
             throw err;
         } else {
-            return this.emailVerificationRecipe.handleError(err, request, response);
+            return await this.emailVerificationRecipe.handleError(err, request, response);
         }
     };
 

--- a/lib/ts/recipe/thirdpartyemailpassword/recipe.ts
+++ b/lib/ts/recipe/thirdpartyemailpassword/recipe.ts
@@ -235,20 +235,20 @@ export default class Recipe extends RecipeModule {
         return await this.emailVerificationRecipe.handleAPIRequest(id, req, res, path, method);
     };
 
-    handleError = (
+    handleError = async (
         err: STErrorEmailPassword | STErrorThirdParty,
         request: BaseRequest,
         response: BaseResponse
-    ): void => {
+    ): Promise<void> => {
         if (err.fromRecipe === Recipe.RECIPE_ID) {
             throw err;
         } else {
             if (this.emailPasswordRecipe.isErrorFromThisRecipe(err)) {
-                return this.emailPasswordRecipe.handleError(err, request, response);
+                return await this.emailPasswordRecipe.handleError(err, request, response);
             } else if (this.thirdPartyRecipe !== undefined && this.thirdPartyRecipe.isErrorFromThisRecipe(err)) {
-                return this.thirdPartyRecipe.handleError(err, request, response);
+                return await this.thirdPartyRecipe.handleError(err, request, response);
             }
-            return this.emailVerificationRecipe.handleError(err, request, response);
+            return await this.emailVerificationRecipe.handleError(err, request, response);
         }
     };
 

--- a/lib/ts/recipeModule.ts
+++ b/lib/ts/recipeModule.ts
@@ -61,7 +61,7 @@ export default abstract class RecipeModule {
         method: HTTPMethod
     ): Promise<boolean>;
 
-    abstract handleError(error: STError, request: BaseRequest, response: BaseResponse): void;
+    abstract handleError(error: STError, request: BaseRequest, response: BaseResponse): Promise<void>;
 
     abstract getAllCORSHeaders(): string[];
 

--- a/lib/ts/supertokens.ts
+++ b/lib/ts/supertokens.ts
@@ -274,7 +274,7 @@ export default class SuperTokens {
         }
     };
 
-    errorHandler = (err: any, request: BaseRequest, response: BaseResponse) => {
+    errorHandler = async (err: any, request: BaseRequest, response: BaseResponse) => {
         if (STError.isErrorFromSuperTokens(err)) {
             if (err.type === STError.BAD_INPUT_ERROR) {
                 return sendNon200Response(response, err.message, 400);
@@ -282,7 +282,7 @@ export default class SuperTokens {
 
             for (let i = 0; i < this.recipeModules.length; i++) {
                 if (this.recipeModules[i].isErrorFromThisRecipe(err)) {
-                    return this.recipeModules[i].handleError(err, request, response);
+                    return await this.recipeModules[i].handleError(err, request, response);
                 }
             }
         }

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,6 +12,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "7.0.0";
+export const version = "7.0.1";
 
 export const cdiSupported = ["2.7", "2.8"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "7.0.0",
+    "version": "7.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "7.0.0",
+    "version": "7.0.1",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {

--- a/test/with-typescript/index.ts
+++ b/test/with-typescript/index.ts
@@ -97,6 +97,16 @@ app.use(
     }
 );
 
+app.use(verifySession(), async (req: SessionRequest, res) => {
+    let session = req.session;
+    if (session === undefined) {
+        throw Error("this error should not get thrown");
+    }
+    res.json({
+        userId: session.getUserId(),
+    });
+});
+
 app.use(errorHandler());
 
 app.listen();


### PR DESCRIPTION
## Summary of change

- Error Handler in supertokens.ts and all errorHandler functions in recipes changed to async and awaited for
- Session error callbacks are now async
- Changed `verifySession` function signature to have optional options

## Related issues

- #175 

## Test Plan
- added test `test session error handler overriding` in `sessionExpress.test.js`
- Added example of using verifySession() in with-typescript test folder

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.