### PR TITLE
Add api version check to jwt tests

### DIFF
--- a/test/jwt/config.test.js
+++ b/test/jwt/config.test.js
@@ -4,6 +4,8 @@ const { printPath, setupST, startST, killAllST, cleanST } = require("../utils");
 let { ProcessState } = require("../../lib/build/processState");
 let STExpress = require("../../");
 const JWTRecipe = require("../../lib/build/recipe/jwt/recipe").default;
+let { Querier } = require("../../lib/build/querier");
+const { maxVersion } = require("../../lib/build/utils");
 
 describe(`configTest: ${printPath("[test/jwt/config.test.js]")}`, function () {
     beforeEach(async function () {
@@ -31,6 +33,13 @@ describe(`configTest: ${printPath("[test/jwt/config.test.js]")}`, function () {
             recipeList: [JWTRecipe.init()],
         });
 
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
+
         let jwtRecipe = await JWTRecipe.getInstanceOrThrowError();
         assert(jwtRecipe.config.jwtValiditySeconds === 3153600000);
     });
@@ -52,6 +61,13 @@ describe(`configTest: ${printPath("[test/jwt/config.test.js]")}`, function () {
                 }),
             ],
         });
+
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
 
         let jwtRecipe = await JWTRecipe.getInstanceOrThrowError();
         assert(jwtRecipe.config.jwtValiditySeconds === 24 * 60 * 60);

--- a/test/jwt/createJWTFeature.test.js
+++ b/test/jwt/createJWTFeature.test.js
@@ -1,10 +1,12 @@
 let assert = require("assert");
+const e = require("cors");
 
 const { printPath, setupST, startST, killAllST, cleanST } = require("../utils");
 let STExpress = require("../../");
 let JWTRecipe = require("../../lib/build/recipe/jwt");
 let { ProcessState } = require("../../lib/build/processState");
-const e = require("cors");
+let { Querier } = require("../../lib/build/querier");
+const { maxVersion } = require("../../lib/build/utils");
 
 describe(`createJWTFeature: ${printPath("[test/jwt/createJWTFeature.test.js]")}`, function () {
     beforeEach(async function () {
@@ -32,6 +34,13 @@ describe(`createJWTFeature: ${printPath("[test/jwt/createJWTFeature.test.js]")}`
             recipeList: [JWTRecipe.init()],
         });
 
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
+
         try {
             await JWTRecipe.createJWT({}, 0);
             assert.fail();
@@ -53,6 +62,13 @@ describe(`createJWTFeature: ${printPath("[test/jwt/createJWTFeature.test.js]")}`
             },
             recipeList: [JWTRecipe.init()],
         });
+
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
 
         let jwt = undefined;
 
@@ -78,6 +94,13 @@ describe(`createJWTFeature: ${printPath("[test/jwt/createJWTFeature.test.js]")}`
             },
             recipeList: [JWTRecipe.init()],
         });
+
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
 
         let currentTimeInSeconds = Date.now() / 1000;
         let jwt = (await JWTRecipe.createJWT({})).jwt.split(".")[1];
@@ -111,6 +134,13 @@ describe(`createJWTFeature: ${printPath("[test/jwt/createJWTFeature.test.js]")}`
             ],
         });
 
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
+
         let currentTimeInSeconds = Date.now() / 1000;
         let jwt = (await JWTRecipe.createJWT({})).jwt.split(".")[1];
         let decodedJWTPayload = Buffer.from(jwt, "base64").toString("utf-8");
@@ -142,6 +172,13 @@ describe(`createJWTFeature: ${printPath("[test/jwt/createJWTFeature.test.js]")}`
                 }),
             ],
         });
+
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
 
         let currentTimeInSeconds = Date.now() / 1000;
         let targetExpiryDuration = 500; // 100 years in seconds

--- a/test/jwt/getJWKS.test.js
+++ b/test/jwt/getJWKS.test.js
@@ -6,6 +6,8 @@ const { printPath, setupST, startST, killAllST, cleanST } = require("../utils");
 let STExpress = require("../../");
 let { ProcessState } = require("../../lib/build/processState");
 let JWTRecipe = require("../../lib/build/recipe/jwt");
+let { Querier } = require("../../lib/build/querier");
+const { maxVersion } = require("../../lib/build/utils");
 
 describe(`getJWKS: ${printPath("[test/jwt/getJWKS.test.js]")}`, function () {
     beforeEach(async function () {
@@ -44,6 +46,13 @@ describe(`getJWKS: ${printPath("[test/jwt/getJWKS.test.js]")}`, function () {
             ],
         });
 
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
+
         const app = express();
 
         app.use(STExpress.middleware());
@@ -78,6 +87,13 @@ describe(`getJWKS: ${printPath("[test/jwt/getJWKS.test.js]")}`, function () {
             },
             recipeList: [JWTRecipe.init({})],
         });
+
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
 
         const app = express();
 

--- a/test/jwt/override.test.js
+++ b/test/jwt/override.test.js
@@ -6,6 +6,8 @@ const { printPath, setupST, startST, killAllST, cleanST } = require("../utils");
 let STExpress = require("../../");
 let { ProcessState } = require("../../lib/build/processState");
 let JWTRecipe = require("../../lib/build/recipe/jwt");
+let { Querier } = require("../../lib/build/querier");
+const { maxVersion } = require("../../lib/build/utils");
 
 describe(`overrideTest: ${printPath("[test/jwt/override.test.js]")}`, function () {
     beforeEach(async function () {
@@ -64,6 +66,13 @@ describe(`overrideTest: ${printPath("[test/jwt/override.test.js]")}`, function (
                 }),
             ],
         });
+
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
 
         let app = express();
 
@@ -142,6 +151,13 @@ describe(`overrideTest: ${printPath("[test/jwt/override.test.js]")}`, function (
                 }),
             ],
         });
+
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
 
         let app = express();
 


### PR DESCRIPTION
## Summary of change

Adds a check to make sure the JWT tests run on CDI version 2.9 and above

## Test Plan

Changes existing tests

## Documentation changes

None 

## Checklist for important updates

-   [x] ~~Changelog has been updated~~
-   [x] ~~`coreDriverInterfaceSupported.json` file has been updated (if needed)~~
    -   ~~Along with the associated array in `lib/ts/version.ts`~~
-   [x] ~~`frontendDriverInterfaceSupported.json` file has been updated (if needed)~~
-   [x] ~~Changes to the version if needed~~
    -   ~~In `package.json`~~
    -   ~~In `package-lock.json`~~
    -   ~~In `lib/ts/version.ts`~~
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] ~~If have added a new web framework, update the `add-ts-no-check.js` file to include that~~

## Remaining TODOs for this PR
None
