### PR TITLE
Added axios-mock-adapter to the test html for frontend integration test to match supertokens-website

### DIFF
--- a/test/frontendIntegration/index.html
+++ b/test/frontendIntegration/index.html
@@ -1,5 +1,6 @@
 <html>
     <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
+    <script src="https://unpkg.com/axios-mock-adapter/dist/axios-mock-adapter.js"></script>
 
     <script>
         async function getNumberOfTimesRefreshCalled(BASE_URL = "http://localhost.org:8080") {


### PR DESCRIPTION
## Summary of change

Frontend tests now use axios-mock-adapter so I added it to the frontend integration `index.html`

## Related issues

-   supertokens/supertokens-website#85

## Test Plan
CI test run will run using this HTML

## Documentation changes
N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
