### PR TITLE
Draft: feat: added possibility to add route options to supertokens route (Hapi framework)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 .
 
+## [7.4.0] - 2021-10-11
+
+### Added
+
+-   Hapi framework: Adds possibility to pass `RouteOptions` when registering the plugin. These route options will be applied to all supported routes.
+
 ## [7.3.0] - 2021-10-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 .
 
-## [7.4.0] - 2021-10-11
+## [7.4.0] - 2021-10-13
 
 ### Added
 

--- a/lib/build/framework/hapi/framework.d.ts
+++ b/lib/build/framework/hapi/framework.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import type { Request, ResponseToolkit, Plugin, ResponseObject } from "@hapi/hapi";
+import type { Request, ResponseToolkit, Plugin, ResponseObject, RouteOptions } from "@hapi/hapi";
 import type { HTTPMethod } from "../../types";
 import { BaseRequest } from "../request";
 import { BaseResponse } from "../response";
@@ -45,10 +45,13 @@ export declare class HapiResponse extends BaseResponse {
     sendJSONResponse: (content: any) => void;
     sendResponse: (overwriteHeaders?: boolean) => ResponseObject;
 }
+export interface SupertokensPluginOptions {
+    routeOptions: RouteOptions;
+}
 export interface SessionRequest extends Request {
     session?: SessionContainerInterface;
 }
 export interface HapiFramework extends Framework {
-    plugin: Plugin<{}>;
+    plugin: Plugin<SupertokensPluginOptions>;
 }
 export declare const HapiWrapper: HapiFramework;

--- a/lib/build/framework/hapi/framework.d.ts
+++ b/lib/build/framework/hapi/framework.d.ts
@@ -46,7 +46,7 @@ export declare class HapiResponse extends BaseResponse {
     sendResponse: (overwriteHeaders?: boolean) => ResponseObject;
 }
 export interface SupertokensPluginOptions {
-    routeOptions: RouteOptions;
+    routeOptions?: RouteOptions;
 }
 export interface SessionRequest extends Request {
     session?: SessionContainerInterface;

--- a/lib/build/framework/hapi/framework.js
+++ b/lib/build/framework/hapi/framework.js
@@ -139,7 +139,7 @@ exports.HapiResponse = HapiResponse;
 const plugin = {
     name: "supertokens-hapi-middleware",
     version: "1.0.0",
-    register: function (server, _) {
+    register: function (server, options) {
         return __awaiter(this, void 0, void 0, function* () {
             let supertokens = supertokens_1.default.getInstanceOrThrowError();
             server.ext("onPreHandler", (req, h) =>
@@ -199,6 +199,7 @@ const plugin = {
                         supportedRoutes.push({
                             path,
                             method: api.method,
+                            options: options.routeOptions,
                             handler: (_, h) => {
                                 return h.continue;
                             },

--- a/lib/build/framework/hapi/framework.js
+++ b/lib/build/framework/hapi/framework.js
@@ -139,7 +139,12 @@ exports.HapiResponse = HapiResponse;
 const plugin = {
     name: "supertokens-hapi-middleware",
     version: "1.0.0",
-    register: function (server, options) {
+    register: function (
+        server,
+        options = {
+            routeOptions: {},
+        }
+    ) {
         return __awaiter(this, void 0, void 0, function* () {
             let supertokens = supertokens_1.default.getInstanceOrThrowError();
             server.ext("onPreHandler", (req, h) =>
@@ -199,7 +204,7 @@ const plugin = {
                         supportedRoutes.push({
                             path,
                             method: api.method,
-                            options: options.routeOptions,
+                            options: options.routeOptions || {},
                             handler: (_, h) => {
                                 return h.continue;
                             },

--- a/lib/build/framework/hapi/index.d.ts
+++ b/lib/build/framework/hapi/index.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
 export type { SessionRequest } from "./framework";
-export declare const plugin: import("@hapi/hapi").Plugin<{}>;
+export declare const plugin: import("@hapi/hapi").Plugin<import("./framework").SupertokensPluginOptions>;
 export declare const wrapRequest: (unwrapped: any) => import("..").BaseRequest;
 export declare const wrapResponse: (unwrapped: any) => import("..").BaseResponse;

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-export declare const version = "7.3.0";
+export declare const version = "7.4.0";
 export declare const cdiSupported: string[];

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -14,5 +14,5 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "7.3.0";
+exports.version = "7.4.0";
 exports.cdiSupported = ["2.7", "2.8", "2.9"];

--- a/lib/ts/framework/hapi/framework.ts
+++ b/lib/ts/framework/hapi/framework.ts
@@ -141,13 +141,18 @@ export class HapiResponse extends BaseResponse {
 }
 
 export interface SupertokensPluginOptions {
-    routeOptions: RouteOptions;
+    routeOptions?: RouteOptions;
 }
 
 const plugin: Plugin<SupertokensPluginOptions> = {
     name: "supertokens-hapi-middleware",
     version: "1.0.0",
-    register: async function (server, options) {
+    register: async function (
+        server,
+        options = {
+            routeOptions: {},
+        }
+    ) {
         let supertokens = SuperTokens.getInstanceOrThrowError();
         server.ext("onPreHandler", async (req, h) => {
             let request = new HapiRequest(req);
@@ -215,7 +220,7 @@ const plugin: Plugin<SupertokensPluginOptions> = {
                     supportedRoutes.push({
                         path,
                         method: api.method,
-                        options: options.routeOptions,
+                        options: options.routeOptions || {},
                         handler: (_, h) => {
                             return h.continue;
                         },

--- a/lib/ts/framework/hapi/framework.ts
+++ b/lib/ts/framework/hapi/framework.ts
@@ -13,7 +13,7 @@
  * under the License.
  */
 
-import type { Request, ResponseToolkit, Plugin, ResponseObject, ServerRoute } from "@hapi/hapi";
+import type { Request, ResponseToolkit, Plugin, ResponseObject, ServerRoute, RouteOptions } from "@hapi/hapi";
 import type { Boom } from "@hapi/boom";
 import type { HTTPMethod } from "../../types";
 import { normaliseHttpMethod } from "../../utils";
@@ -140,10 +140,14 @@ export class HapiResponse extends BaseResponse {
     };
 }
 
-const plugin: Plugin<{}> = {
+export interface SupertokensPluginOptions {
+    routeOptions: RouteOptions;
+}
+
+const plugin: Plugin<SupertokensPluginOptions> = {
     name: "supertokens-hapi-middleware",
     version: "1.0.0",
-    register: async function (server, _) {
+    register: async function (server, options) {
         let supertokens = SuperTokens.getInstanceOrThrowError();
         server.ext("onPreHandler", async (req, h) => {
             let request = new HapiRequest(req);
@@ -211,6 +215,7 @@ const plugin: Plugin<{}> = {
                     supportedRoutes.push({
                         path,
                         method: api.method,
+                        options: options.routeOptions,
                         handler: (_, h) => {
                             return h.continue;
                         },
@@ -227,7 +232,7 @@ export interface SessionRequest extends Request {
 }
 
 export interface HapiFramework extends Framework {
-    plugin: Plugin<{}>;
+    plugin: Plugin<SupertokensPluginOptions>;
 }
 
 export const HapiWrapper: HapiFramework = {

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,6 +12,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "7.3.0";
+export const version = "7.4.0";
 
 export const cdiSupported = ["2.7", "2.8", "2.9"];

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
     "name": "supertokens-node",
-    "version": "7.3.0",
+    "version": "7.4.0",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {
-        "test": "TEST_MODE=testing npx mocha --timeout 500000",
+        "test": "INSTALL_PATH=../supertokens-root TEST_MODE=testing npx mocha --timeout 500000",
         "build-check": "cd lib && npx tsc -p tsconfig.json --noEmit && cd ../test/with-typescript && npx tsc -p tsconfig.json --noEmit",
         "build": "cd lib && rm -rf build && npx tsc -p tsconfig.json && cd ../test/with-typescript && npx tsc -p tsconfig.json --noEmit && cd ../.. && npm run post-build",
         "pretty": "npx pretty-quick .",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {
-        "test": "INSTALL_PATH=../supertokens-root TEST_MODE=testing npx mocha --timeout 500000",
+        "test": "TEST_MODE=testing npx mocha --timeout 500000",
         "build-check": "cd lib && npx tsc -p tsconfig.json --noEmit && cd ../test/with-typescript && npx tsc -p tsconfig.json --noEmit",
         "build": "cd lib && rm -rf build && npx tsc -p tsconfig.json && cd ../test/with-typescript && npx tsc -p tsconfig.json --noEmit && cd ../.. && npm run post-build",
         "pretty": "npx pretty-quick .",


### PR DESCRIPTION
Hello, this is my first PR in an open-source project :)

## Summary of change

It adds the possibility to add options to supertokens route when registering the Hapi plugin.

**Use case description :** 
I needed this in a project because I wanted to implement session verification as Hapi auth scheme ([see here](https://hapi.dev/tutorials/auth?lang=en_US#authenticate)) and not as a lifecycle method (`verifySession()`) like it is implemented right now.
However, by implementing the scheme into the project, auth is enabled by default on all routes, even on the routes added by supertokens. So calling when calling `/auth/session/refresh`, the method authenticating the call threw and it didn't refresh.

Now, I can just disable authentication on supertokens route this way :
```typescript
server.register(supertokensPlugin, {
  options: {
    routeOptions: { auth: false },
  }
})
```
## Related issues

## Test Plan

## Documentation changes

- Maybe add documentation for this new option

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
