### PR TITLE
fixes issue with samesite config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 .
 
+## [7.3.1] - 2021-10-18
+
+### Fixed
+
+-   URL protocol is being taken into account when determining the value of cookie same site: https://github.com/supertokens/supertokens-golang/issues/36
+
 ## [7.3.0] - 2021-10-11
 
 ### Added

--- a/lib/build/recipe/session/utils.d.ts
+++ b/lib/build/recipe/session/utils.d.ts
@@ -24,6 +24,7 @@ export declare function sendTokenTheftDetectedResponse(
 ): Promise<void>;
 export declare function normaliseSessionScopeOrThrowError(sessionScope: string): string;
 export declare function getTopLevelDomainForSameSiteResolution(url: string): string;
+export declare function getURLProtocol(url: string): string;
 export declare function validateAndNormaliseUserInput(
     recipeInstance: SessionRecipe,
     appInfo: NormalisedAppinfo,

--- a/lib/build/recipe/session/utils.js
+++ b/lib/build/recipe/session/utils.js
@@ -118,6 +118,11 @@ function getTopLevelDomainForSameSiteResolution(url) {
     return parsedURL.domain;
 }
 exports.getTopLevelDomainForSameSiteResolution = getTopLevelDomainForSameSiteResolution;
+function getURLProtocol(url) {
+    let urlObj = new url_1.URL(url);
+    return urlObj.protocol;
+}
+exports.getURLProtocol = getURLProtocol;
 function validateAndNormaliseUserInput(recipeInstance, appInfo, config) {
     utils_1.validateTheStructureOfUserInput(config, types_1.InputSchema, "session recipe");
     let cookieDomain =
@@ -126,7 +131,10 @@ function validateAndNormaliseUserInput(recipeInstance, appInfo, config) {
             : normaliseSessionScopeOrThrowError(config.cookieDomain);
     let topLevelAPIDomain = getTopLevelDomainForSameSiteResolution(appInfo.apiDomain.getAsStringDangerous());
     let topLevelWebsiteDomain = getTopLevelDomainForSameSiteResolution(appInfo.websiteDomain.getAsStringDangerous());
-    let cookieSameSite = topLevelAPIDomain !== topLevelWebsiteDomain ? "none" : "lax";
+    let protocolOfAPIDomain = getURLProtocol(appInfo.apiDomain.getAsStringDangerous());
+    let protocolOfWebsiteDomain = getURLProtocol(appInfo.websiteDomain.getAsStringDangerous());
+    let cookieSameSite =
+        topLevelAPIDomain !== topLevelWebsiteDomain || protocolOfAPIDomain !== protocolOfWebsiteDomain ? "none" : "lax";
     cookieSameSite =
         config === undefined || config.cookieSameSite === undefined
             ? cookieSameSite

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-export declare const version = "7.3.0";
+export declare const version = "7.3.1";
 export declare const cdiSupported: string[];

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -14,5 +14,5 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "7.3.0";
+exports.version = "7.3.1";
 exports.cdiSupported = ["2.7", "2.8", "2.9"];

--- a/lib/ts/recipe/session/utils.ts
+++ b/lib/ts/recipe/session/utils.ts
@@ -122,6 +122,11 @@ export function getTopLevelDomainForSameSiteResolution(url: string): string {
     return parsedURL.domain;
 }
 
+export function getURLProtocol(url: string): string {
+    let urlObj = new URL(url);
+    return urlObj.protocol;
+}
+
 export function validateAndNormaliseUserInput(
     recipeInstance: SessionRecipe,
     appInfo: NormalisedAppinfo,
@@ -136,7 +141,11 @@ export function validateAndNormaliseUserInput(
     let topLevelAPIDomain = getTopLevelDomainForSameSiteResolution(appInfo.apiDomain.getAsStringDangerous());
     let topLevelWebsiteDomain = getTopLevelDomainForSameSiteResolution(appInfo.websiteDomain.getAsStringDangerous());
 
-    let cookieSameSite: "strict" | "lax" | "none" = topLevelAPIDomain !== topLevelWebsiteDomain ? "none" : "lax";
+    let protocolOfAPIDomain = getURLProtocol(appInfo.apiDomain.getAsStringDangerous());
+    let protocolOfWebsiteDomain = getURLProtocol(appInfo.websiteDomain.getAsStringDangerous());
+
+    let cookieSameSite: "strict" | "lax" | "none" =
+        topLevelAPIDomain !== topLevelWebsiteDomain || protocolOfAPIDomain !== protocolOfWebsiteDomain ? "none" : "lax";
     cookieSameSite =
         config === undefined || config.cookieSameSite === undefined
             ? cookieSameSite

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,6 +12,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "7.3.0";
+export const version = "7.3.1";
 
 export const cdiSupported = ["2.7", "2.8", "2.9"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "7.3.0",
+    "version": "7.3.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "7.3.0",
+    "version": "7.3.1",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1068,6 +1068,25 @@ describe(`configTest: ${printPath("[test/config.test.js]")}`, function () {
             }
             resetAll();
         }
+
+        {
+            STExpress.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                },
+                appInfo: {
+                    apiDomain: "https://localhost",
+                    appName: "Supertokens",
+                    websiteDomain: "http://localhost:3000",
+                },
+                recipeList: [Session.init()],
+            });
+
+            assert(SessionRecipe.getInstanceOrThrowError().config.cookieSecure);
+            assert(SessionRecipe.getInstanceOrThrowError().config.cookieSameSite === "none");
+
+            resetAll();
+        }
     });
 
     it("test config schema", async function () {


### PR DESCRIPTION
## Summary of change

Determines value of cookie same site also based on protocol of the URL

## Related issues

-   https://github.com/supertokens/supertokens-golang/issues/36

## Test Plan

Added one config test for this + did manual testing

## Documentation changes

None

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
