### PR TITLE
Fix for Github provider when getting the users primary email

### DIFF
--- a/lib/build/recipe/thirdparty/providers/github.js
+++ b/lib/build/recipe/thirdparty/providers/github.js
@@ -82,10 +82,22 @@ function Github(config) {
                 let userInfo = response.data;
                 let emailsInfo = emailsInfoResponse.data;
                 let id = userInfo.id.toString(); // github userId will be a number
-                // if user has choosen not to show their email publicly, userInfo here will
-                // have email as null. So we instead get the info from the emails api and
-                // use the email which is maked as isDefault one.
-                let emailInfo = emailsInfo.find((e) => e.isDefault);
+                /*
+                    if user has choosen not to show their email publicly, userInfo here will
+                    have email as null. So we instead get the info from the emails api and
+                    use the email which is marked as primary one.
+    
+                    Sample github response for email info
+                    [
+                        {
+                            email: '<email>',
+                            primary: true,
+                            verified: true,
+                            visibility: 'public'
+                        }
+                    ]
+                */
+                let emailInfo = emailsInfo.find((e) => e.primary);
                 if (emailInfo === undefined) {
                     return {
                         id,

--- a/lib/ts/recipe/thirdparty/providers/github.ts
+++ b/lib/ts/recipe/thirdparty/providers/github.ts
@@ -81,10 +81,22 @@ export default function Github(config: TypeThirdPartyProviderGithubConfig): Type
             let userInfo = response.data;
             let emailsInfo = emailsInfoResponse.data;
             let id = userInfo.id.toString(); // github userId will be a number
-            // if user has choosen not to show their email publicly, userInfo here will
-            // have email as null. So we instead get the info from the emails api and
-            // use the email which is maked as isDefault one.
-            let emailInfo = emailsInfo.find((e: any) => e.isDefault);
+            /*
+                if user has choosen not to show their email publicly, userInfo here will
+                have email as null. So we instead get the info from the emails api and
+                use the email which is marked as primary one.
+
+                Sample github response for email info
+                [
+                    {
+                        email: '<email>',
+                        primary: true,
+                        verified: true,
+                        visibility: 'public'
+                    }
+                ]
+            */
+            let emailInfo = emailsInfo.find((e: any) => e.primary);
             if (emailInfo === undefined) {
                 return {
                     id,


### PR DESCRIPTION
## Summary of change
Uses `primary` instead of `isDefault` for the Github third party provider when getting the user's email

## Test Plan
NA

## Documentation changes
NA

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`). If creating a sub recipe, make sure to use `bind(this)` when calling the original implementation from your functions

## Remaining TODOs for this PR
None
