### PR TITLE
uses sub in the id_token as thirdpartyId for apple & verifies id_token from apple's servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     -   Adds apple sign in callback API
 -   Optional `getRedirectURI` function added to social providers in case we set the `redirect_uri` on the backend.
 -   Adds optional `isDefault` param to auth providers so that they can be reused with different credentials.
+-   Verifies ID Token sent for sign in with apple as per https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/verifying_a_user
 
 ## [8.0.4] - 2021-10-28
 

--- a/lib/build/recipe/thirdparty/providers/apple.js
+++ b/lib/build/recipe/thirdparty/providers/apple.js
@@ -36,6 +36,7 @@ const error_1 = require("../error");
 const implementation_1 = require("../api/implementation");
 const supertokens_1 = require("../../../supertokens");
 const constants_1 = require("../constants");
+const verify_apple_id_token_1 = require("verify-apple-id-token");
 function Apple(config) {
     const id = "apple";
     function getClientSecret(clientId, keyId, teamId, privateKey) {
@@ -100,7 +101,16 @@ function Apple(config) {
         );
         function getProfileInfo(accessTokenAPIResponse) {
             return __awaiter(this, void 0, void 0, function* () {
-                let payload = jsonwebtoken_1.decode(accessTokenAPIResponse.id_token);
+                /*
+                - Verify the JWS E256 signature using the server’s public key
+                - Verify the nonce for the authentication
+                - Verify that the iss field contains https://appleid.apple.com
+                - Verify that the aud field is the developer’s client_id
+                - Verify that the time is earlier than the exp value of the token */
+                const payload = yield verify_apple_id_token_1.default({
+                    idToken: accessTokenAPIResponse.id_token,
+                    clientId: implementation_1.getActualClientIdFromDevelopmentClientId(config.clientId),
+                });
                 if (payload === null) {
                     throw new Error("no user info found from user's id token received from apple");
                 }

--- a/lib/build/recipe/thirdparty/providers/apple.js
+++ b/lib/build/recipe/thirdparty/providers/apple.js
@@ -121,7 +121,12 @@ function Apple(config) {
         }
         function getRedirectURI() {
             let supertokens = supertokens_1.default.getInstanceOrThrowError();
-            return supertokens.appInfo.apiDomain.getAsStringDangerous() + constants_1.APPLE_REDIRECT_HANDLER;
+            return (
+                supertokens.appInfo.apiDomain.getAsStringDangerous() +
+                supertokens.appInfo.apiGatewayPath.getAsStringDangerous() +
+                supertokens.appInfo.apiBasePath.getAsStringDangerous() +
+                constants_1.APPLE_REDIRECT_HANDLER
+            );
         }
         return {
             accessTokenAPI: {

--- a/lib/build/recipe/thirdparty/providers/apple.js
+++ b/lib/build/recipe/thirdparty/providers/apple.js
@@ -104,7 +104,8 @@ function Apple(config) {
                 if (payload === null) {
                     throw new Error("no user info found from user's id token received from apple");
                 }
-                let id = payload.email;
+                let id = payload.sub;
+                let email = payload.email;
                 let isVerified = payload.email_verified;
                 if (id === undefined || id === null) {
                     throw new Error("no user info found from user's id token received from apple");
@@ -112,7 +113,7 @@ function Apple(config) {
                 return {
                     id,
                     email: {
-                        id,
+                        id: email,
                         isVerified,
                     },
                 };

--- a/lib/ts/recipe/thirdparty/providers/apple.ts
+++ b/lib/ts/recipe/thirdparty/providers/apple.ts
@@ -113,7 +113,8 @@ export default function Apple(config: TypeThirdPartyProviderAppleConfig): TypePr
             if (payload === null) {
                 throw new Error("no user info found from user's id token received from apple");
             }
-            let id = (payload as any).email as string;
+            let id = (payload as any).sub as string;
+            let email = (payload as any).email as string;
             let isVerified = (payload as any).email_verified;
             if (id === undefined || id === null) {
                 throw new Error("no user info found from user's id token received from apple");
@@ -121,7 +122,7 @@ export default function Apple(config: TypeThirdPartyProviderAppleConfig): TypePr
             return {
                 id,
                 email: {
-                    id,
+                    id: email,
                     isVerified,
                 },
             };

--- a/lib/ts/recipe/thirdparty/providers/apple.ts
+++ b/lib/ts/recipe/thirdparty/providers/apple.ts
@@ -129,7 +129,12 @@ export default function Apple(config: TypeThirdPartyProviderAppleConfig): TypePr
         }
         function getRedirectURI() {
             let supertokens = SuperTokens.getInstanceOrThrowError();
-            return supertokens.appInfo.apiDomain.getAsStringDangerous() + APPLE_REDIRECT_HANDLER;
+            return (
+                supertokens.appInfo.apiDomain.getAsStringDangerous() +
+                supertokens.appInfo.apiGatewayPath.getAsStringDangerous() +
+                supertokens.appInfo.apiBasePath.getAsStringDangerous() +
+                APPLE_REDIRECT_HANDLER
+            );
         }
         return {
             accessTokenAPI: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -928,6 +928,11 @@
                 "fast-deep-equal": "^3.1.3"
             }
         },
+        "@panva/asn1.js": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
+            "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw=="
+        },
         "@sideway/address": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.2.tgz",
@@ -1003,7 +1008,6 @@
             "version": "1.19.1",
             "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz",
             "integrity": "sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==",
-            "dev": true,
             "requires": {
                 "@types/connect": "*",
                 "@types/node": "*"
@@ -1023,7 +1027,6 @@
             "version": "3.4.35",
             "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
             "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-            "dev": true,
             "requires": {
                 "@types/node": "*"
             }
@@ -1071,22 +1074,37 @@
             "version": "4.16.1",
             "resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.1.tgz",
             "integrity": "sha512-V0clmJow23WeyblmACoxbHBu2JKlE5TiIme6Lem14FnPW9gsttyHtk6wq7njcdIWH1njAaFgR8gW09lgY98gQg==",
-            "dev": true,
             "requires": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "*",
                 "@types/serve-static": "*"
             }
         },
+        "@types/express-jwt": {
+            "version": "0.0.42",
+            "resolved": "https://registry.npmjs.org/@types/express-jwt/-/express-jwt-0.0.42.tgz",
+            "integrity": "sha512-WszgUddvM1t5dPpJ3LhWNH8kfNN8GPIBrAGxgIYXVCEGx6Bx4A036aAuf/r5WH9DIEdlmp7gHOYvSM6U87B0ag==",
+            "requires": {
+                "@types/express": "*",
+                "@types/express-unless": "*"
+            }
+        },
         "@types/express-serve-static-core": {
             "version": "4.17.24",
             "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz",
             "integrity": "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==",
-            "dev": true,
             "requires": {
                 "@types/node": "*",
                 "@types/qs": "*",
                 "@types/range-parser": "*"
+            }
+        },
+        "@types/express-unless": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/@types/express-unless/-/express-unless-0.5.2.tgz",
+            "integrity": "sha512-Q74UyYRX/zIgl1HSp9tUX2PlG8glkVm+59r7aK4KGKzC5jqKIOX6rrVLRQrzpZUQ84VukHtRoeAuon2nIssHPQ==",
+            "requires": {
+                "@types/express": "*"
             }
         },
         "@types/hapi__catbox": {
@@ -1199,8 +1217,7 @@
         "@types/mime": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
-            "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-            "dev": true
+            "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
         },
         "@types/mime-db": {
             "version": "1.43.1",
@@ -1223,8 +1240,7 @@
         "@types/node": {
             "version": "16.9.1",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-            "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
-            "dev": true
+            "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="
         },
         "@types/on-finished": {
             "version": "2.3.1",
@@ -1244,20 +1260,17 @@
         "@types/qs": {
             "version": "6.9.7",
             "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-            "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-            "dev": true
+            "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
         },
         "@types/range-parser": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-            "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-            "dev": true
+            "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
         },
         "@types/serve-static": {
             "version": "1.13.9",
             "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.9.tgz",
             "integrity": "sha512-ZFqF6qa48XsPdjXV5Gsz0Zqmux2PerNd3a/ktL45mHpa19cuMi/cL8tcxdAx497yRh+QtYPuofjT9oWw9P7nkA==",
-            "dev": true,
             "requires": {
                 "@types/mime": "^1",
                 "@types/node": "*"
@@ -3601,6 +3614,14 @@
                 "@sideway/pinpoint": "^2.0.0"
             }
         },
+        "jose": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.5.tgz",
+            "integrity": "sha512-BAiDNeDKTMgk4tvD0BbxJ8xHEHBZgpeRZ1zGPPsitSyMgjoMWiLGYAE7H7NpP5h0lPppQajQs871E8NHUrzVPA==",
+            "requires": {
+                "@panva/asn1.js": "^1.0.0"
+            }
+        },
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3729,6 +3750,33 @@
                 "buffer-equal-constant-time": "1.0.1",
                 "ecdsa-sig-formatter": "1.0.11",
                 "safe-buffer": "^5.0.1"
+            }
+        },
+        "jwks-rsa": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-2.0.5.tgz",
+            "integrity": "sha512-fliHfsiBRzEU0nXzSvwnh0hynzGB0WihF+CinKbSRlaqRxbqqKf2xbBPgwc8mzf18/WgwlG8e5eTpfSTBcU4DQ==",
+            "requires": {
+                "@types/express-jwt": "0.0.42",
+                "debug": "^4.3.2",
+                "jose": "^2.0.5",
+                "limiter": "^1.1.5",
+                "lru-memoizer": "^2.1.4"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                }
             }
         },
         "jws": {
@@ -3940,6 +3988,11 @@
                 }
             }
         },
+        "limiter": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+            "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+        },
         "loader-utils": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
@@ -3966,6 +4019,11 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
+        },
+        "lodash.clonedeep": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
         },
         "lodash.get": {
             "version": "4.4.2",
@@ -4123,6 +4181,31 @@
             "dev": true,
             "requires": {
                 "yallist": "^4.0.0"
+            }
+        },
+        "lru-memoizer": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.1.4.tgz",
+            "integrity": "sha512-IXAq50s4qwrOBrXJklY+KhgZF+5y98PDaNo0gi/v2KQBFLyWr+JyFvijZXkGKjQj/h9c0OwoE+JZbwUXce76hQ==",
+            "requires": {
+                "lodash.clonedeep": "^4.5.0",
+                "lru-cache": "~4.0.0"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+                    "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
+                    "requires": {
+                        "pseudomap": "^1.0.1",
+                        "yallist": "^2.0.0"
+                    }
+                },
+                "yallist": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                    "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+                }
             }
         },
         "lunr": {
@@ -5449,6 +5532,11 @@
                 "ipaddr.js": "1.9.1"
             }
         },
+        "pseudomap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+        },
         "psl": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -6559,6 +6647,15 @@
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
             "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
             "dev": true
+        },
+        "verify-apple-id-token": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/verify-apple-id-token/-/verify-apple-id-token-2.1.0.tgz",
+            "integrity": "sha512-YUAJjOhJqTX7513gRPFR6auz3sRIQPu+YMlTRq1XSKTLxQL25+Z/EGTvpM4Yu1CjzskREdhHXhjoAhpyldfXJA==",
+            "requires": {
+                "jsonwebtoken": "^8.5.1",
+                "jwks-rsa": "^2.0.2"
+            }
         },
         "vm-browserify": {
             "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
         "jsonschema": "1.4.0",
         "jsonwebtoken": "8.5.1",
         "psl": "1.8.0",
-        "supertokens-js-override": "git+https://github.com/supertokens/supertokens-js-override.git#v0.0.3"
+        "supertokens-js-override": "git+https://github.com/supertokens/supertokens-js-override.git#v0.0.3",
+        "verify-apple-id-token": "^2.1.0"
     },
     "devDependencies": {
         "@hapi/hapi": "^20.2.0",

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -563,6 +563,7 @@ describe(`configTest: ${printPath("[test/config.test.js]")}`, function () {
         assert.strictEqual(normaliseURLPathOrThrowError("127.0.0.1/one/two"), "/one/two");
         assert.strictEqual(normaliseURLPathOrThrowError("https://127.0.0.1:80/one/two"), "/one/two");
         assert.strictEqual(normaliseURLPathOrThrowError("/"), "");
+        assert.strictEqual(normaliseURLPathOrThrowError(""), "");
 
         assert.strictEqual(normaliseURLPathOrThrowError("/.netlify/functions/api"), "/.netlify/functions/api");
         assert.strictEqual(normaliseURLPathOrThrowError("/netlify/.functions/api"), "/netlify/.functions/api");


### PR DESCRIPTION
## Summary of change

- Uses `sub` claim for apple's userId 
- Uses apiGatewayPath and apiBasePath in paths for redirect_uri for apple
- Verifies id_token sent by apple using their jwks endpoint

## Related issues

-   https://github.com/supertokens/supertokens-core/issues/320


## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`). If creating a sub recipe, make sure to use `bind(this)` when calling the original implementation from your functions

## Remaining TODOs for this PR

-   [x] Verification of id_token before using it
