### PR TITLE
Response sent check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Sign in with Discord, Google workspaces, Active directory and Okta.
 -   If `getProfileInfo` throws an error, then it is sent as a FIELD_ERROR to the frontend
 
+### Changed
+
+-   Changes `sendJSONResponse to not allow setting of result if it has already been set
+
 ## [8.1.1] - 2021-11-08
 
 ### Changes

--- a/lib/build/framework/awsLambda/framework.js
+++ b/lib/build/framework/awsLambda/framework.js
@@ -164,9 +164,11 @@ class AWSResponse extends response_1.BaseResponse {
             this.statusCode = statusCode;
         };
         this.sendJSONResponse = (content) => {
-            this.content = JSON.stringify(content);
-            this.setHeader("Context-Type", "application/json", false);
-            this.responseSet = true;
+            if (!this.responseSet) {
+                this.content = JSON.stringify(content);
+                this.setHeader("Context-Type", "application/json", false);
+                this.responseSet = true;
+            }
         };
         this.sendResponse = (response) => {
             let headers = response.headers;

--- a/lib/build/framework/hapi/framework.js
+++ b/lib/build/framework/hapi/framework.js
@@ -128,8 +128,10 @@ class HapiResponse extends response_1.BaseResponse {
          * @param {any} content
          */
         this.sendJSONResponse = (content) => {
-            this.content = content;
-            this.responseSet = true;
+            if (!this.responseSet) {
+                this.content = content;
+                this.responseSet = true;
+            }
         };
         this.sendResponse = (overwriteHeaders = false) => {
             if (!overwriteHeaders) {

--- a/lib/build/framework/koa/framework.d.ts
+++ b/lib/build/framework/koa/framework.d.ts
@@ -20,6 +20,7 @@ export declare class KoaRequest extends BaseRequest {
 }
 export declare class KoaResponse extends BaseResponse {
     private ctx;
+    responseSet: boolean;
     constructor(ctx: Context);
     sendHTMLResponse: (html: string) => void;
     setHeader: (key: string, value: string, allowDuplicateKey: boolean) => void;

--- a/lib/build/framework/koa/framework.js
+++ b/lib/build/framework/koa/framework.js
@@ -116,6 +116,7 @@ function parseURLEncodedFormData(ctx) {
 class KoaResponse extends response_1.BaseResponse {
     constructor(ctx) {
         super();
+        this.responseSet = false;
         this.sendHTMLResponse = (html) => {
             this.ctx.set("content-type", "text/html");
             this.ctx.body = html;
@@ -153,7 +154,10 @@ class KoaResponse extends response_1.BaseResponse {
             this.ctx.status = statusCode;
         };
         this.sendJSONResponse = (content) => {
-            this.ctx.body = content;
+            if (!this.responseSet) {
+                this.ctx.body = content;
+                this.responseSet = true;
+            }
         };
         this.original = ctx;
         this.ctx = ctx;

--- a/lib/ts/framework/awsLambda/framework.ts
+++ b/lib/ts/framework/awsLambda/framework.ts
@@ -207,9 +207,11 @@ export class AWSResponse extends BaseResponse {
     };
 
     sendJSONResponse = (content: any) => {
-        this.content = JSON.stringify(content);
-        this.setHeader("Context-Type", "application/json", false);
-        this.responseSet = true;
+        if (!this.responseSet) {
+            this.content = JSON.stringify(content);
+            this.setHeader("Context-Type", "application/json", false);
+            this.responseSet = true;
+        }
     };
 
     sendResponse = (response: APIGatewayProxyResult | APIGatewayProxyStructuredResultV2) => {

--- a/lib/ts/framework/hapi/framework.ts
+++ b/lib/ts/framework/hapi/framework.ts
@@ -138,8 +138,10 @@ export class HapiResponse extends BaseResponse {
      * @param {any} content
      */
     sendJSONResponse = (content: any) => {
-        this.content = content;
-        this.responseSet = true;
+        if (!this.responseSet) {
+            this.content = content;
+            this.responseSet = true;
+        }
     };
 
     sendResponse = (overwriteHeaders = false): ResponseObject => {

--- a/lib/ts/framework/koa/framework.ts
+++ b/lib/ts/framework/koa/framework.ts
@@ -95,6 +95,7 @@ async function parseURLEncodedFormData(ctx: Context) {
 
 export class KoaResponse extends BaseResponse {
     private ctx: Context;
+    public responseSet: boolean = false;
 
     constructor(ctx: Context) {
         super();
@@ -153,7 +154,10 @@ export class KoaResponse extends BaseResponse {
     };
 
     sendJSONResponse = (content: any) => {
-        this.ctx.body = content;
+        if (!this.responseSet) {
+            this.ctx.body = content;
+            this.responseSet = true;
+        }
     };
 }
 

--- a/test/framework/awsLambda.test.js
+++ b/test/framework/awsLambda.test.js
@@ -27,6 +27,7 @@ let { ProcessState, PROCESS_STATE } = require("../../lib/build/processState");
 let SuperTokens = require("../../");
 let { middleware } = require("../../framework/awsLambda");
 let Session = require("../../recipe/session");
+let EmailPassword = require("../../recipe/emailpassword");
 let { verifySession } = require("../../recipe/session/framework/awsLambda");
 
 describe(`AWS Lambda: ${printPath("[test/framework/awsLambda.test.js]")}`, function () {
@@ -387,5 +388,46 @@ describe(`AWS Lambda: ${printPath("[test/framework/awsLambda.test.js]")}`, funct
         assert(sessionRevokedResponseExtracted.refreshToken === "");
         assert(sessionRevokedResponseExtracted.idRefreshTokenFromCookie === "");
         assert(sessionRevokedResponseExtracted.idRefreshTokenFromHeader === "remove");
+    });
+
+    it("sending custom response awslambda", async function () {
+        await startST();
+        SuperTokens.init({
+            framework: "awsLambda",
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+                apiGatewayPath: "/dev",
+            },
+            recipeList: [
+                EmailPassword.init({
+                    override: {
+                        apis: (oI) => {
+                            return {
+                                ...oI,
+                                emailExistsGET: async function (input) {
+                                    input.options.res.sendJSONResponse({
+                                        custom: true,
+                                    });
+                                    return oI.emailExistsGET(input);
+                                },
+                            };
+                        },
+                    },
+                }),
+                Session.init(),
+            ],
+        });
+
+        let proxy = "/dev";
+        let event = mockLambdaProxyEventV2("/auth/signup/email/exists", "GET", null, null, proxy, null, {
+            email: "test@example.com",
+        });
+        let result = await middleware()(event, undefined);
+        assert(JSON.parse(result.body).custom);
     });
 });

--- a/test/framework/fastify.test.js
+++ b/test/framework/fastify.test.js
@@ -18,6 +18,7 @@ let { ProcessState, PROCESS_STATE } = require("../../lib/build/processState");
 let SuperTokens = require("../../");
 let FastifyFramework = require("../../framework/fastify");
 const Fastify = require("fastify");
+let EmailPassword = require("../../recipe/emailpassword");
 let Session = require("../../recipe/session");
 let { verifySession } = require("../../recipe/session/framework/fastify");
 
@@ -1291,5 +1292,48 @@ describe(`Fastify: ${printPath("[test/framework/fastify.test.js]")}`, function (
             },
         });
         assert.strictEqual(invalidSessionResponse.json().success, true);
+    });
+
+    it("sending custom response fastify", async function () {
+        await startST();
+        SuperTokens.init({
+            framework: "fastify",
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                EmailPassword.init({
+                    override: {
+                        apis: (oI) => {
+                            return {
+                                ...oI,
+                                emailExistsGET: async function (input) {
+                                    input.options.res.sendJSONResponse({
+                                        custom: true,
+                                    });
+                                    return oI.emailExistsGET(input);
+                                },
+                            };
+                        },
+                    },
+                }),
+                Session.init(),
+            ],
+        });
+
+        await this.server.register(FastifyFramework.plugin);
+
+        //create a new session
+        let response = await this.server.inject({
+            method: "get",
+            url: "/auth/signup/email/exists?email=test@example.com",
+        });
+
+        assert(JSON.parse(response.body).custom);
     });
 });

--- a/test/framework/koa.test.js
+++ b/test/framework/koa.test.js
@@ -18,6 +18,7 @@ let { ProcessState, PROCESS_STATE } = require("../../lib/build/processState");
 let SuperTokens = require("../../");
 let KoaFramework = require("../../framework/koa");
 let Session = require("../../recipe/session");
+let EmailPassword = require("../../recipe/emailpassword");
 let Koa = require("koa");
 const Router = require("@koa/router");
 let { verifySession } = require("../../recipe/session/framework/koa");
@@ -1567,5 +1568,56 @@ describe(`Koa: ${printPath("[test/framework/koa.test.js]")}`, function () {
                 })
         );
         assert.strictEqual(invalidSessionResponse.body.success, true);
+    });
+
+    it("sending custom response koa", async function () {
+        await startST();
+        SuperTokens.init({
+            framework: "koa",
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                EmailPassword.init({
+                    override: {
+                        apis: (oI) => {
+                            return {
+                                ...oI,
+                                emailExistsGET: async function (input) {
+                                    input.options.res.sendJSONResponse({
+                                        custom: true,
+                                    });
+                                    return oI.emailExistsGET(input);
+                                },
+                            };
+                        },
+                    },
+                }),
+                Session.init(),
+            ],
+        });
+
+        const app = new Koa();
+        app.use(KoaFramework.middleware());
+        this.server = app.listen(9999);
+
+        let response = await new Promise((resolve) =>
+            request(this.server)
+                .get("/auth/signup/email/exists?email=test@example.com")
+                .expect(200)
+                .end((err, res) => {
+                    if (err) {
+                        resolve(undefined);
+                    } else {
+                        resolve(res);
+                    }
+                })
+        );
+        assert(response.body.custom);
     });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -402,7 +402,7 @@ module.exports.mockLambdaProxyEvent = function (path, httpMethod, headers, body,
     };
 };
 
-module.exports.mockLambdaProxyEventV2 = function (path, httpMethod, headers, body, proxy, cookies) {
+module.exports.mockLambdaProxyEventV2 = function (path, httpMethod, headers, body, proxy, cookies, queryParams) {
     return {
         version: "2.0",
         httpMethod,
@@ -415,5 +415,6 @@ module.exports.mockLambdaProxyEventV2 = function (path, httpMethod, headers, bod
             },
             stage: proxy.slice(1),
         },
+        queryStringParameters: queryParams,
     };
 };


### PR DESCRIPTION
## Summary of change

Does not send a response if the user has already sent a response.

## Related issues

- https://github.com/supertokens/supertokens-node/issues/197

## Test Plan

- Added tests for all frameworks to send a custom JSON response via an API ovrride and testing that.

## Documentation changes

None

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).

