### PR TITLE
AWS Lambda API route not found update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   Changes `sendJSONResponse to not allow setting of result if it has already been set
+-   AWS lambda middleware will return `404` response if the API route is not served by the middleware and user has not passed a handler.
 
 ## [8.1.1] - 2021-11-08
 

--- a/lib/build/framework/awsLambda/framework.d.ts
+++ b/lib/build/framework/awsLambda/framework.d.ts
@@ -72,7 +72,7 @@ export declare class AWSResponse extends BaseResponse {
     setStatusCode: (statusCode: number) => void;
     sendJSONResponse: (content: any) => void;
     sendResponse: (
-        response: APIGatewayProxyResult | APIGatewayProxyStructuredResultV2
+        response?: APIGatewayProxyResult | APIGatewayProxyStructuredResultV2 | undefined
     ) => APIGatewayProxyResult | APIGatewayProxyStructuredResultV2;
 }
 export interface SessionEventV2 extends SupertokensLambdaEventV2 {
@@ -83,7 +83,7 @@ export interface SessionEvent extends SupertokensLambdaEvent {
 }
 export declare const middleware: (handler?: Handler<any, any> | undefined) => Handler<any, any>;
 export interface AWSFramework extends Framework {
-    middleware: () => Handler;
+    middleware: (handler?: Handler) => Handler;
 }
 export declare const AWSWrapper: AWSFramework;
 export {};

--- a/lib/build/framework/awsLambda/framework.js
+++ b/lib/build/framework/awsLambda/framework.js
@@ -171,6 +171,9 @@ class AWSResponse extends response_1.BaseResponse {
             }
         };
         this.sendResponse = (response) => {
+            if (response === undefined) {
+                response = {};
+            }
             let headers = response.headers;
             if (headers === undefined) {
                 headers = {};
@@ -254,17 +257,25 @@ exports.middleware = (handler) => {
             try {
                 let result = yield supertokens.middleware(request, response);
                 if (result) {
-                    return response.sendResponse({});
+                    return response.sendResponse();
                 }
                 if (handler !== undefined) {
                     let handlerResult = yield handler(event, context, callback);
                     return response.sendResponse(handlerResult);
                 }
-                return response.sendResponse({});
+                /**
+                 * it reaches this point only if the API route was not exposed by
+                 * the SDK and user didn't provide a handler
+                 */
+                response.setStatusCode(404);
+                response.sendJSONResponse({
+                    error: `The middleware couldn't serve the API path ${request.getOriginalURL()}, method: ${request.getMethod()}. If this is an unexpected behaviour, please create an issue here: https://github.com/supertokens/supertokens-node/issues`,
+                });
+                return response.sendResponse();
             } catch (err) {
                 yield supertokens.errorHandler(err, request, response);
                 if (response.responseSet) {
-                    return response.sendResponse({});
+                    return response.sendResponse();
                 }
                 throw err;
             }

--- a/lib/build/framework/awsLambda/index.d.ts
+++ b/lib/build/framework/awsLambda/index.d.ts
@@ -1,5 +1,7 @@
 // @ts-nocheck
 export type { SessionEvent, SessionEventV2 } from "./framework";
-export declare const middleware: () => import("aws-lambda").Handler<any, any>;
+export declare const middleware: (
+    handler?: import("aws-lambda").Handler<any, any> | undefined
+) => import("aws-lambda").Handler<any, any>;
 export declare const wrapRequest: (unwrapped: any) => import("..").BaseRequest;
 export declare const wrapResponse: (unwrapped: any) => import("..").BaseResponse;


### PR DESCRIPTION
## Summary of change

AWS lambda middleware will return `404` response if the API route is not served by the middleware and user has not passed a handler.

## Related issues

-   #196

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).