### PR TITLE
Add open id recipe and change session recipe to use open id instead of jwt directly

### DIFF
--- a/frontendDriverInterfaceSupported.json
+++ b/frontendDriverInterfaceSupported.json
@@ -1,4 +1,4 @@
 {
     "_comment": "contains a list of frontend-driver interfaces branch names that this core supports",
-    "versions": ["1.8", "1.9", "1.10"]
+    "versions": ["1.8", "1.9", "1.10", "1.11"]
 }

--- a/lib/build/recipe/jwt/api/getJWKS.js
+++ b/lib/build/recipe/jwt/api/getJWKS.js
@@ -51,6 +51,7 @@ function getJWKS(apiImplementation, options) {
         if (apiImplementation.getJWKSGET === undefined) {
             return false;
         }
+        options.res.setHeader("Access-Control-Allow-Origin", "*", false);
         let result = yield apiImplementation.getJWKSGET({ options });
         utils_1.send200Response(options.res, { keys: result.keys });
         return true;

--- a/lib/build/recipe/openid/api/getOpenIdDiscoveryConfiguration.d.ts
+++ b/lib/build/recipe/openid/api/getOpenIdDiscoveryConfiguration.d.ts
@@ -1,0 +1,6 @@
+// @ts-nocheck
+import { APIInterface, APIOptions } from "../types";
+export default function getOpenIdDiscoveryConfiguration(
+    apiImplementation: APIInterface,
+    options: APIOptions
+): Promise<boolean>;

--- a/lib/build/recipe/openid/api/getOpenIdDiscoveryConfiguration.js
+++ b/lib/build/recipe/openid/api/getOpenIdDiscoveryConfiguration.js
@@ -51,6 +51,7 @@ function getOpenIdDiscoveryConfiguration(apiImplementation, options) {
         if (apiImplementation.getOpenIdDiscoveryConfigurationGET === undefined) {
             return false;
         }
+        options.res.setHeader("Access-Control-Allow-Origin", "*", false);
         let result = yield apiImplementation.getOpenIdDiscoveryConfigurationGET({ options });
         utils_1.send200Response(options.res, {
             issuer: result.issuer,

--- a/lib/build/recipe/openid/api/getOpenIdDiscoveryConfiguration.js
+++ b/lib/build/recipe/openid/api/getOpenIdDiscoveryConfiguration.js
@@ -1,0 +1,62 @@
+"use strict";
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+Object.defineProperty(exports, "__esModule", { value: true });
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+const utils_1 = require("../../../utils");
+function getOpenIdDiscoveryConfiguration(apiImplementation, options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (apiImplementation.getOpenIdDiscoveryConfigurationGET === undefined) {
+            return false;
+        }
+        let result = yield apiImplementation.getOpenIdDiscoveryConfigurationGET({ options });
+        utils_1.send200Response(options.res, {
+            issuer: result.issuer,
+            jwks_uri: result.jwks_uri,
+        });
+        return true;
+    });
+}
+exports.default = getOpenIdDiscoveryConfiguration;

--- a/lib/build/recipe/openid/api/implementation.d.ts
+++ b/lib/build/recipe/openid/api/implementation.d.ts
@@ -1,0 +1,3 @@
+// @ts-nocheck
+import { APIInterface } from "../types";
+export default function getAPIImplementation(): APIInterface;

--- a/lib/build/recipe/openid/api/implementation.js
+++ b/lib/build/recipe/openid/api/implementation.js
@@ -35,7 +35,7 @@ function getAPIImplementation() {
     return {
         getOpenIdDiscoveryConfigurationGET: function ({ options }) {
             return __awaiter(this, void 0, void 0, function* () {
-                return yield options.recipeImplementation.getDiscoveryConfiguration();
+                return yield options.recipeImplementation.getOpenIdDiscoveryConfiguration();
             });
         },
     };

--- a/lib/build/recipe/openid/api/implementation.js
+++ b/lib/build/recipe/openid/api/implementation.js
@@ -1,0 +1,43 @@
+"use strict";
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+Object.defineProperty(exports, "__esModule", { value: true });
+function getAPIImplementation() {
+    return {
+        getOpenIdDiscoveryConfigurationGET: function ({ options }) {
+            return __awaiter(this, void 0, void 0, function* () {
+                return yield options.recipeImplementation.getDiscoveryConfiguration();
+            });
+        },
+    };
+}
+exports.default = getAPIImplementation;

--- a/lib/build/recipe/openid/constants.d.ts
+++ b/lib/build/recipe/openid/constants.d.ts
@@ -1,0 +1,2 @@
+// @ts-nocheck
+export declare const GET_DISCOVERY_CONFIG_URL = "/.well-known/openid-configuration";

--- a/lib/build/recipe/openid/constants.js
+++ b/lib/build/recipe/openid/constants.js
@@ -1,0 +1,17 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+exports.GET_DISCOVERY_CONFIG_URL = "/.well-known/openid-configuration";

--- a/lib/build/recipe/openid/index.d.ts
+++ b/lib/build/recipe/openid/index.d.ts
@@ -1,8 +1,12 @@
 // @ts-nocheck
-import OpenIDRecipe from "./recipe";
-export default class OpenIDRecipeWrapper {
-    static init: typeof OpenIDRecipe.init;
-    static getDiscoveryConfiguration(): Promise<import("./types").DiscoveryConfiguration>;
+import OpenIdRecipe from "./recipe";
+export default class OpenIdRecipeWrapper {
+    static init: typeof OpenIdRecipe.init;
+    static getOpenIdDiscoveryConfiguration(): Promise<{
+        status: "OK";
+        issuer: string;
+        jwks_uri: string;
+    }>;
     static createJWT(
         payload?: any,
         validitySeconds?: number
@@ -20,7 +24,7 @@ export default class OpenIDRecipeWrapper {
         keys: import("../jwt").JsonWebKey[];
     }>;
 }
-export declare let init: typeof OpenIDRecipe.init;
-export declare let getDiscoveryConfiguration: typeof OpenIDRecipeWrapper.getDiscoveryConfiguration;
-export declare let createJWT: typeof OpenIDRecipeWrapper.createJWT;
-export declare let getJWKS: typeof OpenIDRecipeWrapper.getJWKS;
+export declare let init: typeof OpenIdRecipe.init;
+export declare let getOpenIdDiscoveryConfiguration: typeof OpenIdRecipeWrapper.getOpenIdDiscoveryConfiguration;
+export declare let createJWT: typeof OpenIdRecipeWrapper.createJWT;
+export declare let getJWKS: typeof OpenIdRecipeWrapper.getJWKS;

--- a/lib/build/recipe/openid/index.d.ts
+++ b/lib/build/recipe/openid/index.d.ts
@@ -1,0 +1,26 @@
+// @ts-nocheck
+import OpenIDRecipe from "./recipe";
+export default class OpenIDRecipeWrapper {
+    static init: typeof OpenIDRecipe.init;
+    static getDiscoveryConfiguration(): Promise<import("./types").DiscoveryConfiguration>;
+    static createJWT(
+        payload?: any,
+        validitySeconds?: number
+    ): Promise<
+        | {
+              status: "OK";
+              jwt: string;
+          }
+        | {
+              status: "UNSUPPORTED_ALGORITHM_ERROR";
+          }
+    >;
+    static getJWKS(): Promise<{
+        status: "OK";
+        keys: import("../jwt").JsonWebKey[];
+    }>;
+}
+export declare let init: typeof OpenIDRecipe.init;
+export declare let getDiscoveryConfiguration: typeof OpenIDRecipeWrapper.getDiscoveryConfiguration;
+export declare let createJWT: typeof OpenIDRecipeWrapper.createJWT;
+export declare let getJWKS: typeof OpenIDRecipeWrapper.getJWKS;

--- a/lib/build/recipe/openid/index.js
+++ b/lib/build/recipe/openid/index.js
@@ -1,0 +1,22 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const recipe_1 = require("./recipe");
+class OpenIDRecipeWrapper {
+    static getDiscoveryConfiguration() {
+        return recipe_1.default.getInstanceOrThrowError().recipeImplementation.getDiscoveryConfiguration();
+    }
+    static createJWT(payload, validitySeconds) {
+        return recipe_1.default
+            .getInstanceOrThrowError()
+            .jwtRecipe.recipeInterfaceImpl.createJWT({ payload, validitySeconds });
+    }
+    static getJWKS() {
+        return recipe_1.default.getInstanceOrThrowError().jwtRecipe.recipeInterfaceImpl.getJWKS();
+    }
+}
+exports.default = OpenIDRecipeWrapper;
+OpenIDRecipeWrapper.init = recipe_1.default.init;
+exports.init = OpenIDRecipeWrapper.init;
+exports.getDiscoveryConfiguration = OpenIDRecipeWrapper.getDiscoveryConfiguration;
+exports.createJWT = OpenIDRecipeWrapper.createJWT;
+exports.getJWKS = OpenIDRecipeWrapper.getJWKS;

--- a/lib/build/recipe/openid/index.js
+++ b/lib/build/recipe/openid/index.js
@@ -6,9 +6,10 @@ class OpenIDRecipeWrapper {
         return recipe_1.default.getInstanceOrThrowError().recipeImplementation.getDiscoveryConfiguration();
     }
     static createJWT(payload, validitySeconds) {
-        return recipe_1.default
-            .getInstanceOrThrowError()
-            .jwtRecipe.recipeInterfaceImpl.createJWT({ payload, validitySeconds });
+        return recipe_1.default.getInstanceOrThrowError().jwtRecipe.recipeInterfaceImpl.createJWT({
+            payload,
+            validitySeconds,
+        });
     }
     static getJWKS() {
         return recipe_1.default.getInstanceOrThrowError().jwtRecipe.recipeInterfaceImpl.getJWKS();

--- a/lib/build/recipe/openid/index.js
+++ b/lib/build/recipe/openid/index.js
@@ -1,9 +1,9 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const recipe_1 = require("./recipe");
-class OpenIDRecipeWrapper {
-    static getDiscoveryConfiguration() {
-        return recipe_1.default.getInstanceOrThrowError().recipeImplementation.getDiscoveryConfiguration();
+class OpenIdRecipeWrapper {
+    static getOpenIdDiscoveryConfiguration() {
+        return recipe_1.default.getInstanceOrThrowError().recipeImplementation.getOpenIdDiscoveryConfiguration();
     }
     static createJWT(payload, validitySeconds) {
         return recipe_1.default.getInstanceOrThrowError().jwtRecipe.recipeInterfaceImpl.createJWT({
@@ -15,9 +15,9 @@ class OpenIDRecipeWrapper {
         return recipe_1.default.getInstanceOrThrowError().jwtRecipe.recipeInterfaceImpl.getJWKS();
     }
 }
-exports.default = OpenIDRecipeWrapper;
-OpenIDRecipeWrapper.init = recipe_1.default.init;
-exports.init = OpenIDRecipeWrapper.init;
-exports.getDiscoveryConfiguration = OpenIDRecipeWrapper.getDiscoveryConfiguration;
-exports.createJWT = OpenIDRecipeWrapper.createJWT;
-exports.getJWKS = OpenIDRecipeWrapper.getJWKS;
+exports.default = OpenIdRecipeWrapper;
+OpenIdRecipeWrapper.init = recipe_1.default.init;
+exports.init = OpenIdRecipeWrapper.init;
+exports.getOpenIdDiscoveryConfiguration = OpenIdRecipeWrapper.getOpenIdDiscoveryConfiguration;
+exports.createJWT = OpenIdRecipeWrapper.createJWT;
+exports.getJWKS = OpenIdRecipeWrapper.getJWKS;

--- a/lib/build/recipe/openid/recipe.d.ts
+++ b/lib/build/recipe/openid/recipe.d.ts
@@ -6,7 +6,7 @@ import RecipeModule from "../../recipeModule";
 import { APIHandled, HTTPMethod, NormalisedAppinfo, RecipeListFunction } from "../../types";
 import { APIInterface, RecipeInterface, TypeInput, TypeNormalisedInput } from "./types";
 import JWTRecipe from "../jwt/recipe";
-export default class OpenIDRecipe extends RecipeModule {
+export default class OpenIdRecipe extends RecipeModule {
     static RECIPE_ID: string;
     private static instance;
     config: TypeNormalisedInput;
@@ -14,7 +14,7 @@ export default class OpenIDRecipe extends RecipeModule {
     recipeImplementation: RecipeInterface;
     apiImpl: APIInterface;
     constructor(recipeId: string, appInfo: NormalisedAppinfo, isInServerlessEnv: boolean, config?: TypeInput);
-    static getInstanceOrThrowError(): OpenIDRecipe;
+    static getInstanceOrThrowError(): OpenIdRecipe;
     static init(config?: TypeInput): RecipeListFunction;
     static reset(): void;
     getAPIsHandled: () => APIHandled[];

--- a/lib/build/recipe/openid/recipe.d.ts
+++ b/lib/build/recipe/openid/recipe.d.ts
@@ -1,0 +1,31 @@
+// @ts-nocheck
+import STError from "../../error";
+import { BaseRequest, BaseResponse } from "../../framework";
+import normalisedURLPath from "../../normalisedURLPath";
+import RecipeModule from "../../recipeModule";
+import { APIHandled, HTTPMethod, NormalisedAppinfo, RecipeListFunction } from "../../types";
+import { APIInterface, RecipeInterface, TypeInput, TypeNormalisedInput } from "./types";
+import JWTRecipe from "../jwt/recipe";
+export default class OpenIDRecipe extends RecipeModule {
+    static RECIPE_ID: string;
+    private static instance;
+    config: TypeNormalisedInput;
+    jwtRecipe: JWTRecipe;
+    recipeImplementation: RecipeInterface;
+    apiImpl: APIInterface;
+    constructor(recipeId: string, appInfo: NormalisedAppinfo, isInServerlessEnv: boolean, config?: TypeInput);
+    static getInstanceOrThrowError(): OpenIDRecipe;
+    static init(config?: TypeInput): RecipeListFunction;
+    static reset(): void;
+    getAPIsHandled: () => APIHandled[];
+    handleAPIRequest: (
+        id: string,
+        req: BaseRequest,
+        response: BaseResponse,
+        path: normalisedURLPath,
+        method: HTTPMethod
+    ) => Promise<boolean>;
+    handleError: (error: STError, request: BaseRequest, response: BaseResponse) => Promise<void>;
+    getAllCORSHeaders: () => string[];
+    isErrorFromThisRecipe: (err: any) => err is STError;
+}

--- a/lib/build/recipe/openid/recipe.js
+++ b/lib/build/recipe/openid/recipe.js
@@ -1,0 +1,135 @@
+"use strict";
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+Object.defineProperty(exports, "__esModule", { value: true });
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+const error_1 = require("../../error");
+const recipeModule_1 = require("../../recipeModule");
+const utils_1 = require("./utils");
+const recipe_1 = require("../jwt/recipe");
+const supertokens_js_override_1 = require("supertokens-js-override");
+const recipeImplementation_1 = require("./recipeImplementation");
+const implementation_1 = require("./api/implementation");
+const normalisedURLPath_1 = require("../../normalisedURLPath");
+const constants_1 = require("./constants");
+const getOpenIdDiscoveryConfiguration_1 = require("./api/getOpenIdDiscoveryConfiguration");
+class OpenIDRecipe extends recipeModule_1.default {
+    constructor(recipeId, appInfo, isInServerlessEnv, config) {
+        super(recipeId, appInfo);
+        this.getAPIsHandled = () => {
+            return [
+                {
+                    method: "get",
+                    pathWithoutApiBasePath: new normalisedURLPath_1.default(constants_1.GET_DISCOVERY_CONFIG_URL),
+                    id: constants_1.GET_DISCOVERY_CONFIG_URL,
+                    disabled: this.apiImpl.getOpenIdDiscoveryConfigurationGET === undefined,
+                },
+                ...this.jwtRecipe.getAPIsHandled(),
+            ];
+        };
+        this.handleAPIRequest = (id, req, response, path, method) =>
+            __awaiter(this, void 0, void 0, function* () {
+                let apiOptions = {
+                    recipeImplementation: this.recipeImplementation,
+                    config: this.config,
+                    recipeId: this.getRecipeId(),
+                    req,
+                    res: response,
+                };
+                if (id === constants_1.GET_DISCOVERY_CONFIG_URL) {
+                    return yield getOpenIdDiscoveryConfiguration_1.default(this.apiImpl, apiOptions);
+                } else {
+                    return this.jwtRecipe.handleAPIRequest(id, req, response, path, method);
+                }
+            });
+        this.handleError = (error, request, response) =>
+            __awaiter(this, void 0, void 0, function* () {
+                if (error.fromRecipe === OpenIDRecipe.RECIPE_ID) {
+                    throw error;
+                } else {
+                    return yield this.jwtRecipe.handleError(error, request, response);
+                }
+            });
+        this.getAllCORSHeaders = () => {
+            return [];
+        };
+        this.isErrorFromThisRecipe = (err) => {
+            return error_1.default.isErrorFromSuperTokens(err) && err.fromRecipe === OpenIDRecipe.RECIPE_ID;
+        };
+        this.config = utils_1.validateAndNormaliseUserInput(appInfo, config);
+        this.jwtRecipe = new recipe_1.default(recipeId, appInfo, isInServerlessEnv, {
+            override: this.config.override.jwtFeature,
+        });
+        let builder = new supertokens_js_override_1.default(recipeImplementation_1.default(this.config));
+        this.recipeImplementation = builder.override(this.config.override.functions).build();
+        let apiBuilder = new supertokens_js_override_1.default(implementation_1.default());
+        this.apiImpl = apiBuilder.override(this.config.override.apis).build();
+    }
+    static getInstanceOrThrowError() {
+        if (OpenIDRecipe.instance !== undefined) {
+            return OpenIDRecipe.instance;
+        }
+        throw new Error("Initialisation not done. Did you forget to call the SuperTokens.init function?");
+    }
+    static init(config) {
+        return (appInfo, isInServerlessEnv) => {
+            if (OpenIDRecipe.instance === undefined) {
+                OpenIDRecipe.instance = new OpenIDRecipe(OpenIDRecipe.RECIPE_ID, appInfo, isInServerlessEnv, config);
+                return OpenIDRecipe.instance;
+            } else {
+                throw new Error("OpenID recipe has already been initialised. Please check your code for bugs.");
+            }
+        };
+    }
+    static reset() {
+        if (process.env.TEST_MODE !== "testing") {
+            throw new Error("calling testing function in non testing env");
+        }
+        OpenIDRecipe.instance = undefined;
+    }
+}
+exports.default = OpenIDRecipe;
+OpenIDRecipe.RECIPE_ID = "opeinid";
+OpenIDRecipe.instance = undefined;

--- a/lib/build/recipe/openid/recipe.js
+++ b/lib/build/recipe/openid/recipe.js
@@ -55,7 +55,7 @@ const implementation_1 = require("./api/implementation");
 const normalisedURLPath_1 = require("../../normalisedURLPath");
 const constants_1 = require("./constants");
 const getOpenIdDiscoveryConfiguration_1 = require("./api/getOpenIdDiscoveryConfiguration");
-class OpenIDRecipe extends recipeModule_1.default {
+class OpenIdRecipe extends recipeModule_1.default {
     constructor(recipeId, appInfo, isInServerlessEnv, config) {
         super(recipeId, appInfo);
         this.getAPIsHandled = () => {
@@ -86,7 +86,7 @@ class OpenIDRecipe extends recipeModule_1.default {
             });
         this.handleError = (error, request, response) =>
             __awaiter(this, void 0, void 0, function* () {
-                if (error.fromRecipe === OpenIDRecipe.RECIPE_ID) {
+                if (error.fromRecipe === OpenIdRecipe.RECIPE_ID) {
                     throw error;
                 } else {
                     return yield this.jwtRecipe.handleError(error, request, response);
@@ -96,30 +96,35 @@ class OpenIDRecipe extends recipeModule_1.default {
             return [];
         };
         this.isErrorFromThisRecipe = (err) => {
-            return error_1.default.isErrorFromSuperTokens(err) && err.fromRecipe === OpenIDRecipe.RECIPE_ID;
+            return (
+                (error_1.default.isErrorFromSuperTokens(err) && err.fromRecipe === OpenIdRecipe.RECIPE_ID) ||
+                this.jwtRecipe.isErrorFromThisRecipe(err)
+            );
         };
         this.config = utils_1.validateAndNormaliseUserInput(appInfo, config);
         this.jwtRecipe = new recipe_1.default(recipeId, appInfo, isInServerlessEnv, {
             override: this.config.override.jwtFeature,
         });
-        let builder = new supertokens_js_override_1.default(recipeImplementation_1.default(this.config));
+        let builder = new supertokens_js_override_1.default(
+            recipeImplementation_1.default(this.config, this.jwtRecipe.recipeInterfaceImpl)
+        );
         this.recipeImplementation = builder.override(this.config.override.functions).build();
         let apiBuilder = new supertokens_js_override_1.default(implementation_1.default());
         this.apiImpl = apiBuilder.override(this.config.override.apis).build();
     }
     static getInstanceOrThrowError() {
-        if (OpenIDRecipe.instance !== undefined) {
-            return OpenIDRecipe.instance;
+        if (OpenIdRecipe.instance !== undefined) {
+            return OpenIdRecipe.instance;
         }
         throw new Error("Initialisation not done. Did you forget to call the SuperTokens.init function?");
     }
     static init(config) {
         return (appInfo, isInServerlessEnv) => {
-            if (OpenIDRecipe.instance === undefined) {
-                OpenIDRecipe.instance = new OpenIDRecipe(OpenIDRecipe.RECIPE_ID, appInfo, isInServerlessEnv, config);
-                return OpenIDRecipe.instance;
+            if (OpenIdRecipe.instance === undefined) {
+                OpenIdRecipe.instance = new OpenIdRecipe(OpenIdRecipe.RECIPE_ID, appInfo, isInServerlessEnv, config);
+                return OpenIdRecipe.instance;
             } else {
-                throw new Error("OpenID recipe has already been initialised. Please check your code for bugs.");
+                throw new Error("OpenId recipe has already been initialised. Please check your code for bugs.");
             }
         };
     }
@@ -127,9 +132,9 @@ class OpenIDRecipe extends recipeModule_1.default {
         if (process.env.TEST_MODE !== "testing") {
             throw new Error("calling testing function in non testing env");
         }
-        OpenIDRecipe.instance = undefined;
+        OpenIdRecipe.instance = undefined;
     }
 }
-exports.default = OpenIDRecipe;
-OpenIDRecipe.RECIPE_ID = "opeinid";
-OpenIDRecipe.instance = undefined;
+exports.default = OpenIdRecipe;
+OpenIdRecipe.RECIPE_ID = "opeinid";
+OpenIdRecipe.instance = undefined;

--- a/lib/build/recipe/openid/recipe.js
+++ b/lib/build/recipe/openid/recipe.js
@@ -93,7 +93,7 @@ class OpenIdRecipe extends recipeModule_1.default {
                 }
             });
         this.getAllCORSHeaders = () => {
-            return [];
+            return [...this.jwtRecipe.getAllCORSHeaders()];
         };
         this.isErrorFromThisRecipe = (err) => {
             return (
@@ -103,6 +103,7 @@ class OpenIdRecipe extends recipeModule_1.default {
         };
         this.config = utils_1.validateAndNormaliseUserInput(appInfo, config);
         this.jwtRecipe = new recipe_1.default(recipeId, appInfo, isInServerlessEnv, {
+            jwtValiditySeconds: this.config.jwtValiditySeconds,
             override: this.config.override.jwtFeature,
         });
         let builder = new supertokens_js_override_1.default(

--- a/lib/build/recipe/openid/recipeImplementation.d.ts
+++ b/lib/build/recipe/openid/recipeImplementation.d.ts
@@ -1,3 +1,7 @@
 // @ts-nocheck
 import { RecipeInterface, TypeNormalisedInput } from "./types";
-export default function getRecipeInterface(config: TypeNormalisedInput): RecipeInterface;
+import { RecipeInterface as JWTRecipeInterface } from "../jwt/types";
+export default function getRecipeInterface(
+    config: TypeNormalisedInput,
+    jwtRecipeImplementation: JWTRecipeInterface
+): RecipeInterface;

--- a/lib/build/recipe/openid/recipeImplementation.d.ts
+++ b/lib/build/recipe/openid/recipeImplementation.d.ts
@@ -1,0 +1,3 @@
+// @ts-nocheck
+import { RecipeInterface, TypeNormalisedInput } from "./types";
+export default function getRecipeInterface(config: TypeNormalisedInput): RecipeInterface;

--- a/lib/build/recipe/openid/recipeImplementation.js
+++ b/lib/build/recipe/openid/recipeImplementation.js
@@ -52,6 +52,7 @@ function getRecipeInterface(config, jwtRecipeImplementation) {
         },
         createJWT: function ({ payload, validitySeconds }) {
             return __awaiter(this, void 0, void 0, function* () {
+                payload = payload === undefined ? {} : payload;
                 let issuer = config.issuerDomain.getAsStringDangerous() + config.issuerPath.getAsStringDangerous();
                 return yield jwtRecipeImplementation.createJWT({
                     payload: Object.assign({ iss: issuer }, payload),

--- a/lib/build/recipe/openid/recipeImplementation.js
+++ b/lib/build/recipe/openid/recipeImplementation.js
@@ -31,16 +31,36 @@ var __awaiter =
         });
     };
 Object.defineProperty(exports, "__esModule", { value: true });
-function getRecipeInterface(config) {
+const normalisedURLPath_1 = require("../../normalisedURLPath");
+const constants_1 = require("../jwt/constants");
+function getRecipeInterface(config, jwtRecipeImplementation) {
     return {
-        getDiscoveryConfiguration: function () {
+        getOpenIdDiscoveryConfiguration: function () {
             return __awaiter(this, void 0, void 0, function* () {
                 let issuer = config.issuerDomain.getAsStringDangerous() + config.issuerPath.getAsStringDangerous();
+                let jwks_uri =
+                    config.issuerDomain.getAsStringDangerous() +
+                    config.issuerPath
+                        .appendPath(new normalisedURLPath_1.default(constants_1.GET_JWKS_API))
+                        .getAsStringDangerous();
                 return {
                     status: "OK",
                     issuer,
-                    jwks_uri: issuer + "/jwt/jwks.json",
+                    jwks_uri,
                 };
+            });
+        },
+        createJWT: function ({ payload, validitySeconds }) {
+            return __awaiter(this, void 0, void 0, function* () {
+                return yield jwtRecipeImplementation.createJWT({
+                    payload,
+                    validitySeconds,
+                });
+            });
+        },
+        getJWKS: function () {
+            return __awaiter(this, void 0, void 0, function* () {
+                return yield jwtRecipeImplementation.getJWKS();
             });
         },
     };

--- a/lib/build/recipe/openid/recipeImplementation.js
+++ b/lib/build/recipe/openid/recipeImplementation.js
@@ -52,8 +52,9 @@ function getRecipeInterface(config, jwtRecipeImplementation) {
         },
         createJWT: function ({ payload, validitySeconds }) {
             return __awaiter(this, void 0, void 0, function* () {
+                let issuer = config.issuerDomain.getAsStringDangerous() + config.issuerPath.getAsStringDangerous();
                 return yield jwtRecipeImplementation.createJWT({
-                    payload,
+                    payload: Object.assign({ iss: issuer }, payload),
                     validitySeconds,
                 });
             });

--- a/lib/build/recipe/openid/recipeImplementation.js
+++ b/lib/build/recipe/openid/recipeImplementation.js
@@ -52,7 +52,7 @@ function getRecipeInterface(config, jwtRecipeImplementation) {
         },
         createJWT: function ({ payload, validitySeconds }) {
             return __awaiter(this, void 0, void 0, function* () {
-                payload = payload === undefined ? {} : payload;
+                payload = payload === undefined || payload === null ? {} : payload;
                 let issuer = config.issuerDomain.getAsStringDangerous() + config.issuerPath.getAsStringDangerous();
                 return yield jwtRecipeImplementation.createJWT({
                     payload: Object.assign({ iss: issuer }, payload),

--- a/lib/build/recipe/openid/recipeImplementation.js
+++ b/lib/build/recipe/openid/recipeImplementation.js
@@ -1,0 +1,47 @@
+"use strict";
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+Object.defineProperty(exports, "__esModule", { value: true });
+function getRecipeInterface(config) {
+    return {
+        getDiscoveryConfiguration: function () {
+            return __awaiter(this, void 0, void 0, function* () {
+                return {
+                    status: "OK",
+                    issuer: config.issuer,
+                    jwks_uri: config.issuer + "/jwt/jwks.json",
+                };
+            });
+        },
+    };
+}
+exports.default = getRecipeInterface;

--- a/lib/build/recipe/openid/recipeImplementation.js
+++ b/lib/build/recipe/openid/recipeImplementation.js
@@ -35,10 +35,11 @@ function getRecipeInterface(config) {
     return {
         getDiscoveryConfiguration: function () {
             return __awaiter(this, void 0, void 0, function* () {
+                let issuer = config.issuerDomain.getAsStringDangerous() + config.issuerPath.getAsStringDangerous();
                 return {
                     status: "OK",
-                    issuer: config.issuer,
-                    jwks_uri: config.issuer + "/jwt/jwks.json",
+                    issuer,
+                    jwks_uri: issuer + "/jwt/jwks.json",
                 };
             });
         },

--- a/lib/build/recipe/openid/types.d.ts
+++ b/lib/build/recipe/openid/types.d.ts
@@ -1,6 +1,8 @@
 // @ts-nocheck
 import OverrideableBuilder from "supertokens-js-override";
 import { BaseRequest, BaseResponse } from "../../framework";
+import NormalisedURLDomain from "../../normalisedURLDomain";
+import NormalisedURLPath from "../../normalisedURLPath";
 import { RecipeInterface as JWTRecipeInterface, APIInterface as JWTAPIInterface } from "../jwt/types";
 export declare type TypeInput = {
     issuer: string;
@@ -23,7 +25,8 @@ export declare type TypeInput = {
     };
 };
 export declare type TypeNormalisedInput = {
-    issuer: string;
+    issuerDomain: NormalisedURLDomain;
+    issuerPath: NormalisedURLPath;
     override: {
         functions: (
             originalImplementation: RecipeInterface,

--- a/lib/build/recipe/openid/types.d.ts
+++ b/lib/build/recipe/openid/types.d.ts
@@ -1,0 +1,64 @@
+// @ts-nocheck
+import OverrideableBuilder from "supertokens-js-override";
+import { BaseRequest, BaseResponse } from "../../framework";
+import { RecipeInterface as JWTRecipeInterface, APIInterface as JWTAPIInterface } from "../jwt/types";
+export declare type TypeInput = {
+    issuer: string;
+    override?: {
+        functions?: (
+            originalImplementation: RecipeInterface,
+            builder?: OverrideableBuilder<RecipeInterface>
+        ) => RecipeInterface;
+        apis?: (originalImplementation: APIInterface, builder?: OverrideableBuilder<APIInterface>) => APIInterface;
+        jwtFeature?: {
+            functions?: (
+                originalImplementation: JWTRecipeInterface,
+                builder?: OverrideableBuilder<JWTRecipeInterface>
+            ) => JWTRecipeInterface;
+            apis?: (
+                originalImplementation: JWTAPIInterface,
+                builder?: OverrideableBuilder<JWTAPIInterface>
+            ) => JWTAPIInterface;
+        };
+    };
+};
+export declare type TypeNormalisedInput = {
+    issuer: string;
+    override: {
+        functions: (
+            originalImplementation: RecipeInterface,
+            builder?: OverrideableBuilder<RecipeInterface>
+        ) => RecipeInterface;
+        apis: (originalImplementation: APIInterface, builder?: OverrideableBuilder<APIInterface>) => APIInterface;
+        jwtFeature?: {
+            functions?: (
+                originalImplementation: JWTRecipeInterface,
+                builder?: OverrideableBuilder<JWTRecipeInterface>
+            ) => JWTRecipeInterface;
+            apis?: (
+                originalImplementation: JWTAPIInterface,
+                builder?: OverrideableBuilder<JWTAPIInterface>
+            ) => JWTAPIInterface;
+        };
+    };
+};
+export declare type APIOptions = {
+    recipeImplementation: RecipeInterface;
+    config: TypeNormalisedInput;
+    recipeId: string;
+    req: BaseRequest;
+    res: BaseResponse;
+};
+export declare type APIInterface = {
+    getOpenIdDiscoveryConfigurationGET:
+        | undefined
+        | ((input: { options: APIOptions }) => Promise<DiscoveryConfiguration>);
+};
+export declare type DiscoveryConfiguration = {
+    status: "OK";
+    issuer: string;
+    jwks_uri: string;
+};
+export declare type RecipeInterface = {
+    getDiscoveryConfiguration(): Promise<DiscoveryConfiguration>;
+};

--- a/lib/build/recipe/openid/types.d.ts
+++ b/lib/build/recipe/openid/types.d.ts
@@ -6,6 +6,7 @@ import NormalisedURLPath from "../../normalisedURLPath";
 import { RecipeInterface as JWTRecipeInterface, APIInterface as JWTAPIInterface, JsonWebKey } from "../jwt/types";
 export declare type TypeInput = {
     issuer?: string;
+    jwtValiditySeconds?: number;
     override?: {
         functions?: (
             originalImplementation: RecipeInterface,
@@ -27,6 +28,7 @@ export declare type TypeInput = {
 export declare type TypeNormalisedInput = {
     issuerDomain: NormalisedURLDomain;
     issuerPath: NormalisedURLPath;
+    jwtValiditySeconds?: number;
     override: {
         functions: (
             originalImplementation: RecipeInterface,

--- a/lib/build/recipe/openid/types.d.ts
+++ b/lib/build/recipe/openid/types.d.ts
@@ -3,9 +3,9 @@ import OverrideableBuilder from "supertokens-js-override";
 import { BaseRequest, BaseResponse } from "../../framework";
 import NormalisedURLDomain from "../../normalisedURLDomain";
 import NormalisedURLPath from "../../normalisedURLPath";
-import { RecipeInterface as JWTRecipeInterface, APIInterface as JWTAPIInterface } from "../jwt/types";
+import { RecipeInterface as JWTRecipeInterface, APIInterface as JWTAPIInterface, JsonWebKey } from "../jwt/types";
 export declare type TypeInput = {
-    issuer: string;
+    issuer?: string;
     override?: {
         functions?: (
             originalImplementation: RecipeInterface,
@@ -55,13 +55,34 @@ export declare type APIOptions = {
 export declare type APIInterface = {
     getOpenIdDiscoveryConfigurationGET:
         | undefined
-        | ((input: { options: APIOptions }) => Promise<DiscoveryConfiguration>);
-};
-export declare type DiscoveryConfiguration = {
-    status: "OK";
-    issuer: string;
-    jwks_uri: string;
+        | ((input: {
+              options: APIOptions;
+          }) => Promise<{
+              status: "OK";
+              issuer: string;
+              jwks_uri: string;
+          }>);
 };
 export declare type RecipeInterface = {
-    getDiscoveryConfiguration(): Promise<DiscoveryConfiguration>;
+    getOpenIdDiscoveryConfiguration(): Promise<{
+        status: "OK";
+        issuer: string;
+        jwks_uri: string;
+    }>;
+    createJWT(input: {
+        payload?: any;
+        validitySeconds?: number;
+    }): Promise<
+        | {
+              status: "OK";
+              jwt: string;
+          }
+        | {
+              status: "UNSUPPORTED_ALGORITHM_ERROR";
+          }
+    >;
+    getJWKS(): Promise<{
+        status: "OK";
+        keys: JsonWebKey[];
+    }>;
 };

--- a/lib/build/recipe/openid/types.js
+++ b/lib/build/recipe/openid/types.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/lib/build/recipe/openid/utils.d.ts
+++ b/lib/build/recipe/openid/utils.d.ts
@@ -1,0 +1,7 @@
+// @ts-nocheck
+import { NormalisedAppinfo } from "../../types";
+import { TypeInput, TypeNormalisedInput } from "./types";
+export declare function validateAndNormaliseUserInput(
+    appInfo: NormalisedAppinfo,
+    config?: TypeInput
+): TypeNormalisedInput;

--- a/lib/build/recipe/openid/utils.js
+++ b/lib/build/recipe/openid/utils.js
@@ -1,9 +1,30 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+const normalisedURLDomain_1 = require("../../normalisedURLDomain");
+const normalisedURLPath_1 = require("../../normalisedURLPath");
 function validateAndNormaliseUserInput(appInfo, config) {
-    let issuer = appInfo.apiDomain.getAsStringDangerous() + appInfo.apiBasePath.getAsStringDangerous();
+    let issuerDomain = appInfo.apiDomain;
+    let issuerPath = appInfo.apiBasePath;
     if (config !== undefined) {
-        issuer = config.issuer;
+        issuerDomain = new normalisedURLDomain_1.default(config.issuer);
+        issuerPath = new normalisedURLPath_1.default(config.issuer);
+        if (!issuerPath.equals(appInfo.apiBasePath)) {
+            throw new Error("Issuer URL must end with apiBasePath");
+        }
     }
     let override = Object.assign(
         {
@@ -13,7 +34,8 @@ function validateAndNormaliseUserInput(appInfo, config) {
         config === null || config === void 0 ? void 0 : config.override
     );
     return {
-        issuer,
+        issuerDomain,
+        issuerPath,
         override,
     };
 }

--- a/lib/build/recipe/openid/utils.js
+++ b/lib/build/recipe/openid/utils.js
@@ -1,0 +1,20 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+function validateAndNormaliseUserInput(appInfo, config) {
+    let issuer = appInfo.apiDomain.getAsStringDangerous() + appInfo.apiBasePath.getAsStringDangerous();
+    if (config !== undefined) {
+        issuer = config.issuer;
+    }
+    let override = Object.assign(
+        {
+            functions: (originalImplementation) => originalImplementation,
+            apis: (originalImplementation) => originalImplementation,
+        },
+        config === null || config === void 0 ? void 0 : config.override
+    );
+    return {
+        issuer,
+        override,
+    };
+}
+exports.validateAndNormaliseUserInput = validateAndNormaliseUserInput;

--- a/lib/build/recipe/openid/utils.js
+++ b/lib/build/recipe/openid/utils.js
@@ -18,12 +18,14 @@ const normalisedURLDomain_1 = require("../../normalisedURLDomain");
 const normalisedURLPath_1 = require("../../normalisedURLPath");
 function validateAndNormaliseUserInput(appInfo, config) {
     let issuerDomain = appInfo.apiDomain;
-    let issuerPath = appInfo.apiBasePath;
+    let issuerPath = appInfo.apiGatewayPath.appendPath(appInfo.apiBasePath);
     if (config !== undefined) {
-        issuerDomain = new normalisedURLDomain_1.default(config.issuer);
-        issuerPath = new normalisedURLPath_1.default(config.issuer);
+        if (config.issuer !== undefined) {
+            issuerDomain = new normalisedURLDomain_1.default(config.issuer);
+            issuerPath = new normalisedURLPath_1.default(config.issuer);
+        }
         if (!issuerPath.equals(appInfo.apiBasePath)) {
-            throw new Error("Issuer URL must end with apiBasePath");
+            throw new Error("Issuer URL must end with apiBasePath. The default value is /auth");
         }
     }
     let override = Object.assign(

--- a/lib/build/recipe/openid/utils.js
+++ b/lib/build/recipe/openid/utils.js
@@ -24,8 +24,8 @@ function validateAndNormaliseUserInput(appInfo, config) {
             issuerDomain = new normalisedURLDomain_1.default(config.issuer);
             issuerPath = new normalisedURLPath_1.default(config.issuer);
         }
-        if (!issuerPath.getAsStringDangerous().endsWith(appInfo.apiBasePath.getAsStringDangerous())) {
-            throw new Error("Issuer URL must end with apiBasePath. The default value is /auth");
+        if (!issuerPath.equals(appInfo.apiBasePath)) {
+            throw new Error("The path of the issuer URL must be equal to the apiBasePath. The default value is /auth");
         }
     }
     let override = Object.assign(
@@ -38,6 +38,7 @@ function validateAndNormaliseUserInput(appInfo, config) {
     return {
         issuerDomain,
         issuerPath,
+        jwtValiditySeconds: config === null || config === void 0 ? void 0 : config.jwtValiditySeconds,
         override,
     };
 }

--- a/lib/build/recipe/openid/utils.js
+++ b/lib/build/recipe/openid/utils.js
@@ -18,13 +18,13 @@ const normalisedURLDomain_1 = require("../../normalisedURLDomain");
 const normalisedURLPath_1 = require("../../normalisedURLPath");
 function validateAndNormaliseUserInput(appInfo, config) {
     let issuerDomain = appInfo.apiDomain;
-    let issuerPath = appInfo.apiGatewayPath.appendPath(appInfo.apiBasePath);
+    let issuerPath = appInfo.apiBasePath;
     if (config !== undefined) {
         if (config.issuer !== undefined) {
             issuerDomain = new normalisedURLDomain_1.default(config.issuer);
             issuerPath = new normalisedURLPath_1.default(config.issuer);
         }
-        if (!issuerPath.equals(appInfo.apiBasePath)) {
+        if (!issuerPath.getAsStringDangerous().endsWith(appInfo.apiBasePath.getAsStringDangerous())) {
             throw new Error("Issuer URL must end with apiBasePath. The default value is /auth");
         }
     }

--- a/lib/build/recipe/session/index.d.ts
+++ b/lib/build/recipe/session/index.d.ts
@@ -43,6 +43,7 @@ export default class SessionWrapper {
         status: "OK";
         keys: import("../jwt").JsonWebKey[];
     }>;
+    static getDiscoveryConfiguration(): Promise<import("../openid/types").DiscoveryConfiguration>;
 }
 export declare let init: typeof Recipe.init;
 export declare let createNewSession: typeof SessionWrapper.createNewSession;
@@ -58,4 +59,5 @@ export declare let updateAccessTokenPayload: typeof SessionWrapper.updateAccessT
 export declare let Error: typeof SuperTokensError;
 export declare let createJWT: typeof SessionWrapper.createJWT;
 export declare let getJWKS: typeof SessionWrapper.getJWKS;
+export declare let getDiscoveryConfiguration: typeof SessionWrapper.getDiscoveryConfiguration;
 export type { VerifySessionOptions, RecipeInterface, SessionContainer, APIInterface, APIOptions, SessionInformation };

--- a/lib/build/recipe/session/index.d.ts
+++ b/lib/build/recipe/session/index.d.ts
@@ -43,7 +43,11 @@ export default class SessionWrapper {
         status: "OK";
         keys: import("../jwt").JsonWebKey[];
     }>;
-    static getDiscoveryConfiguration(): Promise<import("../openid/types").DiscoveryConfiguration>;
+    static getDiscoveryConfiguration(): Promise<{
+        status: "OK";
+        issuer: string;
+        jwks_uri: string;
+    }>;
 }
 export declare let init: typeof Recipe.init;
 export declare let createNewSession: typeof SessionWrapper.createNewSession;

--- a/lib/build/recipe/session/index.d.ts
+++ b/lib/build/recipe/session/index.d.ts
@@ -43,7 +43,7 @@ export default class SessionWrapper {
         status: "OK";
         keys: import("../jwt").JsonWebKey[];
     }>;
-    static getDiscoveryConfiguration(): Promise<{
+    static getOpenIdDiscoveryConfiguration(): Promise<{
         status: "OK";
         issuer: string;
         jwks_uri: string;
@@ -63,5 +63,5 @@ export declare let updateAccessTokenPayload: typeof SessionWrapper.updateAccessT
 export declare let Error: typeof SuperTokensError;
 export declare let createJWT: typeof SessionWrapper.createJWT;
 export declare let getJWKS: typeof SessionWrapper.getJWKS;
-export declare let getDiscoveryConfiguration: typeof SessionWrapper.getDiscoveryConfiguration;
+export declare let getOpenIdDiscoveryConfiguration: typeof SessionWrapper.getOpenIdDiscoveryConfiguration;
 export type { VerifySessionOptions, RecipeInterface, SessionContainer, APIInterface, APIOptions, SessionInformation };

--- a/lib/build/recipe/session/index.js
+++ b/lib/build/recipe/session/index.js
@@ -62,26 +62,18 @@ class SessionWrapper {
         });
     }
     static createJWT(payload, validitySeconds) {
-        var _a;
-        let jwtRecipe =
-            (_a = recipe_1.default.getInstanceOrThrowError().openIdRecipe) === null || _a === void 0
-                ? void 0
-                : _a.jwtRecipe;
-        if (jwtRecipe !== undefined) {
-            return jwtRecipe.recipeInterfaceImpl.createJWT({ payload, validitySeconds });
+        let openIdRecipe = recipe_1.default.getInstanceOrThrowError().openIdRecipe;
+        if (openIdRecipe !== undefined) {
+            return openIdRecipe.recipeImplementation.createJWT({ payload, validitySeconds });
         }
         throw new global.Error(
             "createJWT cannot be used without enabling the JWT feature. Please set 'enableJWT: true' when initialising the Session recipe"
         );
     }
     static getJWKS() {
-        var _a;
-        let jwtRecipe =
-            (_a = recipe_1.default.getInstanceOrThrowError().openIdRecipe) === null || _a === void 0
-                ? void 0
-                : _a.jwtRecipe;
-        if (jwtRecipe !== undefined) {
-            return jwtRecipe.recipeInterfaceImpl.getJWKS();
+        let openIdRecipe = recipe_1.default.getInstanceOrThrowError().openIdRecipe;
+        if (openIdRecipe !== undefined) {
+            return openIdRecipe.recipeImplementation.getJWKS();
         }
         throw new global.Error(
             "getJWKS cannot be used without enabling the JWT feature. Please set 'enableJWT: true' when initialising the Session recipe"

--- a/lib/build/recipe/session/index.js
+++ b/lib/build/recipe/session/index.js
@@ -62,7 +62,11 @@ class SessionWrapper {
         });
     }
     static createJWT(payload, validitySeconds) {
-        let jwtRecipe = recipe_1.default.getInstanceOrThrowError().jwtRecipe;
+        var _a;
+        let jwtRecipe =
+            (_a = recipe_1.default.getInstanceOrThrowError().openIdRecipe) === null || _a === void 0
+                ? void 0
+                : _a.jwtRecipe;
         if (jwtRecipe !== undefined) {
             return jwtRecipe.recipeInterfaceImpl.createJWT({ payload, validitySeconds });
         }
@@ -71,7 +75,11 @@ class SessionWrapper {
         );
     }
     static getJWKS() {
-        let jwtRecipe = recipe_1.default.getInstanceOrThrowError().jwtRecipe;
+        var _a;
+        let jwtRecipe =
+            (_a = recipe_1.default.getInstanceOrThrowError().openIdRecipe) === null || _a === void 0
+                ? void 0
+                : _a.jwtRecipe;
         if (jwtRecipe !== undefined) {
             return jwtRecipe.recipeInterfaceImpl.getJWKS();
         }

--- a/lib/build/recipe/session/index.js
+++ b/lib/build/recipe/session/index.js
@@ -90,7 +90,7 @@ class SessionWrapper {
     static getDiscoveryConfiguration() {
         let openIdRecipe = recipe_1.default.getInstanceOrThrowError().openIdRecipe;
         if (openIdRecipe !== undefined) {
-            return openIdRecipe.recipeImplementation.getDiscoveryConfiguration();
+            return openIdRecipe.recipeImplementation.getOpenIdDiscoveryConfiguration();
         }
         throw new global.Error(
             "getDiscoveryConfiguration cannot be used without enabling the JWT feature. Please set 'enableJWT: true' when initialising the Session recipe"

--- a/lib/build/recipe/session/index.js
+++ b/lib/build/recipe/session/index.js
@@ -87,6 +87,15 @@ class SessionWrapper {
             "getJWKS cannot be used without enabling the JWT feature. Please set 'enableJWT: true' when initialising the Session recipe"
         );
     }
+    static getDiscoveryConfiguration() {
+        let openIdRecipe = recipe_1.default.getInstanceOrThrowError().openIdRecipe;
+        if (openIdRecipe !== undefined) {
+            return openIdRecipe.recipeImplementation.getDiscoveryConfiguration();
+        }
+        throw new global.Error(
+            "getDiscoveryConfiguration cannot be used without enabling the JWT feature. Please set 'enableJWT: true' when initialising the Session recipe"
+        );
+    }
 }
 exports.default = SessionWrapper;
 SessionWrapper.init = recipe_1.default.init;
@@ -106,3 +115,5 @@ exports.Error = SessionWrapper.Error;
 // JWT Functions
 exports.createJWT = SessionWrapper.createJWT;
 exports.getJWKS = SessionWrapper.getJWKS;
+// Open id functions
+exports.getDiscoveryConfiguration = SessionWrapper.getDiscoveryConfiguration;

--- a/lib/build/recipe/session/index.js
+++ b/lib/build/recipe/session/index.js
@@ -87,13 +87,13 @@ class SessionWrapper {
             "getJWKS cannot be used without enabling the JWT feature. Please set 'enableJWT: true' when initialising the Session recipe"
         );
     }
-    static getDiscoveryConfiguration() {
+    static getOpenIdDiscoveryConfiguration() {
         let openIdRecipe = recipe_1.default.getInstanceOrThrowError().openIdRecipe;
         if (openIdRecipe !== undefined) {
             return openIdRecipe.recipeImplementation.getOpenIdDiscoveryConfiguration();
         }
         throw new global.Error(
-            "getDiscoveryConfiguration cannot be used without enabling the JWT feature. Please set 'enableJWT: true' when initialising the Session recipe"
+            "getOpenIdDiscoveryConfiguration cannot be used without enabling the JWT feature. Please set 'enableJWT: true' when initialising the Session recipe"
         );
     }
 }
@@ -116,4 +116,4 @@ exports.Error = SessionWrapper.Error;
 exports.createJWT = SessionWrapper.createJWT;
 exports.getJWKS = SessionWrapper.getJWKS;
 // Open id functions
-exports.getDiscoveryConfiguration = SessionWrapper.getDiscoveryConfiguration;
+exports.getOpenIdDiscoveryConfiguration = SessionWrapper.getOpenIdDiscoveryConfiguration;

--- a/lib/build/recipe/session/recipe.d.ts
+++ b/lib/build/recipe/session/recipe.d.ts
@@ -5,13 +5,13 @@ import STError from "./error";
 import { NormalisedAppinfo, RecipeListFunction, APIHandled, HTTPMethod } from "../../types";
 import NormalisedURLPath from "../../normalisedURLPath";
 import { BaseRequest, BaseResponse } from "../../framework";
-import JWTRecipe from "../jwt/recipe";
+import OpenIDRecipe from "../openid/recipe";
 export default class SessionRecipe extends RecipeModule {
     private static instance;
     static RECIPE_ID: string;
     config: TypeNormalisedInput;
     recipeInterfaceImpl: RecipeInterface;
-    jwtRecipe?: JWTRecipe;
+    openIdRecipe?: OpenIDRecipe;
     apiImpl: APIInterface;
     isInServerlessEnv: boolean;
     constructor(recipeId: string, appInfo: NormalisedAppinfo, isInServerlessEnv: boolean, config?: TypeInput);

--- a/lib/build/recipe/session/recipe.d.ts
+++ b/lib/build/recipe/session/recipe.d.ts
@@ -5,13 +5,13 @@ import STError from "./error";
 import { NormalisedAppinfo, RecipeListFunction, APIHandled, HTTPMethod } from "../../types";
 import NormalisedURLPath from "../../normalisedURLPath";
 import { BaseRequest, BaseResponse } from "../../framework";
-import OpenIDRecipe from "../openid/recipe";
+import OpenIdRecipe from "../openid/recipe";
 export default class SessionRecipe extends RecipeModule {
     private static instance;
     static RECIPE_ID: string;
     config: TypeNormalisedInput;
     recipeInterfaceImpl: RecipeInterface;
-    openIdRecipe?: OpenIDRecipe;
+    openIdRecipe?: OpenIdRecipe;
     apiImpl: APIInterface;
     isInServerlessEnv: boolean;
     constructor(recipeId: string, appInfo: NormalisedAppinfo, isInServerlessEnv: boolean, config?: TypeInput);

--- a/lib/build/recipe/session/recipe.js
+++ b/lib/build/recipe/session/recipe.js
@@ -57,8 +57,8 @@ const recipeImplementation_1 = require("./recipeImplementation");
 const with_jwt_1 = require("./with-jwt");
 const querier_1 = require("../../querier");
 const implementation_1 = require("./api/implementation");
-const recipe_1 = require("../jwt/recipe");
 const supertokens_js_override_1 = require("supertokens-js-override");
+const recipe_1 = require("../openid/recipe");
 // For Express
 class SessionRecipe extends recipeModule_1.default {
     constructor(recipeId, appInfo, isInServerlessEnv, config) {
@@ -79,8 +79,8 @@ class SessionRecipe extends recipeModule_1.default {
                     disabled: this.apiImpl.signOutPOST === undefined,
                 },
             ];
-            if (this.jwtRecipe !== undefined) {
-                apisHandled.push(...this.jwtRecipe.getAPIsHandled());
+            if (this.openIdRecipe !== undefined) {
+                apisHandled.push(...this.openIdRecipe.getAPIsHandled());
             }
             return apisHandled;
         };
@@ -93,7 +93,7 @@ class SessionRecipe extends recipeModule_1.default {
                     isInServerlessEnv: this.isInServerlessEnv,
                     recipeImplementation: this.recipeInterfaceImpl,
                     jwtRecipeImplementation:
-                        (_a = this.jwtRecipe) === null || _a === void 0 ? void 0 : _a.recipeInterfaceImpl,
+                        (_a = this.openIdRecipe) === null || _a === void 0 ? void 0 : _a.jwtRecipe.recipeInterfaceImpl,
                     req,
                     res,
                 };
@@ -101,8 +101,8 @@ class SessionRecipe extends recipeModule_1.default {
                     return yield refresh_1.default(this.apiImpl, options);
                 } else if (id === constants_1.SIGNOUT_API_PATH) {
                     return yield signout_1.default(this.apiImpl, options);
-                } else if (this.jwtRecipe !== undefined) {
-                    return yield this.jwtRecipe.handleAPIRequest(id, req, res, path, method);
+                } else if (this.openIdRecipe !== undefined) {
+                    return yield this.openIdRecipe.handleAPIRequest(id, req, res, path, method);
                 } else {
                     return false;
                 }
@@ -124,16 +124,16 @@ class SessionRecipe extends recipeModule_1.default {
                     } else {
                         throw err;
                     }
-                } else if (this.jwtRecipe !== undefined) {
-                    return yield this.jwtRecipe.handleError(err, request, response);
+                } else if (this.openIdRecipe !== undefined) {
+                    return yield this.openIdRecipe.handleError(err, request, response);
                 } else {
                     throw err;
                 }
             });
         this.getAllCORSHeaders = () => {
             let corsHeaders = [...cookieAndHeaders_1.getCORSAllowedHeaders()];
-            if (this.jwtRecipe !== undefined) {
-                corsHeaders.push(...this.jwtRecipe.getAllCORSHeaders());
+            if (this.openIdRecipe !== undefined) {
+                corsHeaders.push(...this.openIdRecipe.getAllCORSHeaders());
             }
             return corsHeaders;
         };
@@ -141,7 +141,7 @@ class SessionRecipe extends recipeModule_1.default {
             return (
                 error_1.default.isErrorFromSuperTokens(err) &&
                 (err.fromRecipe === SessionRecipe.RECIPE_ID ||
-                    (this.jwtRecipe !== undefined && this.jwtRecipe.isErrorFromThisRecipe(err)))
+                    (this.openIdRecipe !== undefined && this.openIdRecipe.isErrorFromThisRecipe(err)))
             );
         };
         this.verifySession = (options, request, response) =>
@@ -157,15 +157,18 @@ class SessionRecipe extends recipeModule_1.default {
                         isInServerlessEnv: this.isInServerlessEnv,
                         recipeImplementation: this.recipeInterfaceImpl,
                         jwtRecipeImplementation:
-                            (_b = this.jwtRecipe) === null || _b === void 0 ? void 0 : _b.recipeInterfaceImpl,
+                            (_b = this.openIdRecipe) === null || _b === void 0
+                                ? void 0
+                                : _b.jwtRecipe.recipeInterfaceImpl,
                     },
                 });
             });
         this.config = utils_1.validateAndNormaliseUserInput(this, appInfo, config);
         this.isInServerlessEnv = isInServerlessEnv;
         if (this.config.jwt.enable === true) {
-            this.jwtRecipe = new recipe_1.default(recipeId, appInfo, isInServerlessEnv, {
-                override: this.config.override.jwtFeature,
+            this.openIdRecipe = new recipe_1.default(recipeId, appInfo, isInServerlessEnv, {
+                issuer: this.config.jwt.issuer,
+                override: this.config.override.openId,
             });
             let builder = new supertokens_js_override_1.default(
                 recipeImplementation_1.default(querier_1.Querier.getNewInstanceOrThrowError(recipeId), this.config)
@@ -175,7 +178,7 @@ class SessionRecipe extends recipeModule_1.default {
                     return with_jwt_1.default(
                         oI,
                         // this.jwtRecipe is never undefined here
-                        this.jwtRecipe.recipeInterfaceImpl,
+                        this.openIdRecipe.jwtRecipe.recipeInterfaceImpl,
                         this.config,
                         appInfo
                     );

--- a/lib/build/recipe/session/recipe.js
+++ b/lib/build/recipe/session/recipe.js
@@ -168,7 +168,7 @@ class SessionRecipe extends recipeModule_1.default {
         if (this.config.jwt.enable === true) {
             this.openIdRecipe = new recipe_1.default(recipeId, appInfo, isInServerlessEnv, {
                 issuer: this.config.jwt.issuer,
-                override: this.config.override.openId,
+                override: this.config.override.openIdFeature,
             });
             let builder = new supertokens_js_override_1.default(
                 recipeImplementation_1.default(querier_1.Querier.getNewInstanceOrThrowError(recipeId), this.config)
@@ -178,7 +178,7 @@ class SessionRecipe extends recipeModule_1.default {
                     return with_jwt_1.default(
                         oI,
                         // this.jwtRecipe is never undefined here
-                        this.openIdRecipe.jwtRecipe.recipeInterfaceImpl,
+                        this.openIdRecipe.recipeImplementation,
                         this.config,
                         appInfo
                     );

--- a/lib/build/recipe/session/recipe.js
+++ b/lib/build/recipe/session/recipe.js
@@ -179,8 +179,7 @@ class SessionRecipe extends recipeModule_1.default {
                         oI,
                         // this.jwtRecipe is never undefined here
                         this.openIdRecipe.recipeImplementation,
-                        this.config,
-                        appInfo
+                        this.config
                     );
                 })
                 .override(this.config.override.functions)

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -86,7 +86,7 @@ export declare type TypeInput = {
             builder?: OverrideableBuilder<RecipeInterface>
         ) => RecipeInterface;
         apis?: (originalImplementation: APIInterface, builder?: OverrideableBuilder<APIInterface>) => APIInterface;
-        openId?: {
+        openIdFeature?: {
             functions?: (
                 originalImplementation: OpenIdRecipeInterface,
                 builder?: OverrideableBuilder<OpenIdRecipeInterface>
@@ -158,7 +158,7 @@ export declare type TypeNormalisedInput = {
     jwt: {
         enable: boolean;
         propertyNameInAccessTokenPayload: string;
-        issuer: string;
+        issuer?: string;
     };
     override: {
         functions: (
@@ -166,7 +166,7 @@ export declare type TypeNormalisedInput = {
             builder?: OverrideableBuilder<RecipeInterface>
         ) => RecipeInterface;
         apis: (originalImplementation: APIInterface, builder?: OverrideableBuilder<APIInterface>) => APIInterface;
-        openId?: {
+        openIdFeature?: {
             functions?: (
                 originalImplementation: OpenIdRecipeInterface,
                 builder?: OverrideableBuilder<OpenIdRecipeInterface>

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -3,6 +3,7 @@ import { BaseRequest, BaseResponse } from "../../framework";
 import NormalisedURLPath from "../../normalisedURLPath";
 import { RecipeInterface as JWTRecipeInterface, APIInterface as JWTAPIInterface } from "../jwt/types";
 import OverrideableBuilder from "supertokens-js-override";
+import { RecipeInterface as OpenIdRecipeInterface, APIInterface as OpenIdAPIInterface } from "../openid/types";
 export declare type KeyInfo = {
     publicKey: string;
     expiryTime: number;
@@ -74,6 +75,7 @@ export declare type TypeInput = {
         | {
               enable: true;
               propertyNameInAccessTokenPayload?: string;
+              issuer?: string;
           }
         | {
               enable: false;
@@ -84,15 +86,25 @@ export declare type TypeInput = {
             builder?: OverrideableBuilder<RecipeInterface>
         ) => RecipeInterface;
         apis?: (originalImplementation: APIInterface, builder?: OverrideableBuilder<APIInterface>) => APIInterface;
-        jwtFeature?: {
+        openId?: {
             functions?: (
-                originalImplementation: JWTRecipeInterface,
-                builder?: OverrideableBuilder<JWTRecipeInterface>
-            ) => JWTRecipeInterface;
+                originalImplementation: OpenIdRecipeInterface,
+                builder?: OverrideableBuilder<OpenIdRecipeInterface>
+            ) => OpenIdRecipeInterface;
             apis?: (
-                originalImplementation: JWTAPIInterface,
-                builder?: OverrideableBuilder<JWTAPIInterface>
-            ) => JWTAPIInterface;
+                originalImplementation: OpenIdAPIInterface,
+                builder?: OverrideableBuilder<OpenIdAPIInterface>
+            ) => OpenIdAPIInterface;
+            jwtFeature?: {
+                functions?: (
+                    originalImplementation: JWTRecipeInterface,
+                    builder?: OverrideableBuilder<JWTRecipeInterface>
+                ) => JWTRecipeInterface;
+                apis?: (
+                    originalImplementation: JWTAPIInterface,
+                    builder?: OverrideableBuilder<JWTAPIInterface>
+                ) => JWTAPIInterface;
+            };
         };
     };
 };
@@ -146,6 +158,7 @@ export declare type TypeNormalisedInput = {
     jwt: {
         enable: boolean;
         propertyNameInAccessTokenPayload: string;
+        issuer: string;
     };
     override: {
         functions: (
@@ -153,15 +166,25 @@ export declare type TypeNormalisedInput = {
             builder?: OverrideableBuilder<RecipeInterface>
         ) => RecipeInterface;
         apis: (originalImplementation: APIInterface, builder?: OverrideableBuilder<APIInterface>) => APIInterface;
-        jwtFeature?: {
+        openId?: {
             functions?: (
-                originalImplementation: JWTRecipeInterface,
-                builder?: OverrideableBuilder<JWTRecipeInterface>
-            ) => JWTRecipeInterface;
+                originalImplementation: OpenIdRecipeInterface,
+                builder?: OverrideableBuilder<OpenIdRecipeInterface>
+            ) => OpenIdRecipeInterface;
             apis?: (
-                originalImplementation: JWTAPIInterface,
-                builder?: OverrideableBuilder<JWTAPIInterface>
-            ) => JWTAPIInterface;
+                originalImplementation: OpenIdAPIInterface,
+                builder?: OverrideableBuilder<OpenIdAPIInterface>
+            ) => OpenIdAPIInterface;
+            jwtFeature?: {
+                functions?: (
+                    originalImplementation: JWTRecipeInterface,
+                    builder?: OverrideableBuilder<JWTRecipeInterface>
+                ) => JWTRecipeInterface;
+                apis?: (
+                    originalImplementation: JWTAPIInterface,
+                    builder?: OverrideableBuilder<JWTAPIInterface>
+                ) => JWTAPIInterface;
+            };
         };
     };
 };

--- a/lib/build/recipe/session/utils.js
+++ b/lib/build/recipe/session/utils.js
@@ -191,14 +191,20 @@ function validateAndNormaliseUserInput(recipeInstance, appInfo, config) {
     }
     let enableJWT = false;
     let accessTokenPayloadJWTPropertyName = "jwt";
+    // By default the issuer should be apiDomain + apiBasePath
+    let jwtIssuer = appInfo.apiDomain.getAsStringDangerous() + appInfo.apiBasePath.getAsStringDangerous();
     if (config !== undefined && config.jwt !== undefined && config.jwt.enable === true) {
         enableJWT = true;
         let jwtPropertyName = config.jwt.propertyNameInAccessTokenPayload;
+        let issuer = config.jwt.issuer;
         if (jwtPropertyName !== undefined) {
             if (jwtPropertyName === constants_2.ACCESS_TOKEN_PAYLOAD_JWT_PROPERTY_NAME_KEY) {
                 throw new Error(constants_2.JWT_RESERVED_KEY_USE_ERROR_MESSAGE);
             }
             accessTokenPayloadJWTPropertyName = jwtPropertyName;
+        }
+        if (issuer !== undefined) {
+            jwtIssuer = issuer;
         }
     }
     let override = Object.assign(
@@ -220,6 +226,7 @@ function validateAndNormaliseUserInput(recipeInstance, appInfo, config) {
         jwt: {
             enable: enableJWT,
             propertyNameInAccessTokenPayload: accessTokenPayloadJWTPropertyName,
+            issuer: jwtIssuer,
         },
     };
 }

--- a/lib/build/recipe/session/utils.js
+++ b/lib/build/recipe/session/utils.js
@@ -191,20 +191,16 @@ function validateAndNormaliseUserInput(recipeInstance, appInfo, config) {
     }
     let enableJWT = false;
     let accessTokenPayloadJWTPropertyName = "jwt";
-    // By default the issuer should be apiDomain + apiBasePath
-    let jwtIssuer = appInfo.apiDomain.getAsStringDangerous() + appInfo.apiBasePath.getAsStringDangerous();
+    let issuer;
     if (config !== undefined && config.jwt !== undefined && config.jwt.enable === true) {
         enableJWT = true;
         let jwtPropertyName = config.jwt.propertyNameInAccessTokenPayload;
-        let issuer = config.jwt.issuer;
+        issuer = config.jwt.issuer;
         if (jwtPropertyName !== undefined) {
             if (jwtPropertyName === constants_2.ACCESS_TOKEN_PAYLOAD_JWT_PROPERTY_NAME_KEY) {
                 throw new Error(constants_2.JWT_RESERVED_KEY_USE_ERROR_MESSAGE);
             }
             accessTokenPayloadJWTPropertyName = jwtPropertyName;
-        }
-        if (issuer !== undefined) {
-            jwtIssuer = issuer;
         }
     }
     let override = Object.assign(
@@ -226,7 +222,7 @@ function validateAndNormaliseUserInput(recipeInstance, appInfo, config) {
         jwt: {
             enable: enableJWT,
             propertyNameInAccessTokenPayload: accessTokenPayloadJWTPropertyName,
-            issuer: jwtIssuer,
+            issuer,
         },
     };
 }

--- a/lib/build/recipe/session/with-jwt/recipeImplementation.d.ts
+++ b/lib/build/recipe/session/with-jwt/recipeImplementation.d.ts
@@ -1,12 +1,10 @@
 // @ts-nocheck
 import { RecipeInterface } from "../";
-import { NormalisedAppinfo } from "../../../types";
 import { RecipeInterface as OpenIdRecipeInterface } from "../../openid/types";
 import { TypeNormalisedInput } from "../types";
 export declare function setJWTExpiryOffsetSecondsForTesting(offset: number): void;
 export default function (
     originalImplementation: RecipeInterface,
     openIdRecipeImplementation: OpenIdRecipeInterface,
-    config: TypeNormalisedInput,
-    appInfo: NormalisedAppinfo
+    config: TypeNormalisedInput
 ): RecipeInterface;

--- a/lib/build/recipe/session/with-jwt/recipeImplementation.d.ts
+++ b/lib/build/recipe/session/with-jwt/recipeImplementation.d.ts
@@ -1,12 +1,12 @@
 // @ts-nocheck
 import { RecipeInterface } from "../";
 import { NormalisedAppinfo } from "../../../types";
-import { RecipeInterface as JWTRecipeInterface } from "../../jwt/types";
+import { RecipeInterface as OpenIdRecipeInterface } from "../../openid/types";
 import { TypeNormalisedInput } from "../types";
 export declare function setJWTExpiryOffsetSecondsForTesting(offset: number): void;
 export default function (
     originalImplementation: RecipeInterface,
-    jwtRecipeImplementation: JWTRecipeInterface,
+    openIdRecipeImplementation: OpenIdRecipeInterface,
     config: TypeNormalisedInput,
     appInfo: NormalisedAppinfo
 ): RecipeInterface;

--- a/lib/build/recipe/session/with-jwt/recipeImplementation.js
+++ b/lib/build/recipe/session/with-jwt/recipeImplementation.js
@@ -60,7 +60,7 @@ function setJWTExpiryOffsetSecondsForTesting(offset) {
     EXPIRY_OFFSET_SECONDS = offset;
 }
 exports.setJWTExpiryOffsetSecondsForTesting = setJWTExpiryOffsetSecondsForTesting;
-function default_1(originalImplementation, jwtRecipeImplementation, config, appInfo) {
+function default_1(originalImplementation, openIdRecipeImplementation, config, appInfo) {
     function getJWTExpiry(accessTokenExpiry) {
         return accessTokenExpiry + EXPIRY_OFFSET_SECONDS;
     }
@@ -76,7 +76,7 @@ function default_1(originalImplementation, jwtRecipeImplementation, config, appI
                     userId,
                     jwtPropertyName: config.jwt.propertyNameInAccessTokenPayload,
                     appInfo,
-                    jwtRecipeImplementation,
+                    openIdRecipeImplementation,
                 });
                 let sessionContainer = yield originalImplementation.createNewSession({
                     res,
@@ -84,7 +84,7 @@ function default_1(originalImplementation, jwtRecipeImplementation, config, appI
                     accessTokenPayload,
                     sessionData,
                 });
-                return new sessionClass_1.default(sessionContainer, jwtRecipeImplementation, appInfo);
+                return new sessionClass_1.default(sessionContainer, openIdRecipeImplementation, appInfo);
             });
         },
         getSession: function ({ req, res, options }) {
@@ -93,7 +93,7 @@ function default_1(originalImplementation, jwtRecipeImplementation, config, appI
                 if (sessionContainer === undefined) {
                     return undefined;
                 }
-                return new sessionClass_1.default(sessionContainer, jwtRecipeImplementation, appInfo);
+                return new sessionClass_1.default(sessionContainer, openIdRecipeImplementation, appInfo);
             });
         },
         refreshSession: function ({ req, res }) {
@@ -108,10 +108,10 @@ function default_1(originalImplementation, jwtRecipeImplementation, config, appI
                     userId: newSession.getUserId(),
                     jwtPropertyName: config.jwt.propertyNameInAccessTokenPayload,
                     appInfo,
-                    jwtRecipeImplementation,
+                    openIdRecipeImplementation,
                 });
                 yield newSession.updateAccessTokenPayload(accessTokenPayload);
-                return new sessionClass_1.default(newSession, jwtRecipeImplementation, appInfo);
+                return new sessionClass_1.default(newSession, openIdRecipeImplementation, appInfo);
             });
         },
         updateAccessTokenPayload: function ({ sessionHandle, newAccessTokenPayload }) {
@@ -151,7 +151,7 @@ function default_1(originalImplementation, jwtRecipeImplementation, config, appI
                     userId: sessionInformation.userId,
                     jwtPropertyName: existingJwtPropertyName,
                     appInfo,
-                    jwtRecipeImplementation,
+                    openIdRecipeImplementation,
                 });
                 return yield originalImplementation.updateAccessTokenPayload({
                     sessionHandle,

--- a/lib/build/recipe/session/with-jwt/recipeImplementation.js
+++ b/lib/build/recipe/session/with-jwt/recipeImplementation.js
@@ -60,7 +60,7 @@ function setJWTExpiryOffsetSecondsForTesting(offset) {
     EXPIRY_OFFSET_SECONDS = offset;
 }
 exports.setJWTExpiryOffsetSecondsForTesting = setJWTExpiryOffsetSecondsForTesting;
-function default_1(originalImplementation, openIdRecipeImplementation, config, appInfo) {
+function default_1(originalImplementation, openIdRecipeImplementation, config) {
     function getJWTExpiry(accessTokenExpiry) {
         return accessTokenExpiry + EXPIRY_OFFSET_SECONDS;
     }
@@ -75,7 +75,6 @@ function default_1(originalImplementation, openIdRecipeImplementation, config, a
                     jwtExpiry: getJWTExpiry(accessTokenValidityInSeconds),
                     userId,
                     jwtPropertyName: config.jwt.propertyNameInAccessTokenPayload,
-                    appInfo,
                     openIdRecipeImplementation,
                 });
                 let sessionContainer = yield originalImplementation.createNewSession({
@@ -84,7 +83,7 @@ function default_1(originalImplementation, openIdRecipeImplementation, config, a
                     accessTokenPayload,
                     sessionData,
                 });
-                return new sessionClass_1.default(sessionContainer, openIdRecipeImplementation, appInfo);
+                return new sessionClass_1.default(sessionContainer, openIdRecipeImplementation);
             });
         },
         getSession: function ({ req, res, options }) {
@@ -93,7 +92,7 @@ function default_1(originalImplementation, openIdRecipeImplementation, config, a
                 if (sessionContainer === undefined) {
                     return undefined;
                 }
-                return new sessionClass_1.default(sessionContainer, openIdRecipeImplementation, appInfo);
+                return new sessionClass_1.default(sessionContainer, openIdRecipeImplementation);
             });
         },
         refreshSession: function ({ req, res }) {
@@ -107,11 +106,10 @@ function default_1(originalImplementation, openIdRecipeImplementation, config, a
                     jwtExpiry: getJWTExpiry(accessTokenValidityInSeconds),
                     userId: newSession.getUserId(),
                     jwtPropertyName: config.jwt.propertyNameInAccessTokenPayload,
-                    appInfo,
                     openIdRecipeImplementation,
                 });
                 yield newSession.updateAccessTokenPayload(accessTokenPayload);
-                return new sessionClass_1.default(newSession, openIdRecipeImplementation, appInfo);
+                return new sessionClass_1.default(newSession, openIdRecipeImplementation);
             });
         },
         updateAccessTokenPayload: function ({ sessionHandle, newAccessTokenPayload }) {
@@ -150,7 +148,6 @@ function default_1(originalImplementation, openIdRecipeImplementation, config, a
                     jwtExpiry,
                     userId: sessionInformation.userId,
                     jwtPropertyName: existingJwtPropertyName,
-                    appInfo,
                     openIdRecipeImplementation,
                 });
                 return yield originalImplementation.updateAccessTokenPayload({

--- a/lib/build/recipe/session/with-jwt/sessionClass.d.ts
+++ b/lib/build/recipe/session/with-jwt/sessionClass.d.ts
@@ -1,16 +1,10 @@
 // @ts-nocheck
-import { NormalisedAppinfo } from "../../../types";
 import { RecipeInterface as OpenIdRecipeInterface } from "../../openid/types";
 import { SessionContainerInterface } from "../types";
 export default class SessionClassWithJWT implements SessionContainerInterface {
     private openIdRecipeImplementation;
     private originalSessionClass;
-    private appInfo;
-    constructor(
-        originalSessionClass: SessionContainerInterface,
-        openIdRecipeImplementation: OpenIdRecipeInterface,
-        appInfo: NormalisedAppinfo
-    );
+    constructor(originalSessionClass: SessionContainerInterface, openIdRecipeImplementation: OpenIdRecipeInterface);
     revokeSession: () => Promise<void>;
     getSessionData: () => Promise<any>;
     updateSessionData: (newSessionData: any) => Promise<any>;

--- a/lib/build/recipe/session/with-jwt/sessionClass.d.ts
+++ b/lib/build/recipe/session/with-jwt/sessionClass.d.ts
@@ -1,14 +1,14 @@
 // @ts-nocheck
 import { NormalisedAppinfo } from "../../../types";
-import { RecipeInterface as JWTRecipeInterface } from "../../jwt/types";
+import { RecipeInterface as OpenIdRecipeInterface } from "../../openid/types";
 import { SessionContainerInterface } from "../types";
 export default class SessionClassWithJWT implements SessionContainerInterface {
-    private jwtRecipeImplementation;
+    private openIdRecipeImplementation;
     private originalSessionClass;
     private appInfo;
     constructor(
         originalSessionClass: SessionContainerInterface,
-        jwtRecipeImplementation: JWTRecipeInterface,
+        openIdRecipeImplementation: OpenIdRecipeInterface,
         appInfo: NormalisedAppinfo
     );
     revokeSession: () => Promise<void>;

--- a/lib/build/recipe/session/with-jwt/sessionClass.js
+++ b/lib/build/recipe/session/with-jwt/sessionClass.js
@@ -50,7 +50,7 @@ const assert = require("assert");
 const constants_1 = require("./constants");
 const utils_1 = require("./utils");
 class SessionClassWithJWT {
-    constructor(originalSessionClass, openIdRecipeImplementation, appInfo) {
+    constructor(originalSessionClass, openIdRecipeImplementation) {
         this.revokeSession = () => {
             return this.originalSessionClass.revokeSession();
         };
@@ -108,14 +108,12 @@ class SessionClassWithJWT {
                     jwtExpiry,
                     userId: this.getUserId(),
                     jwtPropertyName,
-                    appInfo: this.appInfo,
                     openIdRecipeImplementation: this.openIdRecipeImplementation,
                 });
                 return yield this.originalSessionClass.updateAccessTokenPayload(newAccessTokenPayload);
             });
         this.openIdRecipeImplementation = openIdRecipeImplementation;
         this.originalSessionClass = originalSessionClass;
-        this.appInfo = appInfo;
     }
 }
 exports.default = SessionClassWithJWT;

--- a/lib/build/recipe/session/with-jwt/sessionClass.js
+++ b/lib/build/recipe/session/with-jwt/sessionClass.js
@@ -50,7 +50,7 @@ const assert = require("assert");
 const constants_1 = require("./constants");
 const utils_1 = require("./utils");
 class SessionClassWithJWT {
-    constructor(originalSessionClass, jwtRecipeImplementation, appInfo) {
+    constructor(originalSessionClass, openIdRecipeImplementation, appInfo) {
         this.revokeSession = () => {
             return this.originalSessionClass.revokeSession();
         };
@@ -109,11 +109,11 @@ class SessionClassWithJWT {
                     userId: this.getUserId(),
                     jwtPropertyName,
                     appInfo: this.appInfo,
-                    jwtRecipeImplementation: this.jwtRecipeImplementation,
+                    openIdRecipeImplementation: this.openIdRecipeImplementation,
                 });
                 return yield this.originalSessionClass.updateAccessTokenPayload(newAccessTokenPayload);
             });
-        this.jwtRecipeImplementation = jwtRecipeImplementation;
+        this.openIdRecipeImplementation = openIdRecipeImplementation;
         this.originalSessionClass = originalSessionClass;
         this.appInfo = appInfo;
     }

--- a/lib/build/recipe/session/with-jwt/utils.d.ts
+++ b/lib/build/recipe/session/with-jwt/utils.d.ts
@@ -1,18 +1,15 @@
 // @ts-nocheck
-import { NormalisedAppinfo } from "../../../types";
 import { RecipeInterface as OpenIdRecipeInterface } from "../../openid/types";
 export declare function addJWTToAccessTokenPayload({
     accessTokenPayload,
     jwtExpiry,
     userId,
     jwtPropertyName,
-    appInfo,
     openIdRecipeImplementation,
 }: {
     accessTokenPayload: any;
     jwtExpiry: number;
     userId: string;
     jwtPropertyName: string;
-    appInfo: NormalisedAppinfo;
     openIdRecipeImplementation: OpenIdRecipeInterface;
 }): Promise<any>;

--- a/lib/build/recipe/session/with-jwt/utils.d.ts
+++ b/lib/build/recipe/session/with-jwt/utils.d.ts
@@ -1,18 +1,18 @@
 // @ts-nocheck
 import { NormalisedAppinfo } from "../../../types";
-import { RecipeInterface as JWTRecipeInterface } from "../../jwt/types";
+import { RecipeInterface as OpenIdRecipeInterface } from "../../openid/types";
 export declare function addJWTToAccessTokenPayload({
     accessTokenPayload,
     jwtExpiry,
     userId,
     jwtPropertyName,
     appInfo,
-    jwtRecipeImplementation,
+    openIdRecipeImplementation,
 }: {
     accessTokenPayload: any;
     jwtExpiry: number;
     userId: string;
     jwtPropertyName: string;
     appInfo: NormalisedAppinfo;
-    jwtRecipeImplementation: JWTRecipeInterface;
+    openIdRecipeImplementation: OpenIdRecipeInterface;
 }): Promise<any>;

--- a/lib/build/recipe/session/with-jwt/utils.js
+++ b/lib/build/recipe/session/with-jwt/utils.js
@@ -38,7 +38,7 @@ function addJWTToAccessTokenPayload({
     userId,
     jwtPropertyName,
     appInfo,
-    jwtRecipeImplementation,
+    openIdRecipeImplementation,
 }) {
     return __awaiter(this, void 0, void 0, function* () {
         // If jwtPropertyName is not undefined it means that the JWT was added to the access token payload already
@@ -61,7 +61,7 @@ function addJWTToAccessTokenPayload({
             accessTokenPayload
         );
         // Create the JWT
-        let jwtResponse = yield jwtRecipeImplementation.createJWT({
+        let jwtResponse = yield openIdRecipeImplementation.createJWT({
             payload: accessTokenPayload,
             validitySeconds: jwtExpiry,
         });

--- a/lib/build/recipe/session/with-jwt/utils.js
+++ b/lib/build/recipe/session/with-jwt/utils.js
@@ -31,13 +31,26 @@ var __awaiter =
         });
     };
 Object.defineProperty(exports, "__esModule", { value: true });
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 const constants_1 = require("./constants");
 function addJWTToAccessTokenPayload({
     accessTokenPayload,
     jwtExpiry,
     userId,
     jwtPropertyName,
-    appInfo,
     openIdRecipeImplementation,
 }) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -48,21 +61,18 @@ function addJWTToAccessTokenPayload({
             delete accessTokenPayload[existingJwtPropertyName];
             delete accessTokenPayload[constants_1.ACCESS_TOKEN_PAYLOAD_JWT_PROPERTY_NAME_KEY];
         }
-        // Update the access token payload with the default claims to add
-        accessTokenPayload = Object.assign(
-            {
-                /*
-                We add our claims before the user provided ones so that if they use the same claims
-                then the final payload will use the values they provide
-            */
-                sub: userId,
-                iss: appInfo.apiDomain.getAsStringDangerous(),
-            },
-            accessTokenPayload
-        );
         // Create the JWT
         let jwtResponse = yield openIdRecipeImplementation.createJWT({
-            payload: accessTokenPayload,
+            payload: Object.assign(
+                {
+                    /*
+                    We add our claims before the user provided ones so that if they use the same claims
+                    then the final payload will use the values they provide
+                */
+                    sub: userId,
+                },
+                accessTokenPayload
+            ),
             validitySeconds: jwtExpiry,
         });
         if (jwtResponse.status === "UNSUPPORTED_ALGORITHM_ERROR") {

--- a/lib/ts/recipe/jwt/api/getJWKS.ts
+++ b/lib/ts/recipe/jwt/api/getJWKS.ts
@@ -21,6 +21,7 @@ export default async function getJWKS(apiImplementation: APIInterface, options: 
         return false;
     }
 
+    options.res.setHeader("Access-Control-Allow-Origin", "*", false);
     let result = await apiImplementation.getJWKSGET({ options });
     send200Response(options.res, { keys: result.keys });
     return true;

--- a/lib/ts/recipe/openid/api/getOpenIdDiscoveryConfiguration.ts
+++ b/lib/ts/recipe/openid/api/getOpenIdDiscoveryConfiguration.ts
@@ -1,0 +1,32 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+import { send200Response } from "../../../utils";
+import { APIInterface, APIOptions } from "../types";
+
+export default async function getOpenIdDiscoveryConfiguration(
+    apiImplementation: APIInterface,
+    options: APIOptions
+): Promise<boolean> {
+    if (apiImplementation.getOpenIdDiscoveryConfigurationGET === undefined) {
+        return false;
+    }
+
+    let result = await apiImplementation.getOpenIdDiscoveryConfigurationGET({ options });
+    send200Response(options.res, {
+        issuer: result.issuer,
+        jwks_uri: result.jwks_uri,
+    });
+    return true;
+}

--- a/lib/ts/recipe/openid/api/getOpenIdDiscoveryConfiguration.ts
+++ b/lib/ts/recipe/openid/api/getOpenIdDiscoveryConfiguration.ts
@@ -23,6 +23,7 @@ export default async function getOpenIdDiscoveryConfiguration(
         return false;
     }
 
+    options.res.setHeader("Access-Control-Allow-Origin", "*", false);
     let result = await apiImplementation.getOpenIdDiscoveryConfigurationGET({ options });
     send200Response(options.res, {
         issuer: result.issuer,

--- a/lib/ts/recipe/openid/api/implementation.ts
+++ b/lib/ts/recipe/openid/api/implementation.ts
@@ -21,7 +21,7 @@ export default function getAPIImplementation(): APIInterface {
         }: {
             options: APIOptions;
         }): Promise<{ status: "OK"; issuer: string; jwks_uri: string }> {
-            return await options.recipeImplementation.getDiscoveryConfiguration();
+            return await options.recipeImplementation.getOpenIdDiscoveryConfiguration();
         },
     };
 }

--- a/lib/ts/recipe/openid/api/implementation.ts
+++ b/lib/ts/recipe/openid/api/implementation.ts
@@ -1,0 +1,27 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+import { APIInterface, APIOptions } from "../types";
+
+export default function getAPIImplementation(): APIInterface {
+    return {
+        getOpenIdDiscoveryConfigurationGET: async function ({
+            options,
+        }: {
+            options: APIOptions;
+        }): Promise<{ status: "OK"; issuer: string; jwks_uri: string }> {
+            return await options.recipeImplementation.getDiscoveryConfiguration();
+        },
+    };
+}

--- a/lib/ts/recipe/openid/constants.ts
+++ b/lib/ts/recipe/openid/constants.ts
@@ -1,0 +1,15 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+export const GET_DISCOVERY_CONFIG_URL = "/.well-known/openid-configuration";

--- a/lib/ts/recipe/openid/index.ts
+++ b/lib/ts/recipe/openid/index.ts
@@ -1,25 +1,25 @@
-import OpenIDRecipe from "./recipe";
+import OpenIdRecipe from "./recipe";
 
-export default class OpenIDRecipeWrapper {
-    static init = OpenIDRecipe.init;
+export default class OpenIdRecipeWrapper {
+    static init = OpenIdRecipe.init;
 
-    static getDiscoveryConfiguration() {
-        return OpenIDRecipe.getInstanceOrThrowError().recipeImplementation.getDiscoveryConfiguration();
+    static getOpenIdDiscoveryConfiguration() {
+        return OpenIdRecipe.getInstanceOrThrowError().recipeImplementation.getOpenIdDiscoveryConfiguration();
     }
 
     static createJWT(payload?: any, validitySeconds?: number) {
-        return OpenIDRecipe.getInstanceOrThrowError().jwtRecipe.recipeInterfaceImpl.createJWT({
+        return OpenIdRecipe.getInstanceOrThrowError().jwtRecipe.recipeInterfaceImpl.createJWT({
             payload,
             validitySeconds,
         });
     }
 
     static getJWKS() {
-        return OpenIDRecipe.getInstanceOrThrowError().jwtRecipe.recipeInterfaceImpl.getJWKS();
+        return OpenIdRecipe.getInstanceOrThrowError().jwtRecipe.recipeInterfaceImpl.getJWKS();
     }
 }
 
-export let init = OpenIDRecipeWrapper.init;
-export let getDiscoveryConfiguration = OpenIDRecipeWrapper.getDiscoveryConfiguration;
-export let createJWT = OpenIDRecipeWrapper.createJWT;
-export let getJWKS = OpenIDRecipeWrapper.getJWKS;
+export let init = OpenIdRecipeWrapper.init;
+export let getOpenIdDiscoveryConfiguration = OpenIdRecipeWrapper.getOpenIdDiscoveryConfiguration;
+export let createJWT = OpenIdRecipeWrapper.createJWT;
+export let getJWKS = OpenIdRecipeWrapper.getJWKS;

--- a/lib/ts/recipe/openid/index.ts
+++ b/lib/ts/recipe/openid/index.ts
@@ -1,0 +1,25 @@
+import OpenIDRecipe from "./recipe";
+
+export default class OpenIDRecipeWrapper {
+    static init = OpenIDRecipe.init;
+
+    static getDiscoveryConfiguration() {
+        return OpenIDRecipe.getInstanceOrThrowError().recipeImplementation.getDiscoveryConfiguration();
+    }
+
+    static createJWT(payload?: any, validitySeconds?: number) {
+        return OpenIDRecipe.getInstanceOrThrowError().jwtRecipe.recipeInterfaceImpl.createJWT({
+            payload,
+            validitySeconds,
+        });
+    }
+
+    static getJWKS() {
+        return OpenIDRecipe.getInstanceOrThrowError().jwtRecipe.recipeInterfaceImpl.getJWKS();
+    }
+}
+
+export let init = OpenIDRecipeWrapper.init;
+export let getDiscoveryConfiguration = OpenIDRecipeWrapper.getDiscoveryConfiguration;
+export let createJWT = OpenIDRecipeWrapper.createJWT;
+export let getJWKS = OpenIDRecipeWrapper.getJWKS;

--- a/lib/ts/recipe/openid/recipe.ts
+++ b/lib/ts/recipe/openid/recipe.ts
@@ -40,6 +40,7 @@ export default class OpenIdRecipe extends RecipeModule {
 
         this.config = validateAndNormaliseUserInput(appInfo, config);
         this.jwtRecipe = new JWTRecipe(recipeId, appInfo, isInServerlessEnv, {
+            jwtValiditySeconds: this.config.jwtValiditySeconds,
             override: this.config.override.jwtFeature,
         });
 
@@ -117,7 +118,7 @@ export default class OpenIdRecipe extends RecipeModule {
         }
     };
     getAllCORSHeaders = (): string[] => {
-        return [];
+        return [...this.jwtRecipe.getAllCORSHeaders()];
     };
     isErrorFromThisRecipe = (err: any): err is STError => {
         return (

--- a/lib/ts/recipe/openid/recipe.ts
+++ b/lib/ts/recipe/openid/recipe.ts
@@ -1,0 +1,125 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+import STError from "../../error";
+import { BaseRequest, BaseResponse } from "../../framework";
+import normalisedURLPath from "../../normalisedURLPath";
+import RecipeModule from "../../recipeModule";
+import { APIHandled, HTTPMethod, NormalisedAppinfo, RecipeListFunction } from "../../types";
+import { APIInterface, APIOptions, RecipeInterface, TypeInput, TypeNormalisedInput } from "./types";
+import { validateAndNormaliseUserInput } from "./utils";
+import JWTRecipe from "../jwt/recipe";
+import OverrideableBuilder from "supertokens-js-override";
+import RecipeImplementation from "./recipeImplementation";
+import APIImplementation from "./api/implementation";
+import NormalisedURLPath from "../../normalisedURLPath";
+import { GET_DISCOVERY_CONFIG_URL } from "./constants";
+import getOpenIdDiscoveryConfiguration from "./api/getOpenIdDiscoveryConfiguration";
+
+export default class OpenIDRecipe extends RecipeModule {
+    static RECIPE_ID = "opeinid";
+    private static instance: OpenIDRecipe | undefined = undefined;
+    config: TypeNormalisedInput;
+    jwtRecipe: JWTRecipe;
+    recipeImplementation: RecipeInterface;
+    apiImpl: APIInterface;
+
+    constructor(recipeId: string, appInfo: NormalisedAppinfo, isInServerlessEnv: boolean, config?: TypeInput) {
+        super(recipeId, appInfo);
+
+        this.config = validateAndNormaliseUserInput(appInfo, config);
+        this.jwtRecipe = new JWTRecipe(recipeId, appInfo, isInServerlessEnv, {
+            override: this.config.override.jwtFeature,
+        });
+
+        let builder = new OverrideableBuilder(RecipeImplementation(this.config));
+
+        this.recipeImplementation = builder.override(this.config.override.functions).build();
+
+        let apiBuilder = new OverrideableBuilder(APIImplementation());
+
+        this.apiImpl = apiBuilder.override(this.config.override.apis).build();
+    }
+
+    static getInstanceOrThrowError(): OpenIDRecipe {
+        if (OpenIDRecipe.instance !== undefined) {
+            return OpenIDRecipe.instance;
+        }
+        throw new Error("Initialisation not done. Did you forget to call the SuperTokens.init function?");
+    }
+
+    static init(config?: TypeInput): RecipeListFunction {
+        return (appInfo, isInServerlessEnv) => {
+            if (OpenIDRecipe.instance === undefined) {
+                OpenIDRecipe.instance = new OpenIDRecipe(OpenIDRecipe.RECIPE_ID, appInfo, isInServerlessEnv, config);
+                return OpenIDRecipe.instance;
+            } else {
+                throw new Error("OpenID recipe has already been initialised. Please check your code for bugs.");
+            }
+        };
+    }
+
+    static reset() {
+        if (process.env.TEST_MODE !== "testing") {
+            throw new Error("calling testing function in non testing env");
+        }
+        OpenIDRecipe.instance = undefined;
+    }
+
+    getAPIsHandled = (): APIHandled[] => {
+        return [
+            {
+                method: "get",
+                pathWithoutApiBasePath: new NormalisedURLPath(GET_DISCOVERY_CONFIG_URL),
+                id: GET_DISCOVERY_CONFIG_URL,
+                disabled: this.apiImpl.getOpenIdDiscoveryConfigurationGET === undefined,
+            },
+            ...this.jwtRecipe.getAPIsHandled(),
+        ];
+    };
+    handleAPIRequest = async (
+        id: string,
+        req: BaseRequest,
+        response: BaseResponse,
+        path: normalisedURLPath,
+        method: HTTPMethod
+    ): Promise<boolean> => {
+        let apiOptions: APIOptions = {
+            recipeImplementation: this.recipeImplementation,
+            config: this.config,
+            recipeId: this.getRecipeId(),
+            req,
+            res: response,
+        };
+
+        if (id === GET_DISCOVERY_CONFIG_URL) {
+            return await getOpenIdDiscoveryConfiguration(this.apiImpl, apiOptions);
+        } else {
+            return this.jwtRecipe.handleAPIRequest(id, req, response, path, method);
+        }
+    };
+    handleError = async (error: STError, request: BaseRequest, response: BaseResponse): Promise<void> => {
+        if (error.fromRecipe === OpenIDRecipe.RECIPE_ID) {
+            throw error;
+        } else {
+            return await this.jwtRecipe.handleError(error, request, response);
+        }
+    };
+    getAllCORSHeaders = (): string[] => {
+        return [];
+    };
+    isErrorFromThisRecipe = (err: any): err is STError => {
+        return STError.isErrorFromSuperTokens(err) && err.fromRecipe === OpenIDRecipe.RECIPE_ID;
+    };
+}

--- a/lib/ts/recipe/openid/recipeImplementation.ts
+++ b/lib/ts/recipe/openid/recipeImplementation.ts
@@ -1,0 +1,27 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+import { DiscoveryConfiguration, RecipeInterface, TypeNormalisedInput } from "./types";
+
+export default function getRecipeInterface(config: TypeNormalisedInput): RecipeInterface {
+    return {
+        getDiscoveryConfiguration: async function (): Promise<DiscoveryConfiguration> {
+            return {
+                status: "OK",
+                issuer: config.issuer,
+                jwks_uri: config.issuer + "/jwt/jwks.json",
+            };
+        },
+    };
+}

--- a/lib/ts/recipe/openid/recipeImplementation.ts
+++ b/lib/ts/recipe/openid/recipeImplementation.ts
@@ -52,6 +52,8 @@ export default function getRecipeInterface(
                   status: "UNSUPPORTED_ALGORITHM_ERROR";
               }
         > {
+            payload = payload === undefined ? {} : payload;
+
             let issuer = config.issuerDomain.getAsStringDangerous() + config.issuerPath.getAsStringDangerous();
             return await jwtRecipeImplementation.createJWT({
                 payload: {

--- a/lib/ts/recipe/openid/recipeImplementation.ts
+++ b/lib/ts/recipe/openid/recipeImplementation.ts
@@ -52,8 +52,12 @@ export default function getRecipeInterface(
                   status: "UNSUPPORTED_ALGORITHM_ERROR";
               }
         > {
+            let issuer = config.issuerDomain.getAsStringDangerous() + config.issuerPath.getAsStringDangerous();
             return await jwtRecipeImplementation.createJWT({
-                payload,
+                payload: {
+                    iss: issuer,
+                    ...payload,
+                },
                 validitySeconds,
             });
         },

--- a/lib/ts/recipe/openid/recipeImplementation.ts
+++ b/lib/ts/recipe/openid/recipeImplementation.ts
@@ -52,7 +52,7 @@ export default function getRecipeInterface(
                   status: "UNSUPPORTED_ALGORITHM_ERROR";
               }
         > {
-            payload = payload === undefined ? {} : payload;
+            payload = payload === undefined || payload === null ? {} : payload;
 
             let issuer = config.issuerDomain.getAsStringDangerous() + config.issuerPath.getAsStringDangerous();
             return await jwtRecipeImplementation.createJWT({

--- a/lib/ts/recipe/openid/recipeImplementation.ts
+++ b/lib/ts/recipe/openid/recipeImplementation.ts
@@ -17,10 +17,11 @@ import { DiscoveryConfiguration, RecipeInterface, TypeNormalisedInput } from "./
 export default function getRecipeInterface(config: TypeNormalisedInput): RecipeInterface {
     return {
         getDiscoveryConfiguration: async function (): Promise<DiscoveryConfiguration> {
+            let issuer = config.issuerDomain.getAsStringDangerous() + config.issuerPath.getAsStringDangerous();
             return {
                 status: "OK",
-                issuer: config.issuer,
-                jwks_uri: config.issuer + "/jwt/jwks.json",
+                issuer,
+                jwks_uri: issuer + "/jwt/jwks.json",
             };
         },
     };

--- a/lib/ts/recipe/openid/types.ts
+++ b/lib/ts/recipe/openid/types.ts
@@ -16,10 +16,10 @@ import OverrideableBuilder from "supertokens-js-override";
 import { BaseRequest, BaseResponse } from "../../framework";
 import NormalisedURLDomain from "../../normalisedURLDomain";
 import NormalisedURLPath from "../../normalisedURLPath";
-import { RecipeInterface as JWTRecipeInterface, APIInterface as JWTAPIInterface } from "../jwt/types";
+import { RecipeInterface as JWTRecipeInterface, APIInterface as JWTAPIInterface, JsonWebKey } from "../jwt/types";
 
 export type TypeInput = {
-    issuer: string;
+    issuer?: string;
     override?: {
         functions?: (
             originalImplementation: RecipeInterface,
@@ -72,15 +72,36 @@ export type APIOptions = {
 export type APIInterface = {
     getOpenIdDiscoveryConfigurationGET:
         | undefined
-        | ((input: { options: APIOptions }) => Promise<DiscoveryConfiguration>);
-};
-
-export type DiscoveryConfiguration = {
-    status: "OK";
-    issuer: string;
-    jwks_uri: string;
+        | ((input: {
+              options: APIOptions;
+          }) => Promise<{
+              status: "OK";
+              issuer: string;
+              jwks_uri: string;
+          }>);
 };
 
 export type RecipeInterface = {
-    getDiscoveryConfiguration(): Promise<DiscoveryConfiguration>;
+    getOpenIdDiscoveryConfiguration(): Promise<{
+        status: "OK";
+        issuer: string;
+        jwks_uri: string;
+    }>;
+    createJWT(input: {
+        payload?: any;
+        validitySeconds?: number;
+    }): Promise<
+        | {
+              status: "OK";
+              jwt: string;
+          }
+        | {
+              status: "UNSUPPORTED_ALGORITHM_ERROR";
+          }
+    >;
+
+    getJWKS(): Promise<{
+        status: "OK";
+        keys: JsonWebKey[];
+    }>;
 };

--- a/lib/ts/recipe/openid/types.ts
+++ b/lib/ts/recipe/openid/types.ts
@@ -1,0 +1,83 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+import OverrideableBuilder from "supertokens-js-override";
+import { BaseRequest, BaseResponse } from "../../framework";
+import { RecipeInterface as JWTRecipeInterface, APIInterface as JWTAPIInterface } from "../jwt/types";
+
+export type TypeInput = {
+    issuer: string;
+    override?: {
+        functions?: (
+            originalImplementation: RecipeInterface,
+            builder?: OverrideableBuilder<RecipeInterface>
+        ) => RecipeInterface;
+        apis?: (originalImplementation: APIInterface, builder?: OverrideableBuilder<APIInterface>) => APIInterface;
+        jwtFeature?: {
+            functions?: (
+                originalImplementation: JWTRecipeInterface,
+                builder?: OverrideableBuilder<JWTRecipeInterface>
+            ) => JWTRecipeInterface;
+            apis?: (
+                originalImplementation: JWTAPIInterface,
+                builder?: OverrideableBuilder<JWTAPIInterface>
+            ) => JWTAPIInterface;
+        };
+    };
+};
+
+export type TypeNormalisedInput = {
+    issuer: string;
+    override: {
+        functions: (
+            originalImplementation: RecipeInterface,
+            builder?: OverrideableBuilder<RecipeInterface>
+        ) => RecipeInterface;
+        apis: (originalImplementation: APIInterface, builder?: OverrideableBuilder<APIInterface>) => APIInterface;
+        jwtFeature?: {
+            functions?: (
+                originalImplementation: JWTRecipeInterface,
+                builder?: OverrideableBuilder<JWTRecipeInterface>
+            ) => JWTRecipeInterface;
+            apis?: (
+                originalImplementation: JWTAPIInterface,
+                builder?: OverrideableBuilder<JWTAPIInterface>
+            ) => JWTAPIInterface;
+        };
+    };
+};
+
+export type APIOptions = {
+    recipeImplementation: RecipeInterface;
+    config: TypeNormalisedInput;
+    recipeId: string;
+    req: BaseRequest;
+    res: BaseResponse;
+};
+
+export type APIInterface = {
+    getOpenIdDiscoveryConfigurationGET:
+        | undefined
+        | ((input: { options: APIOptions }) => Promise<DiscoveryConfiguration>);
+};
+
+export type DiscoveryConfiguration = {
+    status: "OK";
+    issuer: string;
+    jwks_uri: string;
+};
+
+export type RecipeInterface = {
+    getDiscoveryConfiguration(): Promise<DiscoveryConfiguration>;
+};

--- a/lib/ts/recipe/openid/types.ts
+++ b/lib/ts/recipe/openid/types.ts
@@ -14,6 +14,8 @@
  */
 import OverrideableBuilder from "supertokens-js-override";
 import { BaseRequest, BaseResponse } from "../../framework";
+import NormalisedURLDomain from "../../normalisedURLDomain";
+import NormalisedURLPath from "../../normalisedURLPath";
 import { RecipeInterface as JWTRecipeInterface, APIInterface as JWTAPIInterface } from "../jwt/types";
 
 export type TypeInput = {
@@ -38,7 +40,8 @@ export type TypeInput = {
 };
 
 export type TypeNormalisedInput = {
-    issuer: string;
+    issuerDomain: NormalisedURLDomain;
+    issuerPath: NormalisedURLPath;
     override: {
         functions: (
             originalImplementation: RecipeInterface,

--- a/lib/ts/recipe/openid/types.ts
+++ b/lib/ts/recipe/openid/types.ts
@@ -20,6 +20,7 @@ import { RecipeInterface as JWTRecipeInterface, APIInterface as JWTAPIInterface,
 
 export type TypeInput = {
     issuer?: string;
+    jwtValiditySeconds?: number;
     override?: {
         functions?: (
             originalImplementation: RecipeInterface,
@@ -42,6 +43,7 @@ export type TypeInput = {
 export type TypeNormalisedInput = {
     issuerDomain: NormalisedURLDomain;
     issuerPath: NormalisedURLPath;
+    jwtValiditySeconds?: number;
     override: {
         functions: (
             originalImplementation: RecipeInterface,

--- a/lib/ts/recipe/openid/utils.ts
+++ b/lib/ts/recipe/openid/utils.ts
@@ -1,0 +1,35 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+import { NormalisedAppinfo } from "../../types";
+import { APIInterface, RecipeInterface, TypeInput, TypeNormalisedInput } from "./types";
+
+export function validateAndNormaliseUserInput(appInfo: NormalisedAppinfo, config?: TypeInput): TypeNormalisedInput {
+    let issuer = appInfo.apiDomain.getAsStringDangerous() + appInfo.apiBasePath.getAsStringDangerous();
+
+    if (config !== undefined) {
+        issuer = config.issuer;
+    }
+
+    let override = {
+        functions: (originalImplementation: RecipeInterface) => originalImplementation,
+        apis: (originalImplementation: APIInterface) => originalImplementation,
+        ...config?.override,
+    };
+
+    return {
+        issuer,
+        override,
+    };
+}

--- a/lib/ts/recipe/openid/utils.ts
+++ b/lib/ts/recipe/openid/utils.ts
@@ -19,7 +19,7 @@ import { APIInterface, RecipeInterface, TypeInput, TypeNormalisedInput } from ".
 
 export function validateAndNormaliseUserInput(appInfo: NormalisedAppinfo, config?: TypeInput): TypeNormalisedInput {
     let issuerDomain = appInfo.apiDomain;
-    let issuerPath = appInfo.apiGatewayPath.appendPath(appInfo.apiBasePath);
+    let issuerPath = appInfo.apiBasePath;
 
     if (config !== undefined) {
         if (config.issuer !== undefined) {
@@ -27,7 +27,7 @@ export function validateAndNormaliseUserInput(appInfo: NormalisedAppinfo, config
             issuerPath = new NormalisedURLPath(config.issuer);
         }
 
-        if (!issuerPath.equals(appInfo.apiBasePath)) {
+        if (!issuerPath.getAsStringDangerous().endsWith(appInfo.apiBasePath.getAsStringDangerous())) {
             throw new Error("Issuer URL must end with apiBasePath. The default value is /auth");
         }
     }

--- a/lib/ts/recipe/openid/utils.ts
+++ b/lib/ts/recipe/openid/utils.ts
@@ -27,8 +27,8 @@ export function validateAndNormaliseUserInput(appInfo: NormalisedAppinfo, config
             issuerPath = new NormalisedURLPath(config.issuer);
         }
 
-        if (!issuerPath.getAsStringDangerous().endsWith(appInfo.apiBasePath.getAsStringDangerous())) {
-            throw new Error("Issuer URL must end with apiBasePath. The default value is /auth");
+        if (!issuerPath.equals(appInfo.apiBasePath)) {
+            throw new Error("The path of the issuer URL must be equal to the apiBasePath. The default value is /auth");
         }
     }
 
@@ -41,6 +41,7 @@ export function validateAndNormaliseUserInput(appInfo: NormalisedAppinfo, config
     return {
         issuerDomain,
         issuerPath,
+        jwtValiditySeconds: config?.jwtValiditySeconds,
         override,
     };
 }

--- a/lib/ts/recipe/openid/utils.ts
+++ b/lib/ts/recipe/openid/utils.ts
@@ -19,14 +19,16 @@ import { APIInterface, RecipeInterface, TypeInput, TypeNormalisedInput } from ".
 
 export function validateAndNormaliseUserInput(appInfo: NormalisedAppinfo, config?: TypeInput): TypeNormalisedInput {
     let issuerDomain = appInfo.apiDomain;
-    let issuerPath = appInfo.apiBasePath;
+    let issuerPath = appInfo.apiGatewayPath.appendPath(appInfo.apiBasePath);
 
     if (config !== undefined) {
-        issuerDomain = new NormalisedURLDomain(config.issuer);
-        issuerPath = new NormalisedURLPath(config.issuer);
+        if (config.issuer !== undefined) {
+            issuerDomain = new NormalisedURLDomain(config.issuer);
+            issuerPath = new NormalisedURLPath(config.issuer);
+        }
 
         if (!issuerPath.equals(appInfo.apiBasePath)) {
-            throw new Error("Issuer URL must end with apiBasePath");
+            throw new Error("Issuer URL must end with apiBasePath. The default value is /auth");
         }
     }
 

--- a/lib/ts/recipe/openid/utils.ts
+++ b/lib/ts/recipe/openid/utils.ts
@@ -12,14 +12,22 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+import NormalisedURLDomain from "../../normalisedURLDomain";
+import NormalisedURLPath from "../../normalisedURLPath";
 import { NormalisedAppinfo } from "../../types";
 import { APIInterface, RecipeInterface, TypeInput, TypeNormalisedInput } from "./types";
 
 export function validateAndNormaliseUserInput(appInfo: NormalisedAppinfo, config?: TypeInput): TypeNormalisedInput {
-    let issuer = appInfo.apiDomain.getAsStringDangerous() + appInfo.apiBasePath.getAsStringDangerous();
+    let issuerDomain = appInfo.apiDomain;
+    let issuerPath = appInfo.apiBasePath;
 
     if (config !== undefined) {
-        issuer = config.issuer;
+        issuerDomain = new NormalisedURLDomain(config.issuer);
+        issuerPath = new NormalisedURLPath(config.issuer);
+
+        if (!issuerPath.equals(appInfo.apiBasePath)) {
+            throw new Error("Issuer URL must end with apiBasePath");
+        }
     }
 
     let override = {
@@ -29,7 +37,8 @@ export function validateAndNormaliseUserInput(appInfo: NormalisedAppinfo, config
     };
 
     return {
-        issuer,
+        issuerDomain,
+        issuerPath,
         override,
     };
 }

--- a/lib/ts/recipe/session/index.ts
+++ b/lib/ts/recipe/session/index.ts
@@ -22,6 +22,7 @@ import {
     APIInterface,
     APIOptions,
 } from "./types";
+import OpenIdRecipe from "../openid/recipe";
 import Recipe from "./recipe";
 
 // For Express
@@ -82,10 +83,10 @@ export default class SessionWrapper {
     }
 
     static createJWT(payload?: any, validitySeconds?: number) {
-        let jwtRecipe = Recipe.getInstanceOrThrowError().openIdRecipe?.jwtRecipe;
+        let openIdRecipe: OpenIdRecipe | undefined = Recipe.getInstanceOrThrowError().openIdRecipe;
 
-        if (jwtRecipe !== undefined) {
-            return jwtRecipe.recipeInterfaceImpl.createJWT({ payload, validitySeconds });
+        if (openIdRecipe !== undefined) {
+            return openIdRecipe.recipeImplementation.createJWT({ payload, validitySeconds });
         }
 
         throw new global.Error(
@@ -94,10 +95,10 @@ export default class SessionWrapper {
     }
 
     static getJWKS() {
-        let jwtRecipe = Recipe.getInstanceOrThrowError().openIdRecipe?.jwtRecipe;
+        let openIdRecipe: OpenIdRecipe | undefined = Recipe.getInstanceOrThrowError().openIdRecipe;
 
-        if (jwtRecipe !== undefined) {
-            return jwtRecipe.recipeInterfaceImpl.getJWKS();
+        if (openIdRecipe !== undefined) {
+            return openIdRecipe.recipeImplementation.getJWKS();
         }
 
         throw new global.Error(
@@ -106,7 +107,7 @@ export default class SessionWrapper {
     }
 
     static getOpenIdDiscoveryConfiguration() {
-        let openIdRecipe = Recipe.getInstanceOrThrowError().openIdRecipe;
+        let openIdRecipe: OpenIdRecipe | undefined = Recipe.getInstanceOrThrowError().openIdRecipe;
 
         if (openIdRecipe !== undefined) {
             return openIdRecipe.recipeImplementation.getOpenIdDiscoveryConfiguration();

--- a/lib/ts/recipe/session/index.ts
+++ b/lib/ts/recipe/session/index.ts
@@ -109,7 +109,7 @@ export default class SessionWrapper {
         let openIdRecipe = Recipe.getInstanceOrThrowError().openIdRecipe;
 
         if (openIdRecipe !== undefined) {
-            return openIdRecipe.recipeImplementation.getDiscoveryConfiguration();
+            return openIdRecipe.recipeImplementation.getOpenIdDiscoveryConfiguration();
         }
 
         throw new global.Error(

--- a/lib/ts/recipe/session/index.ts
+++ b/lib/ts/recipe/session/index.ts
@@ -104,6 +104,18 @@ export default class SessionWrapper {
             "getJWKS cannot be used without enabling the JWT feature. Please set 'enableJWT: true' when initialising the Session recipe"
         );
     }
+
+    static getDiscoveryConfiguration() {
+        let openIdRecipe = Recipe.getInstanceOrThrowError().openIdRecipe;
+
+        if (openIdRecipe !== undefined) {
+            return openIdRecipe.recipeImplementation.getDiscoveryConfiguration();
+        }
+
+        throw new global.Error(
+            "getDiscoveryConfiguration cannot be used without enabling the JWT feature. Please set 'enableJWT: true' when initialising the Session recipe"
+        );
+    }
 }
 
 export let init = SessionWrapper.init;
@@ -134,5 +146,9 @@ export let Error = SessionWrapper.Error;
 export let createJWT = SessionWrapper.createJWT;
 
 export let getJWKS = SessionWrapper.getJWKS;
+
+// Open id functions
+
+export let getDiscoveryConfiguration = SessionWrapper.getDiscoveryConfiguration;
 
 export type { VerifySessionOptions, RecipeInterface, SessionContainer, APIInterface, APIOptions, SessionInformation };

--- a/lib/ts/recipe/session/index.ts
+++ b/lib/ts/recipe/session/index.ts
@@ -82,7 +82,7 @@ export default class SessionWrapper {
     }
 
     static createJWT(payload?: any, validitySeconds?: number) {
-        let jwtRecipe = Recipe.getInstanceOrThrowError().jwtRecipe;
+        let jwtRecipe = Recipe.getInstanceOrThrowError().openIdRecipe?.jwtRecipe;
 
         if (jwtRecipe !== undefined) {
             return jwtRecipe.recipeInterfaceImpl.createJWT({ payload, validitySeconds });
@@ -94,7 +94,7 @@ export default class SessionWrapper {
     }
 
     static getJWKS() {
-        let jwtRecipe = Recipe.getInstanceOrThrowError().jwtRecipe;
+        let jwtRecipe = Recipe.getInstanceOrThrowError().openIdRecipe?.jwtRecipe;
 
         if (jwtRecipe !== undefined) {
             return jwtRecipe.recipeInterfaceImpl.getJWKS();

--- a/lib/ts/recipe/session/index.ts
+++ b/lib/ts/recipe/session/index.ts
@@ -105,7 +105,7 @@ export default class SessionWrapper {
         );
     }
 
-    static getDiscoveryConfiguration() {
+    static getOpenIdDiscoveryConfiguration() {
         let openIdRecipe = Recipe.getInstanceOrThrowError().openIdRecipe;
 
         if (openIdRecipe !== undefined) {
@@ -113,7 +113,7 @@ export default class SessionWrapper {
         }
 
         throw new global.Error(
-            "getDiscoveryConfiguration cannot be used without enabling the JWT feature. Please set 'enableJWT: true' when initialising the Session recipe"
+            "getOpenIdDiscoveryConfiguration cannot be used without enabling the JWT feature. Please set 'enableJWT: true' when initialising the Session recipe"
         );
     }
 }
@@ -149,6 +149,6 @@ export let getJWKS = SessionWrapper.getJWKS;
 
 // Open id functions
 
-export let getDiscoveryConfiguration = SessionWrapper.getDiscoveryConfiguration;
+export let getOpenIdDiscoveryConfiguration = SessionWrapper.getOpenIdDiscoveryConfiguration;
 
 export type { VerifySessionOptions, RecipeInterface, SessionContainer, APIInterface, APIOptions, SessionInformation };

--- a/lib/ts/recipe/session/recipe.ts
+++ b/lib/ts/recipe/session/recipe.ts
@@ -30,7 +30,7 @@ import APIImplementation from "./api/implementation";
 import { BaseRequest, BaseResponse } from "../../framework";
 import OverrideableBuilder from "supertokens-js-override";
 import { APIOptions } from ".";
-import OpenIDRecipe from "../openid/recipe";
+import OpenIdRecipe from "../openid/recipe";
 
 // For Express
 export default class SessionRecipe extends RecipeModule {
@@ -40,7 +40,7 @@ export default class SessionRecipe extends RecipeModule {
     config: TypeNormalisedInput;
 
     recipeInterfaceImpl: RecipeInterface;
-    openIdRecipe?: OpenIDRecipe;
+    openIdRecipe?: OpenIdRecipe;
 
     apiImpl: APIInterface;
 
@@ -52,9 +52,9 @@ export default class SessionRecipe extends RecipeModule {
         this.isInServerlessEnv = isInServerlessEnv;
 
         if (this.config.jwt.enable === true) {
-            this.openIdRecipe = new OpenIDRecipe(recipeId, appInfo, isInServerlessEnv, {
+            this.openIdRecipe = new OpenIdRecipe(recipeId, appInfo, isInServerlessEnv, {
                 issuer: this.config.jwt.issuer,
-                override: this.config.override.openId,
+                override: this.config.override.openIdFeature,
             });
 
             let builder = new OverrideableBuilder(
@@ -65,7 +65,7 @@ export default class SessionRecipe extends RecipeModule {
                     return RecipeImplementationWithJWT(
                         oI,
                         // this.jwtRecipe is never undefined here
-                        this.openIdRecipe!.jwtRecipe.recipeInterfaceImpl,
+                        this.openIdRecipe!.recipeImplementation,
                         this.config,
                         appInfo
                     );

--- a/lib/ts/recipe/session/recipe.ts
+++ b/lib/ts/recipe/session/recipe.ts
@@ -66,8 +66,7 @@ export default class SessionRecipe extends RecipeModule {
                         oI,
                         // this.jwtRecipe is never undefined here
                         this.openIdRecipe!.recipeImplementation,
-                        this.config,
-                        appInfo
+                        this.config
                     );
                 })
                 .override(this.config.override.functions)

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -16,6 +16,7 @@ import { BaseRequest, BaseResponse } from "../../framework";
 import NormalisedURLPath from "../../normalisedURLPath";
 import { RecipeInterface as JWTRecipeInterface, APIInterface as JWTAPIInterface } from "../jwt/types";
 import OverrideableBuilder from "supertokens-js-override";
+import { RecipeInterface as OpenIdRecipeInterface, APIInterface as OpenIdAPIInterface } from "../openid/types";
 
 export type KeyInfo = {
     publicKey: string;
@@ -107,6 +108,7 @@ export type TypeInput = {
         | {
               enable: true;
               propertyNameInAccessTokenPayload?: string;
+              issuer?: string;
           }
         | { enable: false };
     override?: {
@@ -115,15 +117,25 @@ export type TypeInput = {
             builder?: OverrideableBuilder<RecipeInterface>
         ) => RecipeInterface;
         apis?: (originalImplementation: APIInterface, builder?: OverrideableBuilder<APIInterface>) => APIInterface;
-        jwtFeature?: {
+        openId?: {
             functions?: (
-                originalImplementation: JWTRecipeInterface,
-                builder?: OverrideableBuilder<JWTRecipeInterface>
-            ) => JWTRecipeInterface;
+                originalImplementation: OpenIdRecipeInterface,
+                builder?: OverrideableBuilder<OpenIdRecipeInterface>
+            ) => OpenIdRecipeInterface;
             apis?: (
-                originalImplementation: JWTAPIInterface,
-                builder?: OverrideableBuilder<JWTAPIInterface>
-            ) => JWTAPIInterface;
+                originalImplementation: OpenIdAPIInterface,
+                builder?: OverrideableBuilder<OpenIdAPIInterface>
+            ) => OpenIdAPIInterface;
+            jwtFeature?: {
+                functions?: (
+                    originalImplementation: JWTRecipeInterface,
+                    builder?: OverrideableBuilder<JWTRecipeInterface>
+                ) => JWTRecipeInterface;
+                apis?: (
+                    originalImplementation: JWTAPIInterface,
+                    builder?: OverrideableBuilder<JWTAPIInterface>
+                ) => JWTAPIInterface;
+            };
         };
     };
 };
@@ -154,6 +166,7 @@ export type TypeNormalisedInput = {
     jwt: {
         enable: boolean;
         propertyNameInAccessTokenPayload: string;
+        issuer: string;
     };
     override: {
         functions: (
@@ -161,15 +174,25 @@ export type TypeNormalisedInput = {
             builder?: OverrideableBuilder<RecipeInterface>
         ) => RecipeInterface;
         apis: (originalImplementation: APIInterface, builder?: OverrideableBuilder<APIInterface>) => APIInterface;
-        jwtFeature?: {
+        openId?: {
             functions?: (
-                originalImplementation: JWTRecipeInterface,
-                builder?: OverrideableBuilder<JWTRecipeInterface>
-            ) => JWTRecipeInterface;
+                originalImplementation: OpenIdRecipeInterface,
+                builder?: OverrideableBuilder<OpenIdRecipeInterface>
+            ) => OpenIdRecipeInterface;
             apis?: (
-                originalImplementation: JWTAPIInterface,
-                builder?: OverrideableBuilder<JWTAPIInterface>
-            ) => JWTAPIInterface;
+                originalImplementation: OpenIdAPIInterface,
+                builder?: OverrideableBuilder<OpenIdAPIInterface>
+            ) => OpenIdAPIInterface;
+            jwtFeature?: {
+                functions?: (
+                    originalImplementation: JWTRecipeInterface,
+                    builder?: OverrideableBuilder<JWTRecipeInterface>
+                ) => JWTRecipeInterface;
+                apis?: (
+                    originalImplementation: JWTAPIInterface,
+                    builder?: OverrideableBuilder<JWTAPIInterface>
+                ) => JWTAPIInterface;
+            };
         };
     };
 };

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -117,7 +117,7 @@ export type TypeInput = {
             builder?: OverrideableBuilder<RecipeInterface>
         ) => RecipeInterface;
         apis?: (originalImplementation: APIInterface, builder?: OverrideableBuilder<APIInterface>) => APIInterface;
-        openId?: {
+        openIdFeature?: {
             functions?: (
                 originalImplementation: OpenIdRecipeInterface,
                 builder?: OverrideableBuilder<OpenIdRecipeInterface>
@@ -166,7 +166,7 @@ export type TypeNormalisedInput = {
     jwt: {
         enable: boolean;
         propertyNameInAccessTokenPayload: string;
-        issuer: string;
+        issuer?: string;
     };
     override: {
         functions: (
@@ -174,7 +174,7 @@ export type TypeNormalisedInput = {
             builder?: OverrideableBuilder<RecipeInterface>
         ) => RecipeInterface;
         apis: (originalImplementation: APIInterface, builder?: OverrideableBuilder<APIInterface>) => APIInterface;
-        openId?: {
+        openIdFeature?: {
             functions?: (
                 originalImplementation: OpenIdRecipeInterface,
                 builder?: OverrideableBuilder<OpenIdRecipeInterface>

--- a/lib/ts/recipe/session/utils.ts
+++ b/lib/ts/recipe/session/utils.ts
@@ -211,13 +211,12 @@ export function validateAndNormaliseUserInput(
 
     let enableJWT = false;
     let accessTokenPayloadJWTPropertyName = "jwt";
-    // By default the issuer should be apiDomain + apiBasePath
-    let jwtIssuer = appInfo.apiDomain.getAsStringDangerous() + appInfo.apiBasePath.getAsStringDangerous();
+    let issuer: string | undefined;
 
     if (config !== undefined && config.jwt !== undefined && config.jwt.enable === true) {
         enableJWT = true;
         let jwtPropertyName = config.jwt.propertyNameInAccessTokenPayload;
-        let issuer = config.jwt.issuer;
+        issuer = config.jwt.issuer;
 
         if (jwtPropertyName !== undefined) {
             if (jwtPropertyName === ACCESS_TOKEN_PAYLOAD_JWT_PROPERTY_NAME_KEY) {
@@ -225,10 +224,6 @@ export function validateAndNormaliseUserInput(
             }
 
             accessTokenPayloadJWTPropertyName = jwtPropertyName;
-        }
-
-        if (issuer !== undefined) {
-            jwtIssuer = issuer;
         }
     }
 
@@ -250,7 +245,7 @@ export function validateAndNormaliseUserInput(
         jwt: {
             enable: enableJWT,
             propertyNameInAccessTokenPayload: accessTokenPayloadJWTPropertyName,
-            issuer: jwtIssuer,
+            issuer,
         },
     };
 }

--- a/lib/ts/recipe/session/utils.ts
+++ b/lib/ts/recipe/session/utils.ts
@@ -211,10 +211,13 @@ export function validateAndNormaliseUserInput(
 
     let enableJWT = false;
     let accessTokenPayloadJWTPropertyName = "jwt";
+    // By default the issuer should be apiDomain + apiBasePath
+    let jwtIssuer = appInfo.apiDomain.getAsStringDangerous() + appInfo.apiBasePath.getAsStringDangerous();
 
     if (config !== undefined && config.jwt !== undefined && config.jwt.enable === true) {
         enableJWT = true;
         let jwtPropertyName = config.jwt.propertyNameInAccessTokenPayload;
+        let issuer = config.jwt.issuer;
 
         if (jwtPropertyName !== undefined) {
             if (jwtPropertyName === ACCESS_TOKEN_PAYLOAD_JWT_PROPERTY_NAME_KEY) {
@@ -222,6 +225,10 @@ export function validateAndNormaliseUserInput(
             }
 
             accessTokenPayloadJWTPropertyName = jwtPropertyName;
+        }
+
+        if (issuer !== undefined) {
+            jwtIssuer = issuer;
         }
     }
 
@@ -243,6 +250,7 @@ export function validateAndNormaliseUserInput(
         jwt: {
             enable: enableJWT,
             propertyNameInAccessTokenPayload: accessTokenPayloadJWTPropertyName,
+            issuer: jwtIssuer,
         },
     };
 }

--- a/lib/ts/recipe/session/with-jwt/recipeImplementation.ts
+++ b/lib/ts/recipe/session/with-jwt/recipeImplementation.ts
@@ -16,7 +16,7 @@ import * as JsonWebToken from "jsonwebtoken";
 
 import { RecipeInterface } from "../";
 import { NormalisedAppinfo } from "../../../types";
-import { RecipeInterface as JWTRecipeInterface } from "../../jwt/types";
+import { RecipeInterface as OpenIdRecipeInterface } from "../../openid/types";
 import { SessionContainerInterface, TypeNormalisedInput, VerifySessionOptions } from "../types";
 import { ACCESS_TOKEN_PAYLOAD_JWT_PROPERTY_NAME_KEY } from "./constants";
 import SessionClassWithJWT from "./sessionClass";
@@ -36,7 +36,7 @@ export function setJWTExpiryOffsetSecondsForTesting(offset: number) {
 
 export default function (
     originalImplementation: RecipeInterface,
-    jwtRecipeImplementation: JWTRecipeInterface,
+    openIdRecipeImplementation: OpenIdRecipeInterface,
     config: TypeNormalisedInput,
     appInfo: NormalisedAppinfo
 ): RecipeInterface {
@@ -66,7 +66,7 @@ export default function (
                 userId,
                 jwtPropertyName: config.jwt.propertyNameInAccessTokenPayload,
                 appInfo,
-                jwtRecipeImplementation,
+                openIdRecipeImplementation,
             });
 
             let sessionContainer = await originalImplementation.createNewSession({
@@ -76,7 +76,7 @@ export default function (
                 sessionData,
             });
 
-            return new SessionClassWithJWT(sessionContainer, jwtRecipeImplementation, appInfo);
+            return new SessionClassWithJWT(sessionContainer, openIdRecipeImplementation, appInfo);
         },
         getSession: async function ({
             req,
@@ -93,7 +93,7 @@ export default function (
                 return undefined;
             }
 
-            return new SessionClassWithJWT(sessionContainer, jwtRecipeImplementation, appInfo);
+            return new SessionClassWithJWT(sessionContainer, openIdRecipeImplementation, appInfo);
         },
         refreshSession: async function ({ req, res }: { req: any; res: any }): Promise<SessionContainerInterface> {
             let accessTokenValidityInSeconds = Math.ceil((await this.getAccessTokenLifeTimeMS()) / 1000);
@@ -108,12 +108,12 @@ export default function (
                 userId: newSession.getUserId(),
                 jwtPropertyName: config.jwt.propertyNameInAccessTokenPayload,
                 appInfo,
-                jwtRecipeImplementation,
+                openIdRecipeImplementation,
             });
 
             await newSession.updateAccessTokenPayload(accessTokenPayload);
 
-            return new SessionClassWithJWT(newSession, jwtRecipeImplementation, appInfo);
+            return new SessionClassWithJWT(newSession, openIdRecipeImplementation, appInfo);
         },
         updateAccessTokenPayload: async function ({
             sessionHandle,
@@ -164,7 +164,7 @@ export default function (
                 userId: sessionInformation.userId,
                 jwtPropertyName: existingJwtPropertyName,
                 appInfo,
-                jwtRecipeImplementation,
+                openIdRecipeImplementation,
             });
 
             return await originalImplementation.updateAccessTokenPayload({

--- a/lib/ts/recipe/session/with-jwt/recipeImplementation.ts
+++ b/lib/ts/recipe/session/with-jwt/recipeImplementation.ts
@@ -15,7 +15,6 @@
 import * as JsonWebToken from "jsonwebtoken";
 
 import { RecipeInterface } from "../";
-import { NormalisedAppinfo } from "../../../types";
 import { RecipeInterface as OpenIdRecipeInterface } from "../../openid/types";
 import { SessionContainerInterface, TypeNormalisedInput, VerifySessionOptions } from "../types";
 import { ACCESS_TOKEN_PAYLOAD_JWT_PROPERTY_NAME_KEY } from "./constants";
@@ -37,8 +36,7 @@ export function setJWTExpiryOffsetSecondsForTesting(offset: number) {
 export default function (
     originalImplementation: RecipeInterface,
     openIdRecipeImplementation: OpenIdRecipeInterface,
-    config: TypeNormalisedInput,
-    appInfo: NormalisedAppinfo
+    config: TypeNormalisedInput
 ): RecipeInterface {
     function getJWTExpiry(accessTokenExpiry: number): number {
         return accessTokenExpiry + EXPIRY_OFFSET_SECONDS;
@@ -65,7 +63,6 @@ export default function (
                 jwtExpiry: getJWTExpiry(accessTokenValidityInSeconds),
                 userId,
                 jwtPropertyName: config.jwt.propertyNameInAccessTokenPayload,
-                appInfo,
                 openIdRecipeImplementation,
             });
 
@@ -76,7 +73,7 @@ export default function (
                 sessionData,
             });
 
-            return new SessionClassWithJWT(sessionContainer, openIdRecipeImplementation, appInfo);
+            return new SessionClassWithJWT(sessionContainer, openIdRecipeImplementation);
         },
         getSession: async function ({
             req,
@@ -93,7 +90,7 @@ export default function (
                 return undefined;
             }
 
-            return new SessionClassWithJWT(sessionContainer, openIdRecipeImplementation, appInfo);
+            return new SessionClassWithJWT(sessionContainer, openIdRecipeImplementation);
         },
         refreshSession: async function ({ req, res }: { req: any; res: any }): Promise<SessionContainerInterface> {
             let accessTokenValidityInSeconds = Math.ceil((await this.getAccessTokenLifeTimeMS()) / 1000);
@@ -107,13 +104,12 @@ export default function (
                 jwtExpiry: getJWTExpiry(accessTokenValidityInSeconds),
                 userId: newSession.getUserId(),
                 jwtPropertyName: config.jwt.propertyNameInAccessTokenPayload,
-                appInfo,
                 openIdRecipeImplementation,
             });
 
             await newSession.updateAccessTokenPayload(accessTokenPayload);
 
-            return new SessionClassWithJWT(newSession, openIdRecipeImplementation, appInfo);
+            return new SessionClassWithJWT(newSession, openIdRecipeImplementation);
         },
         updateAccessTokenPayload: async function ({
             sessionHandle,
@@ -163,7 +159,6 @@ export default function (
                 jwtExpiry,
                 userId: sessionInformation.userId,
                 jwtPropertyName: existingJwtPropertyName,
-                appInfo,
                 openIdRecipeImplementation,
             });
 

--- a/lib/ts/recipe/session/with-jwt/sessionClass.ts
+++ b/lib/ts/recipe/session/with-jwt/sessionClass.ts
@@ -14,7 +14,6 @@
  */
 import * as JsonWebToken from "jsonwebtoken";
 import * as assert from "assert";
-import { NormalisedAppinfo } from "../../../types";
 
 import { RecipeInterface as OpenIdRecipeInterface } from "../../openid/types";
 import { SessionContainerInterface } from "../types";
@@ -24,16 +23,10 @@ import { addJWTToAccessTokenPayload } from "./utils";
 export default class SessionClassWithJWT implements SessionContainerInterface {
     private openIdRecipeImplementation: OpenIdRecipeInterface;
     private originalSessionClass: SessionContainerInterface;
-    private appInfo: NormalisedAppinfo;
 
-    constructor(
-        originalSessionClass: SessionContainerInterface,
-        openIdRecipeImplementation: OpenIdRecipeInterface,
-        appInfo: NormalisedAppinfo
-    ) {
+    constructor(originalSessionClass: SessionContainerInterface, openIdRecipeImplementation: OpenIdRecipeInterface) {
         this.openIdRecipeImplementation = openIdRecipeImplementation;
         this.originalSessionClass = originalSessionClass;
-        this.appInfo = appInfo;
     }
     revokeSession = (): Promise<void> => {
         return this.originalSessionClass.revokeSession();
@@ -99,7 +92,6 @@ export default class SessionClassWithJWT implements SessionContainerInterface {
             jwtExpiry,
             userId: this.getUserId(),
             jwtPropertyName,
-            appInfo: this.appInfo,
             openIdRecipeImplementation: this.openIdRecipeImplementation,
         });
 

--- a/lib/ts/recipe/session/with-jwt/sessionClass.ts
+++ b/lib/ts/recipe/session/with-jwt/sessionClass.ts
@@ -16,22 +16,22 @@ import * as JsonWebToken from "jsonwebtoken";
 import * as assert from "assert";
 import { NormalisedAppinfo } from "../../../types";
 
-import { RecipeInterface as JWTRecipeInterface } from "../../jwt/types";
+import { RecipeInterface as OpenIdRecipeInterface } from "../../openid/types";
 import { SessionContainerInterface } from "../types";
 import { ACCESS_TOKEN_PAYLOAD_JWT_PROPERTY_NAME_KEY } from "./constants";
 import { addJWTToAccessTokenPayload } from "./utils";
 
 export default class SessionClassWithJWT implements SessionContainerInterface {
-    private jwtRecipeImplementation: JWTRecipeInterface;
+    private openIdRecipeImplementation: OpenIdRecipeInterface;
     private originalSessionClass: SessionContainerInterface;
     private appInfo: NormalisedAppinfo;
 
     constructor(
         originalSessionClass: SessionContainerInterface,
-        jwtRecipeImplementation: JWTRecipeInterface,
+        openIdRecipeImplementation: OpenIdRecipeInterface,
         appInfo: NormalisedAppinfo
     ) {
-        this.jwtRecipeImplementation = jwtRecipeImplementation;
+        this.openIdRecipeImplementation = openIdRecipeImplementation;
         this.originalSessionClass = originalSessionClass;
         this.appInfo = appInfo;
     }
@@ -100,7 +100,7 @@ export default class SessionClassWithJWT implements SessionContainerInterface {
             userId: this.getUserId(),
             jwtPropertyName,
             appInfo: this.appInfo,
-            jwtRecipeImplementation: this.jwtRecipeImplementation,
+            openIdRecipeImplementation: this.openIdRecipeImplementation,
         });
 
         return await this.originalSessionClass.updateAccessTokenPayload(newAccessTokenPayload);

--- a/lib/ts/recipe/session/with-jwt/utils.ts
+++ b/lib/ts/recipe/session/with-jwt/utils.ts
@@ -14,7 +14,7 @@
  */
 import { NormalisedAppinfo } from "../../../types";
 import { ACCESS_TOKEN_PAYLOAD_JWT_PROPERTY_NAME_KEY } from "./constants";
-import { RecipeInterface as JWTRecipeInterface } from "../../jwt/types";
+import { RecipeInterface as OpenIdRecipeInterface } from "../../openid/types";
 
 export async function addJWTToAccessTokenPayload({
     accessTokenPayload,
@@ -22,14 +22,14 @@ export async function addJWTToAccessTokenPayload({
     userId,
     jwtPropertyName,
     appInfo,
-    jwtRecipeImplementation,
+    openIdRecipeImplementation,
 }: {
     accessTokenPayload: any;
     jwtExpiry: number;
     userId: string;
     jwtPropertyName: string;
     appInfo: NormalisedAppinfo;
-    jwtRecipeImplementation: JWTRecipeInterface;
+    openIdRecipeImplementation: OpenIdRecipeInterface;
 }): Promise<any> {
     // If jwtPropertyName is not undefined it means that the JWT was added to the access token payload already
     let existingJwtPropertyName = accessTokenPayload[ACCESS_TOKEN_PAYLOAD_JWT_PROPERTY_NAME_KEY];
@@ -52,7 +52,7 @@ export async function addJWTToAccessTokenPayload({
     };
 
     // Create the JWT
-    let jwtResponse = await jwtRecipeImplementation.createJWT({
+    let jwtResponse = await openIdRecipeImplementation.createJWT({
         payload: accessTokenPayload,
         validitySeconds: jwtExpiry,
     });

--- a/lib/ts/recipe/session/with-jwt/utils.ts
+++ b/lib/ts/recipe/session/with-jwt/utils.ts
@@ -12,7 +12,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-import { NormalisedAppinfo } from "../../../types";
 import { ACCESS_TOKEN_PAYLOAD_JWT_PROPERTY_NAME_KEY } from "./constants";
 import { RecipeInterface as OpenIdRecipeInterface } from "../../openid/types";
 
@@ -21,14 +20,12 @@ export async function addJWTToAccessTokenPayload({
     jwtExpiry,
     userId,
     jwtPropertyName,
-    appInfo,
     openIdRecipeImplementation,
 }: {
     accessTokenPayload: any;
     jwtExpiry: number;
     userId: string;
     jwtPropertyName: string;
-    appInfo: NormalisedAppinfo;
     openIdRecipeImplementation: OpenIdRecipeInterface;
 }): Promise<any> {
     // If jwtPropertyName is not undefined it means that the JWT was added to the access token payload already
@@ -40,20 +37,16 @@ export async function addJWTToAccessTokenPayload({
         delete accessTokenPayload[ACCESS_TOKEN_PAYLOAD_JWT_PROPERTY_NAME_KEY];
     }
 
-    // Update the access token payload with the default claims to add
-    accessTokenPayload = {
-        /* 
-            We add our claims before the user provided ones so that if they use the same claims
-            then the final payload will use the values they provide
-        */
-        sub: userId,
-        iss: appInfo.apiDomain.getAsStringDangerous(),
-        ...accessTokenPayload,
-    };
-
     // Create the JWT
     let jwtResponse = await openIdRecipeImplementation.createJWT({
-        payload: accessTokenPayload,
+        payload: {
+            /* 
+                We add our claims before the user provided ones so that if they use the same claims
+                then the final payload will use the values they provide
+            */
+            sub: userId,
+            ...accessTokenPayload,
+        },
         validitySeconds: jwtExpiry,
     });
 

--- a/test/openid/api.test.js
+++ b/test/openid/api.test.js
@@ -1,0 +1,114 @@
+let assert = require("assert");
+const express = require("express");
+const request = require("supertest");
+
+const { printPath, setupST, startST, killAllST, cleanST } = require("../utils");
+let { ProcessState } = require("../../lib/build/processState");
+let STExpress = require("../../");
+const OpenIdRecipe = require("../../lib/build/recipe/openid/recipe").default;
+const OpenId = require("../../lib/build/recipe/openid");
+let { Querier } = require("../../lib/build/querier");
+const { maxVersion } = require("../../lib/build/utils");
+let { middleware, errorHandler } = require("../../framework/express");
+
+describe(`apiTest: ${printPath("[test/openid/api.test.js]")}`, function () {
+    beforeEach(async function () {
+        await killAllST();
+        await setupST();
+        ProcessState.getInstance().reset();
+    });
+
+    after(async function () {
+        await killAllST();
+        await cleanST();
+    });
+
+    it("Test that with default config calling discovery configuration endpoint works as expected", async function () {
+        await startST();
+        STExpress.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [OpenIdRecipe.init()],
+        });
+
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
+
+        const app = express();
+
+        app.use(middleware());
+
+        app.use(errorHandler());
+
+        let response = await new Promise((resolve) => {
+            request(app)
+                .get("/auth/.well-known/openid-configuration")
+                .end((err, res) => {
+                    if (err) {
+                        resolve(undefined);
+                    } else {
+                        resolve(res);
+                    }
+                });
+        });
+
+        assert(response.body !== undefined);
+        assert.equal(response.body.issuer, "https://api.supertokens.io/auth");
+        assert.equal(response.body.jwks_uri, "https://api.supertokens.io/auth/jwt/jwks.json");
+    });
+
+    it("Test that with apiBasePath calling discovery configuration endpoint works as expected", async function () {
+        await startST();
+        STExpress.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                apiBasePath: "/",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [OpenIdRecipe.init()],
+        });
+
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
+
+        const app = express();
+
+        app.use(middleware());
+
+        app.use(errorHandler());
+
+        let response = await new Promise((resolve) => {
+            request(app)
+                .get("/.well-known/openid-configuration")
+                .end((err, res) => {
+                    if (err) {
+                        resolve(undefined);
+                    } else {
+                        resolve(res);
+                    }
+                });
+        });
+
+        assert(response.body !== undefined);
+        assert.equal(response.body.issuer, "https://api.supertokens.io");
+        assert.equal(response.body.jwks_uri, "https://api.supertokens.io/jwt/jwks.json");
+    });
+});

--- a/test/openid/config.test.js
+++ b/test/openid/config.test.js
@@ -131,4 +131,32 @@ describe(`configTest: ${printPath("[test/openid/config.test.js]")}`, function ()
             }
         }
     });
+
+    it("Test that issuer with gateway path works fine", async function () {
+        await startST();
+        STExpress.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                apiGatewayPath: "/gateway",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [OpenIdRecipe.init()],
+        });
+
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
+
+        let openIdRecipe = await OpenIdRecipe.getInstanceOrThrowError();
+
+        assert.equal(openIdRecipe.config.issuerDomain.getAsStringDangerous(), "https://api.supertokens.io");
+        assert.equal(openIdRecipe.config.issuerPath.getAsStringDangerous(), "/gateway/auth");
+    });
 });

--- a/test/openid/config.test.js
+++ b/test/openid/config.test.js
@@ -126,7 +126,9 @@ describe(`configTest: ${printPath("[test/openid/config.test.js]")}`, function ()
                 ],
             });
         } catch (e) {
-            if (e.message !== "Issuer URL must end with apiBasePath. The default value is /auth") {
+            if (
+                e.message !== "The path of the issuer URL must be equal to the apiBasePath. The default value is /auth"
+            ) {
                 throw e;
             }
         }

--- a/test/openid/config.test.js
+++ b/test/openid/config.test.js
@@ -126,7 +126,7 @@ describe(`configTest: ${printPath("[test/openid/config.test.js]")}`, function ()
                 ],
             });
         } catch (e) {
-            if (e.message !== "Issuer URL must end with apiBasePath") {
+            if (e.message !== "Issuer URL must end with apiBasePath. The default value is /auth") {
                 throw e;
             }
         }

--- a/test/openid/config.test.js
+++ b/test/openid/config.test.js
@@ -1,0 +1,134 @@
+let assert = require("assert");
+
+const { printPath, setupST, startST, killAllST, cleanST } = require("../utils");
+let { ProcessState } = require("../../lib/build/processState");
+let STExpress = require("../../");
+const OpenIdRecipe = require("../../lib/build/recipe/openid/recipe").default;
+let { Querier } = require("../../lib/build/querier");
+const { maxVersion } = require("../../lib/build/utils");
+
+describe(`configTest: ${printPath("[test/openid/config.test.js]")}`, function () {
+    beforeEach(async function () {
+        await killAllST();
+        await setupST();
+        ProcessState.getInstance().reset();
+    });
+
+    after(async function () {
+        await killAllST();
+        await cleanST();
+    });
+
+    it("Test that the default config sets values correctly for OpenID recipe", async function () {
+        await startST();
+        STExpress.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [OpenIdRecipe.init()],
+        });
+
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
+
+        let openIdRecipe = await OpenIdRecipe.getInstanceOrThrowError();
+
+        assert(openIdRecipe.config.issuerDomain.getAsStringDangerous() === "https://api.supertokens.io");
+        assert(openIdRecipe.config.issuerPath.getAsStringDangerous() === "/auth");
+    });
+
+    it("Test that the default config sets values correctly for OpenID recipe with apiBasePath", async function () {
+        await startST();
+        STExpress.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                apiBasePath: "/",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [OpenIdRecipe.init()],
+        });
+
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
+
+        let openIdRecipe = await OpenIdRecipe.getInstanceOrThrowError();
+
+        assert(openIdRecipe.config.issuerDomain.getAsStringDangerous() === "https://api.supertokens.io");
+        assert(openIdRecipe.config.issuerPath.getAsStringDangerous() === "");
+    });
+
+    it("Test that the config sets values correctly for OpenID recipe with issuer", async function () {
+        await startST();
+        STExpress.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                apiBasePath: "/",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                OpenIdRecipe.init({
+                    issuer: "https://customissuer.com",
+                }),
+            ],
+        });
+
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
+
+        let openIdRecipe = await OpenIdRecipe.getInstanceOrThrowError();
+
+        assert(openIdRecipe.config.issuerDomain.getAsStringDangerous() === "https://customissuer.com");
+        assert(openIdRecipe.config.issuerPath.getAsStringDangerous() === "");
+    });
+
+    it("Test that issuer without apiBasePath throws error", async function () {
+        await startST();
+
+        try {
+            STExpress.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                },
+                appInfo: {
+                    apiDomain: "api.supertokens.io",
+                    appName: "SuperTokens",
+                    websiteDomain: "supertokens.io",
+                },
+                recipeList: [
+                    OpenIdRecipe.init({
+                        issuer: "https://customissuer.com",
+                    }),
+                ],
+            });
+        } catch (e) {
+            if (e.message !== "Issuer URL must end with apiBasePath") {
+                throw e;
+            }
+        }
+    });
+});

--- a/test/openid/openid.test.js
+++ b/test/openid/openid.test.js
@@ -41,7 +41,7 @@ describe(`openIdTest: ${printPath("[test/openid/openid.test.js]")}`, function ()
             return;
         }
 
-        let discoveryConfig = await OpenId.getDiscoveryConfiguration();
+        let discoveryConfig = await OpenId.getOpenIdDiscoveryConfiguration();
 
         assert.equal(discoveryConfig.issuer, "https://api.supertokens.io/auth");
         assert.equal(discoveryConfig.jwks_uri, "https://api.supertokens.io/auth/jwt/jwks.json");
@@ -69,7 +69,7 @@ describe(`openIdTest: ${printPath("[test/openid/openid.test.js]")}`, function ()
             return;
         }
 
-        let discoveryConfig = await OpenId.getDiscoveryConfiguration();
+        let discoveryConfig = await OpenId.getOpenIdDiscoveryConfiguration();
 
         assert.equal(discoveryConfig.issuer, "https://api.supertokens.io");
         assert.equal(discoveryConfig.jwks_uri, "https://api.supertokens.io/jwt/jwks.json");
@@ -100,7 +100,7 @@ describe(`openIdTest: ${printPath("[test/openid/openid.test.js]")}`, function ()
             return;
         }
 
-        let discoveryConfig = await OpenId.getDiscoveryConfiguration();
+        let discoveryConfig = await OpenId.getOpenIdDiscoveryConfiguration();
 
         assert.equal(discoveryConfig.issuer, "https://cusomissuer/auth");
         assert.equal(discoveryConfig.jwks_uri, "https://cusomissuer/auth/jwt/jwks.json");

--- a/test/openid/openid.test.js
+++ b/test/openid/openid.test.js
@@ -1,0 +1,108 @@
+let assert = require("assert");
+
+const { printPath, setupST, startST, killAllST, cleanST } = require("../utils");
+let { ProcessState } = require("../../lib/build/processState");
+let STExpress = require("../../");
+const OpenIdRecipe = require("../../lib/build/recipe/openid/recipe").default;
+const OpenId = require("../../lib/build/recipe/openid");
+let { Querier } = require("../../lib/build/querier");
+const { maxVersion } = require("../../lib/build/utils");
+
+describe(`openIdTest: ${printPath("[test/openid/openid.test.js]")}`, function () {
+    beforeEach(async function () {
+        await killAllST();
+        await setupST();
+        ProcessState.getInstance().reset();
+    });
+
+    after(async function () {
+        await killAllST();
+        await cleanST();
+    });
+
+    it("Test that with default config discovery configuration is as expected", async function () {
+        await startST();
+        STExpress.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [OpenIdRecipe.init()],
+        });
+
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
+
+        let discoveryConfig = await OpenId.getDiscoveryConfiguration();
+
+        assert.equal(discoveryConfig.issuer, "https://api.supertokens.io/auth");
+        assert.equal(discoveryConfig.jwks_uri, "https://api.supertokens.io/auth/jwt/jwks.json");
+    });
+
+    it("Test that with default config discovery configuration is as expected with api base path", async function () {
+        await startST();
+        STExpress.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                apiBasePath: "/",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [OpenIdRecipe.init()],
+        });
+
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
+
+        let discoveryConfig = await OpenId.getDiscoveryConfiguration();
+
+        assert.equal(discoveryConfig.issuer, "https://api.supertokens.io");
+        assert.equal(discoveryConfig.jwks_uri, "https://api.supertokens.io/jwt/jwks.json");
+    });
+
+    it("Test that with default config discovery configuration is as expected with custom issuer", async function () {
+        await startST();
+        STExpress.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                OpenIdRecipe.init({
+                    issuer: "https://cusomissuer/auth",
+                }),
+            ],
+        });
+
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
+
+        let discoveryConfig = await OpenId.getDiscoveryConfiguration();
+
+        assert.equal(discoveryConfig.issuer, "https://cusomissuer/auth");
+        assert.equal(discoveryConfig.jwks_uri, "https://cusomissuer/auth/jwt/jwks.json");
+    });
+});

--- a/test/openid/override.test.js
+++ b/test/openid/override.test.js
@@ -41,7 +41,7 @@ describe(`overrideTest: ${printPath("[test/openid/override.test.js]")}`, functio
                         functions: function (oi) {
                             return {
                                 ...oi,
-                                getDiscoveryConfiguration: function () {
+                                getOpenIdDiscoveryConfiguration: function () {
                                     return {
                                         issuer: "https://customissuer",
                                         jwks_uri: "https://customissuer/jwks",

--- a/test/session/with-jwt/jwt.override.test.js
+++ b/test/session/with-jwt/jwt.override.test.js
@@ -27,7 +27,7 @@ let { middleware, errorHandler } = require("../../../framework/express");
 /**
  * Test that overriding the jwt recipe functions and apis still work when the JWT feature is enabled
  */
-describe(`jwt: ${printPath("[test/session/with-jwt/jwt.override.test.js]")}`, function () {
+describe(`session-with-jwt: ${printPath("[test/session/with-jwt/jwt.override.test.js]")}`, function () {
     beforeEach(async function () {
         await killAllST();
         await setupST();
@@ -58,29 +58,31 @@ describe(`jwt: ${printPath("[test/session/with-jwt/jwt.override.test.js]")}`, fu
                 Session.init({
                     jwt: { enable: true },
                     override: {
-                        jwtFeature: {
-                            functions: function (originalImplementation) {
-                                return {
-                                    ...originalImplementation,
-                                    createJWT: async function (input) {
-                                        let createJWTResponse = await originalImplementation.createJWT(input);
+                        openId: {
+                            jwtFeature: {
+                                functions: function (originalImplementation) {
+                                    return {
+                                        ...originalImplementation,
+                                        createJWT: async function (input) {
+                                            let createJWTResponse = await originalImplementation.createJWT(input);
 
-                                        if (createJWTResponse.status === "OK") {
-                                            jwtCreated = createJWTResponse.jwt;
-                                        }
+                                            if (createJWTResponse.status === "OK") {
+                                                jwtCreated = createJWTResponse.jwt;
+                                            }
 
-                                        return createJWTResponse;
-                                    },
-                                    getJWKS: async function () {
-                                        let getJWKSResponse = await originalImplementation.getJWKS();
+                                            return createJWTResponse;
+                                        },
+                                        getJWKS: async function () {
+                                            let getJWKSResponse = await originalImplementation.getJWKS();
 
-                                        if (getJWKSResponse.status === "OK") {
-                                            jwksKeys = getJWKSResponse.keys;
-                                        }
+                                            if (getJWKSResponse.status === "OK") {
+                                                jwksKeys = getJWKSResponse.keys;
+                                            }
 
-                                        return getJWKSResponse;
-                                    },
-                                };
+                                            return getJWKSResponse;
+                                        },
+                                    };
+                                },
                             },
                         },
                     },
@@ -160,16 +162,18 @@ describe(`jwt: ${printPath("[test/session/with-jwt/jwt.override.test.js]")}`, fu
                 Session.init({
                     jwt: { enable: true },
                     override: {
-                        jwtFeature: {
-                            apis: function (originalImplementation) {
-                                return {
-                                    ...originalImplementation,
-                                    getJWKSGET: async function (input) {
-                                        let response = await originalImplementation.getJWKSGET(input);
-                                        jwksKeys = response.keys;
-                                        return response;
-                                    },
-                                };
+                        openId: {
+                            jwtFeature: {
+                                apis: function (originalImplementation) {
+                                    return {
+                                        ...originalImplementation,
+                                        getJWKSGET: async function (input) {
+                                            let response = await originalImplementation.getJWKSGET(input);
+                                            jwksKeys = response.keys;
+                                            return response;
+                                        },
+                                    };
+                                },
                             },
                         },
                     },

--- a/test/session/with-jwt/jwt.override.test.js
+++ b/test/session/with-jwt/jwt.override.test.js
@@ -58,7 +58,7 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/jwt.override.tes
                 Session.init({
                     jwt: { enable: true },
                     override: {
-                        openId: {
+                        openIdFeature: {
                             jwtFeature: {
                                 functions: function (originalImplementation) {
                                     return {
@@ -162,7 +162,7 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/jwt.override.tes
                 Session.init({
                     jwt: { enable: true },
                     override: {
-                        openId: {
+                        openIdFeature: {
                             jwtFeature: {
                                 apis: function (originalImplementation) {
                                     return {

--- a/test/session/with-jwt/sessionClass.test.js
+++ b/test/session/with-jwt/sessionClass.test.js
@@ -107,8 +107,8 @@ describe(`session-jwt-functions: ${printPath("[test/session/with-jwt/sessionClas
         );
 
         let accessTokenPayload = createJWTResponse.body.accessTokenPayload;
-        assert.strictEqual(accessTokenPayload.sub, "userId");
-        assert.strictEqual(accessTokenPayload.iss, "https://api.supertokens.io");
+        assert.strictEqual(accessTokenPayload.sub, undefined);
+        assert.strictEqual(accessTokenPayload.iss, undefined);
         assert.strictEqual(accessTokenPayload.newKey, "newValue");
         assert.notStrictEqual(accessTokenPayload.jwt, undefined);
         assert.strictEqual(accessTokenPayload._jwtPName, "jwt");
@@ -116,7 +116,7 @@ describe(`session-jwt-functions: ${printPath("[test/session/with-jwt/sessionClas
         let decodedJWT = JsonWebToken.decode(accessTokenPayload.jwt);
         assert.notStrictEqual(decodedJWT, null);
         assert.strictEqual(decodedJWT["sub"], "userId");
-        assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io");
+        assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io/auth");
         assert.strictEqual(decodedJWT._jwtPName, undefined);
     });
 
@@ -189,8 +189,8 @@ describe(`session-jwt-functions: ${printPath("[test/session/with-jwt/sessionClas
         );
 
         let accessTokenPayload = createJWTResponse.body.accessTokenPayload;
-        assert.equal(accessTokenPayload.sub, "userId");
-        assert.equal(accessTokenPayload.iss, "https://api.supertokens.io");
+        assert.equal(accessTokenPayload.sub, undefined);
+        assert.equal(accessTokenPayload.iss, undefined);
         assert.notStrictEqual(accessTokenPayload.jwt, undefined);
         assert.strictEqual(accessTokenPayload._jwtPName, "jwt");
         assert.strictEqual(accessTokenPayload.customClaim, undefined);
@@ -198,7 +198,7 @@ describe(`session-jwt-functions: ${printPath("[test/session/with-jwt/sessionClas
         let decodedJWT = JsonWebToken.decode(accessTokenPayload.jwt);
         assert.notStrictEqual(decodedJWT, null);
         assert.strictEqual(decodedJWT["sub"], "userId");
-        assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io");
+        assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io/auth");
         assert.strictEqual(decodedJWT._jwtPName, undefined);
         assert.strictEqual(decodedJWT.customClaim, undefined);
     });

--- a/test/session/with-jwt/withjwt.test.js
+++ b/test/session/with-jwt/withjwt.test.js
@@ -120,8 +120,8 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/withjwt.test.js]
         let accessTokenPayload = (await Session.getSessionInformation(sessionHandle)).accessTokenPayload;
         let accessTokenPayloadJWT = accessTokenPayload.jwt;
 
-        assert.strictEqual(accessTokenPayload.sub, "userId");
-        assert.strictEqual(accessTokenPayload.iss, "https://api.supertokens.io");
+        assert.strictEqual(accessTokenPayload.sub, undefined);
+        assert.strictEqual(accessTokenPayload.iss, undefined);
         assert.strictEqual(accessTokenPayload._jwtPName, "jwt");
         assert.notStrictEqual(accessTokenPayloadJWT, undefined);
 
@@ -317,8 +317,8 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/withjwt.test.js]
         jwtPayload = accessTokenPayload.jwt.split(".")[1];
         let newJWTExpiryInSeconds = JSON.parse(Buffer.from(jwtPayload, "base64").toString("utf-8")).exp;
 
-        assert(accessTokenPayload.sub, "userId");
-        assert(accessTokenPayload.iss, "https://api/supertokens.io");
+        assert.strictEqual(accessTokenPayload.sub, undefined);
+        assert.strictEqual(accessTokenPayload.iss, undefined);
         assert.strictEqual(accessTokenPayload._jwtPName, "jwt");
         // Make sure that the new expiry is greater than the old one by the amount of delay before refresh, accounting for a second skew
         assert(
@@ -410,8 +410,8 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/withjwt.test.js]
         jwtPayload = accessTokenPayload.jwt.split(".")[1];
         let newJwtExpiryInSeconds = JSON.parse(Buffer.from(jwtPayload, "base64").toString("utf-8")).exp;
 
-        assert(accessTokenPayload.sub, "userId");
-        assert(accessTokenPayload.iss, "https://api/supertokens.io");
+        assert.strictEqual(accessTokenPayload.sub, undefined);
+        assert.strictEqual(accessTokenPayload.iss, undefined);
         assert.strictEqual(accessTokenPayload._jwtPName, "jwt");
         assert.equal(jwtExpiryInSeconds, newJwtExpiryInSeconds);
     });
@@ -663,8 +663,8 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/withjwt.test.js]
 
         accessTokenPayload = (await Session.getSessionInformation(sessionHandle)).accessTokenPayload;
 
-        assert.equal(accessTokenPayload.sub, "userId");
-        assert.equal(accessTokenPayload.iss, "https://api.supertokens.io");
+        assert.equal(accessTokenPayload.sub, undefined);
+        assert.equal(accessTokenPayload.iss, undefined);
         assert.strictEqual(accessTokenPayload._jwtPName, "jwt");
         assert.notStrictEqual(accessTokenPayload.jwt, undefined);
     });
@@ -739,8 +739,8 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/withjwt.test.js]
         let accessTokenPayload = (await Session.getSessionInformation(sessionHandle)).accessTokenPayload;
         let decodedJWT = JsonWebToken.decode(accessTokenPayload.jwt);
 
-        assert.equal(accessTokenPayload.sub, "userId");
-        assert.equal(accessTokenPayload.iss, "https://api.supertokens.io");
+        assert.equal(accessTokenPayload.sub, undefined);
+        assert.equal(accessTokenPayload.iss, undefined);
         assert.strictEqual(accessTokenPayload._jwtPName, "jwt");
         assert.notStrictEqual(decodedJWT, null);
         assert.strictEqual(decodedJWT["sub"], "userId");
@@ -817,7 +817,7 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/withjwt.test.js]
 
         assert.notStrictEqual(decodedJWT, null);
         assert.strictEqual(decodedJWT["sub"], "customsub");
-        assert.strictEqual(accessTokenPayload.iss, "https://api.supertokens.io");
+        assert.strictEqual(accessTokenPayload.iss, undefined);
         assert.strictEqual(accessTokenPayload._jwtPName, "jwt");
     });
 
@@ -891,11 +891,11 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/withjwt.test.js]
         let accessTokenPayload = (await Session.getSessionInformation(sessionHandle)).accessTokenPayload;
         let decodedJWT = JsonWebToken.decode(accessTokenPayload.jwt);
 
-        assert.equal(accessTokenPayload.sub, "userId");
-        assert.equal(accessTokenPayload.iss, "https://api.supertokens.io");
+        assert.equal(accessTokenPayload.sub, undefined);
+        assert.equal(accessTokenPayload.iss, undefined);
         assert.strictEqual(accessTokenPayload._jwtPName, "jwt");
         assert.notStrictEqual(decodedJWT, null);
-        assert.strictEqual(decodedJWT["iss"], "https://api.supertokens.io");
+        assert.strictEqual(decodedJWT["iss"], "https://api.supertokens.io/auth");
     });
 
     it("Test that when creating a session with jwt enabled and using a custom iss claim, the custom claim value gets used", async function () {
@@ -1040,27 +1040,27 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/withjwt.test.js]
         let accessTokenPayload = (await Session.getSessionInformation(sessionHandle)).accessTokenPayload;
         let decodedJWT = JsonWebToken.decode(accessTokenPayload.jwt);
 
-        assert.equal(accessTokenPayload.sub, "userId");
-        assert.equal(accessTokenPayload.iss, "https://api.supertokens.io");
+        assert.equal(accessTokenPayload.sub, undefined);
+        assert.equal(accessTokenPayload.iss, undefined);
         assert.strictEqual(accessTokenPayload._jwtPName, "jwt");
         assert.notStrictEqual(decodedJWT, null);
         assert.strictEqual(decodedJWT.customClaim, "customValue");
         assert.strictEqual(decodedJWT["sub"], "userId");
-        assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io");
+        assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io/auth");
         assert.strictEqual(decodedJWT._jwtPName, undefined);
 
         await Session.updateAccessTokenPayload(sessionHandle, { newCustomClaim: "newValue" });
         accessTokenPayload = (await Session.getSessionInformation(sessionHandle)).accessTokenPayload;
 
-        assert.strictEqual(accessTokenPayload.sub, "userId");
-        assert.strictEqual(accessTokenPayload.iss, "https://api.supertokens.io");
+        assert.strictEqual(accessTokenPayload.sub, undefined);
+        assert.strictEqual(accessTokenPayload.iss, undefined);
 
         decodedJWT = JsonWebToken.decode(accessTokenPayload.jwt);
 
         assert.notStrictEqual(decodedJWT, null);
         assert.strictEqual(decodedJWT.newCustomClaim, "newValue");
         assert.strictEqual(decodedJWT["sub"], "userId");
-        assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io");
+        assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io/auth");
         assert.strictEqual(decodedJWT._jwtPName, undefined);
     });
 
@@ -1134,13 +1134,13 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/withjwt.test.js]
         let accessTokenPayload = (await Session.getSessionInformation(sessionHandle)).accessTokenPayload;
         let decodedJWT = JsonWebToken.decode(accessTokenPayload.jwt);
 
-        assert.equal(accessTokenPayload.sub, "userId");
-        assert.equal(accessTokenPayload.iss, "https://api.supertokens.io");
+        assert.equal(accessTokenPayload.sub, undefined);
+        assert.equal(accessTokenPayload.iss, undefined);
         assert.strictEqual(accessTokenPayload._jwtPName, "jwt");
         assert.notStrictEqual(decodedJWT, null);
         assert.strictEqual(decodedJWT.customClaim, "customValue");
         assert.strictEqual(decodedJWT["sub"], "userId");
-        assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io");
+        assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io/auth");
         assert.strictEqual(decodedJWT._jwtPName, undefined);
 
         await new Promise((resolve) =>
@@ -1160,14 +1160,14 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/withjwt.test.js]
         );
         accessTokenPayload = (await Session.getSessionInformation(sessionHandle)).accessTokenPayload;
 
-        assert.strictEqual(accessTokenPayload.sub, "userId");
-        assert.strictEqual(accessTokenPayload.iss, "https://api.supertokens.io");
+        assert.strictEqual(accessTokenPayload.sub, undefined);
+        assert.strictEqual(accessTokenPayload.iss, undefined);
 
         decodedJWT = JsonWebToken.decode(accessTokenPayload.jwt);
 
         assert.notStrictEqual(decodedJWT, null);
         assert.strictEqual(decodedJWT["sub"], "userId");
-        assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io");
+        assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io/auth");
     });
 
     it("Test that enabling JWT with a custom property name works as expected", async function () {
@@ -1238,8 +1238,8 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/withjwt.test.js]
         let sessionHandle = createJWTResponse.body.sessionHandle;
         let accessTokenPayload = (await Session.getSessionInformation(sessionHandle)).accessTokenPayload;
 
-        assert.equal(accessTokenPayload.sub, "userId");
-        assert.equal(accessTokenPayload.iss, "https://api.supertokens.io");
+        assert.equal(accessTokenPayload.sub, undefined);
+        assert.equal(accessTokenPayload.iss, undefined);
         assert.strictEqual(accessTokenPayload._jwtPName, "customPropertyName");
         assert.strictEqual(accessTokenPayload.jwt, undefined);
         assert.notStrictEqual(accessTokenPayload.customPropertyName, undefined);
@@ -1335,8 +1335,8 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/withjwt.test.js]
                 })
         );
 
-        assert.equal(refreshResponse.body.accessTokenPayload.sub, "userId");
-        assert.equal(refreshResponse.body.accessTokenPayload.iss, "https://api.supertokens.io");
+        assert.equal(refreshResponse.body.accessTokenPayload.sub, undefined);
+        assert.equal(refreshResponse.body.accessTokenPayload.iss, undefined);
         assert.strictEqual(refreshResponse.body.accessTokenPayload._jwtPName, "jwt");
         assert.notStrictEqual(refreshResponse.body.accessTokenPayload, undefined);
         assert.strictEqual(refreshResponse.body.accessTokenPayload.newClaim, "newValue");
@@ -1414,8 +1414,8 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/withjwt.test.js]
         assert.strictEqual(accessTokenPayload.customClaim, "customValue");
         assert.strictEqual(accessTokenPayload._jwtPName, "jwt");
         assert.notStrictEqual(accessTokenPayload.jwt, undefined);
-        assert.strictEqual(accessTokenPayload.sub, "userId");
-        assert.strictEqual(accessTokenPayload.iss, "https://api.supertokens.io");
+        assert.strictEqual(accessTokenPayload.sub, undefined);
+        assert.strictEqual(accessTokenPayload.iss, undefined);
 
         await Session.updateAccessTokenPayload(sessionHandle, { newKey: "newValue" });
         accessTokenPayload = (await Session.getSessionInformation(sessionHandle)).accessTokenPayload;
@@ -1424,8 +1424,8 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/withjwt.test.js]
         assert.strictEqual(accessTokenPayload.newKey, "newValue");
         assert.strictEqual(accessTokenPayload._jwtPName, "jwt");
         assert.notStrictEqual(accessTokenPayload.jwt, undefined);
-        assert.strictEqual(accessTokenPayload.sub, "userId");
-        assert.strictEqual(accessTokenPayload.iss, "https://api.supertokens.io");
+        assert.strictEqual(accessTokenPayload.sub, undefined);
+        assert.strictEqual(accessTokenPayload.iss, undefined);
 
         await new Promise((resolve) =>
             request(app)
@@ -1447,8 +1447,8 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/withjwt.test.js]
         assert.strictEqual(accessTokenPayload.newKey, "newValue");
         assert.strictEqual(accessTokenPayload._jwtPName, "jwt");
         assert.notStrictEqual(accessTokenPayload.jwt, undefined);
-        assert.strictEqual(accessTokenPayload.sub, "userId");
-        assert.strictEqual(accessTokenPayload.iss, "https://api.supertokens.io");
+        assert.strictEqual(accessTokenPayload.sub, undefined);
+        assert.strictEqual(accessTokenPayload.iss, undefined);
     });
 
     it("Test that after changing the jwt property name, updating access token payload does not change the _jwtPName", async function () {
@@ -1554,8 +1554,8 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/withjwt.test.js]
         await Session.updateAccessTokenPayload(sessionHandle, { newKey: "newValue" });
         let accessTokenPayload = (await Session.getSessionInformation(sessionHandle)).accessTokenPayload;
 
-        assert.equal(accessTokenPayload.sub, "userId");
-        assert.equal(accessTokenPayload.iss, "https://api.supertokens.io");
+        assert.equal(accessTokenPayload.sub, undefined);
+        assert.equal(accessTokenPayload.iss, undefined);
         assert.strictEqual(accessTokenPayload.newKey, "newValue");
         assert.notStrictEqual(accessTokenPayload.jwt, undefined);
         assert.strictEqual(accessTokenPayload.jwtProperty, undefined);
@@ -1681,8 +1681,8 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/withjwt.test.js]
 
         let accessTokenPayload = (await Session.getSessionInformation(sessionHandle)).accessTokenPayload;
 
-        assert.equal(accessTokenPayload.sub, "userId");
-        assert.equal(accessTokenPayload.iss, "https://api.supertokens.io");
+        assert.equal(accessTokenPayload.sub, undefined);
+        assert.equal(accessTokenPayload.iss, undefined);
         assert.strictEqual(accessTokenPayload.customClaim, "customValue");
         assert.strictEqual(accessTokenPayload.jwt, undefined);
         assert.notStrictEqual(accessTokenPayload.jwtProperty, undefined);
@@ -1767,8 +1767,8 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/withjwt.test.js]
         let currentTimeInSeconds = Math.ceil(Date.now() / 1000);
         // Make sure that the JWT has expired
         assert(decodedJWT.exp < currentTimeInSeconds);
-        assert.equal(accessTokenPayload.sub, "userId");
-        assert.equal(accessTokenPayload.iss, "https://api.supertokens.io");
+        assert.equal(accessTokenPayload.sub, undefined);
+        assert.equal(accessTokenPayload.iss, undefined);
         assert.strictEqual(accessTokenPayload.customClaim, "customValue");
         assert.notStrictEqual(accessTokenPayload.jwt, undefined);
         assert.strictEqual(accessTokenPayload._jwtPName, "jwt");
@@ -1790,8 +1790,8 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/withjwt.test.js]
         );
 
         accessTokenPayload = (await Session.getSessionInformation(sessionHandle)).accessTokenPayload;
-        assert.equal(accessTokenPayload.sub, "userId");
-        assert.equal(accessTokenPayload.iss, "https://api.supertokens.io");
+        assert.equal(accessTokenPayload.sub, undefined);
+        assert.equal(accessTokenPayload.iss, undefined);
         assert.strictEqual(accessTokenPayload.customClaim, "customValue");
         assert.notStrictEqual(accessTokenPayload.jwt, undefined);
         assert.strictEqual(accessTokenPayload._jwtPName, "jwt");
@@ -1870,8 +1870,8 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/withjwt.test.js]
         let sessionHandle = createJWTResponse.body.sessionHandle;
 
         let accessTokenPayload = (await Session.getSessionInformation(sessionHandle)).accessTokenPayload;
-        assert.equal(accessTokenPayload.sub, "userId");
-        assert.equal(accessTokenPayload.iss, "https://api.supertokens.io");
+        assert.equal(accessTokenPayload.sub, undefined);
+        assert.equal(accessTokenPayload.iss, undefined);
         assert.strictEqual(accessTokenPayload.customClaim, "customValue");
         assert.notStrictEqual(accessTokenPayload.jwt, undefined);
         assert.strictEqual(accessTokenPayload._jwtPName, "jwt");
@@ -1879,14 +1879,14 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/withjwt.test.js]
         let decodedJWT = JsonWebToken.decode(accessTokenPayload.jwt);
         assert.notStrictEqual(decodedJWT, null);
         assert.strictEqual(decodedJWT["sub"], "userId");
-        assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io");
+        assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io/auth");
         assert.strictEqual(decodedJWT._jwtPName, undefined);
 
         await Session.updateAccessTokenPayload(sessionHandle, undefined);
 
         accessTokenPayload = (await Session.getSessionInformation(sessionHandle)).accessTokenPayload;
-        assert.equal(accessTokenPayload.sub, "userId");
-        assert.equal(accessTokenPayload.iss, "https://api.supertokens.io");
+        assert.equal(accessTokenPayload.sub, undefined);
+        assert.equal(accessTokenPayload.iss, undefined);
         assert.strictEqual(accessTokenPayload.customClaim, undefined);
         assert.notStrictEqual(accessTokenPayload.jwt, undefined);
         assert.strictEqual(accessTokenPayload._jwtPName, "jwt");
@@ -1894,7 +1894,7 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/withjwt.test.js]
         decodedJWT = JsonWebToken.decode(accessTokenPayload.jwt);
         assert.notStrictEqual(decodedJWT, null);
         assert.strictEqual(decodedJWT["sub"], "userId");
-        assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io");
+        assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io/auth");
         assert.strictEqual(decodedJWT._jwtPName, undefined);
     });
 
@@ -1951,15 +1951,15 @@ describe(`session-with-jwt: ${printPath("[test/session/with-jwt/withjwt.test.js]
         let sessionHandle = createJWTResponse.body.sessionHandle;
 
         let accessTokenPayload = (await Session.getSessionInformation(sessionHandle)).accessTokenPayload;
-        assert.equal(accessTokenPayload.sub, "userId");
-        assert.equal(accessTokenPayload.iss, "https://api.supertokens.io");
+        assert.equal(accessTokenPayload.sub, undefined);
+        assert.equal(accessTokenPayload.iss, undefined);
         assert.notStrictEqual(accessTokenPayload.jwt, undefined);
         assert.strictEqual(accessTokenPayload._jwtPName, "jwt");
 
         let decodedJWT = JsonWebToken.decode(accessTokenPayload.jwt);
         assert.notStrictEqual(decodedJWT, null);
         assert.strictEqual(decodedJWT["sub"], "userId");
-        assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io");
+        assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io/auth");
         assert.strictEqual(decodedJWT._jwtPName, undefined);
     });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -23,6 +23,7 @@ let ThirdPartyEmailPasswordRecipe = require("../lib/build/recipe/thirdpartyemail
 let EmailPasswordRecipe = require("../lib/build/recipe/emailpassword/recipe").default;
 let JWTRecipe = require("..//lib/build/recipe/jwt/recipe").default;
 let { ProcessState } = require("../lib/build/processState");
+const { default: OpenIDRecipe } = require("../lib/build/recipe/openid/recipe");
 
 module.exports.printPath = function (path) {
     return `${createFormat([consoleOptions.yellow, consoleOptions.italic, consoleOptions.dim])}${path}${createFormat([
@@ -194,6 +195,7 @@ module.exports.resetAll = function () {
     EmailPasswordRecipe.reset();
     ThirPartyRecipe.reset();
     JWTRecipe.reset();
+    OpenIDRecipe.reset();
     ProcessState.getInstance().reset();
 };
 


### PR DESCRIPTION
## Summary of change
- Creates a new recipe OpenID which uses the JWT recipe internally
- Modifies the session recipe to use the open id recipe instead of jwt directly
- Exposes a open id discovery endpoint, meant to be used by services that rely on open id discovery to determine jwk url and issuer
- Makes the open id discovery API and the jwks api have no cors restrictions (`Access-Control-Allow-Origin: *`)

## Related issues
- https://github.com/supertokens/supertokens-node/issues/224

## Test Plan
- Added unit tests for the open id recipe
- All existing tests pass
- Tested with jwt.io by creating a test server (exposed via ngrok) and verifying that the website can query all APIs using the `iss` claim without any cors errors and that it can verify the signature of the JWT

<img width="365" alt="Screenshot 2021-12-06 at 11 59 49 AM" src="https://user-images.githubusercontent.com/18233774/144798357-5f110665-ea18-4db4-aea5-38a1abc1557a.png">

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] ~~Changelog has been updated~~
-   [ ] ~~`coreDriverInterfaceSupported.json` file has been updated (if needed)~~
    -   ~~Along with the associated array in `lib/ts/version.ts`~~
-   [ ] ~~`frontendDriverInterfaceSupported.json` file has been updated (if needed)~~
-   [ ] ~~Changes to the version if needed~~
    -   ~~In `package.json`~~
    -   ~~In `package-lock.json`~~
    -   ~~In `lib/ts/version.ts`~~
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] ~~Issue this PR against the latest non released version branch.~~
    -   ~~To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.~~
    -   ~~If no such branch exists, then create one from the latest released branch.~~
-   [ ] ~~If have added a new web framework, update the `add-ts-no-check.js` file to include that~~
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).

## Remaining TODOs for this PR

