### PR TITLE
adds support for core base path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased]
 
 -   Fixes https://github.com/supertokens/supertokens-node/issues/244 - throws an error if a user tries to update email / password of a third party login user.
+-   Adds ability to give a path for each of the hostnames in the connectionURI: https://github.com/supertokens/supertokens-node/issues/252
 
 ## [8.5.0] - 2022-01-14
 

--- a/lib/build/querier.d.ts
+++ b/lib/build/querier.d.ts
@@ -15,7 +15,13 @@ export declare class Querier {
     static reset(): void;
     getHostsAliveForTesting: () => Set<string>;
     static getNewInstanceOrThrowError(rIdToCore?: string): Querier;
-    static init(hosts?: NormalisedURLDomain[], apiKey?: string): void;
+    static init(
+        hosts?: {
+            domain: NormalisedURLDomain;
+            basePath: NormalisedURLPath;
+        }[],
+        apiKey?: string
+    ): void;
     sendPostRequest: (path: NormalisedURLPath, body: any) => Promise<any>;
     sendDeleteRequest: (path: NormalisedURLPath, body: any) => Promise<any>;
     sendGetRequest: (path: NormalisedURLPath, params: any) => Promise<any>;

--- a/lib/build/querier.js
+++ b/lib/build/querier.js
@@ -224,16 +224,17 @@ class Querier {
                 if (numberOfTries === 0) {
                     throw Error("No SuperTokens core available to query");
                 }
-                let currentHost = this.__hosts[Querier.lastTriedIndex].getAsStringDangerous();
+                let currentDomain = this.__hosts[Querier.lastTriedIndex].domain.getAsStringDangerous();
+                let currentBasePath = this.__hosts[Querier.lastTriedIndex].basePath.getAsStringDangerous();
                 Querier.lastTriedIndex++;
                 Querier.lastTriedIndex = Querier.lastTriedIndex % this.__hosts.length;
                 try {
                     processState_1.ProcessState.getInstance().addState(
                         processState_1.PROCESS_STATE.CALLING_SERVICE_IN_REQUEST_HELPER
                     );
-                    let response = yield axiosFunction(currentHost + path.getAsStringDangerous());
+                    let response = yield axiosFunction(currentDomain + currentBasePath + path.getAsStringDangerous());
                     if (process.env.TEST_MODE === "testing") {
-                        Querier.hostsAliveForTesting.add(currentHost);
+                        Querier.hostsAliveForTesting.add(currentDomain + currentBasePath);
                     }
                     if (response.status !== 200) {
                         throw response;

--- a/lib/build/supertokens.js
+++ b/lib/build/supertokens.js
@@ -236,7 +236,12 @@ class SuperTokens {
                 : _a.connectionURI
                       .split(";")
                       .filter((h) => h !== "")
-                      .map((h) => new normalisedURLDomain_1.default(h.trim())),
+                      .map((h) => {
+                          return {
+                              domain: new normalisedURLDomain_1.default(h.trim()),
+                              basePath: new normalisedURLPath_1.default(h.trim()),
+                          };
+                      }),
             (_b = config.supertokens) === null || _b === void 0 ? void 0 : _b.apiKey
         );
         if (config.recipeList === undefined || config.recipeList.length === 0) {

--- a/lib/ts/supertokens.ts
+++ b/lib/ts/supertokens.ts
@@ -52,7 +52,12 @@ export default class SuperTokens {
             config.supertokens?.connectionURI
                 .split(";")
                 .filter((h) => h !== "")
-                .map((h) => new NormalisedURLDomain(h.trim())),
+                .map((h) => {
+                    return {
+                        domain: new NormalisedURLDomain(h.trim()),
+                        basePath: new NormalisedURLPath(h.trim()),
+                    };
+                }),
             config.supertokens?.apiKey
         );
 


### PR DESCRIPTION
## Summary of change

Takes into account the path supplied in the connectionURI when querying the core

## Related issues

-   https://github.com/supertokens/supertokens-node/issues/252

## Test Plan

Added unit tests

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
