### PR TITLE
refactor: Removes unused JWT recipe implementation from APIOptions for Session recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 .
 
-## [unreleased]
-
-## [8.6.0] - 2022-01-31
+## [8.6.1] - 2022-02-09
 
 -   Removes unused property from session recipe
+
+## [8.6.0] - 2022-01-31
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [8.6.0] - 2022-01-31
 
+-   Removes unused property from session recipe
+
 ### Changed
 
 -   Added userId as an optional property to the response of `recipe/user/password/reset` (compatibility with CDI 2.12).

--- a/lib/build/recipe/session/recipe.js
+++ b/lib/build/recipe/session/recipe.js
@@ -86,14 +86,11 @@ class SessionRecipe extends recipeModule_1.default {
         };
         this.handleAPIRequest = (id, req, res, path, method) =>
             __awaiter(this, void 0, void 0, function* () {
-                var _a;
                 let options = {
                     config: this.config,
                     recipeId: this.getRecipeId(),
                     isInServerlessEnv: this.isInServerlessEnv,
                     recipeImplementation: this.recipeInterfaceImpl,
-                    jwtRecipeImplementation:
-                        (_a = this.openIdRecipe) === null || _a === void 0 ? void 0 : _a.jwtRecipe.recipeInterfaceImpl,
                     req,
                     res,
                 };
@@ -146,7 +143,6 @@ class SessionRecipe extends recipeModule_1.default {
         };
         this.verifySession = (options, request, response) =>
             __awaiter(this, void 0, void 0, function* () {
-                var _b;
                 return yield this.apiImpl.verifySession({
                     verifySessionOptions: options,
                     options: {
@@ -156,10 +152,6 @@ class SessionRecipe extends recipeModule_1.default {
                         recipeId: this.getRecipeId(),
                         isInServerlessEnv: this.isInServerlessEnv,
                         recipeImplementation: this.recipeInterfaceImpl,
-                        jwtRecipeImplementation:
-                            (_b = this.openIdRecipe) === null || _b === void 0
-                                ? void 0
-                                : _b.jwtRecipe.recipeInterfaceImpl,
                     },
                 });
             });

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -248,7 +248,6 @@ export interface SessionContainerInterface {
 }
 export declare type APIOptions = {
     recipeImplementation: RecipeInterface;
-    jwtRecipeImplementation: JWTRecipeInterface | undefined;
     config: TypeNormalisedInput;
     recipeId: string;
     isInServerlessEnv: boolean;

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-export declare const version = "8.6.0";
+export declare const version = "8.6.1";
 export declare const cdiSupported: string[];

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -14,5 +14,5 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "8.6.0";
+exports.version = "8.6.1";
 exports.cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12"];

--- a/lib/ts/recipe/session/recipe.ts
+++ b/lib/ts/recipe/session/recipe.ts
@@ -147,7 +147,6 @@ export default class SessionRecipe extends RecipeModule {
             recipeId: this.getRecipeId(),
             isInServerlessEnv: this.isInServerlessEnv,
             recipeImplementation: this.recipeInterfaceImpl,
-            jwtRecipeImplementation: this.openIdRecipe?.jwtRecipe.recipeInterfaceImpl,
             req,
             res,
         };
@@ -213,7 +212,6 @@ export default class SessionRecipe extends RecipeModule {
                 recipeId: this.getRecipeId(),
                 isInServerlessEnv: this.isInServerlessEnv,
                 recipeImplementation: this.recipeInterfaceImpl,
-                jwtRecipeImplementation: this.openIdRecipe?.jwtRecipe.recipeInterfaceImpl,
             },
         });
     };

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -283,7 +283,6 @@ export interface SessionContainerInterface {
 
 export type APIOptions = {
     recipeImplementation: RecipeInterface;
-    jwtRecipeImplementation: JWTRecipeInterface | undefined;
     config: TypeNormalisedInput;
     recipeId: string;
     isInServerlessEnv: boolean;

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,6 +12,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "8.6.0";
+export const version = "8.6.1";
 
 export const cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "8.6.0",
+    "version": "8.6.1",
     "lockfileVersion": 1,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "8.6.0",
+    "version": "8.6.1",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

-  Removes `jwtRecipeImplementation` from `APIOptions` for Session recipe

## Related issues

## Test Plan

All existing test cases pass
<img width="469" alt="Screenshot 2022-02-09 at 6 02 45 PM" src="https://user-images.githubusercontent.com/18233774/153201837-d8486754-34b2-4175-baaa-f4e5a616065a.png">

## Documentation changes

None Required

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] ~~`coreDriverInterfaceSupported.json` file has been updated (if needed)~~
    -   ~~Along with the associated array in `lib/ts/version.ts`~~
-   [ ] ~~`frontendDriverInterfaceSupported.json` file has been updated (if needed)~~
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] ~~If have added a new web framework, update the `add-ts-no-check.js` file to include that~~
-   [ ] ~~If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).~~
-   [ ] ~~If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.~~

## Remaining TODOs for this PR

