### PR TITLE
refactor: email sending service, Email Delivery and SMTP class changes for thirdpartypasswordless

### DIFF
--- a/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/backwardCompatibility/index.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/backwardCompatibility/index.d.ts
@@ -1,0 +1,45 @@
+// @ts-nocheck
+import { TypeThirdPartyPasswordlessEmailDeliveryInput, User, RecipeInterface } from "../../../types";
+import { NormalisedAppinfo } from "../../../../../types";
+import { EmailDeliveryInterface } from "../../../../../ingredients/emaildelivery/types";
+export default class BackwardCompatibilityService
+    implements EmailDeliveryInterface<TypeThirdPartyPasswordlessEmailDeliveryInput> {
+    private recipeInterfaceImpl;
+    private isInServerlessEnv;
+    private appInfo;
+    private emailVerificationBackwardCompatibilityService;
+    private passwordlessBackwardCompatibilityService;
+    constructor(
+        recipeInterfaceImpl: RecipeInterface,
+        appInfo: NormalisedAppinfo,
+        isInServerlessEnv: boolean,
+        passwordlessFeature?: {
+            createAndSendCustomEmail?: (
+                input: {
+                    email: string;
+                    userInputCode?: string;
+                    urlWithLinkCode?: string;
+                    codeLifetime: number;
+                    preAuthSessionId: string;
+                },
+                userContext: any
+            ) => Promise<void>;
+        },
+        emailVerificationFeature?: {
+            createAndSendCustomEmail?: (
+                user: User,
+                emailVerificationURLWithToken: string,
+                userContext: any
+            ) => Promise<void>;
+        }
+    );
+    sendEmail: (
+        input:
+            | (import("../../../../emailverification/types").TypeEmailVerificationEmailDeliveryInput & {
+                  userContext: any;
+              })
+            | (import("../../../../passwordless/types").TypePasswordlessEmailDeliveryInput & {
+                  userContext: any;
+              })
+    ) => Promise<void>;
+}

--- a/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/backwardCompatibility/index.js
+++ b/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/backwardCompatibility/index.js
@@ -1,0 +1,86 @@
+"use strict";
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+Object.defineProperty(exports, "__esModule", { value: true });
+const backwardCompatibility_1 = require("../../../../emailverification/emaildelivery/services/backwardCompatibility");
+const backwardCompatibility_2 = require("../../../../passwordless/emaildelivery/services/backwardCompatibility");
+class BackwardCompatibilityService {
+    constructor(recipeInterfaceImpl, appInfo, isInServerlessEnv, passwordlessFeature, emailVerificationFeature) {
+        this.sendEmail = (input) =>
+            __awaiter(this, void 0, void 0, function* () {
+                if (input.type === "EMAIL_VERIFICATION") {
+                    yield this.emailVerificationBackwardCompatibilityService.sendEmail(input);
+                } else {
+                    yield this.passwordlessBackwardCompatibilityService.sendEmail(input);
+                }
+            });
+        this.recipeInterfaceImpl = recipeInterfaceImpl;
+        this.isInServerlessEnv = isInServerlessEnv;
+        this.appInfo = appInfo;
+        {
+            const inputCreateAndSendCustomEmail =
+                emailVerificationFeature === null || emailVerificationFeature === void 0
+                    ? void 0
+                    : emailVerificationFeature.createAndSendCustomEmail;
+            let emailVerificationFeatureNormalisedConfig =
+                inputCreateAndSendCustomEmail !== undefined
+                    ? {
+                          createAndSendCustomEmail: (user, link, userContext) =>
+                              __awaiter(this, void 0, void 0, function* () {
+                                  let userInfo = yield this.recipeInterfaceImpl.getUserById({
+                                      userId: user.id,
+                                      userContext,
+                                  });
+                                  if (userInfo === undefined) {
+                                      throw new Error("Unknown User ID provided");
+                                  }
+                                  return yield inputCreateAndSendCustomEmail(userInfo, link, userContext);
+                              }),
+                      }
+                    : {};
+            this.emailVerificationBackwardCompatibilityService = new backwardCompatibility_1.default(
+                this.appInfo,
+                this.isInServerlessEnv,
+                emailVerificationFeatureNormalisedConfig.createAndSendCustomEmail
+            );
+        }
+        {
+            this.passwordlessBackwardCompatibilityService = new backwardCompatibility_2.default(
+                appInfo,
+                passwordlessFeature === null || passwordlessFeature === void 0
+                    ? void 0
+                    : passwordlessFeature.createAndSendCustomEmail
+            );
+        }
+    }
+}
+exports.default = BackwardCompatibilityService;

--- a/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/index.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/index.d.ts
@@ -1,0 +1,3 @@
+// @ts-nocheck
+import SMTP from "./smtp";
+export declare let STMPService: typeof SMTP;

--- a/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/index.js
+++ b/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/index.js
@@ -1,0 +1,18 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+const smtp_1 = require("./smtp");
+exports.STMPService = smtp_1.default;

--- a/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/index.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/index.d.ts
@@ -1,0 +1,20 @@
+// @ts-nocheck
+import { ServiceInterface, TypeInput } from "../../../../../ingredients/emaildelivery/services/smtp";
+import { TypeThirdPartyPasswordlessEmailDeliveryInput } from "../../../types";
+import { EmailDeliveryInterface } from "../../../../../ingredients/emaildelivery/types";
+export default class SMTPService implements EmailDeliveryInterface<TypeThirdPartyPasswordlessEmailDeliveryInput> {
+    serviceImpl: ServiceInterface<TypeThirdPartyPasswordlessEmailDeliveryInput>;
+    private config;
+    private emailVerificationSMTPService;
+    private passwordlessSMTPService;
+    constructor(config: TypeInput<TypeThirdPartyPasswordlessEmailDeliveryInput>);
+    sendEmail: (
+        input:
+            | (import("../../../../emailverification/types").TypeEmailVerificationEmailDeliveryInput & {
+                  userContext: any;
+              })
+            | (import("../../../../passwordless/types").TypePasswordlessEmailDeliveryInput & {
+                  userContext: any;
+              })
+    ) => Promise<void>;
+}

--- a/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/index.js
+++ b/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/index.js
@@ -1,0 +1,78 @@
+"use strict";
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+Object.defineProperty(exports, "__esModule", { value: true });
+const nodemailer_1 = require("nodemailer");
+const supertokens_js_override_1 = require("supertokens-js-override");
+const serviceImplementation_1 = require("./serviceImplementation");
+const smtp_1 = require("../../../../emailverification/emaildelivery/services/smtp");
+const smtp_2 = require("../../../../passwordless/emaildelivery/services/smtp");
+const emailVerificationServiceImplementation_1 = require("./serviceImplementation/emailVerificationServiceImplementation");
+const passwordlessServiceImplementation_1 = require("./serviceImplementation/passwordlessServiceImplementation");
+class SMTPService {
+    constructor(config) {
+        this.sendEmail = (input) =>
+            __awaiter(this, void 0, void 0, function* () {
+                if (input.type === "EMAIL_VERIFICATION") {
+                    return yield this.emailVerificationSMTPService.sendEmail(input);
+                }
+                return yield this.passwordlessSMTPService.sendEmail(input);
+            });
+        this.config = config;
+        const transporter = nodemailer_1.createTransport({
+            host: config.smtpSettings.host,
+            port: config.smtpSettings.port,
+            auth: config.smtpSettings.auth,
+            secure: config.smtpSettings.secure,
+        });
+        let builder = new supertokens_js_override_1.default(
+            serviceImplementation_1.getServiceImplementation(transporter)
+        );
+        if (config.override !== undefined) {
+            builder = builder.override(config.override);
+        }
+        this.serviceImpl = builder.build();
+        this.emailVerificationSMTPService = new smtp_1.default({
+            smtpSettings: this.config.smtpSettings,
+            override: (_) => {
+                return emailVerificationServiceImplementation_1.default(this.serviceImpl);
+            },
+        });
+        this.passwordlessSMTPService = new smtp_2.default({
+            smtpSettings: this.config.smtpSettings,
+            override: (_) => {
+                return passwordlessServiceImplementation_1.default(this.serviceImpl);
+            },
+        });
+    }
+}
+exports.default = SMTPService;

--- a/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/emailVerificationServiceImplementation.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/emailVerificationServiceImplementation.d.ts
@@ -1,0 +1,7 @@
+// @ts-nocheck
+import { TypeThirdPartyPasswordlessEmailDeliveryInput } from "../../../../types";
+import { ServiceInterface } from "../../../../../../ingredients/emaildelivery/services/smtp";
+import { TypeEmailVerificationEmailDeliveryInput } from "../../../../../emailverification/types";
+export default function getServiceInterface(
+    emailPasswordServiceImplementation: ServiceInterface<TypeThirdPartyPasswordlessEmailDeliveryInput>
+): ServiceInterface<TypeEmailVerificationEmailDeliveryInput>;

--- a/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/emailVerificationServiceImplementation.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/emailVerificationServiceImplementation.d.ts
@@ -3,5 +3,5 @@ import { TypeThirdPartyPasswordlessEmailDeliveryInput } from "../../../../types"
 import { ServiceInterface } from "../../../../../../ingredients/emaildelivery/services/smtp";
 import { TypeEmailVerificationEmailDeliveryInput } from "../../../../../emailverification/types";
 export default function getServiceInterface(
-    emailPasswordServiceImplementation: ServiceInterface<TypeThirdPartyPasswordlessEmailDeliveryInput>
+    thirdpartyPasswordlessServiceImplementation: ServiceInterface<TypeThirdPartyPasswordlessEmailDeliveryInput>
 ): ServiceInterface<TypeEmailVerificationEmailDeliveryInput>;

--- a/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/emailVerificationServiceImplementation.js
+++ b/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/emailVerificationServiceImplementation.js
@@ -1,0 +1,62 @@
+"use strict";
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+Object.defineProperty(exports, "__esModule", { value: true });
+function getServiceInterface(emailPasswordServiceImplementation) {
+    return {
+        sendRawEmail: function (input) {
+            return __awaiter(this, void 0, void 0, function* () {
+                return emailPasswordServiceImplementation.sendRawEmail(input);
+            });
+        },
+        getContent: function (input) {
+            return __awaiter(this, void 0, void 0, function* () {
+                return yield emailPasswordServiceImplementation.getContent(input);
+            });
+        },
+    };
+}
+exports.default = getServiceInterface;

--- a/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/emailVerificationServiceImplementation.js
+++ b/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/emailVerificationServiceImplementation.js
@@ -45,16 +45,16 @@ var __awaiter =
         });
     };
 Object.defineProperty(exports, "__esModule", { value: true });
-function getServiceInterface(emailPasswordServiceImplementation) {
+function getServiceInterface(thirdpartyPasswordlessServiceImplementation) {
     return {
         sendRawEmail: function (input) {
             return __awaiter(this, void 0, void 0, function* () {
-                return emailPasswordServiceImplementation.sendRawEmail(input);
+                return thirdpartyPasswordlessServiceImplementation.sendRawEmail(input);
             });
         },
         getContent: function (input) {
             return __awaiter(this, void 0, void 0, function* () {
-                return yield emailPasswordServiceImplementation.getContent(input);
+                return yield thirdpartyPasswordlessServiceImplementation.getContent(input);
             });
         },
     };

--- a/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/index.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/index.d.ts
@@ -1,0 +1,7 @@
+// @ts-nocheck
+import { TypeThirdPartyPasswordlessEmailDeliveryInput } from "../../../../types";
+import { Transporter } from "nodemailer";
+import { ServiceInterface } from "../../../../../../ingredients/emaildelivery/services/smtp";
+export declare function getServiceImplementation(
+    transporter: Transporter
+): ServiceInterface<TypeThirdPartyPasswordlessEmailDeliveryInput>;

--- a/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/index.js
+++ b/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/index.js
@@ -1,0 +1,80 @@
+"use strict";
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+Object.defineProperty(exports, "__esModule", { value: true });
+const serviceImplementation_1 = require("../../../../../emailverification/emaildelivery/services/smtp/serviceImplementation");
+const serviceImplementation_2 = require("../../../../../passwordless/emaildelivery/services/smtp/serviceImplementation");
+const emailVerificationServiceImplementation_1 = require("./emailVerificationServiceImplementation");
+const passwordlessServiceImplementation_1 = require("./passwordlessServiceImplementation");
+function getServiceImplementation(transporter) {
+    let emailVerificationSeriveImpl = serviceImplementation_1.getServiceImplementation(transporter);
+    let passwordlessSeriveImpl = serviceImplementation_2.getServiceImplementation(transporter);
+    return {
+        sendRawEmail: function (input) {
+            return __awaiter(this, void 0, void 0, function* () {
+                yield transporter.sendMail({
+                    from: `${input.from.name} <${input.from.email}>`,
+                    to: input.toEmail,
+                    subject: input.subject,
+                    html: input.body,
+                });
+            });
+        },
+        getContent: function (input) {
+            return __awaiter(this, void 0, void 0, function* () {
+                if (input.type === "EMAIL_VERIFICATION") {
+                    return yield emailVerificationSeriveImpl.getContent.bind(
+                        emailVerificationServiceImplementation_1.default(this)
+                    )(input);
+                }
+                return yield passwordlessSeriveImpl.getContent.bind(passwordlessServiceImplementation_1.default(this))(
+                    input
+                );
+            });
+        },
+    };
+}
+exports.getServiceImplementation = getServiceImplementation;

--- a/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/passwordlessServiceImplementation.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/passwordlessServiceImplementation.d.ts
@@ -1,0 +1,7 @@
+// @ts-nocheck
+import { TypeThirdPartyPasswordlessEmailDeliveryInput } from "../../../../types";
+import { ServiceInterface } from "../../../../../../ingredients/emaildelivery/services/smtp";
+import { TypePasswordlessEmailDeliveryInput } from "../../../../../passwordless/types";
+export default function getServiceInterface(
+    passwordlessServiceImplementation: ServiceInterface<TypeThirdPartyPasswordlessEmailDeliveryInput>
+): ServiceInterface<TypePasswordlessEmailDeliveryInput>;

--- a/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/passwordlessServiceImplementation.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/passwordlessServiceImplementation.d.ts
@@ -3,5 +3,5 @@ import { TypeThirdPartyPasswordlessEmailDeliveryInput } from "../../../../types"
 import { ServiceInterface } from "../../../../../../ingredients/emaildelivery/services/smtp";
 import { TypePasswordlessEmailDeliveryInput } from "../../../../../passwordless/types";
 export default function getServiceInterface(
-    passwordlessServiceImplementation: ServiceInterface<TypeThirdPartyPasswordlessEmailDeliveryInput>
+    thirdpartyPasswordlessServiceImplementation: ServiceInterface<TypeThirdPartyPasswordlessEmailDeliveryInput>
 ): ServiceInterface<TypePasswordlessEmailDeliveryInput>;

--- a/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/passwordlessServiceImplementation.js
+++ b/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/passwordlessServiceImplementation.js
@@ -45,16 +45,16 @@ var __awaiter =
         });
     };
 Object.defineProperty(exports, "__esModule", { value: true });
-function getServiceInterface(passwordlessServiceImplementation) {
+function getServiceInterface(thirdpartyPasswordlessServiceImplementation) {
     return {
         sendRawEmail: function (input) {
             return __awaiter(this, void 0, void 0, function* () {
-                return passwordlessServiceImplementation.sendRawEmail(input);
+                return thirdpartyPasswordlessServiceImplementation.sendRawEmail(input);
             });
         },
         getContent: function (input) {
             return __awaiter(this, void 0, void 0, function* () {
-                return yield passwordlessServiceImplementation.getContent(input);
+                return yield thirdpartyPasswordlessServiceImplementation.getContent(input);
             });
         },
     };

--- a/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/passwordlessServiceImplementation.js
+++ b/lib/build/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/passwordlessServiceImplementation.js
@@ -1,0 +1,62 @@
+"use strict";
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+Object.defineProperty(exports, "__esModule", { value: true });
+function getServiceInterface(passwordlessServiceImplementation) {
+    return {
+        sendRawEmail: function (input) {
+            return __awaiter(this, void 0, void 0, function* () {
+                return passwordlessServiceImplementation.sendRawEmail(input);
+            });
+        },
+        getContent: function (input) {
+            return __awaiter(this, void 0, void 0, function* () {
+                return yield passwordlessServiceImplementation.getContent(input);
+            });
+        },
+    };
+}
+exports.default = getServiceInterface;

--- a/lib/build/recipe/thirdpartypasswordless/recipe.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/recipe.d.ts
@@ -6,10 +6,17 @@ import PasswordlessRecipe from "../passwordless/recipe";
 import ThirdPartyRecipe from "../thirdparty/recipe";
 import { BaseRequest, BaseResponse } from "../../framework";
 import STError from "./error";
-import { TypeInput, TypeNormalisedInput, RecipeInterface, APIInterface } from "./types";
+import {
+    TypeInput,
+    TypeNormalisedInput,
+    RecipeInterface,
+    APIInterface,
+    TypeThirdPartyPasswordlessEmailDeliveryInput,
+} from "./types";
 import STErrorPasswordless from "../passwordless/error";
 import STErrorThirdParty from "../thirdparty/error";
 import NormalisedURLPath from "../../normalisedURLPath";
+import EmailDeliveryIngredient from "../../ingredients/emaildelivery";
 export default class Recipe extends RecipeModule {
     private static instance;
     static RECIPE_ID: string;
@@ -19,6 +26,8 @@ export default class Recipe extends RecipeModule {
     private thirdPartyRecipe;
     recipeInterfaceImpl: RecipeInterface;
     apiImpl: APIInterface;
+    emailDelivery: EmailDeliveryIngredient<TypeThirdPartyPasswordlessEmailDeliveryInput>;
+    isInServerlessEnv: boolean;
     constructor(
         recipeId: string,
         appInfo: NormalisedAppinfo,
@@ -28,6 +37,9 @@ export default class Recipe extends RecipeModule {
             emailVerificationInstance: EmailVerificationRecipe | undefined;
             thirdPartyInstance: ThirdPartyRecipe | undefined;
             passwordlessInstance: PasswordlessRecipe | undefined;
+        },
+        ingredients: {
+            emailDelivery: EmailDeliveryIngredient<TypeThirdPartyPasswordlessEmailDeliveryInput> | undefined;
         }
     );
     static init(config: TypeInput): RecipeListFunction;

--- a/lib/build/recipe/thirdpartypasswordless/recipe.js
+++ b/lib/build/recipe/thirdpartypasswordless/recipe.js
@@ -280,7 +280,7 @@ class Recipe extends recipeModule_1.default {
                               emailVerificationInstance: this.emailVerificationRecipe,
                           },
                           {
-                              emailDelivery: undefined,
+                              emailDelivery: this.emailDelivery,
                           }
                       );
         }

--- a/lib/build/recipe/thirdpartypasswordless/recipe.js
+++ b/lib/build/recipe/thirdpartypasswordless/recipe.js
@@ -59,8 +59,9 @@ const passwordlessAPIImplementation_1 = require("./api/passwordlessAPIImplementa
 const implementation_1 = require("./api/implementation");
 const querier_1 = require("../../querier");
 const supertokens_js_override_1 = require("supertokens-js-override");
+const emaildelivery_1 = require("../../ingredients/emaildelivery");
 class Recipe extends recipeModule_1.default {
-    constructor(recipeId, appInfo, isInServerlessEnv, config, recipes) {
+    constructor(recipeId, appInfo, isInServerlessEnv, config, recipes, ingredients) {
         super(recipeId, appInfo);
         this.getAPIsHandled = () => {
             let apisHandled = [
@@ -134,6 +135,7 @@ class Recipe extends recipeModule_1.default {
                 }
                 return userInfo.email;
             });
+        this.isInServerlessEnv = isInServerlessEnv;
         this.config = utils_1.validateAndNormaliseUserInput(this, appInfo, config);
         {
             let builder = new supertokens_js_override_1.default(
@@ -150,6 +152,10 @@ class Recipe extends recipeModule_1.default {
         }
         const recipImplReference = this.recipeInterfaceImpl;
         const emailVerificationConfig = this.config.emailVerificationFeature;
+        this.emailDelivery =
+            ingredients.emailDelivery === undefined
+                ? new emaildelivery_1.default(this.config.getEmailDeliveryConfig())
+                : ingredients.emailDelivery;
         this.emailVerificationRecipe =
             recipes.emailVerificationInstance !== undefined
                 ? recipes.emailVerificationInstance
@@ -214,9 +220,20 @@ class Recipe extends recipeModule_1.default {
                           }),
                       }),
                       {
-                          emailDelivery: undefined,
+                          emailDelivery: this.emailDelivery,
                       }
                   );
+        /**
+         * we don't need to pass the emailDelivery config to the
+         * passwordless recipe as we are passing the emailDelivery
+         * object created by this recipe as an ingredient
+         *
+         * if we simply do `...this.config` while calling the PasswordlessRecipe
+         * constructor, it will throw a typescript error as
+         * Type'EmailDeliveryInterface<TypePasswordlessEmailDeliveryInput>' is not assignable
+         * to type 'EmailDeliveryInterface<TypeThirdPartyPasswordlessEmailDeliveryInput>'
+         */
+        let passwordlessConfig = Object.assign(Object.assign({}, this.config), { emailDelivery: undefined });
         this.passwordlessRecipe =
             recipes.passwordlessInstance !== undefined
                 ? recipes.passwordlessInstance
@@ -224,7 +241,7 @@ class Recipe extends recipeModule_1.default {
                       recipeId,
                       appInfo,
                       isInServerlessEnv,
-                      Object.assign(Object.assign({}, this.config), {
+                      Object.assign(Object.assign({}, passwordlessConfig), {
                           override: {
                               functions: (_) => {
                                   return passwordlessRecipeImplementation_1.default(this.recipeInterfaceImpl);
@@ -235,7 +252,7 @@ class Recipe extends recipeModule_1.default {
                           },
                       }),
                       {
-                          emailDelivery: undefined,
+                          emailDelivery: this.emailDelivery,
                       }
                   );
         if (this.config.providers.length !== 0) {
@@ -271,11 +288,20 @@ class Recipe extends recipeModule_1.default {
     static init(config) {
         return (appInfo, isInServerlessEnv) => {
             if (Recipe.instance === undefined) {
-                Recipe.instance = new Recipe(Recipe.RECIPE_ID, appInfo, isInServerlessEnv, config, {
-                    passwordlessInstance: undefined,
-                    emailVerificationInstance: undefined,
-                    thirdPartyInstance: undefined,
-                });
+                Recipe.instance = new Recipe(
+                    Recipe.RECIPE_ID,
+                    appInfo,
+                    isInServerlessEnv,
+                    config,
+                    {
+                        passwordlessInstance: undefined,
+                        emailVerificationInstance: undefined,
+                        thirdPartyInstance: undefined,
+                    },
+                    {
+                        emailDelivery: undefined,
+                    }
+                );
                 return Recipe.instance;
             } else {
                 throw new Error(

--- a/lib/build/recipe/thirdpartypasswordless/types.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/types.d.ts
@@ -1,13 +1,22 @@
 // @ts-nocheck
-import { TypeProvider, APIOptions as ThirdPartyAPIOptionsOriginal } from "../thirdparty/types";
+import {
+    TypeProvider,
+    APIOptions as ThirdPartyAPIOptionsOriginal,
+    TypeThirdPartyEmailDeliveryInput,
+} from "../thirdparty/types";
 import { TypeInput as TypeInputEmailVerification } from "../emailverification/types";
 import {
     RecipeInterface as EmailVerificationRecipeInterface,
     APIInterface as EmailVerificationAPIInterface,
 } from "../emailverification";
-import { DeviceType as DeviceTypeOriginal, APIOptions as PasswordlessAPIOptionsOriginal } from "../passwordless/types";
+import {
+    DeviceType as DeviceTypeOriginal,
+    APIOptions as PasswordlessAPIOptionsOriginal,
+    TypePasswordlessEmailDeliveryInput,
+} from "../passwordless/types";
 import OverrideableBuilder from "supertokens-js-override";
 import { SessionContainerInterface } from "../session/types";
+import { TypeInput as EmailDeliveryTypeInput } from "../../ingredients/emaildelivery/types";
 export declare type DeviceType = DeviceTypeOriginal;
 export declare type User = (
     | {
@@ -27,6 +36,9 @@ export declare type User = (
 };
 export declare type TypeInputEmailVerificationFeature = {
     getEmailVerificationURL?: (user: User, userContext: any) => Promise<string>;
+    /**
+     * @deprecated Please use emailDelivery config instead
+     */
     createAndSendCustomEmail?: (user: User, emailVerificationURLWithToken: string, userContext: any) => Promise<void>;
 };
 export declare type TypeInput = (
@@ -47,6 +59,9 @@ export declare type TypeInput = (
     | {
           contactMethod: "EMAIL";
           validateEmailAddress?: (email: string) => Promise<string | undefined> | string | undefined;
+          /**
+           * @deprecated Please use emailDelivery config instead
+           */
           createAndSendCustomEmail: (
               input: {
                   email: string;
@@ -61,6 +76,9 @@ export declare type TypeInput = (
     | {
           contactMethod: "EMAIL_OR_PHONE";
           validateEmailAddress?: (email: string) => Promise<string | undefined> | string | undefined;
+          /**
+           * @deprecated Please use emailDelivery config instead
+           */
           createAndSendCustomEmail: (
               input: {
                   email: string;
@@ -84,6 +102,11 @@ export declare type TypeInput = (
           ) => Promise<void>;
       }
 ) & {
+    /**
+     * Unlike passwordless recipe, emailDelivery config is outside here because regardless
+     * of `contactMethod` value, the config is required for email verification recipe
+     */
+    emailDelivery?: EmailDeliveryTypeInput<TypeThirdPartyPasswordlessEmailDeliveryInput>;
     providers?: TypeProvider[];
     emailVerificationFeature?: TypeInputEmailVerificationFeature;
     flowType: "USER_INPUT_CODE" | "MAGIC_LINK" | "USER_INPUT_CODE_AND_MAGIC_LINK";
@@ -185,6 +208,7 @@ export declare type TypeNormalisedInput = (
     getCustomUserInputCode?: (userContext: any) => Promise<string> | string;
     providers: TypeProvider[];
     emailVerificationFeature: TypeInputEmailVerification;
+    getEmailDeliveryConfig: () => EmailDeliveryTypeInput<TypeThirdPartyPasswordlessEmailDeliveryInput>;
     override: {
         functions: (
             originalImplementation: RecipeInterface,
@@ -480,3 +504,6 @@ export declare type APIInterface = {
               exists: boolean;
           }>);
 };
+export declare type TypeThirdPartyPasswordlessEmailDeliveryInput =
+    | TypeThirdPartyEmailDeliveryInput
+    | TypePasswordlessEmailDeliveryInput;

--- a/lib/build/recipe/thirdpartypasswordless/utils.js
+++ b/lib/build/recipe/thirdpartypasswordless/utils.js
@@ -45,6 +45,7 @@ var __awaiter =
         });
     };
 Object.defineProperty(exports, "__esModule", { value: true });
+const backwardCompatibility_1 = require("./emaildelivery/services/backwardCompatibility");
 function validateAndNormaliseUserInput(recipeInstance, appInfo, config) {
     let providers = config.providers === undefined ? [] : config.providers;
     let emailVerificationFeature = validateAndNormaliseEmailVerificationConfig(recipeInstance, appInfo, config);
@@ -55,7 +56,56 @@ function validateAndNormaliseUserInput(recipeInstance, appInfo, config) {
         },
         config === null || config === void 0 ? void 0 : config.override
     );
-    return Object.assign(Object.assign({}, config), { providers, emailVerificationFeature, override });
+    function getEmailDeliveryConfig() {
+        var _a;
+        let emailService =
+            (_a = config === null || config === void 0 ? void 0 : config.emailDelivery) === null || _a === void 0
+                ? void 0
+                : _a.service;
+        /**
+         * following code is for backward compatibility.
+         * if user has not passed emailDelivery config, we
+         * use the createAndSendCustomEmail config. If the user
+         * has not passed even that config, we use the default
+         * createAndSendCustomEmail implementation
+         */
+        if (emailService === undefined) {
+            emailService = new backwardCompatibility_1.default(
+                recipeInstance.recipeInterfaceImpl,
+                appInfo,
+                recipeInstance.isInServerlessEnv,
+                {
+                    createAndSendCustomEmail:
+                        (config === null || config === void 0 ? void 0 : config.contactMethod) !== "PHONE"
+                            ? config === null || config === void 0
+                                ? void 0
+                                : config.createAndSendCustomEmail
+                            : undefined,
+                },
+                config === null || config === void 0 ? void 0 : config.emailVerificationFeature
+            );
+        }
+        return Object.assign(Object.assign({}, config === null || config === void 0 ? void 0 : config.emailDelivery), {
+            /**
+             * if we do
+             * let emailDelivery = {
+             *    service: emailService,
+             *    ...config.emailDelivery,
+             * };
+             *
+             * and if the user has passed service as undefined,
+             * it it again get set to undefined, so we
+             * set service at the end
+             */
+            service: emailService,
+        });
+    }
+    return Object.assign(Object.assign({}, config), {
+        providers,
+        emailVerificationFeature,
+        override,
+        getEmailDeliveryConfig,
+    });
 }
 exports.validateAndNormaliseUserInput = validateAndNormaliseUserInput;
 function validateAndNormaliseEmailVerificationConfig(recipeInstance, _, config) {

--- a/lib/ts/recipe/thirdpartypasswordless/emaildelivery/services/backwardCompatibility/index.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/emaildelivery/services/backwardCompatibility/index.ts
@@ -1,0 +1,103 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+import { TypeThirdPartyPasswordlessEmailDeliveryInput, User, RecipeInterface } from "../../../types";
+import { User as EmailVerificationUser } from "../../../../emailverification/types";
+import { NormalisedAppinfo } from "../../../../../types";
+import EmailVerificationBackwardCompatibilityService from "../../../../emailverification/emaildelivery/services/backwardCompatibility";
+import PasswordlessBackwardCompatibilityService from "../../../../passwordless/emaildelivery/services/backwardCompatibility";
+import { EmailDeliveryInterface } from "../../../../../ingredients/emaildelivery/types";
+
+export default class BackwardCompatibilityService
+    implements EmailDeliveryInterface<TypeThirdPartyPasswordlessEmailDeliveryInput> {
+    private recipeInterfaceImpl: RecipeInterface;
+    private isInServerlessEnv: boolean;
+    private appInfo: NormalisedAppinfo;
+    private emailVerificationBackwardCompatibilityService: EmailVerificationBackwardCompatibilityService;
+    private passwordlessBackwardCompatibilityService: PasswordlessBackwardCompatibilityService;
+
+    constructor(
+        recipeInterfaceImpl: RecipeInterface,
+        appInfo: NormalisedAppinfo,
+        isInServerlessEnv: boolean,
+        passwordlessFeature?: {
+            createAndSendCustomEmail?: (
+                input: {
+                    // Where the message should be delivered.
+                    email: string;
+                    // This has to be entered on the starting device  to finish sign in/up
+                    userInputCode?: string;
+                    // Full url that the end-user can click to finish sign in/up
+                    urlWithLinkCode?: string;
+                    codeLifetime: number;
+                    // Unlikely, but someone could display this (or a derived thing) to identify the device
+                    preAuthSessionId: string;
+                },
+                userContext: any
+            ) => Promise<void>;
+        },
+        emailVerificationFeature?: {
+            createAndSendCustomEmail?: (
+                user: User,
+                emailVerificationURLWithToken: string,
+                userContext: any
+            ) => Promise<void>;
+        }
+    ) {
+        this.recipeInterfaceImpl = recipeInterfaceImpl;
+        this.isInServerlessEnv = isInServerlessEnv;
+        this.appInfo = appInfo;
+        {
+            const inputCreateAndSendCustomEmail = emailVerificationFeature?.createAndSendCustomEmail;
+            let emailVerificationFeatureNormalisedConfig =
+                inputCreateAndSendCustomEmail !== undefined
+                    ? {
+                          createAndSendCustomEmail: async (
+                              user: EmailVerificationUser,
+                              link: string,
+                              userContext: any
+                          ) => {
+                              let userInfo = await this.recipeInterfaceImpl.getUserById({
+                                  userId: user.id,
+                                  userContext,
+                              });
+                              if (userInfo === undefined) {
+                                  throw new Error("Unknown User ID provided");
+                              }
+                              return await inputCreateAndSendCustomEmail(userInfo, link, userContext);
+                          },
+                      }
+                    : {};
+            this.emailVerificationBackwardCompatibilityService = new EmailVerificationBackwardCompatibilityService(
+                this.appInfo,
+                this.isInServerlessEnv,
+                emailVerificationFeatureNormalisedConfig.createAndSendCustomEmail
+            );
+        }
+        {
+            this.passwordlessBackwardCompatibilityService = new PasswordlessBackwardCompatibilityService(
+                appInfo,
+                passwordlessFeature?.createAndSendCustomEmail
+            );
+        }
+    }
+
+    sendEmail = async (input: TypeThirdPartyPasswordlessEmailDeliveryInput & { userContext: any }) => {
+        if (input.type === "EMAIL_VERIFICATION") {
+            await this.emailVerificationBackwardCompatibilityService.sendEmail(input);
+        } else {
+            await this.passwordlessBackwardCompatibilityService.sendEmail(input);
+        }
+    };
+}

--- a/lib/ts/recipe/thirdpartypasswordless/emaildelivery/services/index.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/emaildelivery/services/index.ts
@@ -1,0 +1,16 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+import SMTP from "./smtp";
+export let STMPService = SMTP;

--- a/lib/ts/recipe/thirdpartypasswordless/emaildelivery/services/smtp/index.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/emaildelivery/services/smtp/index.ts
@@ -1,0 +1,67 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+import { ServiceInterface, TypeInput } from "../../../../../ingredients/emaildelivery/services/smtp";
+import { TypeThirdPartyPasswordlessEmailDeliveryInput } from "../../../types";
+import { EmailDeliveryInterface } from "../../../../../ingredients/emaildelivery/types";
+import { createTransport } from "nodemailer";
+import OverrideableBuilder from "supertokens-js-override";
+import { getServiceImplementation } from "./serviceImplementation";
+import EmailVerificationSMTPService from "../../../../emailverification/emaildelivery/services/smtp";
+import PasswordlessSMTPService from "../../../../passwordless/emaildelivery/services/smtp";
+import getEmailVerificationServiceImplementation from "./serviceImplementation/emailVerificationServiceImplementation";
+import getPasswordlessServiceImplementation from "./serviceImplementation/passwordlessServiceImplementation";
+
+export default class SMTPService implements EmailDeliveryInterface<TypeThirdPartyPasswordlessEmailDeliveryInput> {
+    serviceImpl: ServiceInterface<TypeThirdPartyPasswordlessEmailDeliveryInput>;
+    private config: TypeInput<TypeThirdPartyPasswordlessEmailDeliveryInput>;
+    private emailVerificationSMTPService: EmailVerificationSMTPService;
+    private passwordlessSMTPService: PasswordlessSMTPService;
+
+    constructor(config: TypeInput<TypeThirdPartyPasswordlessEmailDeliveryInput>) {
+        this.config = config;
+        const transporter = createTransport({
+            host: config.smtpSettings.host,
+            port: config.smtpSettings.port,
+            auth: config.smtpSettings.auth,
+            secure: config.smtpSettings.secure,
+        });
+        let builder = new OverrideableBuilder(getServiceImplementation(transporter));
+        if (config.override !== undefined) {
+            builder = builder.override(config.override);
+        }
+        this.serviceImpl = builder.build();
+
+        this.emailVerificationSMTPService = new EmailVerificationSMTPService({
+            smtpSettings: this.config.smtpSettings,
+            override: (_) => {
+                return getEmailVerificationServiceImplementation(this.serviceImpl);
+            },
+        });
+
+        this.passwordlessSMTPService = new PasswordlessSMTPService({
+            smtpSettings: this.config.smtpSettings,
+            override: (_) => {
+                return getPasswordlessServiceImplementation(this.serviceImpl);
+            },
+        });
+    }
+
+    sendEmail = async (input: TypeThirdPartyPasswordlessEmailDeliveryInput & { userContext: any }) => {
+        if (input.type === "EMAIL_VERIFICATION") {
+            return await this.emailVerificationSMTPService.sendEmail(input);
+        }
+        return await this.passwordlessSMTPService.sendEmail(input);
+    };
+}

--- a/lib/ts/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/emailVerificationServiceImplementation.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/emailVerificationServiceImplementation.ts
@@ -22,16 +22,16 @@ import {
 import { TypeEmailVerificationEmailDeliveryInput } from "../../../../../emailverification/types";
 
 export default function getServiceInterface(
-    emailPasswordServiceImplementation: ServiceInterface<TypeThirdPartyPasswordlessEmailDeliveryInput>
+    thirdpartyPasswordlessServiceImplementation: ServiceInterface<TypeThirdPartyPasswordlessEmailDeliveryInput>
 ): ServiceInterface<TypeEmailVerificationEmailDeliveryInput> {
     return {
         sendRawEmail: async function (input: TypeInputSendRawEmail) {
-            return emailPasswordServiceImplementation.sendRawEmail(input);
+            return thirdpartyPasswordlessServiceImplementation.sendRawEmail(input);
         },
         getContent: async function (
             input: TypeEmailVerificationEmailDeliveryInput & { userContext: any }
         ): Promise<GetContentResult> {
-            return await emailPasswordServiceImplementation.getContent(input);
+            return await thirdpartyPasswordlessServiceImplementation.getContent(input);
         },
     };
 }

--- a/lib/ts/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/emailVerificationServiceImplementation.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/emailVerificationServiceImplementation.ts
@@ -1,0 +1,37 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TypeThirdPartyPasswordlessEmailDeliveryInput } from "../../../../types";
+import {
+    ServiceInterface,
+    TypeInputSendRawEmail,
+    GetContentResult,
+} from "../../../../../../ingredients/emaildelivery/services/smtp";
+import { TypeEmailVerificationEmailDeliveryInput } from "../../../../../emailverification/types";
+
+export default function getServiceInterface(
+    emailPasswordServiceImplementation: ServiceInterface<TypeThirdPartyPasswordlessEmailDeliveryInput>
+): ServiceInterface<TypeEmailVerificationEmailDeliveryInput> {
+    return {
+        sendRawEmail: async function (input: TypeInputSendRawEmail) {
+            return emailPasswordServiceImplementation.sendRawEmail(input);
+        },
+        getContent: async function (
+            input: TypeEmailVerificationEmailDeliveryInput & { userContext: any }
+        ): Promise<GetContentResult> {
+            return await emailPasswordServiceImplementation.getContent(input);
+        },
+    };
+}

--- a/lib/ts/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/index.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/index.ts
@@ -1,0 +1,51 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TypeThirdPartyPasswordlessEmailDeliveryInput } from "../../../../types";
+import { Transporter } from "nodemailer";
+import {
+    ServiceInterface,
+    TypeInputSendRawEmail,
+    GetContentResult,
+} from "../../../../../../ingredients/emaildelivery/services/smtp";
+import { getServiceImplementation as getEmailVerificationServiceImplementation } from "../../../../../emailverification/emaildelivery/services/smtp/serviceImplementation";
+import { getServiceImplementation as getPasswordlessServiceImplementation } from "../../../../../passwordless/emaildelivery/services/smtp/serviceImplementation";
+import DerivedEV from "./emailVerificationServiceImplementation";
+import DerivedPwdless from "./passwordlessServiceImplementation";
+
+export function getServiceImplementation(
+    transporter: Transporter
+): ServiceInterface<TypeThirdPartyPasswordlessEmailDeliveryInput> {
+    let emailVerificationSeriveImpl = getEmailVerificationServiceImplementation(transporter);
+    let passwordlessSeriveImpl = getPasswordlessServiceImplementation(transporter);
+    return {
+        sendRawEmail: async function (input: TypeInputSendRawEmail) {
+            await transporter.sendMail({
+                from: `${input.from.name} <${input.from.email}>`,
+                to: input.toEmail,
+                subject: input.subject,
+                html: input.body,
+            });
+        },
+        getContent: async function (
+            input: TypeThirdPartyPasswordlessEmailDeliveryInput & { userContext: any }
+        ): Promise<GetContentResult> {
+            if (input.type === "EMAIL_VERIFICATION") {
+                return await emailVerificationSeriveImpl.getContent.bind(DerivedEV(this))(input);
+            }
+            return await passwordlessSeriveImpl.getContent.bind(DerivedPwdless(this))(input);
+        },
+    };
+}

--- a/lib/ts/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/passwordlessServiceImplementation.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/passwordlessServiceImplementation.ts
@@ -22,16 +22,16 @@ import {
 import { TypePasswordlessEmailDeliveryInput } from "../../../../../passwordless/types";
 
 export default function getServiceInterface(
-    passwordlessServiceImplementation: ServiceInterface<TypeThirdPartyPasswordlessEmailDeliveryInput>
+    thirdpartyPasswordlessServiceImplementation: ServiceInterface<TypeThirdPartyPasswordlessEmailDeliveryInput>
 ): ServiceInterface<TypePasswordlessEmailDeliveryInput> {
     return {
         sendRawEmail: async function (input: TypeInputSendRawEmail) {
-            return passwordlessServiceImplementation.sendRawEmail(input);
+            return thirdpartyPasswordlessServiceImplementation.sendRawEmail(input);
         },
         getContent: async function (
             input: TypePasswordlessEmailDeliveryInput & { userContext: any }
         ): Promise<GetContentResult> {
-            return await passwordlessServiceImplementation.getContent(input);
+            return await thirdpartyPasswordlessServiceImplementation.getContent(input);
         },
     };
 }

--- a/lib/ts/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/passwordlessServiceImplementation.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/emaildelivery/services/smtp/serviceImplementation/passwordlessServiceImplementation.ts
@@ -1,0 +1,37 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TypeThirdPartyPasswordlessEmailDeliveryInput } from "../../../../types";
+import {
+    ServiceInterface,
+    TypeInputSendRawEmail,
+    GetContentResult,
+} from "../../../../../../ingredients/emaildelivery/services/smtp";
+import { TypePasswordlessEmailDeliveryInput } from "../../../../../passwordless/types";
+
+export default function getServiceInterface(
+    passwordlessServiceImplementation: ServiceInterface<TypeThirdPartyPasswordlessEmailDeliveryInput>
+): ServiceInterface<TypePasswordlessEmailDeliveryInput> {
+    return {
+        sendRawEmail: async function (input: TypeInputSendRawEmail) {
+            return passwordlessServiceImplementation.sendRawEmail(input);
+        },
+        getContent: async function (
+            input: TypePasswordlessEmailDeliveryInput & { userContext: any }
+        ): Promise<GetContentResult> {
+            return await passwordlessServiceImplementation.getContent(input);
+        },
+    };
+}

--- a/lib/ts/recipe/thirdpartypasswordless/recipe.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/recipe.ts
@@ -229,7 +229,7 @@ export default class Recipe extends RecipeModule {
                               emailVerificationInstance: this.emailVerificationRecipe,
                           },
                           {
-                              emailDelivery: undefined,
+                              emailDelivery: this.emailDelivery,
                           }
                       );
         }

--- a/lib/ts/recipe/thirdpartypasswordless/recipe.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/recipe.ts
@@ -20,7 +20,13 @@ import PasswordlessRecipe from "../passwordless/recipe";
 import ThirdPartyRecipe from "../thirdparty/recipe";
 import { BaseRequest, BaseResponse } from "../../framework";
 import STError from "./error";
-import { TypeInput, TypeNormalisedInput, RecipeInterface, APIInterface } from "./types";
+import {
+    TypeInput,
+    TypeNormalisedInput,
+    RecipeInterface,
+    APIInterface,
+    TypeThirdPartyPasswordlessEmailDeliveryInput,
+} from "./types";
 import { validateAndNormaliseUserInput } from "./utils";
 import STErrorPasswordless from "../passwordless/error";
 import STErrorThirdParty from "../thirdparty/error";
@@ -33,6 +39,7 @@ import getPasswordlessIterfaceImpl from "./api/passwordlessAPIImplementation";
 import APIImplementation from "./api/implementation";
 import { Querier } from "../../querier";
 import OverrideableBuilder from "supertokens-js-override";
+import EmailDeliveryIngredient from "../../ingredients/emaildelivery";
 
 export default class Recipe extends RecipeModule {
     private static instance: Recipe | undefined = undefined;
@@ -50,6 +57,10 @@ export default class Recipe extends RecipeModule {
 
     apiImpl: APIInterface;
 
+    emailDelivery: EmailDeliveryIngredient<TypeThirdPartyPasswordlessEmailDeliveryInput>;
+
+    isInServerlessEnv: boolean;
+
     constructor(
         recipeId: string,
         appInfo: NormalisedAppinfo,
@@ -59,9 +70,13 @@ export default class Recipe extends RecipeModule {
             emailVerificationInstance: EmailVerificationRecipe | undefined;
             thirdPartyInstance: ThirdPartyRecipe | undefined;
             passwordlessInstance: PasswordlessRecipe | undefined;
+        },
+        ingredients: {
+            emailDelivery: EmailDeliveryIngredient<TypeThirdPartyPasswordlessEmailDeliveryInput> | undefined;
         }
     ) {
         super(recipeId, appInfo);
+        this.isInServerlessEnv = isInServerlessEnv;
         this.config = validateAndNormaliseUserInput(this, appInfo, config);
 
         {
@@ -80,6 +95,11 @@ export default class Recipe extends RecipeModule {
 
         const recipImplReference = this.recipeInterfaceImpl;
         const emailVerificationConfig = this.config.emailVerificationFeature;
+
+        this.emailDelivery =
+            ingredients.emailDelivery === undefined
+                ? new EmailDeliveryIngredient(this.config.getEmailDeliveryConfig())
+                : ingredients.emailDelivery;
 
         this.emailVerificationRecipe =
             recipes.emailVerificationInstance !== undefined
@@ -143,10 +163,24 @@ export default class Recipe extends RecipeModule {
                           },
                       },
                       {
-                          emailDelivery: undefined,
+                          emailDelivery: this.emailDelivery,
                       }
                   );
 
+        /**
+         * we don't need to pass the emailDelivery config to the
+         * passwordless recipe as we are passing the emailDelivery
+         * object created by this recipe as an ingredient
+         *
+         * if we simply do `...this.config` while calling the PasswordlessRecipe
+         * constructor, it will throw a typescript error as
+         * Type'EmailDeliveryInterface<TypePasswordlessEmailDeliveryInput>' is not assignable
+         * to type 'EmailDeliveryInterface<TypeThirdPartyPasswordlessEmailDeliveryInput>'
+         */
+        let passwordlessConfig = {
+            ...this.config,
+            emailDelivery: undefined,
+        };
         this.passwordlessRecipe =
             recipes.passwordlessInstance !== undefined
                 ? recipes.passwordlessInstance
@@ -155,7 +189,7 @@ export default class Recipe extends RecipeModule {
                       appInfo,
                       isInServerlessEnv,
                       {
-                          ...this.config,
+                          ...passwordlessConfig,
                           override: {
                               functions: (_) => {
                                   return PasswordlessRecipeImplementation(this.recipeInterfaceImpl);
@@ -166,7 +200,7 @@ export default class Recipe extends RecipeModule {
                           },
                       },
                       {
-                          emailDelivery: undefined,
+                          emailDelivery: this.emailDelivery,
                       }
                   );
 
@@ -204,11 +238,20 @@ export default class Recipe extends RecipeModule {
     static init(config: TypeInput): RecipeListFunction {
         return (appInfo, isInServerlessEnv) => {
             if (Recipe.instance === undefined) {
-                Recipe.instance = new Recipe(Recipe.RECIPE_ID, appInfo, isInServerlessEnv, config, {
-                    passwordlessInstance: undefined,
-                    emailVerificationInstance: undefined,
-                    thirdPartyInstance: undefined,
-                });
+                Recipe.instance = new Recipe(
+                    Recipe.RECIPE_ID,
+                    appInfo,
+                    isInServerlessEnv,
+                    config,
+                    {
+                        passwordlessInstance: undefined,
+                        emailVerificationInstance: undefined,
+                        thirdPartyInstance: undefined,
+                    },
+                    {
+                        emailDelivery: undefined,
+                    }
+                );
                 return Recipe.instance;
             } else {
                 throw new Error(

--- a/lib/ts/recipe/thirdpartypasswordless/types.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/types.ts
@@ -12,15 +12,24 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-import { TypeProvider, APIOptions as ThirdPartyAPIOptionsOriginal } from "../thirdparty/types";
+import {
+    TypeProvider,
+    APIOptions as ThirdPartyAPIOptionsOriginal,
+    TypeThirdPartyEmailDeliveryInput,
+} from "../thirdparty/types";
 import { TypeInput as TypeInputEmailVerification } from "../emailverification/types";
 import {
     RecipeInterface as EmailVerificationRecipeInterface,
     APIInterface as EmailVerificationAPIInterface,
 } from "../emailverification";
-import { DeviceType as DeviceTypeOriginal, APIOptions as PasswordlessAPIOptionsOriginal } from "../passwordless/types";
+import {
+    DeviceType as DeviceTypeOriginal,
+    APIOptions as PasswordlessAPIOptionsOriginal,
+    TypePasswordlessEmailDeliveryInput,
+} from "../passwordless/types";
 import OverrideableBuilder from "supertokens-js-override";
 import { SessionContainerInterface } from "../session/types";
+import { TypeInput as EmailDeliveryTypeInput } from "../../ingredients/emaildelivery/types";
 
 export type DeviceType = DeviceTypeOriginal;
 
@@ -45,6 +54,9 @@ export type User = (
 
 export type TypeInputEmailVerificationFeature = {
     getEmailVerificationURL?: (user: User, userContext: any) => Promise<string>;
+    /**
+     * @deprecated Please use emailDelivery config instead
+     */
     createAndSendCustomEmail?: (user: User, emailVerificationURLWithToken: string, userContext: any) => Promise<void>;
 };
 
@@ -74,6 +86,9 @@ export type TypeInput = (
           validateEmailAddress?: (email: string) => Promise<string | undefined> | string | undefined;
 
           // Override to use custom template/contact method
+          /**
+           * @deprecated Please use emailDelivery config instead
+           */
           createAndSendCustomEmail: (
               input: {
                   // Where the message should be delivered.
@@ -94,6 +109,9 @@ export type TypeInput = (
           validateEmailAddress?: (email: string) => Promise<string | undefined> | string | undefined;
 
           // Override to use custom template/contact method
+          /**
+           * @deprecated Please use emailDelivery config instead
+           */
           createAndSendCustomEmail: (
               input: {
                   // Where the message should be delivered.
@@ -127,6 +145,11 @@ export type TypeInput = (
           ) => Promise<void>;
       }
 ) & {
+    /**
+     * Unlike passwordless recipe, emailDelivery config is outside here because regardless
+     * of `contactMethod` value, the config is required for email verification recipe
+     */
+    emailDelivery?: EmailDeliveryTypeInput<TypeThirdPartyPasswordlessEmailDeliveryInput>;
     providers?: TypeProvider[];
     emailVerificationFeature?: TypeInputEmailVerificationFeature;
     flowType: "USER_INPUT_CODE" | "MAGIC_LINK" | "USER_INPUT_CODE_AND_MAGIC_LINK";
@@ -264,6 +287,7 @@ export type TypeNormalisedInput = (
     getCustomUserInputCode?: (userContext: any) => Promise<string> | string;
     providers: TypeProvider[];
     emailVerificationFeature: TypeInputEmailVerification;
+    getEmailDeliveryConfig: () => EmailDeliveryTypeInput<TypeThirdPartyPasswordlessEmailDeliveryInput>;
     override: {
         functions: (
             originalImplementation: RecipeInterface,
@@ -546,3 +570,7 @@ export type APIInterface = {
               exists: boolean;
           }>);
 };
+
+export type TypeThirdPartyPasswordlessEmailDeliveryInput =
+    | TypeThirdPartyEmailDeliveryInput
+    | TypePasswordlessEmailDeliveryInput;


### PR DESCRIPTION
## Summary of change

- refactored emailDelivery config for thirdpartypasswordless recipe
- added SMTP class for thirdpartypasswordless recipe
- refactored how email delivery config is return after normalisation. Only did the change so far for thirdpartypasswordless recipe. Reference comment: https://github.com/supertokens/supertokens-node/pull/274#discussion_r830789606

## Related PR

-  #274 