### PR TITLE
feat!: Recipe functions to call each other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+-   Email verification recipe change:
+    -   `createEmailVerificationToken` calls `isEmailVerified` to exist early
+-   Emailpassword recipe:
+    -   `signUp` calls `getUserByEmail`
+    -   `signIn` calls `getUserByEmail`
+    -   `createResetPasswordToken` calls `getUserById`
+    -   `updateEmailOrPassword` calls `getUserById` and `getUserByEmail`
+
 ## [9.2.0] - 2022-04-18
 
 # Adds

--- a/lib/build/recipe/emailpassword/recipeImplementation.js
+++ b/lib/build/recipe/emailpassword/recipeImplementation.js
@@ -34,8 +34,18 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const normalisedURLPath_1 = require("../../normalisedURLPath");
 function getRecipeInterface(querier) {
     return {
-        signUp: function ({ email, password }) {
+        signUp: function ({ email, password, userContext }) {
             return __awaiter(this, void 0, void 0, function* () {
+                if (
+                    (yield this.getUserByEmail({
+                        email,
+                        userContext,
+                    })) !== undefined
+                ) {
+                    return {
+                        status: "EMAIL_ALREADY_EXISTS_ERROR",
+                    };
+                }
                 let response = yield querier.sendPostRequest(new normalisedURLPath_1.default("/recipe/signup"), {
                     email,
                     password,
@@ -49,8 +59,18 @@ function getRecipeInterface(querier) {
                 }
             });
         },
-        signIn: function ({ email, password }) {
+        signIn: function ({ email, password, userContext }) {
             return __awaiter(this, void 0, void 0, function* () {
+                if (
+                    (yield this.getUserByEmail({
+                        email,
+                        userContext,
+                    })) === undefined
+                ) {
+                    return {
+                        status: "WRONG_CREDENTIALS_ERROR",
+                    };
+                }
                 let response = yield querier.sendPostRequest(new normalisedURLPath_1.default("/recipe/signin"), {
                     email,
                     password,
@@ -88,8 +108,13 @@ function getRecipeInterface(querier) {
                 }
             });
         },
-        createResetPasswordToken: function ({ userId }) {
+        createResetPasswordToken: function ({ userId, userContext }) {
             return __awaiter(this, void 0, void 0, function* () {
+                if ((yield this.getUserById({ userId, userContext })) === undefined) {
+                    return {
+                        status: "UNKNOWN_USER_ID_ERROR",
+                    };
+                }
                 let response = yield querier.sendPostRequest(
                     new normalisedURLPath_1.default("/recipe/user/password/reset/token"),
                     {
@@ -123,6 +148,23 @@ function getRecipeInterface(querier) {
         },
         updateEmailOrPassword: function (input) {
             return __awaiter(this, void 0, void 0, function* () {
+                let user = yield this.getUserById({ userId: input.userId, userContext: input.userContext });
+                if (user === undefined) {
+                    return {
+                        status: "UNKNOWN_USER_ID_ERROR",
+                    };
+                }
+                if (input.email !== undefined) {
+                    let userBasedOnEmail = yield this.getUserByEmail({
+                        email: input.email,
+                        userContext: input.userContext,
+                    });
+                    if (userBasedOnEmail !== undefined && userBasedOnEmail.id !== input.userId) {
+                        return {
+                            status: "EMAIL_ALREADY_EXISTS_ERROR",
+                        };
+                    }
+                }
                 let response = yield querier.sendPutRequest(new normalisedURLPath_1.default("/recipe/user"), {
                     userId: input.userId,
                     email: input.email,

--- a/lib/build/recipe/emailpassword/recipeImplementation.js
+++ b/lib/build/recipe/emailpassword/recipeImplementation.js
@@ -148,6 +148,7 @@ function getRecipeInterface(querier) {
         },
         updateEmailOrPassword: function (input) {
             return __awaiter(this, void 0, void 0, function* () {
+                // TODO: need to solve issue of user ID mapping in general, but especially for this function because we are comparing the input userId with the output userId of another recipe function below
                 let user = yield this.getUserById({ userId: input.userId, userContext: input.userContext });
                 if (user === undefined) {
                     return {

--- a/lib/build/recipe/emailverification/recipeImplementation.js
+++ b/lib/build/recipe/emailverification/recipeImplementation.js
@@ -34,8 +34,19 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const normalisedURLPath_1 = require("../../normalisedURLPath");
 function getRecipeInterface(querier) {
     return {
-        createEmailVerificationToken: function ({ userId, email }) {
+        createEmailVerificationToken: function ({ userId, email, userContext }) {
             return __awaiter(this, void 0, void 0, function* () {
+                if (
+                    yield this.isEmailVerified({
+                        userId,
+                        email,
+                        userContext,
+                    })
+                ) {
+                    return {
+                        status: "EMAIL_ALREADY_VERIFIED_ERROR",
+                    };
+                }
                 let response = yield querier.sendPostRequest(
                     new normalisedURLPath_1.default("/recipe/user/email/verify/token"),
                     {

--- a/lib/ts/recipe/emailpassword/recipeImplementation.ts
+++ b/lib/ts/recipe/emailpassword/recipeImplementation.ts
@@ -166,6 +166,7 @@ export default function getRecipeInterface(querier: Querier): RecipeInterface {
                 userContext: any;
             }
         ): Promise<{ status: "OK" | "UNKNOWN_USER_ID_ERROR" | "EMAIL_ALREADY_EXISTS_ERROR" }> {
+            // TODO: need to solve issue of user ID mapping in general, but especially for this function because we are comparing the input userId with the output userId of another recipe function below
             let user = await this.getUserById({ userId: input.userId, userContext: input.userContext });
             if (user === undefined) {
                 return {

--- a/lib/ts/recipe/emailverification/recipeImplementation.ts
+++ b/lib/ts/recipe/emailverification/recipeImplementation.ts
@@ -4,19 +4,36 @@ import NormalisedURLPath from "../../normalisedURLPath";
 
 export default function getRecipeInterface(querier: Querier): RecipeInterface {
     return {
-        createEmailVerificationToken: async function ({
-            userId,
-            email,
-        }: {
-            userId: string;
-            email: string;
-        }): Promise<
+        createEmailVerificationToken: async function (
+            this: RecipeInterface,
+            {
+                userId,
+                email,
+                userContext,
+            }: {
+                userId: string;
+                email: string;
+                userContext: any;
+            }
+        ): Promise<
             | {
                   status: "OK";
                   token: string;
               }
             | { status: "EMAIL_ALREADY_VERIFIED_ERROR" }
         > {
+            if (
+                await this.isEmailVerified({
+                    userId,
+                    email,
+                    userContext,
+                })
+            ) {
+                return {
+                    status: "EMAIL_ALREADY_VERIFIED_ERROR",
+                };
+            }
+
             let response = await querier.sendPostRequest(new NormalisedURLPath("/recipe/user/email/verify/token"), {
                 userId,
                 email,


### PR DESCRIPTION
## Summary of change

We make recipe functions call each other based on the output values of the function. This is done to make the functions logic more consistent with user's overrides.

For example, if the user overrides the getUserByEmail function in the emailpassword recipe, to return true in case the email exists from another recipe (to prevent sign up of the same email), the signUp function for emailpassword will still accept this email. So if the signUp function also calls the getUserByEmail function, then it's consistent.

However, this causes an issue where you want to force signUp even though getUserByEmail might return a user (for example during migration), in this case. the user has to be careful to pass a flag in the user context so that in their getUserByEmail function, they only check the old provider in case the flag is missing.

## Related issues

-  https://github.com/supertokens/supertokens-node/issues/149

## Test Plan
TODO

## Documentation changes

- example app changes for all of them that do override? Especially account linking

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## TODO:
- [ ] Need for user ID mapping? When `updateEmailOrPassword` calls `getUserByEmail`, if the userID passed to `updateEmailOrPassword` is ST's user ID, but the user ID returned from `getUserByEmail` is non-ST userId, it will break the logic.