### PR TITLE
fix: assertThatBodyParserHasBeenUsedForExpressLikeRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [9.2.2] - 2022-05-24
+
+### Fixes:
+
+-   Calling the setImmediate function inside assertThatBodyParserHasBeenUsedForExpressLikeRequest only if the function is getting executed in NextJS env
+
 ## [9.2.1] - 2022-05-19
 
 ### Fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes:
 
--   Calling the setImmediate function inside assertThatBodyParserHasBeenUsedForExpressLikeRequest only if the function is getting executed in NextJS env
+-   Calling the setImmediate function inside assertThatBodyParserHasBeenUsedForExpressLikeRequest only if the function is getting executed in NextJS env. Fixes #313
 
 ## [9.2.1] - 2022-05-19
 

--- a/lib/build/framework/utils.d.ts
+++ b/lib/build/framework/utils.d.ts
@@ -11,7 +11,9 @@ export declare function getHeaderValueFromIncomingMessage(request: IncomingMessa
 export declare function normalizeHeaderValue(value: string | string[] | undefined): string | undefined;
 export declare function assertThatBodyParserHasBeenUsedForExpressLikeRequest(
     method: HTTPMethod,
-    request: Request | NextApiRequest
+    request: (Request | NextApiRequest) & {
+        fromNextJS?: true;
+    }
 ): Promise<void>;
 export declare function assertForDataBodyParserHasBeenUsedForExpressLikeRequest(
     request: Request | NextApiRequest

--- a/lib/build/framework/utils.d.ts
+++ b/lib/build/framework/utils.d.ts
@@ -12,7 +12,7 @@ export declare function normalizeHeaderValue(value: string | string[] | undefine
 export declare function assertThatBodyParserHasBeenUsedForExpressLikeRequest(
     method: HTTPMethod,
     request: (Request | NextApiRequest) & {
-        fromNextJS?: true;
+        __supertokensFromNextJS?: true;
     }
 ): Promise<void>;
 export declare function assertForDataBodyParserHasBeenUsedForExpressLikeRequest(

--- a/lib/build/framework/utils.js
+++ b/lib/build/framework/utils.js
@@ -148,7 +148,7 @@ function assertThatBodyParserHasBeenUsedForExpressLikeRequest(method, request) {
                 let jsonParser = body_parser_1.json();
                 let err = yield new Promise((resolve) => {
                     let resolvedCalled = false;
-                    if (request.fromNextJS === true) {
+                    if (request.__supertokensFromNextJS === true) {
                         /**
                          * the setImmediate here is to counter the next.js issue
                          * where the json parser would not resolve and thus the request

--- a/lib/build/framework/utils.js
+++ b/lib/build/framework/utils.js
@@ -148,6 +148,10 @@ function assertThatBodyParserHasBeenUsedForExpressLikeRequest(method, request) {
                 let jsonParser = body_parser_1.json();
                 let err = yield new Promise((resolve) => {
                     let resolvedCalled = false;
+                    /**
+                     * Nextjs allow users to disable the default parser.
+                     * To handle that scenario, we are still parsing the request body
+                     */
                     if (request.__supertokensFromNextJS === true) {
                         /**
                          * the setImmediate here is to counter the next.js issue

--- a/lib/build/framework/utils.js
+++ b/lib/build/framework/utils.js
@@ -148,17 +148,19 @@ function assertThatBodyParserHasBeenUsedForExpressLikeRequest(method, request) {
                 let jsonParser = body_parser_1.json();
                 let err = yield new Promise((resolve) => {
                     let resolvedCalled = false;
-                    /**
-                     * the setImmediate here is to counter the next.js issue
-                     * where the json parser would not resolve and thus the request
-                     * just hangs forever. Next.JS does json parsing on its own.
-                     */
-                    setImmediate(() => {
-                        if (!resolvedCalled) {
-                            resolvedCalled = true;
-                            resolve(undefined);
-                        }
-                    });
+                    if (request.fromNextJS === true) {
+                        /**
+                         * the setImmediate here is to counter the next.js issue
+                         * where the json parser would not resolve and thus the request
+                         * just hangs forever. Next.JS does json parsing on its own.
+                         */
+                        setImmediate(() => {
+                            if (!resolvedCalled) {
+                                resolvedCalled = true;
+                                resolve(undefined);
+                            }
+                        });
+                    }
                     jsonParser(request, new http_1.ServerResponse(request), (e) => {
                         if (!resolvedCalled) {
                             resolvedCalled = true;

--- a/lib/build/nextjs.js
+++ b/lib/build/nextjs.js
@@ -66,7 +66,7 @@ class NextJS {
         return __awaiter(this, void 0, void 0, function* () {
             return new Promise((resolve, reject) =>
                 __awaiter(this, void 0, void 0, function* () {
-                    request.fromNextJS = true;
+                    request.__supertokensFromNextJS = true;
                     try {
                         let callbackCalled = false;
                         const result = yield middleware((err) => {

--- a/lib/build/nextjs.js
+++ b/lib/build/nextjs.js
@@ -66,6 +66,7 @@ class NextJS {
         return __awaiter(this, void 0, void 0, function* () {
             return new Promise((resolve, reject) =>
                 __awaiter(this, void 0, void 0, function* () {
+                    request.fromNextJS = true;
                     try {
                         let callbackCalled = false;
                         const result = yield middleware((err) => {

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-export declare const version = "9.2.1";
+export declare const version = "9.2.2";
 export declare const cdiSupported: string[];

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -14,5 +14,5 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "9.2.1";
+exports.version = "9.2.2";
 exports.cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13"];

--- a/lib/ts/framework/utils.ts
+++ b/lib/ts/framework/utils.ts
@@ -110,7 +110,7 @@ function JSONCookies(obj: any) {
 
 export async function assertThatBodyParserHasBeenUsedForExpressLikeRequest(
     method: HTTPMethod,
-    request: (Request | NextApiRequest) & { fromNextJS?: true }
+    request: (Request | NextApiRequest) & { __supertokensFromNextJS?: true }
 ) {
     // according to https://github.com/supertokens/supertokens-node/issues/33
     if (method === "post" || method === "put") {
@@ -136,7 +136,7 @@ export async function assertThatBodyParserHasBeenUsedForExpressLikeRequest(
             let jsonParser = json();
             let err = await new Promise((resolve) => {
                 let resolvedCalled = false;
-                if (request.fromNextJS === true) {
+                if (request.__supertokensFromNextJS === true) {
                     /**
                      * the setImmediate here is to counter the next.js issue
                      * where the json parser would not resolve and thus the request

--- a/lib/ts/framework/utils.ts
+++ b/lib/ts/framework/utils.ts
@@ -136,6 +136,10 @@ export async function assertThatBodyParserHasBeenUsedForExpressLikeRequest(
             let jsonParser = json();
             let err = await new Promise((resolve) => {
                 let resolvedCalled = false;
+                /**
+                 * Nextjs allow users to disable the default parser.
+                 * To handle that scenario, we are still parsing the request body
+                 */
                 if (request.__supertokensFromNextJS === true) {
                     /**
                      * the setImmediate here is to counter the next.js issue

--- a/lib/ts/nextjs.ts
+++ b/lib/ts/nextjs.ts
@@ -39,6 +39,7 @@ export default class NextJS {
         response: any
     ): Promise<T> {
         return new Promise<T>(async (resolve: any, reject: any) => {
+            request.fromNextJS = true;
             try {
                 let callbackCalled = false;
                 const result = await middleware((err) => {

--- a/lib/ts/nextjs.ts
+++ b/lib/ts/nextjs.ts
@@ -39,7 +39,7 @@ export default class NextJS {
         response: any
     ): Promise<T> {
         return new Promise<T>(async (resolve: any, reject: any) => {
-            request.fromNextJS = true;
+            request.__supertokensFromNextJS = true;
             try {
                 let callbackCalled = false;
                 const result = await middleware((err) => {

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,6 +12,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "9.2.1";
+export const version = "9.2.2";
 
 export const cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "9.2.1",
+    "version": "9.2.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "9.2.1",
+    "version": "9.2.2",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

- added `fromNextJS` property for next js request

## Related issues

-   #313

### Test

- [x] disable nextjs parser and verify that the json parser deosn't get stuck and also parses the request body correctly
- [x] disable nextjs praser, modify the code to disable json parser. Call a POST API with correct request body and the request should fail
- [x] send empty json as request body and the request should not get stuck during the json parsing part
- [x] send no request body and the request should not get stuck during the json parsing part
- [x] send correct request body and the API should yield correct response