### PR TITLE
refactor: email and sms delviery test changes

### DIFF
--- a/test/emailpassword/emailDelivery.test.js
+++ b/test/emailpassword/emailDelivery.test.js
@@ -32,6 +32,7 @@ describe(`emailDelivery: ${printPath("[test/emailpassword/emailDelivery.test.js]
     });
 
     after(async function () {
+        process.env.TEST_MODE = "testing";
         await killAllST();
         await cleanST();
     });

--- a/test/passwordless/emailDelivery.test.js
+++ b/test/passwordless/emailDelivery.test.js
@@ -23,6 +23,7 @@ let nock = require("nock");
 let supertest = require("supertest");
 const { middleware, errorHandler } = require("../../framework/express");
 let express = require("express");
+let { isCDIVersionCompatible } = require("../utils");
 
 describe(`emailDelivery: ${printPath("[test/passwordless/emailDelivery.test.js]")}`, function () {
     beforeEach(async function () {
@@ -32,6 +33,7 @@ describe(`emailDelivery: ${printPath("[test/passwordless/emailDelivery.test.js]"
     });
 
     after(async function () {
+        process.env.TEST_MODE = "testing";
         await killAllST();
         await cleanST();
     });
@@ -56,6 +58,11 @@ describe(`emailDelivery: ${printPath("[test/passwordless/emailDelivery.test.js]"
             ],
             telemetry: false,
         });
+
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
 
         const app = express();
         app.use(express.json());
@@ -130,6 +137,11 @@ describe(`emailDelivery: ${printPath("[test/passwordless/emailDelivery.test.js]"
             telemetry: false,
         });
 
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
+
         const app = express();
         app.use(express.json());
         app.use(middleware());
@@ -190,6 +202,11 @@ describe(`emailDelivery: ${printPath("[test/passwordless/emailDelivery.test.js]"
             ],
             telemetry: false,
         });
+
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
 
         const app = express();
         app.use(express.json());
@@ -297,6 +314,11 @@ describe(`emailDelivery: ${printPath("[test/passwordless/emailDelivery.test.js]"
             telemetry: false,
         });
 
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
+
         const app = express();
         app.use(express.json());
         app.use(middleware());
@@ -339,6 +361,11 @@ describe(`emailDelivery: ${printPath("[test/passwordless/emailDelivery.test.js]"
             ],
             telemetry: false,
         });
+
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
 
         const app = express();
         app.use(express.json());

--- a/test/passwordless/smsDelivery.test.js
+++ b/test/passwordless/smsDelivery.test.js
@@ -23,6 +23,7 @@ let nock = require("nock");
 let supertest = require("supertest");
 const { middleware, errorHandler } = require("../../framework/express");
 let express = require("express");
+let { isCDIVersionCompatible } = require("../utils");
 
 describe(`smsDelivery: ${printPath("[test/passwordless/smsDelivery.test.js]")}`, function () {
     beforeEach(async function () {
@@ -32,6 +33,7 @@ describe(`smsDelivery: ${printPath("[test/passwordless/smsDelivery.test.js]")}`,
     });
 
     after(async function () {
+        process.env.TEST_MODE = "testing";
         await killAllST();
         await cleanST();
     });
@@ -56,6 +58,11 @@ describe(`smsDelivery: ${printPath("[test/passwordless/smsDelivery.test.js]")}`,
             ],
             telemetry: false,
         });
+
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
 
         const app = express();
         app.use(express.json());
@@ -133,6 +140,11 @@ describe(`smsDelivery: ${printPath("[test/passwordless/smsDelivery.test.js]")}`,
             telemetry: false,
         });
 
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
+
         const app = express();
         app.use(express.json());
         app.use(middleware());
@@ -193,6 +205,11 @@ describe(`smsDelivery: ${printPath("[test/passwordless/smsDelivery.test.js]")}`,
             ],
             telemetry: false,
         });
+
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
 
         const app = express();
         app.use(express.json());
@@ -295,6 +312,11 @@ describe(`smsDelivery: ${printPath("[test/passwordless/smsDelivery.test.js]")}`,
             telemetry: false,
         });
 
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
+
         const app = express();
         app.use(express.json());
         app.use(middleware());
@@ -345,6 +367,11 @@ describe(`smsDelivery: ${printPath("[test/passwordless/smsDelivery.test.js]")}`,
             ],
             telemetry: false,
         });
+
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
 
         const app = express();
         app.use(express.json());
@@ -430,6 +457,11 @@ describe(`smsDelivery: ${printPath("[test/passwordless/smsDelivery.test.js]")}`,
             telemetry: false,
         });
 
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
+
         const app = express();
         app.use(express.json());
         app.use(middleware());
@@ -486,6 +518,11 @@ describe(`smsDelivery: ${printPath("[test/passwordless/smsDelivery.test.js]")}`,
             ],
             telemetry: false,
         });
+
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
 
         const app = express();
         app.use(express.json());

--- a/test/thirdparty/emailDelivery.test.js
+++ b/test/thirdparty/emailDelivery.test.js
@@ -60,6 +60,7 @@ describe(`emailDelivery: ${printPath("[test/thirdparty/emailDelivery.test.js]")}
     });
 
     after(async function () {
+        process.env.TEST_MODE = "testing";
         await killAllST();
         await cleanST();
     });

--- a/test/thirdpartyemailpassword/emailDelivery.test.js
+++ b/test/thirdpartyemailpassword/emailDelivery.test.js
@@ -32,6 +32,7 @@ describe(`emailDelivery: ${printPath("[test/thirdpartyemailpassword/emailDeliver
     });
 
     after(async function () {
+        process.env.TEST_MODE = "testing";
         await killAllST();
         await cleanST();
     });

--- a/test/thirdpartypasswordless/emailDelivery.test.js
+++ b/test/thirdpartypasswordless/emailDelivery.test.js
@@ -60,6 +60,7 @@ describe(`emailDelivery: ${printPath("[test/thirdpartypasswordless/emailDelivery
     });
 
     after(async function () {
+        process.env.TEST_MODE = "testing";
         await killAllST();
         await cleanST();
     });

--- a/test/thirdpartypasswordless/emailDelivery.test.js
+++ b/test/thirdpartypasswordless/emailDelivery.test.js
@@ -23,6 +23,7 @@ let nock = require("nock");
 let supertest = require("supertest");
 const { middleware, errorHandler } = require("../../framework/express");
 let express = require("express");
+let { isCDIVersionCompatible } = require("../utils");
 
 describe(`emailDelivery: ${printPath("[test/thirdpartypasswordless/emailDelivery.test.js]")}`, function () {
     before(function () {
@@ -86,6 +87,11 @@ describe(`emailDelivery: ${printPath("[test/thirdpartypasswordless/emailDelivery
             ],
             telemetry: false,
         });
+
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
 
         const app = express();
         app.use(express.json());
@@ -151,6 +157,11 @@ describe(`emailDelivery: ${printPath("[test/thirdpartypasswordless/emailDelivery
             ],
             telemetry: false,
         });
+
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
 
         const app = express();
         app.use(express.json());
@@ -230,6 +241,11 @@ describe(`emailDelivery: ${printPath("[test/thirdpartypasswordless/emailDelivery
             telemetry: false,
         });
 
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
+
         const app = express();
         app.use(express.json());
         app.use(middleware());
@@ -289,6 +305,11 @@ describe(`emailDelivery: ${printPath("[test/thirdpartypasswordless/emailDelivery
             ],
             telemetry: false,
         });
+
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
 
         const app = express();
         app.use(express.json());
@@ -352,6 +373,11 @@ describe(`emailDelivery: ${printPath("[test/thirdpartypasswordless/emailDelivery
             ],
             telemetry: false,
         });
+
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
 
         const app = express();
         app.use(express.json());
@@ -462,6 +488,11 @@ describe(`emailDelivery: ${printPath("[test/thirdpartypasswordless/emailDelivery
             telemetry: false,
         });
 
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
+
         const app = express();
         app.use(express.json());
         app.use(middleware());
@@ -511,6 +542,11 @@ describe(`emailDelivery: ${printPath("[test/thirdpartypasswordless/emailDelivery
             ],
             telemetry: false,
         });
+
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
 
         const app = express();
         app.use(express.json());
@@ -585,6 +621,11 @@ describe(`emailDelivery: ${printPath("[test/thirdpartypasswordless/emailDelivery
             telemetry: false,
         });
 
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
+
         const app = express();
         app.use(express.json());
         app.use(middleware());
@@ -645,6 +686,11 @@ describe(`emailDelivery: ${printPath("[test/thirdpartypasswordless/emailDelivery
             ],
             telemetry: false,
         });
+
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
 
         const app = express();
         app.use(express.json());
@@ -753,6 +799,11 @@ describe(`emailDelivery: ${printPath("[test/thirdpartypasswordless/emailDelivery
             telemetry: false,
         });
 
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
+
         const app = express();
         app.use(express.json());
         app.use(middleware());
@@ -795,6 +846,11 @@ describe(`emailDelivery: ${printPath("[test/thirdpartypasswordless/emailDelivery
             ],
             telemetry: false,
         });
+
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
 
         const app = express();
         app.use(express.json());

--- a/test/thirdpartypasswordless/smsDelivery.test.js
+++ b/test/thirdpartypasswordless/smsDelivery.test.js
@@ -32,6 +32,7 @@ describe(`smsDelivery: ${printPath("[test/thirdpartypasswordless/smsDelivery.tes
     });
 
     after(async function () {
+        process.env.TEST_MODE = "testing";
         await killAllST();
         await cleanST();
     });

--- a/test/thirdpartypasswordless/smsDelivery.test.js
+++ b/test/thirdpartypasswordless/smsDelivery.test.js
@@ -23,6 +23,7 @@ let nock = require("nock");
 let supertest = require("supertest");
 const { middleware, errorHandler } = require("../../framework/express");
 let express = require("express");
+let { isCDIVersionCompatible } = require("../utils");
 
 describe(`smsDelivery: ${printPath("[test/thirdpartypasswordless/smsDelivery.test.js]")}`, function () {
     beforeEach(async function () {
@@ -57,6 +58,11 @@ describe(`smsDelivery: ${printPath("[test/thirdpartypasswordless/smsDelivery.tes
             ],
             telemetry: false,
         });
+
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
 
         const app = express();
         app.use(express.json());
@@ -134,6 +140,11 @@ describe(`smsDelivery: ${printPath("[test/thirdpartypasswordless/smsDelivery.tes
             telemetry: false,
         });
 
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
+
         const app = express();
         app.use(express.json());
         app.use(middleware());
@@ -194,6 +205,11 @@ describe(`smsDelivery: ${printPath("[test/thirdpartypasswordless/smsDelivery.tes
             ],
             telemetry: false,
         });
+
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
 
         const app = express();
         app.use(express.json());
@@ -296,6 +312,11 @@ describe(`smsDelivery: ${printPath("[test/thirdpartypasswordless/smsDelivery.tes
             telemetry: false,
         });
 
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
+
         const app = express();
         app.use(express.json());
         app.use(middleware());
@@ -346,6 +367,11 @@ describe(`smsDelivery: ${printPath("[test/thirdpartypasswordless/smsDelivery.tes
             ],
             telemetry: false,
         });
+
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
 
         const app = express();
         app.use(express.json());
@@ -431,6 +457,11 @@ describe(`smsDelivery: ${printPath("[test/thirdpartypasswordless/smsDelivery.tes
             telemetry: false,
         });
 
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
+
         const app = express();
         app.use(express.json());
         app.use(middleware());
@@ -487,6 +518,11 @@ describe(`smsDelivery: ${printPath("[test/thirdpartypasswordless/smsDelivery.tes
             ],
             telemetry: false,
         });
+
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
 
         const app = express();
         app.use(express.json());


### PR DESCRIPTION
## Summary of change

- added `process.env.TEST_MODE = "testing";` in the after hook for the tests in which the env gets changed to production
- for email delivery and sms delivery tests (passwordless and thirdpartypasswordless recipes), checking if the cdi version is >= 2.11