### PR TITLE
fix: thirdpartypasswordless email verification fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Changes
+
+-   Fixes a few typos
+-   Changes `getEmailForUserIdForEmailVerification` function inside thirdpartypasswordless to take into account passwordless emails and return an empty string in case a passwordless email doesn't exist. This helps situations where the dev wants to customise the email verification functions in the thirdpartypasswordless recipe.
+
 ## [9.3.0] - 2022-06-17
 
 ### Added

--- a/lib/build/recipe/thirdpartypasswordless/recipe.js
+++ b/lib/build/recipe/thirdpartypasswordless/recipe.js
@@ -129,12 +129,20 @@ class Recipe extends recipeModule_1.default {
                 if (userInfo === undefined) {
                     throw new Error("Unknown User ID provided");
                 } else if (!("thirdParty" in userInfo)) {
-                    // this is a passwordless user.. so we always return some random email,
-                    // and in the function for isEmailVerified, we will check if the user
-                    // is a passwordless user, and if they are, we will return true in there
-                    return "_____supertokens_passwordless_user@supertokens.com";
+                    // this is a passwordless user
+                    if (userInfo.email !== undefined) {
+                        return userInfo.email;
+                    } else {
+                        // this is a passwordless user with only a phone number.
+                        // returning an empty string here is not a problem since
+                        // we override the email verification functions above to
+                        // send that the email is already verified for passwordless users.
+                        return "";
+                    }
+                } else {
+                    // third party user
+                    return userInfo.email;
                 }
-                return userInfo.email;
             });
         this.isInServerlessEnv = isInServerlessEnv;
         this.config = utils_1.validateAndNormaliseUserInput(this, appInfo, config);
@@ -151,7 +159,7 @@ class Recipe extends recipeModule_1.default {
             let builder = new supertokens_js_override_1.default(implementation_1.default());
             this.apiImpl = builder.override(this.config.override.apis).build();
         }
-        const recipImplReference = this.recipeInterfaceImpl;
+        const recipeImplReference = this.recipeInterfaceImpl;
         const emailVerificationConfig = this.config.emailVerificationFeature;
         this.emailDelivery =
             ingredients.emailDelivery === undefined
@@ -178,7 +186,7 @@ class Recipe extends recipeModule_1.default {
                                       return Object.assign(Object.assign({}, oI), {
                                           createEmailVerificationToken: function (input) {
                                               return __awaiter(this, void 0, void 0, function* () {
-                                                  let user = yield recipImplReference.getUserById({
+                                                  let user = yield recipeImplReference.getUserById({
                                                       userId: input.userId,
                                                       userContext: input.userContext,
                                                   });
@@ -193,7 +201,7 @@ class Recipe extends recipeModule_1.default {
                                           },
                                           isEmailVerified: function (input) {
                                               return __awaiter(this, void 0, void 0, function* () {
-                                                  let user = yield recipImplReference.getUserById({
+                                                  let user = yield recipeImplReference.getUserById({
                                                       userId: input.userId,
                                                       userContext: input.userContext,
                                                   });


### PR DESCRIPTION
## Summary of change

Changes `getEmailForUserIdForEmailVerification` in thirdpartypasswordless to take into account passwordless user email as well in case the dev wants to customise the thirdpartypasswordless recipe's email verification functions to take into account passwordless users as well.

## Related issues

-   https://discord.com/channels/603466164219281420/987701400433725440/988016274443489300