### PR TITLE
feat: Adds request object to default user context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [10.0.0] - 2022-06-2
 
+### Adds:
+
+-   Adds default userContext for API calls that contains the request object. It can be used in APIs / functions override like so:
+
+```ts
+signIn: async function (input) {
+    if (input.userContext._default && input.userContext._default.request) {
+        // do something here with the request object
+    }
+}
+```
+
 ### Breaking change
 
 -   https://github.com/supertokens/supertokens-node/issues/220

--- a/lib/build/recipe/emailpassword/api/emailExists.js
+++ b/lib/build/recipe/emailpassword/api/emailExists.js
@@ -47,6 +47,7 @@ var __awaiter =
 Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = require("../../../utils");
 const error_1 = require("../error");
+const utils_2 = require("../../../utils");
 function emailExists(apiImplementation, options) {
     return __awaiter(this, void 0, void 0, function* () {
         // Logic as per https://github.com/supertokens/supertokens-node/issues/47#issue-751571692
@@ -60,7 +61,11 @@ function emailExists(apiImplementation, options) {
                 message: "Please provide the email as a GET param",
             });
         }
-        let result = yield apiImplementation.emailExistsGET({ email, options, userContext: {} });
+        let result = yield apiImplementation.emailExistsGET({
+            email,
+            options,
+            userContext: utils_2.makeDefaultUserContextFromAPI(options.req),
+        });
         utils_1.send200Response(options.res, result);
         return true;
     });

--- a/lib/build/recipe/emailpassword/api/generatePasswordResetToken.js
+++ b/lib/build/recipe/emailpassword/api/generatePasswordResetToken.js
@@ -47,6 +47,7 @@ var __awaiter =
 Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = require("../../../utils");
 const utils_2 = require("./utils");
+const utils_3 = require("../../../utils");
 function generatePasswordResetToken(apiImplementation, options) {
     return __awaiter(this, void 0, void 0, function* () {
         // Logic as per https://github.com/supertokens/supertokens-node/issues/22#issuecomment-710512442
@@ -58,7 +59,11 @@ function generatePasswordResetToken(apiImplementation, options) {
             options.config.resetPasswordUsingTokenFeature.formFieldsForGenerateTokenForm,
             (yield options.req.getJSONBody()).formFields
         );
-        let result = yield apiImplementation.generatePasswordResetTokenPOST({ formFields, options, userContext: {} });
+        let result = yield apiImplementation.generatePasswordResetTokenPOST({
+            formFields,
+            options,
+            userContext: utils_3.makeDefaultUserContextFromAPI(options.req),
+        });
         utils_1.send200Response(options.res, result);
         return true;
     });

--- a/lib/build/recipe/emailpassword/api/passwordReset.js
+++ b/lib/build/recipe/emailpassword/api/passwordReset.js
@@ -48,6 +48,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = require("../../../utils");
 const utils_2 = require("./utils");
 const error_1 = require("../error");
+const utils_3 = require("../../../utils");
 function passwordReset(apiImplementation, options) {
     return __awaiter(this, void 0, void 0, function* () {
         // Logic as per https://github.com/supertokens/supertokens-node/issues/22#issuecomment-710512442
@@ -72,7 +73,12 @@ function passwordReset(apiImplementation, options) {
                 message: "The password reset token must be a string",
             });
         }
-        let result = yield apiImplementation.passwordResetPOST({ formFields, token, options, userContext: {} });
+        let result = yield apiImplementation.passwordResetPOST({
+            formFields,
+            token,
+            options,
+            userContext: utils_3.makeDefaultUserContextFromAPI(options.req),
+        });
         utils_1.send200Response(
             options.res,
             result.status === "OK"

--- a/lib/build/recipe/emailpassword/api/signin.js
+++ b/lib/build/recipe/emailpassword/api/signin.js
@@ -47,6 +47,7 @@ var __awaiter =
 Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = require("../../../utils");
 const utils_2 = require("./utils");
+const utils_3 = require("../../../utils");
 function signInAPI(apiImplementation, options) {
     return __awaiter(this, void 0, void 0, function* () {
         // Logic as per https://github.com/supertokens/supertokens-node/issues/20#issuecomment-710346362
@@ -58,7 +59,11 @@ function signInAPI(apiImplementation, options) {
             options.config.signInFeature.formFields,
             (yield options.req.getJSONBody()).formFields
         );
-        let result = yield apiImplementation.signInPOST({ formFields, options, userContext: {} });
+        let result = yield apiImplementation.signInPOST({
+            formFields,
+            options,
+            userContext: utils_3.makeDefaultUserContextFromAPI(options.req),
+        });
         if (result.status === "OK") {
             utils_1.send200Response(options.res, {
                 status: "OK",

--- a/lib/build/recipe/emailpassword/api/signup.js
+++ b/lib/build/recipe/emailpassword/api/signup.js
@@ -48,6 +48,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = require("../../../utils");
 const utils_2 = require("./utils");
 const error_1 = require("../error");
+const utils_3 = require("../../../utils");
 function signUpAPI(apiImplementation, options) {
     return __awaiter(this, void 0, void 0, function* () {
         // Logic as per https://github.com/supertokens/supertokens-node/issues/21#issuecomment-710423536
@@ -59,7 +60,11 @@ function signUpAPI(apiImplementation, options) {
             options.config.signUpFeature.formFields,
             (yield options.req.getJSONBody()).formFields
         );
-        let result = yield apiImplementation.signUpPOST({ formFields, options, userContext: {} });
+        let result = yield apiImplementation.signUpPOST({
+            formFields,
+            options,
+            userContext: utils_3.makeDefaultUserContextFromAPI(options.req),
+        });
         if (result.status === "OK") {
             utils_1.send200Response(options.res, {
                 status: "OK",

--- a/lib/build/recipe/emailverification/api/emailVerify.js
+++ b/lib/build/recipe/emailverification/api/emailVerify.js
@@ -47,6 +47,7 @@ var __awaiter =
 Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = require("../../../utils");
 const error_1 = require("../error");
+const utils_2 = require("../../../utils");
 function emailVerify(apiImplementation, options) {
     return __awaiter(this, void 0, void 0, function* () {
         let result;
@@ -68,7 +69,11 @@ function emailVerify(apiImplementation, options) {
                     message: "The email verification token must be a string",
                 });
             }
-            let response = yield apiImplementation.verifyEmailPOST({ token, options, userContext: {} });
+            let response = yield apiImplementation.verifyEmailPOST({
+                token,
+                options,
+                userContext: utils_2.makeDefaultUserContextFromAPI(options.req),
+            });
             if (response.status === "OK") {
                 result = { status: "OK" };
             } else {
@@ -78,7 +83,10 @@ function emailVerify(apiImplementation, options) {
             if (apiImplementation.isEmailVerifiedGET === undefined) {
                 return false;
             }
-            result = yield apiImplementation.isEmailVerifiedGET({ options, userContext: {} });
+            result = yield apiImplementation.isEmailVerifiedGET({
+                options,
+                userContext: utils_2.makeDefaultUserContextFromAPI(options.req),
+            });
         }
         utils_1.send200Response(options.res, result);
         return true;

--- a/lib/build/recipe/emailverification/api/generateEmailVerifyToken.js
+++ b/lib/build/recipe/emailverification/api/generateEmailVerifyToken.js
@@ -46,13 +46,17 @@ var __awaiter =
     };
 Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = require("../../../utils");
+const utils_2 = require("../../../utils");
 function generateEmailVerifyToken(apiImplementation, options) {
     return __awaiter(this, void 0, void 0, function* () {
         // Logic as per https://github.com/supertokens/supertokens-node/issues/62#issuecomment-751616106
         if (apiImplementation.generateEmailVerifyTokenPOST === undefined) {
             return false;
         }
-        let result = yield apiImplementation.generateEmailVerifyTokenPOST({ options, userContext: {} });
+        let result = yield apiImplementation.generateEmailVerifyTokenPOST({
+            options,
+            userContext: utils_2.makeDefaultUserContextFromAPI(options.req),
+        });
         utils_1.send200Response(options.res, result);
         return true;
     });

--- a/lib/build/recipe/jwt/api/getJWKS.js
+++ b/lib/build/recipe/jwt/api/getJWKS.js
@@ -46,12 +46,16 @@ var __awaiter =
     };
 Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = require("../../../utils");
+const utils_2 = require("../../../utils");
 function getJWKS(apiImplementation, options) {
     return __awaiter(this, void 0, void 0, function* () {
         if (apiImplementation.getJWKSGET === undefined) {
             return false;
         }
-        let result = yield apiImplementation.getJWKSGET({ options, userContext: {} });
+        let result = yield apiImplementation.getJWKSGET({
+            options,
+            userContext: utils_2.makeDefaultUserContextFromAPI(options.req),
+        });
         if (result.status === "OK") {
             options.res.setHeader("Access-Control-Allow-Origin", "*", false);
             utils_1.send200Response(options.res, { keys: result.keys });

--- a/lib/build/recipe/openid/api/getOpenIdDiscoveryConfiguration.js
+++ b/lib/build/recipe/openid/api/getOpenIdDiscoveryConfiguration.js
@@ -46,12 +46,16 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * under the License.
  */
 const utils_1 = require("../../../utils");
+const utils_2 = require("../../../utils");
 function getOpenIdDiscoveryConfiguration(apiImplementation, options) {
     return __awaiter(this, void 0, void 0, function* () {
         if (apiImplementation.getOpenIdDiscoveryConfigurationGET === undefined) {
             return false;
         }
-        let result = yield apiImplementation.getOpenIdDiscoveryConfigurationGET({ options, userContext: {} });
+        let result = yield apiImplementation.getOpenIdDiscoveryConfigurationGET({
+            options,
+            userContext: utils_2.makeDefaultUserContextFromAPI(options.req),
+        });
         if (result.status === "OK") {
             options.res.setHeader("Access-Control-Allow-Origin", "*", false);
             utils_1.send200Response(options.res, {

--- a/lib/build/recipe/passwordless/api/consumeCode.js
+++ b/lib/build/recipe/passwordless/api/consumeCode.js
@@ -47,6 +47,7 @@ var __awaiter =
 Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = require("../../../utils");
 const error_1 = require("../error");
+const utils_2 = require("../../../utils");
 function consumeCode(apiImplementation, options) {
     return __awaiter(this, void 0, void 0, function* () {
         if (apiImplementation.consumeCodePOST === undefined) {
@@ -84,12 +85,18 @@ function consumeCode(apiImplementation, options) {
         }
         let result = yield apiImplementation.consumeCodePOST(
             deviceId !== undefined
-                ? { deviceId, userInputCode, preAuthSessionId, options, userContext: {} }
+                ? {
+                      deviceId,
+                      userInputCode,
+                      preAuthSessionId,
+                      options,
+                      userContext: utils_2.makeDefaultUserContextFromAPI(options.req),
+                  }
                 : {
                       linkCode,
                       options,
                       preAuthSessionId,
-                      userContext: {},
+                      userContext: utils_2.makeDefaultUserContextFromAPI(options.req),
                   }
         );
         if (result.status === "OK") {

--- a/lib/build/recipe/passwordless/api/createCode.js
+++ b/lib/build/recipe/passwordless/api/createCode.js
@@ -48,6 +48,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = require("../../../utils");
 const error_1 = require("../error");
 const max_1 = require("libphonenumber-js/max");
+const utils_2 = require("../../../utils");
 function createCode(apiImplementation, options) {
     return __awaiter(this, void 0, void 0, function* () {
         if (apiImplementation.createCodePOST === undefined) {
@@ -112,8 +113,8 @@ function createCode(apiImplementation, options) {
         }
         let result = yield apiImplementation.createCodePOST(
             email !== undefined
-                ? { email, options, userContext: {} }
-                : { phoneNumber: phoneNumber, options, userContext: {} }
+                ? { email, options, userContext: utils_2.makeDefaultUserContextFromAPI(options.req) }
+                : { phoneNumber: phoneNumber, options, userContext: utils_2.makeDefaultUserContextFromAPI(options.req) }
         );
         utils_1.send200Response(options.res, result);
         return true;

--- a/lib/build/recipe/passwordless/api/emailExists.js
+++ b/lib/build/recipe/passwordless/api/emailExists.js
@@ -47,6 +47,7 @@ var __awaiter =
 Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = require("../../../utils");
 const error_1 = require("../error");
+const utils_2 = require("../../../utils");
 function emailExists(apiImplementation, options) {
     return __awaiter(this, void 0, void 0, function* () {
         if (apiImplementation.emailExistsGET === undefined) {
@@ -59,7 +60,11 @@ function emailExists(apiImplementation, options) {
                 message: "Please provide the email as a GET param",
             });
         }
-        let result = yield apiImplementation.emailExistsGET({ email, options, userContext: {} });
+        let result = yield apiImplementation.emailExistsGET({
+            email,
+            options,
+            userContext: utils_2.makeDefaultUserContextFromAPI(options.req),
+        });
         utils_1.send200Response(options.res, result);
         return true;
     });

--- a/lib/build/recipe/passwordless/api/phoneNumberExists.js
+++ b/lib/build/recipe/passwordless/api/phoneNumberExists.js
@@ -47,6 +47,7 @@ var __awaiter =
 Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = require("../../../utils");
 const error_1 = require("../error");
+const utils_2 = require("../../../utils");
 function phoneNumberExists(apiImplementation, options) {
     return __awaiter(this, void 0, void 0, function* () {
         if (apiImplementation.phoneNumberExistsGET === undefined) {
@@ -59,7 +60,11 @@ function phoneNumberExists(apiImplementation, options) {
                 message: "Please provide the phoneNumber as a GET param",
             });
         }
-        let result = yield apiImplementation.phoneNumberExistsGET({ phoneNumber, options, userContext: {} });
+        let result = yield apiImplementation.phoneNumberExistsGET({
+            phoneNumber,
+            options,
+            userContext: utils_2.makeDefaultUserContextFromAPI(options.req),
+        });
         utils_1.send200Response(options.res, result);
         return true;
     });

--- a/lib/build/recipe/passwordless/api/resendCode.js
+++ b/lib/build/recipe/passwordless/api/resendCode.js
@@ -47,6 +47,7 @@ var __awaiter =
 Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = require("../../../utils");
 const error_1 = require("../error");
+const utils_2 = require("../../../utils");
 function resendCode(apiImplementation, options) {
     return __awaiter(this, void 0, void 0, function* () {
         if (apiImplementation.resendCodePOST === undefined) {
@@ -67,7 +68,12 @@ function resendCode(apiImplementation, options) {
                 message: "Please provide a deviceId",
             });
         }
-        let result = yield apiImplementation.resendCodePOST({ deviceId, preAuthSessionId, options, userContext: {} });
+        let result = yield apiImplementation.resendCodePOST({
+            deviceId,
+            preAuthSessionId,
+            options,
+            userContext: utils_2.makeDefaultUserContextFromAPI(options.req),
+        });
         utils_1.send200Response(options.res, result);
         return true;
     });

--- a/lib/build/recipe/session/api/refresh.js
+++ b/lib/build/recipe/session/api/refresh.js
@@ -46,12 +46,16 @@ var __awaiter =
     };
 Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = require("../../../utils");
+const utils_2 = require("../../../utils");
 function handleRefreshAPI(apiImplementation, options) {
     return __awaiter(this, void 0, void 0, function* () {
         if (apiImplementation.refreshPOST === undefined) {
             return false;
         }
-        yield apiImplementation.refreshPOST({ options, userContext: {} });
+        yield apiImplementation.refreshPOST({
+            options,
+            userContext: utils_2.makeDefaultUserContextFromAPI(options.req),
+        });
         utils_1.send200Response(options.res, {});
         return true;
     });

--- a/lib/build/recipe/session/api/signout.js
+++ b/lib/build/recipe/session/api/signout.js
@@ -46,13 +46,17 @@ var __awaiter =
     };
 Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = require("../../../utils");
+const utils_2 = require("../../../utils");
 function signOutAPI(apiImplementation, options) {
     return __awaiter(this, void 0, void 0, function* () {
         // Logic as per https://github.com/supertokens/supertokens-node/issues/34#issuecomment-717958537
         if (apiImplementation.signOutPOST === undefined) {
             return false;
         }
-        let result = yield apiImplementation.signOutPOST({ options, userContext: {} });
+        let result = yield apiImplementation.signOutPOST({
+            options,
+            userContext: utils_2.makeDefaultUserContextFromAPI(options.req),
+        });
         utils_1.send200Response(options.res, result);
         return true;
     });

--- a/lib/build/recipe/thirdparty/api/appleRedirect.js
+++ b/lib/build/recipe/thirdparty/api/appleRedirect.js
@@ -45,6 +45,7 @@ var __awaiter =
         });
     };
 Object.defineProperty(exports, "__esModule", { value: true });
+const utils_1 = require("../../../utils");
 function appleRedirectHandler(apiImplementation, options) {
     return __awaiter(this, void 0, void 0, function* () {
         if (apiImplementation.appleRedirectHandlerPOST === undefined) {
@@ -58,7 +59,7 @@ function appleRedirectHandler(apiImplementation, options) {
             code,
             state,
             options,
-            userContext: {},
+            userContext: utils_1.makeDefaultUserContextFromAPI(options.req),
         });
         return true;
     });

--- a/lib/build/recipe/thirdparty/api/authorisationUrl.js
+++ b/lib/build/recipe/thirdparty/api/authorisationUrl.js
@@ -48,6 +48,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = require("../../../utils");
 const error_1 = require("../error");
 const utils_2 = require("../utils");
+const utils_3 = require("../../../utils");
 function authorisationUrlAPI(apiImplementation, options) {
     return __awaiter(this, void 0, void 0, function* () {
         if (apiImplementation.authorisationUrlGET === undefined) {
@@ -67,7 +68,11 @@ function authorisationUrlAPI(apiImplementation, options) {
                 message: "The third party provider " + thirdPartyId + ` seems to be missing from the backend configs.`,
             });
         }
-        let result = yield apiImplementation.authorisationUrlGET({ provider, options, userContext: {} });
+        let result = yield apiImplementation.authorisationUrlGET({
+            provider,
+            options,
+            userContext: utils_3.makeDefaultUserContextFromAPI(options.req),
+        });
         utils_1.send200Response(options.res, result);
         return true;
     });

--- a/lib/build/recipe/thirdparty/api/signinup.js
+++ b/lib/build/recipe/thirdparty/api/signinup.js
@@ -48,6 +48,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const error_1 = require("../error");
 const utils_1 = require("../../../utils");
 const utils_2 = require("../utils");
+const utils_3 = require("../../../utils");
 function signInUpAPI(apiImplementation, options) {
     return __awaiter(this, void 0, void 0, function* () {
         if (apiImplementation.signInUpPOST === undefined) {
@@ -114,7 +115,7 @@ function signInUpAPI(apiImplementation, options) {
             redirectURI,
             options,
             authCodeResponse,
-            userContext: {},
+            userContext: utils_3.makeDefaultUserContextFromAPI(options.req),
         });
         if (result.status === "OK") {
             utils_1.send200Response(options.res, {

--- a/lib/build/utils.d.ts
+++ b/lib/build/utils.d.ts
@@ -11,3 +11,4 @@ export declare function send200Response(res: BaseResponse, responseJson: any): v
 export declare function isAnIpAddress(ipaddress: string): boolean;
 export declare function frontendHasInterceptor(req: BaseRequest): boolean;
 export declare function humaniseMilliseconds(ms: number): string;
+export declare function makeDefaultUserContextFromAPI(request: BaseRequest): any;

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -119,3 +119,11 @@ function humaniseMilliseconds(ms) {
     }
 }
 exports.humaniseMilliseconds = humaniseMilliseconds;
+function makeDefaultUserContextFromAPI(request) {
+    return {
+        _default: {
+            request,
+        },
+    };
+}
+exports.makeDefaultUserContextFromAPI = makeDefaultUserContextFromAPI;

--- a/lib/ts/recipe/emailpassword/api/emailExists.ts
+++ b/lib/ts/recipe/emailpassword/api/emailExists.ts
@@ -16,6 +16,7 @@
 import { send200Response } from "../../../utils";
 import STError from "../error";
 import { APIInterface, APIOptions } from "../";
+import { makeDefaultUserContextFromAPI } from "../../../utils";
 
 export default async function emailExists(apiImplementation: APIInterface, options: APIOptions): Promise<boolean> {
     // Logic as per https://github.com/supertokens/supertokens-node/issues/47#issue-751571692
@@ -33,7 +34,11 @@ export default async function emailExists(apiImplementation: APIInterface, optio
         });
     }
 
-    let result = await apiImplementation.emailExistsGET({ email, options, userContext: {} });
+    let result = await apiImplementation.emailExistsGET({
+        email,
+        options,
+        userContext: makeDefaultUserContextFromAPI(options.req),
+    });
 
     send200Response(options.res, result);
     return true;

--- a/lib/ts/recipe/emailpassword/api/generatePasswordResetToken.ts
+++ b/lib/ts/recipe/emailpassword/api/generatePasswordResetToken.ts
@@ -16,6 +16,7 @@
 import { send200Response } from "../../../utils";
 import { validateFormFieldsOrThrowError } from "./utils";
 import { APIInterface, APIOptions } from "../";
+import { makeDefaultUserContextFromAPI } from "../../../utils";
 
 export default async function generatePasswordResetToken(
     apiImplementation: APIInterface,
@@ -36,7 +37,11 @@ export default async function generatePasswordResetToken(
         (await options.req.getJSONBody()).formFields
     );
 
-    let result = await apiImplementation.generatePasswordResetTokenPOST({ formFields, options, userContext: {} });
+    let result = await apiImplementation.generatePasswordResetTokenPOST({
+        formFields,
+        options,
+        userContext: makeDefaultUserContextFromAPI(options.req),
+    });
 
     send200Response(options.res, result);
     return true;

--- a/lib/ts/recipe/emailpassword/api/passwordReset.ts
+++ b/lib/ts/recipe/emailpassword/api/passwordReset.ts
@@ -17,6 +17,7 @@ import { send200Response } from "../../../utils";
 import { validateFormFieldsOrThrowError } from "./utils";
 import STError from "../error";
 import { APIInterface, APIOptions } from "../";
+import { makeDefaultUserContextFromAPI } from "../../../utils";
 
 export default async function passwordReset(apiImplementation: APIInterface, options: APIOptions): Promise<boolean> {
     // Logic as per https://github.com/supertokens/supertokens-node/issues/22#issuecomment-710512442
@@ -48,7 +49,12 @@ export default async function passwordReset(apiImplementation: APIInterface, opt
         });
     }
 
-    let result = await apiImplementation.passwordResetPOST({ formFields, token, options, userContext: {} });
+    let result = await apiImplementation.passwordResetPOST({
+        formFields,
+        token,
+        options,
+        userContext: makeDefaultUserContextFromAPI(options.req),
+    });
 
     send200Response(
         options.res,

--- a/lib/ts/recipe/emailpassword/api/signin.ts
+++ b/lib/ts/recipe/emailpassword/api/signin.ts
@@ -16,6 +16,7 @@
 import { send200Response } from "../../../utils";
 import { validateFormFieldsOrThrowError } from "./utils";
 import { APIInterface, APIOptions } from "../";
+import { makeDefaultUserContextFromAPI } from "../../../utils";
 
 export default async function signInAPI(apiImplementation: APIInterface, options: APIOptions): Promise<boolean> {
     // Logic as per https://github.com/supertokens/supertokens-node/issues/20#issuecomment-710346362
@@ -32,7 +33,11 @@ export default async function signInAPI(apiImplementation: APIInterface, options
         (await options.req.getJSONBody()).formFields
     );
 
-    let result = await apiImplementation.signInPOST({ formFields, options, userContext: {} });
+    let result = await apiImplementation.signInPOST({
+        formFields,
+        options,
+        userContext: makeDefaultUserContextFromAPI(options.req),
+    });
 
     if (result.status === "OK") {
         send200Response(options.res, {

--- a/lib/ts/recipe/emailpassword/api/signup.ts
+++ b/lib/ts/recipe/emailpassword/api/signup.ts
@@ -17,6 +17,7 @@ import { send200Response } from "../../../utils";
 import { validateFormFieldsOrThrowError } from "./utils";
 import { APIInterface, APIOptions } from "../";
 import STError from "../error";
+import { makeDefaultUserContextFromAPI } from "../../../utils";
 
 export default async function signUpAPI(apiImplementation: APIInterface, options: APIOptions): Promise<boolean> {
     // Logic as per https://github.com/supertokens/supertokens-node/issues/21#issuecomment-710423536
@@ -34,7 +35,11 @@ export default async function signUpAPI(apiImplementation: APIInterface, options
         (await options.req.getJSONBody()).formFields
     );
 
-    let result = await apiImplementation.signUpPOST({ formFields, options, userContext: {} });
+    let result = await apiImplementation.signUpPOST({
+        formFields,
+        options,
+        userContext: makeDefaultUserContextFromAPI(options.req),
+    });
     if (result.status === "OK") {
         send200Response(options.res, {
             status: "OK",

--- a/lib/ts/recipe/emailverification/api/emailVerify.ts
+++ b/lib/ts/recipe/emailverification/api/emailVerify.ts
@@ -16,6 +16,7 @@
 import { send200Response, normaliseHttpMethod } from "../../../utils";
 import STError from "../error";
 import { APIInterface, APIOptions } from "../";
+import { makeDefaultUserContextFromAPI } from "../../../utils";
 
 export default async function emailVerify(apiImplementation: APIInterface, options: APIOptions): Promise<boolean> {
     let result;
@@ -41,7 +42,11 @@ export default async function emailVerify(apiImplementation: APIInterface, optio
             });
         }
 
-        let response = await apiImplementation.verifyEmailPOST({ token, options, userContext: {} });
+        let response = await apiImplementation.verifyEmailPOST({
+            token,
+            options,
+            userContext: makeDefaultUserContextFromAPI(options.req),
+        });
         if (response.status === "OK") {
             result = { status: "OK" };
         } else {
@@ -52,7 +57,10 @@ export default async function emailVerify(apiImplementation: APIInterface, optio
             return false;
         }
 
-        result = await apiImplementation.isEmailVerifiedGET({ options, userContext: {} });
+        result = await apiImplementation.isEmailVerifiedGET({
+            options,
+            userContext: makeDefaultUserContextFromAPI(options.req),
+        });
     }
     send200Response(options.res, result);
     return true;

--- a/lib/ts/recipe/emailverification/api/generateEmailVerifyToken.ts
+++ b/lib/ts/recipe/emailverification/api/generateEmailVerifyToken.ts
@@ -15,6 +15,7 @@
 
 import { send200Response } from "../../../utils";
 import { APIInterface, APIOptions } from "../";
+import { makeDefaultUserContextFromAPI } from "../../../utils";
 
 export default async function generateEmailVerifyToken(
     apiImplementation: APIInterface,
@@ -26,7 +27,10 @@ export default async function generateEmailVerifyToken(
         return false;
     }
 
-    let result = await apiImplementation.generateEmailVerifyTokenPOST({ options, userContext: {} });
+    let result = await apiImplementation.generateEmailVerifyTokenPOST({
+        options,
+        userContext: makeDefaultUserContextFromAPI(options.req),
+    });
 
     send200Response(options.res, result);
     return true;

--- a/lib/ts/recipe/jwt/api/getJWKS.ts
+++ b/lib/ts/recipe/jwt/api/getJWKS.ts
@@ -15,13 +15,17 @@
 
 import { send200Response } from "../../../utils";
 import { APIInterface, APIOptions } from "../types";
+import { makeDefaultUserContextFromAPI } from "../../../utils";
 
 export default async function getJWKS(apiImplementation: APIInterface, options: APIOptions): Promise<boolean> {
     if (apiImplementation.getJWKSGET === undefined) {
         return false;
     }
 
-    let result = await apiImplementation.getJWKSGET({ options, userContext: {} });
+    let result = await apiImplementation.getJWKSGET({
+        options,
+        userContext: makeDefaultUserContextFromAPI(options.req),
+    });
     if (result.status === "OK") {
         options.res.setHeader("Access-Control-Allow-Origin", "*", false);
         send200Response(options.res, { keys: result.keys });

--- a/lib/ts/recipe/openid/api/getOpenIdDiscoveryConfiguration.ts
+++ b/lib/ts/recipe/openid/api/getOpenIdDiscoveryConfiguration.ts
@@ -14,6 +14,7 @@
  */
 import { send200Response } from "../../../utils";
 import { APIInterface, APIOptions } from "../types";
+import { makeDefaultUserContextFromAPI } from "../../../utils";
 
 export default async function getOpenIdDiscoveryConfiguration(
     apiImplementation: APIInterface,
@@ -23,7 +24,10 @@ export default async function getOpenIdDiscoveryConfiguration(
         return false;
     }
 
-    let result = await apiImplementation.getOpenIdDiscoveryConfigurationGET({ options, userContext: {} });
+    let result = await apiImplementation.getOpenIdDiscoveryConfigurationGET({
+        options,
+        userContext: makeDefaultUserContextFromAPI(options.req),
+    });
     if (result.status === "OK") {
         options.res.setHeader("Access-Control-Allow-Origin", "*", false);
         send200Response(options.res, {

--- a/lib/ts/recipe/passwordless/api/consumeCode.ts
+++ b/lib/ts/recipe/passwordless/api/consumeCode.ts
@@ -16,6 +16,7 @@
 import { send200Response } from "../../../utils";
 import STError from "../error";
 import { APIInterface, APIOptions } from "..";
+import { makeDefaultUserContextFromAPI } from "../../../utils";
 
 export default async function consumeCode(apiImplementation: APIInterface, options: APIOptions): Promise<boolean> {
     if (apiImplementation.consumeCodePOST === undefined) {
@@ -57,12 +58,18 @@ export default async function consumeCode(apiImplementation: APIInterface, optio
 
     let result = await apiImplementation.consumeCodePOST(
         deviceId !== undefined
-            ? { deviceId, userInputCode, preAuthSessionId, options, userContext: {} }
+            ? {
+                  deviceId,
+                  userInputCode,
+                  preAuthSessionId,
+                  options,
+                  userContext: makeDefaultUserContextFromAPI(options.req),
+              }
             : {
                   linkCode,
                   options,
                   preAuthSessionId,
-                  userContext: {},
+                  userContext: makeDefaultUserContextFromAPI(options.req),
               }
     );
 

--- a/lib/ts/recipe/passwordless/api/createCode.ts
+++ b/lib/ts/recipe/passwordless/api/createCode.ts
@@ -17,6 +17,7 @@ import { send200Response } from "../../../utils";
 import STError from "../error";
 import { APIInterface, APIOptions } from "..";
 import parsePhoneNumber from "libphonenumber-js/max";
+import { makeDefaultUserContextFromAPI } from "../../../utils";
 
 export default async function createCode(apiImplementation: APIInterface, options: APIOptions): Promise<boolean> {
     if (apiImplementation.createCodePOST === undefined) {
@@ -88,8 +89,8 @@ export default async function createCode(apiImplementation: APIInterface, option
 
     let result = await apiImplementation.createCodePOST(
         email !== undefined
-            ? { email, options, userContext: {} }
-            : { phoneNumber: phoneNumber!, options, userContext: {} }
+            ? { email, options, userContext: makeDefaultUserContextFromAPI(options.req) }
+            : { phoneNumber: phoneNumber!, options, userContext: makeDefaultUserContextFromAPI(options.req) }
     );
 
     send200Response(options.res, result);

--- a/lib/ts/recipe/passwordless/api/emailExists.ts
+++ b/lib/ts/recipe/passwordless/api/emailExists.ts
@@ -16,6 +16,7 @@
 import { send200Response } from "../../../utils";
 import STError from "../error";
 import { APIInterface, APIOptions } from "../";
+import { makeDefaultUserContextFromAPI } from "../../../utils";
 
 export default async function emailExists(apiImplementation: APIInterface, options: APIOptions): Promise<boolean> {
     if (apiImplementation.emailExistsGET === undefined) {
@@ -31,7 +32,11 @@ export default async function emailExists(apiImplementation: APIInterface, optio
         });
     }
 
-    let result = await apiImplementation.emailExistsGET({ email, options, userContext: {} });
+    let result = await apiImplementation.emailExistsGET({
+        email,
+        options,
+        userContext: makeDefaultUserContextFromAPI(options.req),
+    });
 
     send200Response(options.res, result);
     return true;

--- a/lib/ts/recipe/passwordless/api/phoneNumberExists.ts
+++ b/lib/ts/recipe/passwordless/api/phoneNumberExists.ts
@@ -16,6 +16,7 @@
 import { send200Response } from "../../../utils";
 import STError from "../error";
 import { APIInterface, APIOptions } from "..";
+import { makeDefaultUserContextFromAPI } from "../../../utils";
 
 export default async function phoneNumberExists(
     apiImplementation: APIInterface,
@@ -34,7 +35,11 @@ export default async function phoneNumberExists(
         });
     }
 
-    let result = await apiImplementation.phoneNumberExistsGET({ phoneNumber, options, userContext: {} });
+    let result = await apiImplementation.phoneNumberExistsGET({
+        phoneNumber,
+        options,
+        userContext: makeDefaultUserContextFromAPI(options.req),
+    });
 
     send200Response(options.res, result);
     return true;

--- a/lib/ts/recipe/passwordless/api/resendCode.ts
+++ b/lib/ts/recipe/passwordless/api/resendCode.ts
@@ -16,6 +16,7 @@
 import { send200Response } from "../../../utils";
 import STError from "../error";
 import { APIInterface, APIOptions } from "..";
+import { makeDefaultUserContextFromAPI } from "../../../utils";
 
 export default async function resendCode(apiImplementation: APIInterface, options: APIOptions): Promise<boolean> {
     if (apiImplementation.resendCodePOST === undefined) {
@@ -40,7 +41,12 @@ export default async function resendCode(apiImplementation: APIInterface, option
         });
     }
 
-    let result = await apiImplementation.resendCodePOST({ deviceId, preAuthSessionId, options, userContext: {} });
+    let result = await apiImplementation.resendCodePOST({
+        deviceId,
+        preAuthSessionId,
+        options,
+        userContext: makeDefaultUserContextFromAPI(options.req),
+    });
 
     send200Response(options.res, result);
     return true;

--- a/lib/ts/recipe/session/api/refresh.ts
+++ b/lib/ts/recipe/session/api/refresh.ts
@@ -15,13 +15,14 @@
 
 import { send200Response } from "../../../utils";
 import { APIInterface, APIOptions } from "../";
+import { makeDefaultUserContextFromAPI } from "../../../utils";
 
 export default async function handleRefreshAPI(apiImplementation: APIInterface, options: APIOptions): Promise<boolean> {
     if (apiImplementation.refreshPOST === undefined) {
         return false;
     }
 
-    await apiImplementation.refreshPOST({ options, userContext: {} });
+    await apiImplementation.refreshPOST({ options, userContext: makeDefaultUserContextFromAPI(options.req) });
     send200Response(options.res, {});
     return true;
 }

--- a/lib/ts/recipe/session/api/signout.ts
+++ b/lib/ts/recipe/session/api/signout.ts
@@ -15,6 +15,7 @@
 
 import { send200Response } from "../../../utils";
 import { APIInterface, APIOptions } from "../";
+import { makeDefaultUserContextFromAPI } from "../../../utils";
 
 export default async function signOutAPI(apiImplementation: APIInterface, options: APIOptions): Promise<boolean> {
     // Logic as per https://github.com/supertokens/supertokens-node/issues/34#issuecomment-717958537
@@ -23,7 +24,10 @@ export default async function signOutAPI(apiImplementation: APIInterface, option
         return false;
     }
 
-    let result = await apiImplementation.signOutPOST({ options, userContext: {} });
+    let result = await apiImplementation.signOutPOST({
+        options,
+        userContext: makeDefaultUserContextFromAPI(options.req),
+    });
 
     send200Response(options.res, result);
     return true;

--- a/lib/ts/recipe/thirdparty/api/appleRedirect.ts
+++ b/lib/ts/recipe/thirdparty/api/appleRedirect.ts
@@ -14,6 +14,7 @@
  */
 
 import { APIInterface, APIOptions } from "../";
+import { makeDefaultUserContextFromAPI } from "../../../utils";
 
 export default async function appleRedirectHandler(
     apiImplementation: APIInterface,
@@ -33,7 +34,7 @@ export default async function appleRedirectHandler(
         code,
         state,
         options,
-        userContext: {},
+        userContext: makeDefaultUserContextFromAPI(options.req),
     });
 
     return true;

--- a/lib/ts/recipe/thirdparty/api/authorisationUrl.ts
+++ b/lib/ts/recipe/thirdparty/api/authorisationUrl.ts
@@ -17,6 +17,7 @@ import { send200Response } from "../../../utils";
 import STError from "../error";
 import { APIInterface, APIOptions } from "../";
 import { findRightProvider } from "../utils";
+import { makeDefaultUserContextFromAPI } from "../../../utils";
 
 export default async function authorisationUrlAPI(
     apiImplementation: APIInterface,
@@ -43,7 +44,11 @@ export default async function authorisationUrlAPI(
         });
     }
 
-    let result = await apiImplementation.authorisationUrlGET({ provider, options, userContext: {} });
+    let result = await apiImplementation.authorisationUrlGET({
+        provider,
+        options,
+        userContext: makeDefaultUserContextFromAPI(options.req),
+    });
 
     send200Response(options.res, result);
     return true;

--- a/lib/ts/recipe/thirdparty/api/signinup.ts
+++ b/lib/ts/recipe/thirdparty/api/signinup.ts
@@ -17,6 +17,7 @@ import STError from "../error";
 import { send200Response } from "../../../utils";
 import { APIInterface, APIOptions } from "../";
 import { findRightProvider } from "../utils";
+import { makeDefaultUserContextFromAPI } from "../../../utils";
 
 export default async function signInUpAPI(apiImplementation: APIInterface, options: APIOptions): Promise<boolean> {
     if (apiImplementation.signInUpPOST === undefined) {
@@ -90,7 +91,7 @@ export default async function signInUpAPI(apiImplementation: APIInterface, optio
         redirectURI,
         options,
         authCodeResponse,
-        userContext: {},
+        userContext: makeDefaultUserContextFromAPI(options.req),
     });
 
     if (result.status === "OK") {

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -120,3 +120,11 @@ export function humaniseMilliseconds(ms: number): string {
         return `${h} hour${suffix}`;
     }
 }
+
+export function makeDefaultUserContextFromAPI(request: BaseRequest): any {
+    return {
+        _default: {
+            request,
+        },
+    };
+}


### PR DESCRIPTION
## Summary of change
Adds the request (of type BaseRequest) object from the API to the userContext object by default.

## Test Plan

Unit tests to check that this is added for recipes and for combination of recipes

## Documentation changes

- [ ] Simplify SAML docs
- [ ] Add about default object in request context.

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR
