### PR TITLE
fix: content-type header for put requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixes
+
+-   Fixed handling of unicode characters in usermetadata (and emails, roles, session/access token payload data)
+
 ## [10.0.0] - 2022-06-2
 
 ### Breaking change

--- a/lib/build/querier.js
+++ b/lib/build/querier.js
@@ -193,12 +193,12 @@ class Querier {
                     (url) =>
                         __awaiter(this, void 0, void 0, function* () {
                             let apiVersion = yield this.getAPIVersion();
-                            let headers = { "cdi-version": apiVersion };
+                            let headers = {
+                                "cdi-version": apiVersion,
+                                "content-type": "application/json; charset=utf-8",
+                            };
                             if (Querier.apiKey !== undefined) {
-                                headers = Object.assign(Object.assign({}, headers), {
-                                    "api-key": Querier.apiKey,
-                                    "content-type": "application/json; charset=utf-8",
-                                });
+                                headers = Object.assign(Object.assign({}, headers), { "api-key": Querier.apiKey });
                             }
                             if (path.isARecipePath() && this.rIdToCore !== undefined) {
                                 headers = Object.assign(Object.assign({}, headers), { rid: this.rIdToCore });

--- a/lib/ts/querier.ts
+++ b/lib/ts/querier.ts
@@ -208,12 +208,11 @@ export class Querier {
             "PUT",
             async (url: string) => {
                 let apiVersion = await this.getAPIVersion();
-                let headers: any = { "cdi-version": apiVersion };
+                let headers: any = { "cdi-version": apiVersion, "content-type": "application/json; charset=utf-8" };
                 if (Querier.apiKey !== undefined) {
                     headers = {
                         ...headers,
                         "api-key": Querier.apiKey,
-                        "content-type": "application/json; charset=utf-8",
                     };
                 }
                 if (path.isARecipePath() && this.rIdToCore !== undefined) {

--- a/test/usermetadata/updateUserMetadata.test.js
+++ b/test/usermetadata/updateUserMetadata.test.js
@@ -57,6 +57,43 @@ describe(`updateUserMetadataTest: ${printPath("[test/usermetadata/updateUserMeta
             assert.deepStrictEqual(getResult.metadata, testMetadata);
         });
 
+        it("should create metadata with utf8 encoding", async function () {
+            await startST();
+
+            const testUserId = "userId";
+            const testMetadata = {
+                role: "\uFDFD   Æää",
+            };
+
+            STExpress.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                },
+                appInfo: {
+                    apiDomain: "api.supertokens.io",
+                    appName: "SuperTokens",
+                    websiteDomain: "supertokens.io",
+                },
+                recipeList: [UserMetadataRecipe.init()],
+            });
+
+            // Only run for version >= 2.13
+            let querier = Querier.getNewInstanceOrThrowError(undefined);
+            let apiVersion = await querier.getAPIVersion();
+            if (maxVersion(apiVersion, "2.12") === "2.12") {
+                return this.skip();
+            }
+
+            const updateResult = await UserMetadataRecipe.updateUserMetadata(testUserId, testMetadata);
+
+            const getResult = await UserMetadataRecipe.getUserMetadata(testUserId);
+
+            assert.strictEqual(updateResult.status, "OK");
+            assert.deepStrictEqual(updateResult.metadata, testMetadata);
+            assert.strictEqual(getResult.status, "OK");
+            assert.deepStrictEqual(getResult.metadata, testMetadata);
+        });
+
         it("should create metadata for cleared user id", async function () {
             await startST();
 


### PR DESCRIPTION
## Summary of change

fix: content-type header for put requests

## Related issues

-   [User issue on discord](https://discord.com/channels/603466164219281420/990922887730987018)

## Test Plan

Added extra test that uses unicode characters.

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
