### PR TITLE
fix!: makes changes to the session recipe functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Breaking change:
+
+-   Changes session function recipe interfaces to not throw an UNAUTHORISED error when the input is a sessionHandle: https://github.com/supertokens/backend/issues/83
+    -   `getSessionInformation` now returns `undefined` is the session does not exist
+    -   `updateSessionData` now returns `false` if the input `sessionHandle` does not exist.
+    -   `updateAccessTokenPayload` now returns `false` if the input `sessionHandle` does not exist.
+    -   `regenerateAccessToken` now returns `undefined` if the input access token's `sessionHandle` does not exist.
+    -   The sessionClass functions have not changed in behaviour and still throw UNAUTHORISED. This works cause the sessionClass works on the current session and not some other session.
+
 ## [10.0.1] - 2022-06-28
 
 ### Fixes

--- a/lib/build/recipe/session/index.d.ts
+++ b/lib/build/recipe/session/index.d.ts
@@ -25,37 +25,40 @@ export default class SessionWrapper {
         options?: VerifySessionOptions,
         userContext?: any
     ): Promise<SessionContainer | undefined>;
-    static getSessionInformation(sessionHandle: string, userContext?: any): Promise<SessionInformation>;
+    static getSessionInformation(sessionHandle: string, userContext?: any): Promise<SessionInformation | undefined>;
     static refreshSession(req: any, res: any, userContext?: any): Promise<SessionContainer>;
     static revokeAllSessionsForUser(userId: string, userContext?: any): Promise<string[]>;
     static getAllSessionHandlesForUser(userId: string, userContext?: any): Promise<string[]>;
     static revokeSession(sessionHandle: string, userContext?: any): Promise<boolean>;
     static revokeMultipleSessions(sessionHandles: string[], userContext?: any): Promise<string[]>;
-    static updateSessionData(sessionHandle: string, newSessionData: any, userContext?: any): Promise<void>;
+    static updateSessionData(sessionHandle: string, newSessionData: any, userContext?: any): Promise<boolean>;
     static regenerateAccessToken(
         accessToken: string,
         newAccessTokenPayload?: any,
         userContext?: any
-    ): Promise<{
-        status: "OK";
-        session: {
-            handle: string;
-            userId: string;
-            userDataInJWT: any;
-        };
-        accessToken?:
-            | {
-                  token: string;
-                  expiry: number;
-                  createdTime: number;
-              }
-            | undefined;
-    }>;
+    ): Promise<
+        | {
+              status: "OK";
+              session: {
+                  handle: string;
+                  userId: string;
+                  userDataInJWT: any;
+              };
+              accessToken?:
+                  | {
+                        token: string;
+                        expiry: number;
+                        createdTime: number;
+                    }
+                  | undefined;
+          }
+        | undefined
+    >;
     static updateAccessTokenPayload(
         sessionHandle: string,
         newAccessTokenPayload: any,
         userContext?: any
-    ): Promise<void>;
+    ): Promise<boolean>;
     static createJWT(
         payload?: any,
         validitySeconds?: number,

--- a/lib/build/recipe/session/recipeImplementation.js
+++ b/lib/build/recipe/session/recipeImplementation.js
@@ -306,10 +306,7 @@ function getRecipeInterface(querier, config) {
                     }
                 );
                 if (response.status === "UNAUTHORISED") {
-                    throw new error_1.default({
-                        message: response.message,
-                        type: error_1.default.UNAUTHORISED,
-                    });
+                    return undefined;
                 }
                 return response;
             });

--- a/lib/build/recipe/session/sessionClass.js
+++ b/lib/build/recipe/session/sessionClass.js
@@ -49,10 +49,17 @@ class Session {
         this.getSessionData = (userContext) =>
             __awaiter(this, void 0, void 0, function* () {
                 try {
-                    return (yield this.helpers.sessionRecipeImpl.getSessionInformation({
+                    let sessionInfo = yield this.helpers.sessionRecipeImpl.getSessionInformation({
                         sessionHandle: this.sessionHandle,
                         userContext: userContext === undefined ? {} : userContext,
-                    })).sessionData;
+                    });
+                    if (sessionInfo === undefined) {
+                        throw new error_1.default({
+                            message: "Session information does not exist.",
+                            type: error_1.default.UNAUTHORISED,
+                        });
+                    }
+                    return sessionInfo.sessionData;
                 } catch (err) {
                     if (err.type === error_1.default.UNAUTHORISED) {
                         cookieAndHeaders_1.clearSessionFromCookie(this.helpers.config, this.res);
@@ -63,11 +70,18 @@ class Session {
         this.updateSessionData = (newSessionData, userContext) =>
             __awaiter(this, void 0, void 0, function* () {
                 try {
-                    yield this.helpers.sessionRecipeImpl.updateSessionData({
-                        sessionHandle: this.sessionHandle,
-                        newSessionData,
-                        userContext: userContext === undefined ? {} : userContext,
-                    });
+                    if (
+                        !(yield this.helpers.sessionRecipeImpl.updateSessionData({
+                            sessionHandle: this.sessionHandle,
+                            newSessionData,
+                            userContext: userContext === undefined ? {} : userContext,
+                        }))
+                    ) {
+                        throw new error_1.default({
+                            message: "Session does not exist anymore.",
+                            type: error_1.default.UNAUTHORISED,
+                        });
+                    }
                 } catch (err) {
                     if (err.type === error_1.default.UNAUTHORISED) {
                         cookieAndHeaders_1.clearSessionFromCookie(this.helpers.config, this.res);
@@ -95,6 +109,12 @@ class Session {
                         newAccessTokenPayload,
                         userContext: userContext === undefined ? {} : userContext,
                     });
+                    if (response === undefined) {
+                        throw new error_1.default({
+                            message: "Session information does not exist.",
+                            type: error_1.default.UNAUTHORISED,
+                        });
+                    }
                     this.userDataInAccessToken = response.session.userDataInJWT;
                     if (response.accessToken !== undefined) {
                         this.accessToken = response.accessToken.token;
@@ -121,10 +141,17 @@ class Session {
         this.getTimeCreated = (userContext) =>
             __awaiter(this, void 0, void 0, function* () {
                 try {
-                    return (yield this.helpers.sessionRecipeImpl.getSessionInformation({
+                    let sessionInfo = yield this.helpers.sessionRecipeImpl.getSessionInformation({
                         sessionHandle: this.sessionHandle,
                         userContext: userContext === undefined ? {} : userContext,
-                    })).timeCreated;
+                    });
+                    if (sessionInfo === undefined) {
+                        throw new error_1.default({
+                            message: "Session information does not exist.",
+                            type: error_1.default.UNAUTHORISED,
+                        });
+                    }
+                    return sessionInfo.timeCreated;
                 } catch (err) {
                     if (err.type === error_1.default.UNAUTHORISED) {
                         cookieAndHeaders_1.clearSessionFromCookie(this.helpers.config, this.res);
@@ -135,10 +162,17 @@ class Session {
         this.getExpiry = (userContext) =>
             __awaiter(this, void 0, void 0, function* () {
                 try {
-                    return (yield this.helpers.sessionRecipeImpl.getSessionInformation({
+                    let sessionInfo = yield this.helpers.sessionRecipeImpl.getSessionInformation({
                         sessionHandle: this.sessionHandle,
                         userContext: userContext === undefined ? {} : userContext,
-                    })).expiry;
+                    });
+                    if (sessionInfo === undefined) {
+                        throw new error_1.default({
+                            message: "Session information does not exist.",
+                            type: error_1.default.UNAUTHORISED,
+                        });
+                    }
+                    return sessionInfo.expiry;
                 } catch (err) {
                     if (err.type === error_1.default.UNAUTHORISED) {
                         cookieAndHeaders_1.clearSessionFromCookie(this.helpers.config, this.res);

--- a/lib/build/recipe/session/sessionClass.js
+++ b/lib/build/recipe/session/sessionClass.js
@@ -48,45 +48,33 @@ class Session {
             });
         this.getSessionData = (userContext) =>
             __awaiter(this, void 0, void 0, function* () {
-                try {
-                    let sessionInfo = yield this.helpers.sessionRecipeImpl.getSessionInformation({
-                        sessionHandle: this.sessionHandle,
-                        userContext: userContext === undefined ? {} : userContext,
+                let sessionInfo = yield this.helpers.sessionRecipeImpl.getSessionInformation({
+                    sessionHandle: this.sessionHandle,
+                    userContext: userContext === undefined ? {} : userContext,
+                });
+                if (sessionInfo === undefined) {
+                    cookieAndHeaders_1.clearSessionFromCookie(this.helpers.config, this.res);
+                    throw new error_1.default({
+                        message: "Session does not exist anymore",
+                        type: error_1.default.UNAUTHORISED,
                     });
-                    if (sessionInfo === undefined) {
-                        throw new error_1.default({
-                            message: "Session information does not exist.",
-                            type: error_1.default.UNAUTHORISED,
-                        });
-                    }
-                    return sessionInfo.sessionData;
-                } catch (err) {
-                    if (err.type === error_1.default.UNAUTHORISED) {
-                        cookieAndHeaders_1.clearSessionFromCookie(this.helpers.config, this.res);
-                    }
-                    throw err;
                 }
+                return sessionInfo.sessionData;
             });
         this.updateSessionData = (newSessionData, userContext) =>
             __awaiter(this, void 0, void 0, function* () {
-                try {
-                    if (
-                        !(yield this.helpers.sessionRecipeImpl.updateSessionData({
-                            sessionHandle: this.sessionHandle,
-                            newSessionData,
-                            userContext: userContext === undefined ? {} : userContext,
-                        }))
-                    ) {
-                        throw new error_1.default({
-                            message: "Session does not exist anymore.",
-                            type: error_1.default.UNAUTHORISED,
-                        });
-                    }
-                } catch (err) {
-                    if (err.type === error_1.default.UNAUTHORISED) {
-                        cookieAndHeaders_1.clearSessionFromCookie(this.helpers.config, this.res);
-                    }
-                    throw err;
+                if (
+                    !(yield this.helpers.sessionRecipeImpl.updateSessionData({
+                        sessionHandle: this.sessionHandle,
+                        newSessionData,
+                        userContext: userContext === undefined ? {} : userContext,
+                    }))
+                ) {
+                    cookieAndHeaders_1.clearSessionFromCookie(this.helpers.config, this.res);
+                    throw new error_1.default({
+                        message: "Session does not exist anymore",
+                        type: error_1.default.UNAUTHORISED,
+                    });
                 }
             });
         this.getUserId = () => {
@@ -103,82 +91,64 @@ class Session {
         };
         this.updateAccessTokenPayload = (newAccessTokenPayload, userContext) =>
             __awaiter(this, void 0, void 0, function* () {
-                try {
-                    let response = yield this.helpers.sessionRecipeImpl.regenerateAccessToken({
-                        accessToken: this.getAccessToken(),
-                        newAccessTokenPayload,
-                        userContext: userContext === undefined ? {} : userContext,
+                let response = yield this.helpers.sessionRecipeImpl.regenerateAccessToken({
+                    accessToken: this.getAccessToken(),
+                    newAccessTokenPayload,
+                    userContext: userContext === undefined ? {} : userContext,
+                });
+                if (response === undefined) {
+                    cookieAndHeaders_1.clearSessionFromCookie(this.helpers.config, this.res);
+                    throw new error_1.default({
+                        message: "Session does not exist anymore",
+                        type: error_1.default.UNAUTHORISED,
                     });
-                    if (response === undefined) {
-                        throw new error_1.default({
-                            message: "Session information does not exist.",
-                            type: error_1.default.UNAUTHORISED,
-                        });
-                    }
-                    this.userDataInAccessToken = response.session.userDataInJWT;
-                    if (response.accessToken !== undefined) {
-                        this.accessToken = response.accessToken.token;
-                        cookieAndHeaders_1.setFrontTokenInHeaders(
-                            this.res,
-                            response.session.userId,
-                            response.accessToken.expiry,
-                            response.session.userDataInJWT
-                        );
-                        cookieAndHeaders_1.attachAccessTokenToCookie(
-                            this.helpers.config,
-                            this.res,
-                            response.accessToken.token,
-                            response.accessToken.expiry
-                        );
-                    }
-                } catch (err) {
-                    if (err.type === error_1.default.UNAUTHORISED) {
-                        cookieAndHeaders_1.clearSessionFromCookie(this.helpers.config, this.res);
-                    }
-                    throw err;
+                }
+                this.userDataInAccessToken = response.session.userDataInJWT;
+                if (response.accessToken !== undefined) {
+                    this.accessToken = response.accessToken.token;
+                    cookieAndHeaders_1.setFrontTokenInHeaders(
+                        this.res,
+                        response.session.userId,
+                        response.accessToken.expiry,
+                        response.session.userDataInJWT
+                    );
+                    cookieAndHeaders_1.attachAccessTokenToCookie(
+                        this.helpers.config,
+                        this.res,
+                        response.accessToken.token,
+                        response.accessToken.expiry
+                    );
                 }
             });
         this.getTimeCreated = (userContext) =>
             __awaiter(this, void 0, void 0, function* () {
-                try {
-                    let sessionInfo = yield this.helpers.sessionRecipeImpl.getSessionInformation({
-                        sessionHandle: this.sessionHandle,
-                        userContext: userContext === undefined ? {} : userContext,
+                let sessionInfo = yield this.helpers.sessionRecipeImpl.getSessionInformation({
+                    sessionHandle: this.sessionHandle,
+                    userContext: userContext === undefined ? {} : userContext,
+                });
+                if (sessionInfo === undefined) {
+                    cookieAndHeaders_1.clearSessionFromCookie(this.helpers.config, this.res);
+                    throw new error_1.default({
+                        message: "Session does not exist anymore",
+                        type: error_1.default.UNAUTHORISED,
                     });
-                    if (sessionInfo === undefined) {
-                        throw new error_1.default({
-                            message: "Session information does not exist.",
-                            type: error_1.default.UNAUTHORISED,
-                        });
-                    }
-                    return sessionInfo.timeCreated;
-                } catch (err) {
-                    if (err.type === error_1.default.UNAUTHORISED) {
-                        cookieAndHeaders_1.clearSessionFromCookie(this.helpers.config, this.res);
-                    }
-                    throw err;
                 }
+                return sessionInfo.timeCreated;
             });
         this.getExpiry = (userContext) =>
             __awaiter(this, void 0, void 0, function* () {
-                try {
-                    let sessionInfo = yield this.helpers.sessionRecipeImpl.getSessionInformation({
-                        sessionHandle: this.sessionHandle,
-                        userContext: userContext === undefined ? {} : userContext,
+                let sessionInfo = yield this.helpers.sessionRecipeImpl.getSessionInformation({
+                    sessionHandle: this.sessionHandle,
+                    userContext: userContext === undefined ? {} : userContext,
+                });
+                if (sessionInfo === undefined) {
+                    cookieAndHeaders_1.clearSessionFromCookie(this.helpers.config, this.res);
+                    throw new error_1.default({
+                        message: "Session does not exist anymore",
+                        type: error_1.default.UNAUTHORISED,
                     });
-                    if (sessionInfo === undefined) {
-                        throw new error_1.default({
-                            message: "Session information does not exist.",
-                            type: error_1.default.UNAUTHORISED,
-                        });
-                    }
-                    return sessionInfo.expiry;
-                } catch (err) {
-                    if (err.type === error_1.default.UNAUTHORISED) {
-                        cookieAndHeaders_1.clearSessionFromCookie(this.helpers.config, this.res);
-                    }
-                    throw err;
                 }
+                return sessionInfo.expiry;
             });
         this.sessionHandle = sessionHandle;
         this.userId = userId;

--- a/lib/build/recipe/session/sessionFunctions.d.ts
+++ b/lib/build/recipe/session/sessionFunctions.d.ts
@@ -33,9 +33,12 @@ export declare function getSession(
 }>;
 /**
  * @description Retrieves session information from storage for a given session handle
- * @returns session data stored in the database, including userData and access token payload
+ * @returns session data stored in the database, including userData and access token payload, or undefined if sessionHandle is invalid
  */
-export declare function getSessionInformation(helpers: Helpers, sessionHandle: string): Promise<SessionInformation>;
+export declare function getSessionInformation(
+    helpers: Helpers,
+    sessionHandle: string
+): Promise<SessionInformation | undefined>;
 /**
  * @description generates new access and refresh tokens for a given refresh token. Called when client's access token has expired.
  * @sideEffects calls onTokenTheftDetection if token theft is detected.
@@ -68,14 +71,13 @@ export declare function revokeMultipleSessions(helpers: Helpers, sessionHandles:
 /**
  * @description: It provides no locking mechanism in case other processes are updating session data for this session as well.
  */
-export declare function updateSessionData(helpers: Helpers, sessionHandle: string, newSessionData: any): Promise<void>;
-/**
- * @deprecated use getSessionInformation() instead
- * @returns access token payload as provided by the user earlier
- */
-export declare function getAccessTokenPayload(helpers: Helpers, sessionHandle: string): Promise<any>;
+export declare function updateSessionData(
+    helpers: Helpers,
+    sessionHandle: string,
+    newSessionData: any
+): Promise<boolean>;
 export declare function updateAccessTokenPayload(
     helpers: Helpers,
     sessionHandle: string,
     newAccessTokenPayload: any
-): Promise<void>;
+): Promise<boolean>;

--- a/lib/build/recipe/session/sessionFunctions.js
+++ b/lib/build/recipe/session/sessionFunctions.js
@@ -272,7 +272,7 @@ function getSession(helpers, accessToken, antiCsrfToken, doAntiCsrfCheck, contai
 exports.getSession = getSession;
 /**
  * @description Retrieves session information from storage for a given session handle
- * @returns session data stored in the database, including userData and access token payload
+ * @returns session data stored in the database, including userData and access token payload, or undefined if sessionHandle is invalid
  */
 function getSessionInformation(helpers, sessionHandle) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -291,10 +291,7 @@ function getSessionInformation(helpers, sessionHandle) {
             delete response.userDataInJWT;
             return response;
         } else {
-            throw new error_1.default({
-                message: response.message,
-                type: error_1.default.UNAUTHORISED,
-            });
+            return undefined;
         }
     });
 }
@@ -423,34 +420,12 @@ function updateSessionData(helpers, sessionHandle, newSessionData) {
             userDataInDatabase: newSessionData,
         });
         if (response.status === "UNAUTHORISED") {
-            throw new error_1.default({
-                message: response.message,
-                type: error_1.default.UNAUTHORISED,
-            });
+            return false;
         }
+        return true;
     });
 }
 exports.updateSessionData = updateSessionData;
-/**
- * @deprecated use getSessionInformation() instead
- * @returns access token payload as provided by the user earlier
- */
-function getAccessTokenPayload(helpers, sessionHandle) {
-    return __awaiter(this, void 0, void 0, function* () {
-        let response = yield helpers.querier.sendGetRequest(new normalisedURLPath_1.default("/recipe/jwt/data"), {
-            sessionHandle,
-        });
-        if (response.status === "OK") {
-            return response.userDataInJWT;
-        } else {
-            throw new error_1.default({
-                message: response.message,
-                type: error_1.default.UNAUTHORISED,
-            });
-        }
-    });
-}
-exports.getAccessTokenPayload = getAccessTokenPayload;
 function updateAccessTokenPayload(helpers, sessionHandle, newAccessTokenPayload) {
     return __awaiter(this, void 0, void 0, function* () {
         newAccessTokenPayload =
@@ -460,11 +435,9 @@ function updateAccessTokenPayload(helpers, sessionHandle, newAccessTokenPayload)
             userDataInJWT: newAccessTokenPayload,
         });
         if (response.status === "UNAUTHORISED") {
-            throw new error_1.default({
-                message: response.message,
-                type: error_1.default.UNAUTHORISED,
-            });
+            return false;
         }
+        return true;
     });
 }
 exports.updateAccessTokenPayload = updateAccessTokenPayload;

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -179,35 +179,40 @@ export declare type RecipeInterface = {
      * Used to retrieve all session information for a given session handle. Can be used in place of:
      * - getSessionData
      * - getAccessTokenPayload
+     *
+     * Returns undefined if the sessionHandle does not exist
      */
-    getSessionInformation(input: { sessionHandle: string; userContext: any }): Promise<SessionInformation>;
+    getSessionInformation(input: { sessionHandle: string; userContext: any }): Promise<SessionInformation | undefined>;
     revokeAllSessionsForUser(input: { userId: string; userContext: any }): Promise<string[]>;
     getAllSessionHandlesForUser(input: { userId: string; userContext: any }): Promise<string[]>;
     revokeSession(input: { sessionHandle: string; userContext: any }): Promise<boolean>;
     revokeMultipleSessions(input: { sessionHandles: string[]; userContext: any }): Promise<string[]>;
-    updateSessionData(input: { sessionHandle: string; newSessionData: any; userContext: any }): Promise<void>;
+    updateSessionData(input: { sessionHandle: string; newSessionData: any; userContext: any }): Promise<boolean>;
     updateAccessTokenPayload(input: {
         sessionHandle: string;
         newAccessTokenPayload: any;
         userContext: any;
-    }): Promise<void>;
+    }): Promise<boolean>;
     regenerateAccessToken(input: {
         accessToken: string;
         newAccessTokenPayload?: any;
         userContext: any;
-    }): Promise<{
-        status: "OK";
-        session: {
-            handle: string;
-            userId: string;
-            userDataInJWT: any;
-        };
-        accessToken?: {
-            token: string;
-            expiry: number;
-            createdTime: number;
-        };
-    }>;
+    }): Promise<
+        | {
+              status: "OK";
+              session: {
+                  handle: string;
+                  userId: string;
+                  userDataInJWT: any;
+              };
+              accessToken?: {
+                  token: string;
+                  expiry: number;
+                  createdTime: number;
+              };
+          }
+        | undefined
+    >;
     getAccessTokenLifeTimeMS(input: { userContext: any }): Promise<number>;
     getRefreshTokenLifeTimeMS(input: { userContext: any }): Promise<number>;
 };

--- a/lib/build/recipe/session/with-jwt/recipeImplementation.js
+++ b/lib/build/recipe/session/with-jwt/recipeImplementation.js
@@ -124,6 +124,9 @@ function default_1(originalImplementation, openIdRecipeImplementation, config) {
                 newAccessTokenPayload =
                     newAccessTokenPayload === null || newAccessTokenPayload === undefined ? {} : newAccessTokenPayload;
                 let sessionInformation = yield this.getSessionInformation({ sessionHandle, userContext });
+                if (sessionInformation === undefined) {
+                    return false;
+                }
                 let accessTokenPayload = sessionInformation.accessTokenPayload;
                 let existingJwtPropertyName =
                     accessTokenPayload[constants_1.ACCESS_TOKEN_PAYLOAD_JWT_PROPERTY_NAME_KEY];

--- a/lib/ts/recipe/session/recipeImplementation.ts
+++ b/lib/ts/recipe/session/recipeImplementation.ts
@@ -231,7 +231,7 @@ export default function getRecipeInterface(querier: Querier, config: TypeNormali
             sessionHandle,
         }: {
             sessionHandle: string;
-        }): Promise<SessionInformation> {
+        }): Promise<SessionInformation | undefined> {
             return SessionFunctions.getSessionInformation(helpers, sessionHandle);
         },
 
@@ -297,19 +297,22 @@ export default function getRecipeInterface(querier: Querier, config: TypeNormali
                 newAccessTokenPayload?: any;
                 userContext: any;
             }
-        ): Promise<{
-            status: "OK";
-            session: {
-                handle: string;
-                userId: string;
-                userDataInJWT: any;
-            };
-            accessToken?: {
-                token: string;
-                expiry: number;
-                createdTime: number;
-            };
-        }> {
+        ): Promise<
+            | {
+                  status: "OK";
+                  session: {
+                      handle: string;
+                      userId: string;
+                      userDataInJWT: any;
+                  };
+                  accessToken?: {
+                      token: string;
+                      expiry: number;
+                      createdTime: number;
+                  };
+              }
+            | undefined
+        > {
             let newAccessTokenPayload =
                 input.newAccessTokenPayload === null || input.newAccessTokenPayload === undefined
                     ? {}
@@ -319,10 +322,7 @@ export default function getRecipeInterface(querier: Querier, config: TypeNormali
                 userDataInJWT: newAccessTokenPayload,
             });
             if (response.status === "UNAUTHORISED") {
-                throw new STError({
-                    message: response.message,
-                    type: STError.UNAUTHORISED,
-                });
+                return undefined;
             }
             return response;
         },
@@ -349,7 +349,7 @@ export default function getRecipeInterface(querier: Querier, config: TypeNormali
         }: {
             sessionHandle: string;
             newSessionData: any;
-        }) {
+        }): Promise<boolean> {
             return SessionFunctions.updateSessionData(helpers, sessionHandle, newSessionData);
         },
 
@@ -359,7 +359,7 @@ export default function getRecipeInterface(querier: Querier, config: TypeNormali
         }: {
             sessionHandle: string;
             newAccessTokenPayload: any;
-        }) {
+        }): Promise<boolean> {
             return SessionFunctions.updateAccessTokenPayload(helpers, sessionHandle, newAccessTokenPayload);
         },
 

--- a/lib/ts/recipe/session/sessionClass.ts
+++ b/lib/ts/recipe/session/sessionClass.ts
@@ -54,45 +54,33 @@ export default class Session implements SessionContainerInterface {
     };
 
     getSessionData = async (userContext?: any): Promise<any> => {
-        try {
-            let sessionInfo = await this.helpers.sessionRecipeImpl.getSessionInformation({
-                sessionHandle: this.sessionHandle,
-                userContext: userContext === undefined ? {} : userContext,
+        let sessionInfo = await this.helpers.sessionRecipeImpl.getSessionInformation({
+            sessionHandle: this.sessionHandle,
+            userContext: userContext === undefined ? {} : userContext,
+        });
+        if (sessionInfo === undefined) {
+            clearSessionFromCookie(this.helpers.config, this.res);
+            throw new STError({
+                message: "Session does not exist anymore",
+                type: STError.UNAUTHORISED,
             });
-            if (sessionInfo === undefined) {
-                throw new STError({
-                    message: "Session information does not exist.",
-                    type: STError.UNAUTHORISED,
-                });
-            }
-            return sessionInfo.sessionData;
-        } catch (err) {
-            if (err.type === STError.UNAUTHORISED) {
-                clearSessionFromCookie(this.helpers.config, this.res);
-            }
-            throw err;
         }
+        return sessionInfo.sessionData;
     };
 
     updateSessionData = async (newSessionData: any, userContext?: any) => {
-        try {
-            if (
-                !(await this.helpers.sessionRecipeImpl.updateSessionData({
-                    sessionHandle: this.sessionHandle,
-                    newSessionData,
-                    userContext: userContext === undefined ? {} : userContext,
-                }))
-            ) {
-                throw new STError({
-                    message: "Session does not exist anymore.",
-                    type: STError.UNAUTHORISED,
-                });
-            }
-        } catch (err) {
-            if (err.type === STError.UNAUTHORISED) {
-                clearSessionFromCookie(this.helpers.config, this.res);
-            }
-            throw err;
+        if (
+            !(await this.helpers.sessionRecipeImpl.updateSessionData({
+                sessionHandle: this.sessionHandle,
+                newSessionData,
+                userContext: userContext === undefined ? {} : userContext,
+            }))
+        ) {
+            clearSessionFromCookie(this.helpers.config, this.res);
+            throw new STError({
+                message: "Session does not exist anymore",
+                type: STError.UNAUTHORISED,
+            });
         }
     };
 
@@ -113,81 +101,63 @@ export default class Session implements SessionContainerInterface {
     };
 
     updateAccessTokenPayload = async (newAccessTokenPayload: any, userContext?: any) => {
-        try {
-            let response = await this.helpers.sessionRecipeImpl.regenerateAccessToken({
-                accessToken: this.getAccessToken(),
-                newAccessTokenPayload,
-                userContext: userContext === undefined ? {} : userContext,
+        let response = await this.helpers.sessionRecipeImpl.regenerateAccessToken({
+            accessToken: this.getAccessToken(),
+            newAccessTokenPayload,
+            userContext: userContext === undefined ? {} : userContext,
+        });
+        if (response === undefined) {
+            clearSessionFromCookie(this.helpers.config, this.res);
+            throw new STError({
+                message: "Session does not exist anymore",
+                type: STError.UNAUTHORISED,
             });
-            if (response === undefined) {
-                throw new STError({
-                    message: "Session information does not exist.",
-                    type: STError.UNAUTHORISED,
-                });
-            }
-            this.userDataInAccessToken = response.session.userDataInJWT;
-            if (response.accessToken !== undefined) {
-                this.accessToken = response.accessToken.token;
-                setFrontTokenInHeaders(
-                    this.res,
-                    response.session.userId,
-                    response.accessToken.expiry,
-                    response.session.userDataInJWT
-                );
-                attachAccessTokenToCookie(
-                    this.helpers.config,
-                    this.res,
-                    response.accessToken.token,
-                    response.accessToken.expiry
-                );
-            }
-        } catch (err) {
-            if (err.type === STError.UNAUTHORISED) {
-                clearSessionFromCookie(this.helpers.config, this.res);
-            }
-            throw err;
+        }
+        this.userDataInAccessToken = response.session.userDataInJWT;
+        if (response.accessToken !== undefined) {
+            this.accessToken = response.accessToken.token;
+            setFrontTokenInHeaders(
+                this.res,
+                response.session.userId,
+                response.accessToken.expiry,
+                response.session.userDataInJWT
+            );
+            attachAccessTokenToCookie(
+                this.helpers.config,
+                this.res,
+                response.accessToken.token,
+                response.accessToken.expiry
+            );
         }
     };
 
     getTimeCreated = async (userContext?: any): Promise<number> => {
-        try {
-            let sessionInfo = await this.helpers.sessionRecipeImpl.getSessionInformation({
-                sessionHandle: this.sessionHandle,
-                userContext: userContext === undefined ? {} : userContext,
+        let sessionInfo = await this.helpers.sessionRecipeImpl.getSessionInformation({
+            sessionHandle: this.sessionHandle,
+            userContext: userContext === undefined ? {} : userContext,
+        });
+        if (sessionInfo === undefined) {
+            clearSessionFromCookie(this.helpers.config, this.res);
+            throw new STError({
+                message: "Session does not exist anymore",
+                type: STError.UNAUTHORISED,
             });
-            if (sessionInfo === undefined) {
-                throw new STError({
-                    message: "Session information does not exist.",
-                    type: STError.UNAUTHORISED,
-                });
-            }
-            return sessionInfo.timeCreated;
-        } catch (err) {
-            if (err.type === STError.UNAUTHORISED) {
-                clearSessionFromCookie(this.helpers.config, this.res);
-            }
-            throw err;
         }
+        return sessionInfo.timeCreated;
     };
 
     getExpiry = async (userContext?: any): Promise<number> => {
-        try {
-            let sessionInfo = await this.helpers.sessionRecipeImpl.getSessionInformation({
-                sessionHandle: this.sessionHandle,
-                userContext: userContext === undefined ? {} : userContext,
+        let sessionInfo = await this.helpers.sessionRecipeImpl.getSessionInformation({
+            sessionHandle: this.sessionHandle,
+            userContext: userContext === undefined ? {} : userContext,
+        });
+        if (sessionInfo === undefined) {
+            clearSessionFromCookie(this.helpers.config, this.res);
+            throw new STError({
+                message: "Session does not exist anymore",
+                type: STError.UNAUTHORISED,
             });
-            if (sessionInfo === undefined) {
-                throw new STError({
-                    message: "Session information does not exist.",
-                    type: STError.UNAUTHORISED,
-                });
-            }
-            return sessionInfo.expiry;
-        } catch (err) {
-            if (err.type === STError.UNAUTHORISED) {
-                clearSessionFromCookie(this.helpers.config, this.res);
-            }
-            throw err;
         }
+        return sessionInfo.expiry;
     };
 }

--- a/lib/ts/recipe/session/sessionClass.ts
+++ b/lib/ts/recipe/session/sessionClass.ts
@@ -55,12 +55,17 @@ export default class Session implements SessionContainerInterface {
 
     getSessionData = async (userContext?: any): Promise<any> => {
         try {
-            return (
-                await this.helpers.sessionRecipeImpl.getSessionInformation({
-                    sessionHandle: this.sessionHandle,
-                    userContext: userContext === undefined ? {} : userContext,
-                })
-            ).sessionData;
+            let sessionInfo = await this.helpers.sessionRecipeImpl.getSessionInformation({
+                sessionHandle: this.sessionHandle,
+                userContext: userContext === undefined ? {} : userContext,
+            });
+            if (sessionInfo === undefined) {
+                throw new STError({
+                    message: "Session information does not exist.",
+                    type: STError.UNAUTHORISED,
+                });
+            }
+            return sessionInfo.sessionData;
         } catch (err) {
             if (err.type === STError.UNAUTHORISED) {
                 clearSessionFromCookie(this.helpers.config, this.res);
@@ -71,11 +76,18 @@ export default class Session implements SessionContainerInterface {
 
     updateSessionData = async (newSessionData: any, userContext?: any) => {
         try {
-            await this.helpers.sessionRecipeImpl.updateSessionData({
-                sessionHandle: this.sessionHandle,
-                newSessionData,
-                userContext: userContext === undefined ? {} : userContext,
-            });
+            if (
+                !(await this.helpers.sessionRecipeImpl.updateSessionData({
+                    sessionHandle: this.sessionHandle,
+                    newSessionData,
+                    userContext: userContext === undefined ? {} : userContext,
+                }))
+            ) {
+                throw new STError({
+                    message: "Session does not exist anymore.",
+                    type: STError.UNAUTHORISED,
+                });
+            }
         } catch (err) {
             if (err.type === STError.UNAUTHORISED) {
                 clearSessionFromCookie(this.helpers.config, this.res);
@@ -107,6 +119,12 @@ export default class Session implements SessionContainerInterface {
                 newAccessTokenPayload,
                 userContext: userContext === undefined ? {} : userContext,
             });
+            if (response === undefined) {
+                throw new STError({
+                    message: "Session information does not exist.",
+                    type: STError.UNAUTHORISED,
+                });
+            }
             this.userDataInAccessToken = response.session.userDataInJWT;
             if (response.accessToken !== undefined) {
                 this.accessToken = response.accessToken.token;
@@ -133,12 +151,17 @@ export default class Session implements SessionContainerInterface {
 
     getTimeCreated = async (userContext?: any): Promise<number> => {
         try {
-            return (
-                await this.helpers.sessionRecipeImpl.getSessionInformation({
-                    sessionHandle: this.sessionHandle,
-                    userContext: userContext === undefined ? {} : userContext,
-                })
-            ).timeCreated;
+            let sessionInfo = await this.helpers.sessionRecipeImpl.getSessionInformation({
+                sessionHandle: this.sessionHandle,
+                userContext: userContext === undefined ? {} : userContext,
+            });
+            if (sessionInfo === undefined) {
+                throw new STError({
+                    message: "Session information does not exist.",
+                    type: STError.UNAUTHORISED,
+                });
+            }
+            return sessionInfo.timeCreated;
         } catch (err) {
             if (err.type === STError.UNAUTHORISED) {
                 clearSessionFromCookie(this.helpers.config, this.res);
@@ -149,12 +172,17 @@ export default class Session implements SessionContainerInterface {
 
     getExpiry = async (userContext?: any): Promise<number> => {
         try {
-            return (
-                await this.helpers.sessionRecipeImpl.getSessionInformation({
-                    sessionHandle: this.sessionHandle,
-                    userContext: userContext === undefined ? {} : userContext,
-                })
-            ).expiry;
+            let sessionInfo = await this.helpers.sessionRecipeImpl.getSessionInformation({
+                sessionHandle: this.sessionHandle,
+                userContext: userContext === undefined ? {} : userContext,
+            });
+            if (sessionInfo === undefined) {
+                throw new STError({
+                    message: "Session information does not exist.",
+                    type: STError.UNAUTHORISED,
+                });
+            }
+            return sessionInfo.expiry;
         } catch (err) {
             if (err.type === STError.UNAUTHORISED) {
                 clearSessionFromCookie(this.helpers.config, this.res);

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -206,8 +206,10 @@ export type RecipeInterface = {
      * Used to retrieve all session information for a given session handle. Can be used in place of:
      * - getSessionData
      * - getAccessTokenPayload
+     *
+     * Returns undefined if the sessionHandle does not exist
      */
-    getSessionInformation(input: { sessionHandle: string; userContext: any }): Promise<SessionInformation>;
+    getSessionInformation(input: { sessionHandle: string; userContext: any }): Promise<SessionInformation | undefined>;
 
     revokeAllSessionsForUser(input: { userId: string; userContext: any }): Promise<string[]>;
 
@@ -217,31 +219,37 @@ export type RecipeInterface = {
 
     revokeMultipleSessions(input: { sessionHandles: string[]; userContext: any }): Promise<string[]>;
 
-    updateSessionData(input: { sessionHandle: string; newSessionData: any; userContext: any }): Promise<void>;
+    // Returns false if the sessionHandle does not exist
+    updateSessionData(input: { sessionHandle: string; newSessionData: any; userContext: any }): Promise<boolean>;
 
+    // Returns false if the sessionHandle does not exist
     updateAccessTokenPayload(input: {
         sessionHandle: string;
         newAccessTokenPayload: any;
         userContext: any;
-    }): Promise<void>;
+    }): Promise<boolean>;
 
+    // Returns undefined if the sessionHandle does not exist
     regenerateAccessToken(input: {
         accessToken: string;
         newAccessTokenPayload?: any;
         userContext: any;
-    }): Promise<{
-        status: "OK";
-        session: {
-            handle: string;
-            userId: string;
-            userDataInJWT: any;
-        };
-        accessToken?: {
-            token: string;
-            expiry: number;
-            createdTime: number;
-        };
-    }>;
+    }): Promise<
+        | {
+              status: "OK";
+              session: {
+                  handle: string;
+                  userId: string;
+                  userDataInJWT: any;
+              };
+              accessToken?: {
+                  token: string;
+                  expiry: number;
+                  createdTime: number;
+              };
+          }
+        | undefined
+    >;
 
     getAccessTokenLifeTimeMS(input: { userContext: any }): Promise<number>;
 

--- a/lib/ts/recipe/session/with-jwt/recipeImplementation.ts
+++ b/lib/ts/recipe/session/with-jwt/recipeImplementation.ts
@@ -46,19 +46,22 @@ export default function (
 
     return {
         ...originalImplementation,
-        createNewSession: async function ({
-            res,
-            userId,
-            accessTokenPayload,
-            sessionData,
-            userContext,
-        }: {
-            res: BaseResponse;
-            userId: string;
-            accessTokenPayload?: any;
-            sessionData?: any;
-            userContext: any;
-        }): Promise<SessionContainerInterface> {
+        createNewSession: async function (
+            this: RecipeInterface,
+            {
+                res,
+                userId,
+                accessTokenPayload,
+                sessionData,
+                userContext,
+            }: {
+                res: BaseResponse;
+                userId: string;
+                accessTokenPayload?: any;
+                sessionData?: any;
+                userContext: any;
+            }
+        ): Promise<SessionContainerInterface> {
             accessTokenPayload =
                 accessTokenPayload === null || accessTokenPayload === undefined ? {} : accessTokenPayload;
             let accessTokenValidityInSeconds = Math.ceil((await this.getAccessTokenLifeTimeMS({ userContext })) / 1000);
@@ -128,18 +131,24 @@ export default function (
 
             return new SessionClassWithJWT(newSession, openIdRecipeImplementation);
         },
-        updateAccessTokenPayload: async function ({
-            sessionHandle,
-            newAccessTokenPayload,
-            userContext,
-        }: {
-            sessionHandle: string;
-            newAccessTokenPayload: any;
-            userContext: any;
-        }): Promise<void> {
+        updateAccessTokenPayload: async function (
+            this: RecipeInterface,
+            {
+                sessionHandle,
+                newAccessTokenPayload,
+                userContext,
+            }: {
+                sessionHandle: string;
+                newAccessTokenPayload: any;
+                userContext: any;
+            }
+        ): Promise<boolean> {
             newAccessTokenPayload =
                 newAccessTokenPayload === null || newAccessTokenPayload === undefined ? {} : newAccessTokenPayload;
             let sessionInformation = await this.getSessionInformation({ sessionHandle, userContext });
+            if (sessionInformation === undefined) {
+                return false;
+            }
             let accessTokenPayload = sessionInformation.accessTokenPayload;
 
             let existingJwtPropertyName = accessTokenPayload[ACCESS_TOKEN_PAYLOAD_JWT_PROPERTY_NAME_KEY];

--- a/test/framework/fastify.test.js
+++ b/test/framework/fastify.test.js
@@ -1042,16 +1042,9 @@ describe(`Fastify: ${printPath("[test/framework/fastify.test.js]")}`, function (
         );
 
         this.server.post("/updateSessionDataInvalidSessionHandle", async (req, res) => {
-            try {
-                await Session.updateSessionData("InvalidHandle", { key: "value3" });
-                return res.send({ success: false }).code(200);
-            } catch (err) {
-                return res
-                    .send({
-                        success: err.type === Session.Error.UNAUTHORISED,
-                    })
-                    .code(200);
-            }
+            return res
+                .send({ success: !(await Session.updateSessionData("InvalidHandle", { key: "value3" })) })
+                .code(200);
         });
 
         await this.server.register(FastifyFramework.plugin);
@@ -1184,16 +1177,9 @@ describe(`Fastify: ${printPath("[test/framework/fastify.test.js]")}`, function (
         );
 
         this.server.post("/updateAccessTokenPayloadInvalidSessionHandle", async (req, res) => {
-            try {
-                await Session.updateSessionData("InvalidHandle", { key: "value3" });
-                return res.send({ success: false }).code(200);
-            } catch (err) {
-                return res
-                    .send({
-                        success: err.type === Session.Error.UNAUTHORISED,
-                    })
-                    .code(200);
-            }
+            return res
+                .send({ success: !(await Session.updateSessionData("InvalidHandle", { key: "value3" })) })
+                .code(200);
         });
 
         await this.server.register(FastifyFramework.plugin);

--- a/test/framework/hapi.test.js
+++ b/test/framework/hapi.test.js
@@ -1050,16 +1050,9 @@ describe(`Hapi: ${printPath("[test/framework/hapi.test.js]")}`, function () {
             path: "/updateSessionDataInvalidSessionHandle",
             method: "post",
             handler: async (req, res) => {
-                try {
-                    await Session.updateSessionData("InvalidHandle", { key: "value3" });
-                    return res.response({ success: false }).code(200);
-                } catch (err) {
-                    return res
-                        .response({
-                            success: err.type === Session.Error.UNAUTHORISED,
-                        })
-                        .code(200);
-                }
+                return res
+                    .response({ success: !(await Session.updateSessionData("InvalidHandle", { key: "value3" })) })
+                    .code(200);
             },
         });
 
@@ -1211,16 +1204,9 @@ describe(`Hapi: ${printPath("[test/framework/hapi.test.js]")}`, function () {
             path: "/updateAccessTokenPayloadInvalidSessionHandle",
             method: "post",
             handler: async (req, res) => {
-                try {
-                    await Session.updateSessionData("InvalidHandle", { key: "value3" });
-                    return res.response({ success: false }).code(200);
-                } catch (err) {
-                    return res
-                        .response({
-                            success: err.type === Session.Error.UNAUTHORISED,
-                        })
-                        .code(200);
-                }
+                return res
+                    .response({ success: !(await Session.updateSessionData("InvalidHandle", { key: "value3" })) })
+                    .code(200);
             },
         });
 

--- a/test/framework/koa.test.js
+++ b/test/framework/koa.test.js
@@ -1214,14 +1214,7 @@ describe(`Koa: ${printPath("[test/framework/koa.test.js]")}`, function () {
         });
 
         router.post("/updateSessionDataInvalidSessionHandle", async (ctx, _) => {
-            try {
-                await Session.updateSessionData("InvalidHandle", { key: "value3" });
-                ctx.body = { success: false };
-            } catch (err) {
-                ctx.body = {
-                    success: err.type === Session.Error.UNAUTHORISED,
-                };
-            }
+            ctx.body = { success: !(await Session.updateSessionData("InvalidHandle", { key: "value3" })) };
         });
 
         app.use(router.routes());
@@ -1388,13 +1381,9 @@ describe(`Koa: ${printPath("[test/framework/koa.test.js]")}`, function () {
         });
 
         router.post("/updateAccessTokenPayloadInvalidSessionHandle", async (ctx, _) => {
-            try {
-                await Session.updateAccessTokenPayload("InvalidHandle", { key: "value3" });
-            } catch (err) {
-                ctx.body = {
-                    success: err.type === Session.Error.UNAUTHORISED,
-                };
-            }
+            ctx.body = {
+                success: !(await Session.updateAccessTokenPayload("InvalidHandle", { key: "value3" })),
+            };
         });
 
         app.use(router.routes());

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -712,14 +712,7 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
         assert.deepEqual(res3, { key: "value 2" });
 
         //passing invalid session handle when updating session data
-        try {
-            await SessionFunctions.updateSessionData(s.helpers, "random", { key2: "value2" });
-            assert(false);
-        } catch (error) {
-            if (error.type !== Session.Error.UNAUTHORISED) {
-                throw error;
-            }
-        }
+        assert(!(await SessionFunctions.updateSessionData(s.helpers, "random", { key2: "value2" })));
     });
 
     it("test manipulating session data with new get session function", async function () {
@@ -763,14 +756,7 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
         assert.deepEqual(res3.sessionData, { key: "value 2" });
 
         //passing invalid session handle when updating session data
-        try {
-            await SessionFunctions.updateSessionData(s.helpers, "random", { key2: "value2" });
-            assert(false);
-        } catch (error) {
-            if (error.type !== Session.Error.UNAUTHORISED) {
-                throw error;
-            }
-        }
+        assert(!(await SessionFunctions.updateSessionData(s.helpers, "random", { key2: "value2" })));
     });
 
     it("test null and undefined values passed for session data", async function () {
@@ -898,24 +884,17 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
 
         await SessionFunctions.updateAccessTokenPayload(s.helpers, res.session.handle, { key: "value" });
 
-        let res2 = await SessionFunctions.getAccessTokenPayload(s.helpers, res.session.handle);
+        let res2 = (await SessionFunctions.getSessionInformation(s.helpers, res.session.handle)).accessTokenPayload;
         assert.deepEqual(res2, { key: "value" });
 
         //changing the value of jwt payload with the same key
         await SessionFunctions.updateAccessTokenPayload(s.helpers, res.session.handle, { key: "value 2" });
 
-        let res3 = await SessionFunctions.getAccessTokenPayload(s.helpers, res.session.handle);
+        let res3 = (await SessionFunctions.getSessionInformation(s.helpers, res.session.handle)).accessTokenPayload;
         assert.deepEqual(res3, { key: "value 2" });
 
         //passing invalid session handle when updating jwt payload
-        try {
-            await SessionFunctions.updateAccessTokenPayload(s.helpers, "random", { key2: "value2" });
-            throw new Error();
-        } catch (error) {
-            if (error.type !== Session.Error.UNAUTHORISED) {
-                throw error;
-            }
-        }
+        assert(!(await SessionFunctions.updateAccessTokenPayload(s.helpers, "random", { key2: "value2" })));
     });
 
     it("test manipulating jwt payload with new get session method", async function () {
@@ -960,14 +939,7 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
         assert.deepEqual(res3.accessTokenPayload, { key: "value 2" });
 
         //passing invalid session handle when updating jwt payload
-        try {
-            await SessionFunctions.updateAccessTokenPayload(s.helpers, "random", { key2: "value2" });
-            throw new Error();
-        } catch (error) {
-            if (error.type !== Session.Error.UNAUTHORISED) {
-                throw error;
-            }
-        }
+        assert(!(await SessionFunctions.updateAccessTokenPayload(s.helpers, "random", { key2: "value2" })));
     });
 
     it("test null and undefined values passed for jwt payload", async function () {
@@ -992,27 +964,28 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
         //adding jwt payload
         let res = await SessionFunctions.createNewSession(s.helpers, "", null, {});
 
-        let res2 = await SessionFunctions.getAccessTokenPayload(s.helpers, res.session.handle);
+        let res2 = (await SessionFunctions.getSessionInformation(s.helpers, res.session.handle)).accessTokenPayload;
         assert.deepStrictEqual(res2, {});
 
         await SessionFunctions.updateAccessTokenPayload(s.helpers, res.session.handle, { key: "value" });
 
-        let res3 = await SessionFunctions.getAccessTokenPayload(s.helpers, res.session.handle);
+        let res3 = (await SessionFunctions.getSessionInformation(s.helpers, res.session.handle)).accessTokenPayload;
         assert.deepStrictEqual(res3, { key: "value" });
 
         await SessionFunctions.updateAccessTokenPayload(s.helpers, res.session.handle);
 
-        let res4 = await SessionFunctions.getAccessTokenPayload(s.helpers, res.session.handle, undefined);
+        let res4 = (await SessionFunctions.getSessionInformation(s.helpers, res.session.handle, undefined))
+            .accessTokenPayload;
         assert.deepStrictEqual(res4, {});
 
         await SessionFunctions.updateAccessTokenPayload(s.helpers, res.session.handle, { key: "value 2" });
 
-        let res5 = await SessionFunctions.getAccessTokenPayload(s.helpers, res.session.handle);
+        let res5 = (await SessionFunctions.getSessionInformation(s.helpers, res.session.handle)).accessTokenPayload;
         assert.deepStrictEqual(res5, { key: "value 2" });
 
         await SessionFunctions.updateAccessTokenPayload(s.helpers, res.session.handle, null);
 
-        let res6 = await SessionFunctions.getAccessTokenPayload(s.helpers, res.session.handle);
+        let res6 = (await SessionFunctions.getSessionInformation(s.helpers, res.session.handle)).accessTokenPayload;
         assert.deepStrictEqual(res6, {});
     });
 
@@ -1290,13 +1263,6 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
         let response = await SessionFunctions.revokeAllSessionsForUser(s.helpers, "someid");
         assert(response.length === 1);
 
-        try {
-            await SessionFunctions.getSessionInformation(s.helpers, res.session.handle);
-            assert(false);
-        } catch (e) {
-            if (e.type !== Session.Error.UNAUTHORISED) {
-                throw e;
-            }
-        }
+        assert(!(await SessionFunctions.getSessionInformation(s.helpers, res.session.handle)));
     });
 });

--- a/test/sessionExpress.test.js
+++ b/test/sessionExpress.test.js
@@ -1157,14 +1157,7 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
         });
 
         app.post("/updateSessionDataInvalidSessionHandle", async (req, res) => {
-            try {
-                await Session.updateSessionData("InvalidHandle", { key: "value3" });
-                res.status(200).json({ success: false });
-            } catch (err) {
-                res.status(200).json({
-                    success: err.type === Session.Error.UNAUTHORISED,
-                });
-            }
+            res.status(200).json({ success: !(await Session.updateSessionData("InvalidHandle", { key: "value3" })) });
         });
 
         //create a new session
@@ -1328,13 +1321,9 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
         });
 
         app.post("/updateAccessTokenPayloadInvalidSessionHandle", async (req, res) => {
-            try {
-                await Session.updateAccessTokenPayload("InvalidHandle", { key: "value3" });
-            } catch (err) {
-                res.status(200).json({
-                    success: err.type === Session.Error.UNAUTHORISED,
-                });
-            }
+            res.status(200).json({
+                success: !(await Session.updateAccessTokenPayload("InvalidHandle", { key: "value3" })),
+            });
         });
 
         //create a new session


### PR DESCRIPTION
## Summary of change

Makes changes to the session recipe for not throwing unauthorised error from functions that accept a session handle / access token and may not be working with the current session.

## Related issues

-   https://github.com/supertokens/backend/issues/83

## Test Plan

TODO

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] Tests
