### PR TITLE
fixes issue https://github.com/supertokens/supertokens-node/issues/343

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     -   `regenerateAccessToken` now returns `undefined` if the input access token's `sessionHandle` does not exist.
     -   The sessionClass functions have not changed in behaviour and still throw UNAUTHORISED. This works cause the sessionClass works on the current session and not some other session.
 
+### Bug fix:
+
+-   Clears cookies when revokeSession is called using the session container, even if the session did not exist from before: https://github.com/supertokens/supertokens-node/issues/343
+
 ## [10.0.1] - 2022-06-28
 
 ### Fixes

--- a/lib/build/recipe/session/sessionClass.js
+++ b/lib/build/recipe/session/sessionClass.js
@@ -37,14 +37,17 @@ class Session {
     constructor(helpers, accessToken, sessionHandle, userId, userDataInAccessToken, res) {
         this.revokeSession = (userContext) =>
             __awaiter(this, void 0, void 0, function* () {
-                if (
-                    yield this.helpers.sessionRecipeImpl.revokeSession({
-                        sessionHandle: this.sessionHandle,
-                        userContext: userContext === undefined ? {} : userContext,
-                    })
-                ) {
-                    cookieAndHeaders_1.clearSessionFromCookie(this.helpers.config, this.res);
-                }
+                yield this.helpers.sessionRecipeImpl.revokeSession({
+                    sessionHandle: this.sessionHandle,
+                    userContext: userContext === undefined ? {} : userContext,
+                });
+                // we do not check the output of calling revokeSession
+                // before clearing the cookies because we are revoking the
+                // current API request's session.
+                // If we instead clear the cookies only when revokeSession
+                // returns true, it can cause this kind of a bug:
+                // https://github.com/supertokens/supertokens-node/issues/343
+                cookieAndHeaders_1.clearSessionFromCookie(this.helpers.config, this.res);
             });
         this.getSessionData = (userContext) =>
             __awaiter(this, void 0, void 0, function* () {

--- a/lib/ts/recipe/session/sessionClass.ts
+++ b/lib/ts/recipe/session/sessionClass.ts
@@ -43,14 +43,18 @@ export default class Session implements SessionContainerInterface {
     }
 
     revokeSession = async (userContext?: any) => {
-        if (
-            await this.helpers.sessionRecipeImpl.revokeSession({
-                sessionHandle: this.sessionHandle,
-                userContext: userContext === undefined ? {} : userContext,
-            })
-        ) {
-            clearSessionFromCookie(this.helpers.config, this.res);
-        }
+        await this.helpers.sessionRecipeImpl.revokeSession({
+            sessionHandle: this.sessionHandle,
+            userContext: userContext === undefined ? {} : userContext,
+        });
+
+        // we do not check the output of calling revokeSession
+        // before clearing the cookies because we are revoking the
+        // current API request's session.
+        // If we instead clear the cookies only when revokeSession
+        // returns true, it can cause this kind of a bug:
+        // https://github.com/supertokens/supertokens-node/issues/343
+        clearSessionFromCookie(this.helpers.config, this.res);
     };
 
     getSessionData = async (userContext?: any): Promise<any> => {

--- a/test/sessionExpress.test.js
+++ b/test/sessionExpress.test.js
@@ -631,6 +631,75 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
         assert(sessionRevokedResponseExtracted.idRefreshTokenFromHeader === "remove");
     });
 
+    it("test signout API works if even session is deleted on the backend after creation", async function () {
+        await startST();
+        SuperTokens.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                Session.init({
+                    antiCsrf: "VIA_TOKEN",
+                }),
+            ],
+        });
+        const app = express();
+        app.use(middleware());
+
+        let sessionHandle = "";
+
+        app.post("/create", async (req, res) => {
+            let session = await Session.createNewSession(res, "", {}, {});
+            sessionHandle = session.getHandle();
+            res.status(200).send("");
+        });
+
+        let res = extractInfoFromResponse(
+            await new Promise((resolve) =>
+                request(app)
+                    .post("/create")
+                    .expect(200)
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                            resolve(res);
+                        }
+                    })
+            )
+        );
+
+        await Session.revokeSession(sessionHandle);
+
+        let sessionRevokedResponse = await new Promise((resolve) =>
+            request(app)
+                .post("/auth/signout")
+                .set("Cookie", ["sAccessToken=" + res.accessToken + ";sIdRefreshToken=" + res.idRefreshTokenFromCookie])
+                .set("anti-csrf", res.antiCsrf)
+                .end((err, res) => {
+                    if (err) {
+                        resolve(undefined);
+                    } else {
+                        resolve(res);
+                    }
+                })
+        );
+
+        let sessionRevokedResponseExtracted = extractInfoFromResponse(sessionRevokedResponse);
+        assert(sessionRevokedResponseExtracted.accessTokenExpiry === "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert(sessionRevokedResponseExtracted.refreshTokenExpiry === "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert(sessionRevokedResponseExtracted.idRefreshTokenExpiry === "Thu, 01 Jan 1970 00:00:00 GMT");
+        assert(sessionRevokedResponseExtracted.accessToken === "");
+        assert(sessionRevokedResponseExtracted.refreshToken === "");
+        assert(sessionRevokedResponseExtracted.idRefreshTokenFromCookie === "");
+        assert(sessionRevokedResponseExtracted.idRefreshTokenFromHeader === "remove");
+    });
+
     //check basic usage of session
     it("test basic usage of express sessions with auto refresh", async function () {
         await startST();


### PR DESCRIPTION
## Summary of change

When calling session.revokeSession, we used to clear the cookies only if the session used to exist in the core. This was an incorrect thing to do cause at the time of API session verification, the session did exist, so we should always clear the cookie when this function is called.

## Related issues

-   https://github.com/supertokens/supertokens-node/issues/343

## Test Plan

Wrote a unit test that checks the output of calling the sign out API when the session is removed from the core before the sign out API is called

## Documentation changes

None

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
