### PR TITLE
refactor: updated setHeaderForExpressLikeResponse function to use res.get instead of res.getHeaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
-## [11.0.1] - 2022-07-06
-
-### Changes:
-
 -   for express framework, while fetching the existing response header, use `get` function instead of `getHeaders`
 
 ## [11.0.0] - 2022-07-05

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-export declare const version = "11.0.1";
+export declare const version = "11.0.0";
 export declare const cdiSupported: string[];

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -14,5 +14,5 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "11.0.1";
+exports.version = "11.0.0";
 exports.cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14"];

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,6 +12,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "11.0.1";
+export const version = "11.0.0";
 
 export const cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "11.0.1",
+    "version": "11.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "11.0.1",
+            "version": "11.0.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "axios": "0.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "11.0.1",
+    "version": "11.0.0",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

- updated setHeaderForExpressLikeResponse function to use res.get instead of res.getHeaders
