### PR TITLE
feat: Improve Type Definitions for `SessionWrapper.getSession`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Adds:
+
+-   Improved type definitions for `SessionWrapper.getSession`.
+
 ## [11.0.0] - 2022-07-05
 
 ### Breaking change:

--- a/lib/build/recipe/session/index.d.ts
+++ b/lib/build/recipe/session/index.d.ts
@@ -19,10 +19,21 @@ export default class SessionWrapper {
         sessionData?: any,
         userContext?: any
     ): Promise<SessionContainer>;
+    static getSession(req: any, res: any): Promise<SessionContainer>;
     static getSession(
         req: any,
         res: any,
-        options?: VerifySessionOptions,
+        options?: VerifySessionOptions & {
+            sessionRequired?: true;
+        },
+        userContext?: any
+    ): Promise<SessionContainer>;
+    static getSession(
+        req: any,
+        res: any,
+        options?: VerifySessionOptions & {
+            sessionRequired: false;
+        },
         userContext?: any
     ): Promise<SessionContainer | undefined>;
     static getSessionInformation(sessionHandle: string, userContext?: any): Promise<SessionInformation | undefined>;

--- a/lib/ts/recipe/session/index.ts
+++ b/lib/ts/recipe/session/index.ts
@@ -52,6 +52,19 @@ export default class SessionWrapper {
         });
     }
 
+    static getSession(req: any, res: any): Promise<SessionContainer>;
+    static getSession(
+        req: any,
+        res: any,
+        options?: VerifySessionOptions & { sessionRequired?: true },
+        userContext?: any
+    ): Promise<SessionContainer>;
+    static getSession(
+        req: any,
+        res: any,
+        options?: VerifySessionOptions & { sessionRequired: false },
+        userContext?: any
+    ): Promise<SessionContainer | undefined>;
     static getSession(req: any, res: any, options?: VerifySessionOptions, userContext: any = {}) {
         if (!res.wrapperUsed) {
             res = frameworks[SuperTokens.getInstanceOrThrowError().framework].wrapResponse(res);

--- a/test/with-typescript/index.ts
+++ b/test/with-typescript/index.ts
@@ -967,7 +967,19 @@ app.use(
         // nextJS types
         let session2 = await NextJS.superTokensNextWrapper(
             async (next) => {
-                return await Session.getSession(req, res);
+                // Works without null checking by default
+                const defaultSession = await Session.getSession(req, res);
+                defaultSession.getUserId();
+
+                // Works without null checking when sessions are explicitly required
+                const requiredSession = await Session.getSession(req, res, { sessionRequired: true });
+                requiredSession.getUserId();
+
+                // REQUIRES null checking when sessions are explicitly NOT required
+                const optionalSession = await Session.getSession(req, res, { sessionRequired: false });
+                optionalSession?.getUserId();
+
+                return defaultSession;
             },
             req,
             res


### PR DESCRIPTION
**NOTE**: I was unable to get the tests running properly from the information in CONTRIBUTING.md. (Also, it seems the `./startTestingEnv` script is deprecated.) The information may be outdated? Or perhaps I just need help in getting setup. Even so, I'm hoping this should be fine since these are just type definition changes.

These types will enable TS to know whether or not the value returned from `SessionWrapper.getSession` is guaranteed to be `defined`.

## Summary of Changes

Provided 3 TypeScript `overload`s for `SessionWrapper.getSession`. These will improve TS types and IntelliSense for consumers of SuperTokens who use TS.

## Related issues

N/A

## Test Plan

Check the types for the various overloads and verify that they are what you expect.

```typescript
import Session from"supertokens-node/recipe/session";

const sessionContainer1 = await Session.getSession(req, res);
const sessionContainer2 = await Session.getSession(req, res, {});
const sessionContainer3 = await Session.getSession(req, res, { sessionRequired: true });
const sessionContainerOrUndefined = await Session.getSession(req, res, { sessionRequired: false});
```

## Documentation changes

N/A -- No changes to implementation were made.

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] ~~`coreDriverInterfaceSupported.json` file has been updated (if needed)~~ N/A
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] ~~`frontendDriverInterfaceSupported.json` file has been updated (if needed)~~ N/A
-   [x] ~~Changes to the version if needed~~ N/A
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] ~~Issue this PR against the latest non released version branch.~~ [Unnecessary](https://discord.com/channels/603466164219281420/757927552999227393/994274648181178579)
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] ~~If have added a new web framework, update the `add-ts-no-check.js` file to include that~~ N/A
-   [x] ~~If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).~~ N/A
-   [x] ~~If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.~~ N/A

## Remaining TODOs for this PR

None
