### PR TITLE
feat(sessionclaims): review feedback

### DIFF
--- a/lib/build/recipe/session/claimBaseClasses/primitiveClaim.js
+++ b/lib/build/recipe/session/claimBaseClasses/primitiveClaim.js
@@ -1,4 +1,35 @@
 "use strict";
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 const types_1 = require("../types");
 class PrimitiveClaim extends types_1.SessionClaim {
@@ -10,16 +41,17 @@ class PrimitiveClaim extends types_1.SessionClaim {
                     claim: this,
                     id: id !== null && id !== void 0 ? id : this.key,
                     shouldRefetch: (payload, ctx) => this.getValueFromPayload(payload, ctx) === undefined,
-                    validate: (payload, ctx) => {
-                        const claimVal = this.getValueFromPayload(payload, ctx);
-                        const isValid = claimVal === val;
-                        return isValid
-                            ? { isValid: isValid }
-                            : {
-                                  isValid,
-                                  reason: { message: "wrong value", expectedValue: val, actualValue: claimVal },
-                              };
-                    },
+                    validate: (payload, ctx) =>
+                        __awaiter(this, void 0, void 0, function* () {
+                            const claimVal = this.getValueFromPayload(payload, ctx);
+                            const isValid = claimVal === val;
+                            return isValid
+                                ? { isValid: isValid }
+                                : {
+                                      isValid,
+                                      reason: { message: "wrong value", expectedValue: val, actualValue: claimVal },
+                                  };
+                        }),
                 };
             },
             hasFreshValue: (val, maxAgeInSeconds, id) => {
@@ -30,27 +62,28 @@ class PrimitiveClaim extends types_1.SessionClaim {
                         this.getValueFromPayload(payload, ctx) === undefined ||
                         // We know payload[this.id] is defined since the value is not undefined in this branch
                         payload[this.key].t < Date.now() - maxAgeInSeconds * 1000,
-                    validate: (payload, ctx) => {
-                        const claimVal = this.getValueFromPayload(payload, ctx);
-                        if (claimVal !== val) {
-                            return {
-                                isValid: false,
-                                reason: { message: "wrong value", expectedValue: val, actualValue: claimVal },
-                            };
-                        }
-                        const ageInSeconds = (Date.now() - payload[this.key].t) / 1000;
-                        if (ageInSeconds > maxAgeInSeconds) {
-                            return {
-                                isValid: false,
-                                reason: {
-                                    message: "expired",
-                                    ageInSeconds,
-                                    maxAgeInSeconds,
-                                },
-                            };
-                        }
-                        return { isValid: true };
-                    },
+                    validate: (payload, ctx) =>
+                        __awaiter(this, void 0, void 0, function* () {
+                            const claimVal = this.getValueFromPayload(payload, ctx);
+                            if (claimVal !== val) {
+                                return {
+                                    isValid: false,
+                                    reason: { message: "wrong value", expectedValue: val, actualValue: claimVal },
+                                };
+                            }
+                            const ageInSeconds = (Date.now() - payload[this.key].t) / 1000;
+                            if (ageInSeconds > maxAgeInSeconds) {
+                                return {
+                                    isValid: false,
+                                    reason: {
+                                        message: "expired",
+                                        ageInSeconds,
+                                        maxAgeInSeconds,
+                                    },
+                                };
+                            }
+                            return { isValid: true };
+                        }),
                 };
             },
         };

--- a/lib/build/recipe/session/claimBaseClasses/primitiveClaim.js
+++ b/lib/build/recipe/session/claimBaseClasses/primitiveClaim.js
@@ -65,13 +65,13 @@ class PrimitiveClaim extends types_1.SessionClaim {
                     validate: (payload, ctx) =>
                         __awaiter(this, void 0, void 0, function* () {
                             const claimVal = this.getValueFromPayload(payload, ctx);
-                            if (claimVal !== val) {
+                            if (claimVal === undefined) {
                                 return {
                                     isValid: false,
                                     reason: { message: "wrong value", expectedValue: val, actualValue: claimVal },
                                 };
                             }
-                            const ageInSeconds = (Date.now() - payload[this.key].t) / 1000;
+                            const ageInSeconds = (Date.now() - this.getLastRefetchTime(payload, ctx)) / 1000;
                             if (ageInSeconds > maxAgeInSeconds) {
                                 return {
                                     isValid: false,
@@ -80,6 +80,12 @@ class PrimitiveClaim extends types_1.SessionClaim {
                                         ageInSeconds,
                                         maxAgeInSeconds,
                                     },
+                                };
+                            }
+                            if (claimVal !== val) {
+                                return {
+                                    isValid: false,
+                                    reason: { message: "wrong value", expectedValue: val, actualValue: claimVal },
                                 };
                             }
                             return { isValid: true };

--- a/lib/build/recipe/session/index.d.ts
+++ b/lib/build/recipe/session/index.d.ts
@@ -100,7 +100,19 @@ export default class SessionWrapper {
         value: T,
         userContext?: any
     ): Promise<boolean>;
-    static getClaimValue<T>(sessionHandle: string, claim: SessionClaim<T>, userContext?: any): Promise<T | undefined>;
+    static getClaimValue<T>(
+        sessionHandle: string,
+        claim: SessionClaim<T>,
+        userContext?: any
+    ): Promise<
+        | {
+              status: "SESSION_DOES_NOT_EXIST_ERROR";
+          }
+        | {
+              status: "OK";
+              value: T | undefined;
+          }
+    >;
     static removeClaim(sessionHandle: string, claim: SessionClaim<any>, userContext?: any): Promise<boolean>;
 }
 export declare let init: typeof Recipe.init;

--- a/lib/build/recipe/session/recipe.d.ts
+++ b/lib/build/recipe/session/recipe.d.ts
@@ -28,7 +28,7 @@ export default class SessionRecipe extends RecipeModule {
     static getInstanceOrThrowError(): SessionRecipe;
     static init(config?: TypeInput): RecipeListFunction;
     static reset(): void;
-    static addClaimFromOtherRecipe: (builder: SessionClaim<any>) => void;
+    static addClaimFromOtherRecipe: (claim: SessionClaim<any>) => void;
     static getClaimsAddedByOtherRecipes: () => SessionClaim<any>[];
     static addClaimValidatorFromOtherRecipe: (builder: SessionClaimValidator) => void;
     static getClaimValidatorsAddedByOtherRecipes: () => SessionClaimValidator[];

--- a/lib/build/recipe/session/recipe.js
+++ b/lib/build/recipe/session/recipe.js
@@ -232,8 +232,11 @@ SessionRecipe.instance = undefined;
 SessionRecipe.claimsAddedByOtherRecipes = [];
 SessionRecipe.claimValidatorsAddedByOtherRecipes = [];
 SessionRecipe.RECIPE_ID = "session";
-SessionRecipe.addClaimFromOtherRecipe = (builder) => {
-    SessionRecipe.claimsAddedByOtherRecipes.push(builder);
+SessionRecipe.addClaimFromOtherRecipe = (claim) => {
+    if (SessionRecipe.claimsAddedByOtherRecipes.some((c) => c.key === claim.key)) {
+        throw new Error("Claim added by multiple recipes");
+    }
+    SessionRecipe.claimsAddedByOtherRecipes.push(claim);
 };
 SessionRecipe.getClaimsAddedByOtherRecipes = () => {
     return SessionRecipe.claimsAddedByOtherRecipes;

--- a/lib/build/recipe/session/recipeImplementation.js
+++ b/lib/build/recipe/session/recipeImplementation.js
@@ -419,9 +419,14 @@ function getRecipeInterface(querier, config) {
                     userContext: input.userContext,
                 });
                 if (sessionInfo === undefined) {
-                    throw new Error("Session does not exist");
+                    return {
+                        status: "SESSION_DOES_NOT_EXIST_ERROR",
+                    };
                 }
-                return input.claim.getValueFromPayload(sessionInfo.accessTokenPayload, input.userContext);
+                return {
+                    status: "OK",
+                    value: input.claim.getValueFromPayload(sessionInfo.accessTokenPayload, input.userContext),
+                };
             });
         },
         removeClaim: function (input) {

--- a/lib/build/recipe/session/recipeImplementation.js
+++ b/lib/build/recipe/session/recipeImplementation.js
@@ -393,12 +393,10 @@ function getRecipeInterface(querier, config) {
                     sessionHandle: input.sessionHandle,
                     userContext: input.userContext,
                 });
-                console.log(input, sessionInfo);
                 if (sessionInfo === undefined) {
                     return false;
                 }
                 const accessTokenPayloadUpdate = yield input.claim.build(sessionInfo.userId, input.userContext);
-                console.log(accessTokenPayloadUpdate);
                 return this.mergeIntoAccessTokenPayload({
                     sessionHandle: input.sessionHandle,
                     accessTokenPayloadUpdate,

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -267,7 +267,15 @@ export declare type RecipeInterface = {
         sessionHandle: string;
         claim: SessionClaim<T>;
         userContext?: any;
-    }): Promise<T | undefined>;
+    }): Promise<
+        | {
+              status: "SESSION_DOES_NOT_EXIST_ERROR";
+          }
+        | {
+              status: "OK";
+              value: T | undefined;
+          }
+    >;
     removeClaim(input: { sessionHandle: string; claim: SessionClaim<any>; userContext?: any }): Promise<boolean>;
 };
 export interface SessionContainerInterface {

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -359,7 +359,7 @@ export declare type SessionClaimValidator = (
     /**
      * Decides if the claim is valid based on the payload (and not checking DB or anything else)
      */
-    validate: (payload: any, userContext: any) => Promise<ClaimValidationResult> | ClaimValidationResult;
+    validate: (payload: any, userContext: any) => Promise<ClaimValidationResult>;
 };
 export declare abstract class SessionClaim<T> {
     readonly key: string;

--- a/lib/ts/recipe/session/claimBaseClasses/primitiveClaim.ts
+++ b/lib/ts/recipe/session/claimBaseClasses/primitiveClaim.ts
@@ -69,13 +69,13 @@ export class PrimitiveClaim<T extends JSONPrimitive> extends SessionClaim<T> {
                     payload[this.key].t < Date.now() - maxAgeInSeconds * 1000,
                 validate: async (payload, ctx) => {
                     const claimVal = this.getValueFromPayload(payload, ctx);
-                    if (claimVal !== val) {
+                    if (claimVal === undefined) {
                         return {
                             isValid: false,
                             reason: { message: "wrong value", expectedValue: val, actualValue: claimVal },
                         };
                     }
-                    const ageInSeconds = (Date.now() - payload[this.key].t) / 1000;
+                    const ageInSeconds = (Date.now() - this.getLastRefetchTime(payload, ctx)!) / 1000;
                     if (ageInSeconds > maxAgeInSeconds) {
                         return {
                             isValid: false,
@@ -84,6 +84,12 @@ export class PrimitiveClaim<T extends JSONPrimitive> extends SessionClaim<T> {
                                 ageInSeconds,
                                 maxAgeInSeconds,
                             },
+                        };
+                    }
+                    if (claimVal !== val) {
+                        return {
+                            isValid: false,
+                            reason: { message: "wrong value", expectedValue: val, actualValue: claimVal },
                         };
                     }
                     return { isValid: true };

--- a/lib/ts/recipe/session/claimBaseClasses/primitiveClaim.ts
+++ b/lib/ts/recipe/session/claimBaseClasses/primitiveClaim.ts
@@ -50,7 +50,7 @@ export class PrimitiveClaim<T extends JSONPrimitive> extends SessionClaim<T> {
                 claim: this,
                 id: id ?? this.key,
                 shouldRefetch: (payload, ctx) => this.getValueFromPayload(payload, ctx) === undefined,
-                validate: (payload, ctx) => {
+                validate: async (payload, ctx) => {
                     const claimVal = this.getValueFromPayload(payload, ctx);
                     const isValid = claimVal === val;
                     return isValid
@@ -67,7 +67,7 @@ export class PrimitiveClaim<T extends JSONPrimitive> extends SessionClaim<T> {
                     this.getValueFromPayload(payload, ctx) === undefined ||
                     // We know payload[this.id] is defined since the value is not undefined in this branch
                     payload[this.key].t < Date.now() - maxAgeInSeconds * 1000,
-                validate: (payload, ctx) => {
+                validate: async (payload, ctx) => {
                     const claimVal = this.getValueFromPayload(payload, ctx);
                     if (claimVal !== val) {
                         return {

--- a/lib/ts/recipe/session/index.ts
+++ b/lib/ts/recipe/session/index.ts
@@ -223,7 +223,15 @@ export default class SessionWrapper {
         sessionHandle: string,
         claim: SessionClaim<T>,
         userContext: any = {}
-    ): Promise<T | undefined> {
+    ): Promise<
+        | {
+              status: "SESSION_DOES_NOT_EXIST_ERROR";
+          }
+        | {
+              status: "OK";
+              value: T | undefined;
+          }
+    > {
         return Recipe.getInstanceOrThrowError().recipeInterfaceImpl.getClaimValue({
             sessionHandle,
             claim,

--- a/lib/ts/recipe/session/recipe.ts
+++ b/lib/ts/recipe/session/recipe.ts
@@ -128,8 +128,11 @@ export default class SessionRecipe extends RecipeModule {
         SessionRecipe.instance = undefined;
     }
 
-    static addClaimFromOtherRecipe = (builder: SessionClaim<any>) => {
-        SessionRecipe.claimsAddedByOtherRecipes.push(builder);
+    static addClaimFromOtherRecipe = (claim: SessionClaim<any>) => {
+        if (SessionRecipe.claimsAddedByOtherRecipes.some((c) => c.key === claim.key)) {
+            throw new Error("Claim added by multiple recipes");
+        }
+        SessionRecipe.claimsAddedByOtherRecipes.push(claim);
     };
 
     static getClaimsAddedByOtherRecipes = (): SessionClaim<any>[] => {

--- a/lib/ts/recipe/session/recipeImplementation.ts
+++ b/lib/ts/recipe/session/recipeImplementation.ts
@@ -496,10 +496,15 @@ export default function getRecipeInterface(querier: Querier, config: TypeNormali
             });
 
             if (sessionInfo === undefined) {
-                throw new Error("Session does not exist");
+                return {
+                    status: "SESSION_DOES_NOT_EXIST_ERROR",
+                };
             }
 
-            return input.claim.getValueFromPayload(sessionInfo.accessTokenPayload, input.userContext);
+            return {
+                status: "OK",
+                value: input.claim.getValueFromPayload(sessionInfo.accessTokenPayload, input.userContext),
+            };
         },
 
         removeClaim: function (

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -415,7 +415,7 @@ export type SessionClaimValidator = (
     /**
      * Decides if the claim is valid based on the payload (and not checking DB or anything else)
      */
-    validate: (payload: any, userContext: any) => Promise<ClaimValidationResult> | ClaimValidationResult;
+    validate: (payload: any, userContext: any) => Promise<ClaimValidationResult>;
 };
 
 export abstract class SessionClaim<T> {

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -311,7 +311,15 @@ export type RecipeInterface = {
         sessionHandle: string;
         claim: SessionClaim<T>;
         userContext?: any;
-    }): Promise<T | undefined>;
+    }): Promise<
+        | {
+              status: "SESSION_DOES_NOT_EXIST_ERROR";
+          }
+        | {
+              status: "OK";
+              value: T | undefined;
+          }
+    >;
 
     removeClaim(input: { sessionHandle: string; claim: SessionClaim<any>; userContext?: any }): Promise<boolean>;
 };

--- a/test/session/claims/getClaimValue.test.js
+++ b/test/session/claims/getClaimValue.test.js
@@ -108,10 +108,13 @@ describe(`sessionClaims/getClaimValue: ${printPath("[test/session/claims/getClai
             const session = await Session.createNewSession(response, "someId");
 
             const res = await Session.getClaimValue(session.getHandle(), TrueClaim);
-            assert.equal(res, true);
+            assert.deepStrictEqual(res, {
+                status: "OK",
+                value: true,
+            });
         });
 
-        it("should throw for not existing handle", async function () {
+        it("should work for not existing handle", async function () {
             await startST();
 
             SuperTokens.init({
@@ -126,7 +129,9 @@ describe(`sessionClaims/getClaimValue: ${printPath("[test/session/claims/getClai
                 recipeList: [Session.init()],
             });
 
-            await assert.rejects(Session.getClaimValue("asfd", TrueClaim), /Session does not exist/);
+            assert.deepStrictEqual(await Session.getClaimValue("asfd", TrueClaim), {
+                status: "SESSION_DOES_NOT_EXIST_ERROR",
+            });
         });
     });
 });

--- a/test/session/claims/primitiveClaim.test.js
+++ b/test/session/claims/primitiveClaim.test.js
@@ -193,7 +193,7 @@ describe(`sessionClaims/primitiveClaim: ${printPath("[test/session/claims/primit
 
             it("should not validate mismatching payload", async () => {
                 const payload = await claim.build("userId");
-                const res = claim.validators.hasValue(val2).validate(payload, {});
+                const res = await claim.validators.hasValue(val2).validate(payload, {});
                 assert.deepStrictEqual(res, {
                     isValid: false,
                     reason: {
@@ -206,7 +206,7 @@ describe(`sessionClaims/primitiveClaim: ${printPath("[test/session/claims/primit
 
             it("should validate matching payload", async () => {
                 const payload = await claim.build("userId");
-                const res = claim.validators.hasValue(val).validate(payload, {});
+                const res = await claim.validators.hasValue(val).validate(payload, {});
                 assert.deepStrictEqual(res, {
                     isValid: true,
                 });
@@ -221,20 +221,20 @@ describe(`sessionClaims/primitiveClaim: ${printPath("[test/session/claims/primit
                 // advance clock by one week
                 clock.tick(6.048e8);
 
-                const res = claim.validators.hasValue(val).validate(payload, {});
+                const res = await claim.validators.hasValue(val).validate(payload, {});
                 assert.deepStrictEqual(res, {
                     isValid: true,
                 });
             });
 
-            it("should refetch if value is not set", () => {
-                assert.equal(claim.validators.hasValue(val2).shouldRefetch({}), true);
+            it("should refetch if value is not set", async () => {
+                assert.equal(await claim.validators.hasValue(val2).shouldRefetch({}), true);
             });
 
             it("should not refetch if value is set", async () => {
                 const payload = await claim.build("userId");
 
-                assert.equal(claim.validators.hasValue(val2).shouldRefetch(payload), false);
+                assert.equal(await claim.validators.hasValue(val2).shouldRefetch(payload), false);
             });
         });
 
@@ -260,7 +260,7 @@ describe(`sessionClaims/primitiveClaim: ${printPath("[test/session/claims/primit
 
             it("should not validate mismatching payload", async () => {
                 const payload = await claim.build("userId");
-                const res = claim.validators.hasFreshValue(val2, 600).validate(payload, {});
+                const res = await claim.validators.hasFreshValue(val2, 600).validate(payload, {});
                 assert.deepStrictEqual(res, {
                     isValid: false,
                     reason: {
@@ -273,7 +273,7 @@ describe(`sessionClaims/primitiveClaim: ${printPath("[test/session/claims/primit
 
             it("should validate matching payload", async () => {
                 const payload = await claim.build("userId");
-                const res = claim.validators.hasFreshValue(val, 600).validate(payload, {});
+                const res = await claim.validators.hasFreshValue(val, 600).validate(payload, {});
                 assert.deepStrictEqual(res, {
                     isValid: true,
                 });
@@ -288,7 +288,7 @@ describe(`sessionClaims/primitiveClaim: ${printPath("[test/session/claims/primit
                 // advance clock by one week
                 clock.tick(6.048e8);
 
-                const res = claim.validators.hasFreshValue(val, 600).validate(payload, {});
+                const res = await claim.validators.hasFreshValue(val, 600).validate(payload, {});
                 assert.deepStrictEqual(res, {
                     isValid: false,
                     reason: {

--- a/test/with-typescript/index.ts
+++ b/test/with-typescript/index.ts
@@ -973,7 +973,7 @@ class StringClaim extends PrimitiveClaim<string> {
                 claim: this,
                 id: key,
                 shouldRefetch: () => false,
-                validate: (payload) => {
+                validate: async (payload) => {
                     const value = this.getValueFromPayload(payload);
                     if (!value || !value.startsWith(str)) {
                         return {


### PR DESCRIPTION
## Summary of change

- make getClaimValue non-throwing
- update tests for async validators
- throw on duplicate claims added by recipes
- check expiration first in primitive claims
- make validators return only promises

## Related issues

-   #278 
