### PR TITLE
fix: fastify set-cookie header issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [11.0.1] - 2022-07-18
+
+### Fixes
+
+-   Fixed fastify issue where same cookie was getting set multiple times on the response object
+
 ## [11.0.0] - 2022-07-05
 
 ### Breaking change:

--- a/lib/build/framework/express/framework.d.ts
+++ b/lib/build/framework/express/framework.d.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+/// <reference types="qs" />
 import type { Request, Response, NextFunction } from "express";
 import type { HTTPMethod } from "../../types";
 import { BaseRequest } from "../request";
@@ -43,8 +44,29 @@ export declare class ExpressResponse extends BaseResponse {
 export interface SessionRequest extends Request {
     session?: SessionContainerInterface;
 }
-export declare const middleware: () => (req: Request, res: Response, next: NextFunction) => Promise<void>;
-export declare const errorHandler: () => (err: any, req: Request, res: Response, next: NextFunction) => Promise<void>;
+export declare const middleware: () => (
+    req: Request<
+        import("express-serve-static-core").ParamsDictionary,
+        any,
+        any,
+        import("qs").ParsedQs,
+        Record<string, any>
+    >,
+    res: Response<any, Record<string, any>>,
+    next: NextFunction
+) => Promise<void>;
+export declare const errorHandler: () => (
+    err: any,
+    req: Request<
+        import("express-serve-static-core").ParamsDictionary,
+        any,
+        any,
+        import("qs").ParsedQs,
+        Record<string, any>
+    >,
+    res: Response<any, Record<string, any>>,
+    next: NextFunction
+) => Promise<void>;
 export interface ExpressFramework extends Framework {
     middleware: () => (req: Request, res: Response, next: NextFunction) => Promise<void>;
     errorHandler: () => (err: any, req: Request, res: Response, next: NextFunction) => Promise<void>;

--- a/lib/build/framework/express/index.d.ts
+++ b/lib/build/framework/express/index.d.ts
@@ -1,14 +1,27 @@
 // @ts-nocheck
+/// <reference types="qs" />
 export type { SessionRequest } from "./framework";
 export declare const middleware: () => (
-    req: import("express").Request,
-    res: import("express").Response,
+    req: import("express").Request<
+        import("express-serve-static-core").ParamsDictionary,
+        any,
+        any,
+        import("qs").ParsedQs,
+        Record<string, any>
+    >,
+    res: import("express").Response<any, Record<string, any>>,
     next: import("express").NextFunction
 ) => Promise<void>;
 export declare const errorHandler: () => (
     err: any,
-    req: import("express").Request,
-    res: import("express").Response,
+    req: import("express").Request<
+        import("express-serve-static-core").ParamsDictionary,
+        any,
+        any,
+        import("qs").ParsedQs,
+        Record<string, any>
+    >,
+    res: import("express").Response<any, Record<string, any>>,
     next: import("express").NextFunction
 ) => Promise<void>;
 export declare const wrapRequest: (unwrapped: any) => import("..").BaseRequest;

--- a/lib/build/framework/fastify/framework.js
+++ b/lib/build/framework/fastify/framework.js
@@ -126,9 +126,43 @@ class FastifyResponse extends response_1.BaseResponse {
                 path,
                 sameSite
             );
-            let prev = this.response.getHeader(constants_1.COOKIE_HEADER);
-            let cookieValueToSetInHeader = utils_2.getCookieValueToSetInHeader(prev, serialisedCookie, key);
-            this.response.header(constants_1.COOKIE_HEADER, cookieValueToSetInHeader);
+            /**
+             * lets say if current value is undefined, prev -> undefined
+             *
+             * now if add AT,
+             * cookieValueToSetInHeader -> AT
+             * response header object will be:
+             *
+             * 'set-cookie': AT
+             *
+             * now if add RT,
+             *
+             * prev -> AT
+             * cookieValueToSetInHeader -> AT + RT
+             * and response header object will be:
+             *
+             * 'set-cookie': AT + AT + RT
+             *
+             * now if add IRT,
+             *
+             * prev -> AT + AT + RT
+             * cookieValueToSetInHeader -> IRT + AT + AT + RT
+             * and response header object will be:
+             *
+             * 'set-cookie': AT + AT + RT + IRT + AT + AT + RT
+             *
+             * To avoid this, we no longer get and use the previous value
+             *
+             * Old code:
+             *
+             * let prev: string | string[] | undefined = this.response.getHeader(COOKIE_HEADER) as
+             * | string
+             * | string[]
+             * | undefined;
+             * let cookieValueToSetInHeader = getCookieValueToSetInHeader(prev, serialisedCookie, key);
+             * this.response.header(COOKIE_HEADER, cookieValueToSetInHeader);
+             */
+            this.response.header(constants_1.COOKIE_HEADER, serialisedCookie);
         };
         /**
          * @param {number} statusCode

--- a/lib/build/recipe/session/framework/express.d.ts
+++ b/lib/build/recipe/session/framework/express.d.ts
@@ -4,4 +4,4 @@ import type { SessionRequest } from "../../../framework/express/framework";
 import type { NextFunction, Response } from "express";
 export declare function verifySession(
     options?: VerifySessionOptions
-): (req: SessionRequest, res: Response, next: NextFunction) => Promise<void>;
+): (req: SessionRequest, res: Response<any, Record<string, any>>, next: NextFunction) => Promise<void>;

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
-export declare const version = "11.0.0";
+export declare const version = "11.0.1";
 export declare const cdiSupported: string[];

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -14,5 +14,5 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "11.0.0";
+exports.version = "11.0.1";
 exports.cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14"];

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,6 +12,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "11.0.0";
+export const version = "11.0.1";
 
 export const cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "11.0.0",
+    "version": "11.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "11.0.0",
+            "version": "11.0.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "axios": "0.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "11.0.0",
+    "version": "11.0.1",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {

--- a/test/framework/fastify.test.js
+++ b/test/framework/fastify.test.js
@@ -12,7 +12,15 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-const { printPath, setupST, startST, killAllST, cleanST, extractInfoFromResponse } = require("../utils");
+const {
+    printPath,
+    setupST,
+    startST,
+    killAllST,
+    cleanST,
+    extractInfoFromResponse,
+    extractCookieCountInfo,
+} = require("../utils");
 let assert = require("assert");
 let { ProcessState, PROCESS_STATE } = require("../../lib/build/processState");
 let SuperTokens = require("../../");
@@ -1375,5 +1383,42 @@ describe(`Fastify: ${printPath("[test/framework/fastify.test.js]")}`, function (
         });
 
         assert(res2.statusCode === 200);
+    });
+
+    it("test same cookie is not getting set multiple times", async function () {
+        await startST();
+        SuperTokens.init({
+            framework: "fastify",
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                Session.init({
+                    antiCsrf: "VIA_TOKEN",
+                }),
+            ],
+        });
+
+        await this.server.register(FastifyFramework.plugin);
+
+        this.server.post("/create", async (req, res) => {
+            await Session.createNewSession(res, "id1", {}, {});
+            return res.send("").code(200);
+        });
+
+        let res = extractCookieCountInfo(
+            await this.server.inject({
+                method: "post",
+                url: "/create",
+            })
+        );
+        assert.strictEqual(res.accessToken, 1);
+        assert.strictEqual(res.refreshToken, 1);
+        assert.strictEqual(res.idRefreshToken, 1);
     });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -158,6 +158,31 @@ module.exports.extractInfoFromResponse = function (res) {
     };
 };
 
+module.exports.extractCookieCountInfo = function (res) {
+    let accessToken = 0;
+    let refreshToken = 0;
+    let idRefreshToken = 0;
+    let cookies = res.headers["set-cookie"] || res.headers["Set-Cookie"];
+    cookies = cookies === undefined ? [] : cookies;
+    if (!Array.isArray(cookies)) {
+        cookies = [cookies];
+    }
+    cookies.forEach((i) => {
+        if (i.split(";")[0].split("=")[0] === "sAccessToken") {
+            accessToken += 1;
+        } else if (i.split(";")[0].split("=")[0] === "sRefreshToken") {
+            refreshToken += 1;
+        } else {
+            idRefreshToken += 1;
+        }
+    });
+    return {
+        accessToken,
+        refreshToken,
+        idRefreshToken,
+    };
+};
+
 module.exports.setupST = async function () {
     let installationPath = process.env.INSTALL_PATH;
     try {


### PR DESCRIPTION
## Summary of change
- Updated fastify set cookie function to not use getCookieValueToSetInHeader function while setting cookie in header
