### PR TITLE
feat(sessionclaims): verify session user context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added `fetchAndSetClaim`, `getClaimValue`, `setClaimValue` and `removeClaim` to the Session recipe to manage claims.
 -   Added `assertClaims`, `fetchAndSetClaim`, `getClaimValue`, `setClaimValue` and `removeClaim` to session objects to manage claims.
 -   Added session to the input of `generateEmailVerifyTokenPOST`, `verifyEmailPOST`, `isEmailVerifiedGET`.
+-   Adds default userContext for verifySession calls that contains the request object.
 
 ### Breaking changes
 

--- a/lib/build/recipe/session/recipe.js
+++ b/lib/build/recipe/session/recipe.js
@@ -60,6 +60,7 @@ const implementation_1 = require("./api/implementation");
 const supertokens_js_override_1 = require("supertokens-js-override");
 const recipe_1 = require("../openid/recipe");
 const logger_1 = require("../../logger");
+const utils_2 = require("../../utils");
 // For Express
 class SessionRecipe extends recipeModule_1.default {
     constructor(recipeId, appInfo, isInServerlessEnv, config) {
@@ -179,7 +180,7 @@ class SessionRecipe extends recipeModule_1.default {
                         isInServerlessEnv: this.isInServerlessEnv,
                         recipeImplementation: this.recipeInterfaceImpl,
                     },
-                    userContext: {},
+                    userContext: utils_2.makeDefaultUserContextFromAPI(request),
                 });
             });
         this.config = utils_1.validateAndNormaliseUserInput(this, appInfo, config);

--- a/lib/ts/recipe/session/recipe.ts
+++ b/lib/ts/recipe/session/recipe.ts
@@ -40,6 +40,7 @@ import OverrideableBuilder from "supertokens-js-override";
 import { APIOptions } from ".";
 import OpenIdRecipe from "../openid/recipe";
 import { logDebugMessage } from "../../logger";
+import { makeDefaultUserContextFromAPI } from "../../utils";
 
 // For Express
 export default class SessionRecipe extends RecipeModule {
@@ -259,7 +260,7 @@ export default class SessionRecipe extends RecipeModule {
                 isInServerlessEnv: this.isInServerlessEnv,
                 recipeImplementation: this.recipeInterfaceImpl,
             },
-            userContext: {},
+            userContext: makeDefaultUserContextFromAPI(request),
         });
     };
 }


### PR DESCRIPTION
## Summary of change

Add the request to the default user context of `verifySession`. This is used during testing + can be useful for the user in `overrideGlobalClaimValidators`

## Related issues

-   

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
