### PR TITLE
fix: use recipe functions with overrides in SessionContainer methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Bug fix:
+
+-   Fixes overrides not applying correctly in methods called on SessionContainer instances
+
 ## [11.0.2] - 2022-08-02
 
 ### Bug fix:

--- a/lib/build/recipe/session/recipe.js
+++ b/lib/build/recipe/session/recipe.js
@@ -176,7 +176,11 @@ class SessionRecipe extends recipeModule_1.default {
                 override: this.config.override.openIdFeature,
             });
             let builder = new supertokens_js_override_1.default(
-                recipeImplementation_1.default(querier_1.Querier.getNewInstanceOrThrowError(recipeId), this.config)
+                recipeImplementation_1.default(
+                    querier_1.Querier.getNewInstanceOrThrowError(recipeId),
+                    this.config,
+                    () => this.recipeInterfaceImpl
+                )
             );
             this.recipeInterfaceImpl = builder
                 .override((oI) => {
@@ -192,7 +196,11 @@ class SessionRecipe extends recipeModule_1.default {
         } else {
             {
                 let builder = new supertokens_js_override_1.default(
-                    recipeImplementation_1.default(querier_1.Querier.getNewInstanceOrThrowError(recipeId), this.config)
+                    recipeImplementation_1.default(
+                        querier_1.Querier.getNewInstanceOrThrowError(recipeId),
+                        this.config,
+                        () => this.recipeInterfaceImpl
+                    )
                 );
                 this.recipeInterfaceImpl = builder.override(this.config.override.functions).build();
             }

--- a/lib/build/recipe/session/recipeImplementation.d.ts
+++ b/lib/build/recipe/session/recipeImplementation.d.ts
@@ -23,6 +23,10 @@ export declare type Helpers = {
     getHandshakeInfo: (forceRefetch?: boolean) => Promise<HandshakeInfo>;
     updateJwtSigningPublicKeyInfo: (keyList: KeyInfo[] | undefined, publicKey: string, expiryTime: number) => void;
     config: TypeNormalisedInput;
-    sessionRecipeImpl: RecipeInterface;
+    getRecipeImpl: () => RecipeInterface;
 };
-export default function getRecipeInterface(querier: Querier, config: TypeNormalisedInput): RecipeInterface;
+export default function getRecipeInterface(
+    querier: Querier,
+    config: TypeNormalisedInput,
+    getRecipeImplAfterOverrides: () => RecipeInterface
+): RecipeInterface;

--- a/lib/build/recipe/session/recipeImplementation.js
+++ b/lib/build/recipe/session/recipeImplementation.js
@@ -71,7 +71,7 @@ class HandshakeInfo {
     }
 }
 exports.HandshakeInfo = HandshakeInfo;
-function getRecipeInterface(querier, config) {
+function getRecipeInterface(querier, config, getRecipeImplAfterOverrides) {
     let handshakeInfo;
     function getHandshakeInfo(forceRefetch = false) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -345,7 +345,7 @@ function getRecipeInterface(querier, config) {
         updateJwtSigningPublicKeyInfo,
         getHandshakeInfo,
         config,
-        sessionRecipeImpl: obj,
+        getRecipeImpl: getRecipeImplAfterOverrides,
     };
     if (process.env.TEST_MODE === "testing") {
         // testing mode, we add some of the help functions to the obj

--- a/lib/build/recipe/session/sessionClass.d.ts
+++ b/lib/build/recipe/session/sessionClass.d.ts
@@ -20,7 +20,7 @@ export default class Session implements SessionContainerInterface {
     revokeSession: (userContext?: any) => Promise<void>;
     getSessionData: (userContext?: any) => Promise<any>;
     updateSessionData: (newSessionData: any, userContext?: any) => Promise<void>;
-    getUserId: () => string;
+    getUserId: (_userContext?: any) => string;
     getAccessTokenPayload: () => any;
     getHandle: () => string;
     getAccessToken: () => string;

--- a/lib/build/recipe/session/sessionClass.js
+++ b/lib/build/recipe/session/sessionClass.js
@@ -37,7 +37,7 @@ class Session {
     constructor(helpers, accessToken, sessionHandle, userId, userDataInAccessToken, res) {
         this.revokeSession = (userContext) =>
             __awaiter(this, void 0, void 0, function* () {
-                yield this.helpers.sessionRecipeImpl.revokeSession({
+                yield this.helpers.getRecipeImpl().revokeSession({
                     sessionHandle: this.sessionHandle,
                     userContext: userContext === undefined ? {} : userContext,
                 });
@@ -51,7 +51,7 @@ class Session {
             });
         this.getSessionData = (userContext) =>
             __awaiter(this, void 0, void 0, function* () {
-                let sessionInfo = yield this.helpers.sessionRecipeImpl.getSessionInformation({
+                let sessionInfo = yield this.helpers.getRecipeImpl().getSessionInformation({
                     sessionHandle: this.sessionHandle,
                     userContext: userContext === undefined ? {} : userContext,
                 });
@@ -67,7 +67,7 @@ class Session {
         this.updateSessionData = (newSessionData, userContext) =>
             __awaiter(this, void 0, void 0, function* () {
                 if (
-                    !(yield this.helpers.sessionRecipeImpl.updateSessionData({
+                    !(yield this.helpers.getRecipeImpl().updateSessionData({
                         sessionHandle: this.sessionHandle,
                         newSessionData,
                         userContext: userContext === undefined ? {} : userContext,
@@ -80,7 +80,7 @@ class Session {
                     });
                 }
             });
-        this.getUserId = () => {
+        this.getUserId = (_userContext) => {
             return this.userId;
         };
         this.getAccessTokenPayload = () => {
@@ -94,7 +94,7 @@ class Session {
         };
         this.updateAccessTokenPayload = (newAccessTokenPayload, userContext) =>
             __awaiter(this, void 0, void 0, function* () {
-                let response = yield this.helpers.sessionRecipeImpl.regenerateAccessToken({
+                let response = yield this.helpers.getRecipeImpl().regenerateAccessToken({
                     accessToken: this.getAccessToken(),
                     newAccessTokenPayload,
                     userContext: userContext === undefined ? {} : userContext,
@@ -125,7 +125,7 @@ class Session {
             });
         this.getTimeCreated = (userContext) =>
             __awaiter(this, void 0, void 0, function* () {
-                let sessionInfo = yield this.helpers.sessionRecipeImpl.getSessionInformation({
+                let sessionInfo = yield this.helpers.getRecipeImpl().getSessionInformation({
                     sessionHandle: this.sessionHandle,
                     userContext: userContext === undefined ? {} : userContext,
                 });
@@ -140,7 +140,7 @@ class Session {
             });
         this.getExpiry = (userContext) =>
             __awaiter(this, void 0, void 0, function* () {
-                let sessionInfo = yield this.helpers.sessionRecipeImpl.getSessionInformation({
+                let sessionInfo = yield this.helpers.getRecipeImpl().getSessionInformation({
                     sessionHandle: this.sessionHandle,
                     userContext: userContext === undefined ? {} : userContext,
                 });

--- a/lib/ts/recipe/session/recipe.ts
+++ b/lib/ts/recipe/session/recipe.ts
@@ -66,7 +66,11 @@ export default class SessionRecipe extends RecipeModule {
             });
 
             let builder = new OverrideableBuilder(
-                RecipeImplementation(Querier.getNewInstanceOrThrowError(recipeId), this.config)
+                RecipeImplementation(
+                    Querier.getNewInstanceOrThrowError(recipeId),
+                    this.config,
+                    () => this.recipeInterfaceImpl
+                )
             );
             this.recipeInterfaceImpl = builder
                 .override((oI) => {
@@ -82,7 +86,11 @@ export default class SessionRecipe extends RecipeModule {
         } else {
             {
                 let builder = new OverrideableBuilder(
-                    RecipeImplementation(Querier.getNewInstanceOrThrowError(recipeId), this.config)
+                    RecipeImplementation(
+                        Querier.getNewInstanceOrThrowError(recipeId),
+                        this.config,
+                        () => this.recipeInterfaceImpl
+                    )
                 );
                 this.recipeInterfaceImpl = builder.override(this.config.override.functions).build();
             }

--- a/lib/ts/recipe/session/recipeImplementation.ts
+++ b/lib/ts/recipe/session/recipeImplementation.ts
@@ -61,10 +61,14 @@ export type Helpers = {
     getHandshakeInfo: (forceRefetch?: boolean) => Promise<HandshakeInfo>;
     updateJwtSigningPublicKeyInfo: (keyList: KeyInfo[] | undefined, publicKey: string, expiryTime: number) => void;
     config: TypeNormalisedInput;
-    sessionRecipeImpl: RecipeInterface;
+    getRecipeImpl: () => RecipeInterface;
 };
 
-export default function getRecipeInterface(querier: Querier, config: TypeNormalisedInput): RecipeInterface {
+export default function getRecipeInterface(
+    querier: Querier,
+    config: TypeNormalisedInput,
+    getRecipeImplAfterOverrides: () => RecipeInterface
+): RecipeInterface {
     let handshakeInfo: undefined | HandshakeInfo;
 
     async function getHandshakeInfo(forceRefetch = false): Promise<HandshakeInfo> {
@@ -377,7 +381,7 @@ export default function getRecipeInterface(querier: Querier, config: TypeNormali
         updateJwtSigningPublicKeyInfo,
         getHandshakeInfo,
         config,
-        sessionRecipeImpl: obj,
+        getRecipeImpl: getRecipeImplAfterOverrides,
     };
 
     if (process.env.TEST_MODE === "testing") {

--- a/lib/ts/recipe/session/sessionClass.ts
+++ b/lib/ts/recipe/session/sessionClass.ts
@@ -43,7 +43,7 @@ export default class Session implements SessionContainerInterface {
     }
 
     revokeSession = async (userContext?: any) => {
-        await this.helpers.sessionRecipeImpl.revokeSession({
+        await this.helpers.getRecipeImpl().revokeSession({
             sessionHandle: this.sessionHandle,
             userContext: userContext === undefined ? {} : userContext,
         });
@@ -58,7 +58,7 @@ export default class Session implements SessionContainerInterface {
     };
 
     getSessionData = async (userContext?: any): Promise<any> => {
-        let sessionInfo = await this.helpers.sessionRecipeImpl.getSessionInformation({
+        let sessionInfo = await this.helpers.getRecipeImpl().getSessionInformation({
             sessionHandle: this.sessionHandle,
             userContext: userContext === undefined ? {} : userContext,
         });
@@ -74,7 +74,7 @@ export default class Session implements SessionContainerInterface {
 
     updateSessionData = async (newSessionData: any, userContext?: any) => {
         if (
-            !(await this.helpers.sessionRecipeImpl.updateSessionData({
+            !(await this.helpers.getRecipeImpl().updateSessionData({
                 sessionHandle: this.sessionHandle,
                 newSessionData,
                 userContext: userContext === undefined ? {} : userContext,
@@ -88,7 +88,7 @@ export default class Session implements SessionContainerInterface {
         }
     };
 
-    getUserId = () => {
+    getUserId = (_userContext?: any) => {
         return this.userId;
     };
 
@@ -105,7 +105,7 @@ export default class Session implements SessionContainerInterface {
     };
 
     updateAccessTokenPayload = async (newAccessTokenPayload: any, userContext?: any) => {
-        let response = await this.helpers.sessionRecipeImpl.regenerateAccessToken({
+        let response = await this.helpers.getRecipeImpl().regenerateAccessToken({
             accessToken: this.getAccessToken(),
             newAccessTokenPayload,
             userContext: userContext === undefined ? {} : userContext,
@@ -136,7 +136,7 @@ export default class Session implements SessionContainerInterface {
     };
 
     getTimeCreated = async (userContext?: any): Promise<number> => {
-        let sessionInfo = await this.helpers.sessionRecipeImpl.getSessionInformation({
+        let sessionInfo = await this.helpers.getRecipeImpl().getSessionInformation({
             sessionHandle: this.sessionHandle,
             userContext: userContext === undefined ? {} : userContext,
         });
@@ -151,7 +151,7 @@ export default class Session implements SessionContainerInterface {
     };
 
     getExpiry = async (userContext?: any): Promise<number> => {
-        let sessionInfo = await this.helpers.sessionRecipeImpl.getSessionInformation({
+        let sessionInfo = await this.helpers.getRecipeImpl().getSessionInformation({
             sessionHandle: this.sessionHandle,
             userContext: userContext === undefined ? {} : userContext,
         });

--- a/test/utils.js
+++ b/test/utils.js
@@ -531,3 +531,17 @@ module.exports.areArraysEqual = function (arr1, arr2) {
 
     return true;
 };
+
+/**
+ *
+ * @returns {import("express").Response}
+ */
+module.exports.mockResponse = () => {
+    const headers = {};
+    const res = {
+        getHeaders: () => headers,
+        getHeader: (key) => headers[key],
+        setHeader: (key, val) => (headers[key] = val),
+    };
+    return res;
+};


### PR DESCRIPTION
## Summary of change

Use recipe functions with overrides in SessionContainer methods.

## Related issues

-   #366

## Test Plan

Added a simple test case that checks if the override is applied (it fails without the fix)

## Documentation changes

N/A, bugfix

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
