### PR TITLE
feat(sessionclaims): review feedback

### DIFF
--- a/lib/build/recipe/emailverification/emailVerificationClaim.js
+++ b/lib/build/recipe/emailverification/emailVerificationClaim.js
@@ -63,7 +63,7 @@ class EmailVerificationClaimClass extends claims_1.BooleanClaim {
         });
         this.validators = Object.assign(Object.assign({}, this.validators), {
             isVerified: (refetchTimeOnFalseInSeconds = 10) =>
-                Object.assign(Object.assign({}, this.validators.hasValue(true, "st-ev-isVerified")), {
+                Object.assign(Object.assign({}, this.validators.hasValue(true)), {
                     shouldRefetch: (payload, userContext) => {
                         const value = this.getValueFromPayload(payload, userContext);
                         return (

--- a/lib/build/recipe/session/claimBaseClasses/booleanClaim.d.ts
+++ b/lib/build/recipe/session/claimBaseClasses/booleanClaim.d.ts
@@ -2,7 +2,11 @@
 import { SessionClaim, SessionClaimValidator } from "../types";
 import { PrimitiveClaim } from "./primitiveClaim";
 export declare class BooleanClaim extends PrimitiveClaim<boolean> {
-    constructor(conf: { key: string; fetchValue: SessionClaim<boolean>["fetchValue"] });
+    constructor(conf: {
+        key: string;
+        fetchValue: SessionClaim<boolean>["fetchValue"];
+        defaultMaxAgeInSeconds?: number;
+    });
     validators: PrimitiveClaim<boolean>["validators"] & {
         isTrue: (maxAge?: number) => SessionClaimValidator;
         isFalse: (maxAge?: number) => SessionClaimValidator;

--- a/lib/build/recipe/session/claimBaseClasses/booleanClaim.d.ts
+++ b/lib/build/recipe/session/claimBaseClasses/booleanClaim.d.ts
@@ -8,7 +8,7 @@ export declare class BooleanClaim extends PrimitiveClaim<boolean> {
         defaultMaxAgeInSeconds?: number;
     });
     validators: PrimitiveClaim<boolean>["validators"] & {
-        isTrue: (maxAge?: number) => SessionClaimValidator;
-        isFalse: (maxAge?: number) => SessionClaimValidator;
+        isTrue: (maxAge?: number, id?: string) => SessionClaimValidator;
+        isFalse: (maxAge?: number, id?: string) => SessionClaimValidator;
     };
 }

--- a/lib/build/recipe/session/claimBaseClasses/booleanClaim.js
+++ b/lib/build/recipe/session/claimBaseClasses/booleanClaim.js
@@ -5,8 +5,8 @@ class BooleanClaim extends primitiveClaim_1.PrimitiveClaim {
     constructor(conf) {
         super(conf);
         this.validators = Object.assign(Object.assign({}, this.validators), {
-            isTrue: (maxAge) => this.validators.hasValue(true, maxAge),
-            isFalse: (maxAge) => this.validators.hasValue(false, maxAge),
+            isTrue: (maxAge, id) => this.validators.hasValue(true, maxAge, id),
+            isFalse: (maxAge, id) => this.validators.hasValue(false, maxAge, id),
         });
     }
 }

--- a/lib/build/recipe/session/claimBaseClasses/booleanClaim.js
+++ b/lib/build/recipe/session/claimBaseClasses/booleanClaim.js
@@ -5,18 +5,8 @@ class BooleanClaim extends primitiveClaim_1.PrimitiveClaim {
     constructor(conf) {
         super(conf);
         this.validators = Object.assign(Object.assign({}, this.validators), {
-            isTrue: (maxAge) => {
-                if (maxAge) {
-                    return this.validators.hasFreshValue(true, maxAge);
-                }
-                return this.validators.hasValue(true);
-            },
-            isFalse: (maxAge) => {
-                if (maxAge) {
-                    return this.validators.hasFreshValue(false, maxAge);
-                }
-                return this.validators.hasValue(false);
-            },
+            isTrue: (maxAge) => this.validators.hasValue(true, maxAge),
+            isFalse: (maxAge) => this.validators.hasValue(false, maxAge),
         });
     }
 }

--- a/lib/build/recipe/session/claimBaseClasses/primitiveArrayClaim.d.ts
+++ b/lib/build/recipe/session/claimBaseClasses/primitiveArrayClaim.d.ts
@@ -2,17 +2,18 @@
 import { JSONPrimitive } from "../../../types";
 import { SessionClaim, SessionClaimValidator } from "../types";
 export declare class PrimitiveArrayClaim<T extends JSONPrimitive> extends SessionClaim<T[]> {
-    fetchValue: (userId: string, userContext: any) => Promise<T[] | undefined> | T[] | undefined;
-    constructor(config: { key: string; fetchValue: SessionClaim<T[]>["fetchValue"] });
+    readonly fetchValue: (userId: string, userContext: any) => Promise<T[] | undefined> | T[] | undefined;
+    readonly defaultMaxAgeInSeconds: number;
+    constructor(config: { key: string; fetchValue: SessionClaim<T[]>["fetchValue"]; defaultMaxAgeInSeconds?: number });
     addToPayload_internal(payload: any, value: T[], _userContext: any): any;
     removeFromPayloadByMerge_internal(payload: any, _userContext?: any): any;
     removeFromPayload(payload: any, _userContext?: any): any;
     getValueFromPayload(payload: any, _userContext?: any): T[] | undefined;
     getLastRefetchTime(payload: any, _userContext?: any): number | undefined;
     validators: {
-        includes: (val: T, maxAgeInSeconds?: number | undefined, id?: string | undefined) => SessionClaimValidator;
-        excludes: (val: T, maxAgeInSeconds?: number | undefined, id?: string | undefined) => SessionClaimValidator;
-        includesAll: (val: T[], maxAgeInSeconds: number, id?: string | undefined) => SessionClaimValidator;
-        excludesAll: (val: T[], maxAgeInSeconds: number, id?: string | undefined) => SessionClaimValidator;
+        includes: (val: T, maxAgeInSeconds?: number, id?: string | undefined) => SessionClaimValidator;
+        excludes: (val: T, maxAgeInSeconds?: number, id?: string | undefined) => SessionClaimValidator;
+        includesAll: (val: T[], maxAgeInSeconds?: number, id?: string | undefined) => SessionClaimValidator;
+        excludesAll: (val: T[], maxAgeInSeconds?: number, id?: string | undefined) => SessionClaimValidator;
     };
 }

--- a/lib/build/recipe/session/claimBaseClasses/primitiveArrayClaim.js
+++ b/lib/build/recipe/session/claimBaseClasses/primitiveArrayClaim.js
@@ -36,10 +36,10 @@ class PrimitiveArrayClaim extends types_1.SessionClaim {
     constructor(config) {
         super(config.key);
         this.validators = {
-            includes: (val, maxAgeInSeconds, id) => {
+            includes: (val, maxAgeInSeconds = this.defaultMaxAgeInSeconds, id) => {
                 return {
                     claim: this,
-                    id: id !== null && id !== void 0 ? id : this.key + "-includes",
+                    id: id !== null && id !== void 0 ? id : this.key,
                     shouldRefetch: (payload, ctx) =>
                         this.getValueFromPayload(payload, ctx) === undefined ||
                         // We know payload[this.id] is defined since the value is not undefined in this branch
@@ -78,10 +78,10 @@ class PrimitiveArrayClaim extends types_1.SessionClaim {
                         }),
                 };
             },
-            excludes: (val, maxAgeInSeconds, id) => {
+            excludes: (val, maxAgeInSeconds = this.defaultMaxAgeInSeconds, id) => {
                 return {
                     claim: this,
-                    id: id !== null && id !== void 0 ? id : this.key + "-excludes",
+                    id: id !== null && id !== void 0 ? id : this.key,
                     shouldRefetch: (payload, ctx) =>
                         this.getValueFromPayload(payload, ctx) === undefined ||
                         // We know payload[this.id] is defined since the value is not undefined in this branch
@@ -124,10 +124,10 @@ class PrimitiveArrayClaim extends types_1.SessionClaim {
                         }),
                 };
             },
-            includesAll: (val, maxAgeInSeconds, id) => {
+            includesAll: (val, maxAgeInSeconds = this.defaultMaxAgeInSeconds, id) => {
                 return {
                     claim: this,
-                    id: id !== null && id !== void 0 ? id : this.key + "-includesAll",
+                    id: id !== null && id !== void 0 ? id : this.key,
                     shouldRefetch: (payload, ctx) =>
                         this.getValueFromPayload(payload, ctx) === undefined ||
                         // We know payload[this.id] is defined since the value is not undefined in this branch
@@ -167,10 +167,10 @@ class PrimitiveArrayClaim extends types_1.SessionClaim {
                         }),
                 };
             },
-            excludesAll: (val, maxAgeInSeconds, id) => {
+            excludesAll: (val, maxAgeInSeconds = this.defaultMaxAgeInSeconds, id) => {
                 return {
                     claim: this,
-                    id: id !== null && id !== void 0 ? id : this.key + "excludesAll",
+                    id: id !== null && id !== void 0 ? id : this.key,
                     shouldRefetch: (payload, ctx) =>
                         this.getValueFromPayload(payload, ctx) === undefined ||
                         // We know payload[this.id] is defined since the value is not undefined in this branch
@@ -216,6 +216,7 @@ class PrimitiveArrayClaim extends types_1.SessionClaim {
             },
         };
         this.fetchValue = config.fetchValue;
+        this.defaultMaxAgeInSeconds = config.defaultMaxAgeInSeconds === undefined ? 300 : config.defaultMaxAgeInSeconds;
     }
     addToPayload_internal(payload, value, _userContext) {
         return Object.assign(Object.assign({}, payload), {

--- a/lib/build/recipe/session/claimBaseClasses/primitiveClaim.d.ts
+++ b/lib/build/recipe/session/claimBaseClasses/primitiveClaim.d.ts
@@ -2,15 +2,15 @@
 import { JSONPrimitive } from "../../../types";
 import { SessionClaim, SessionClaimValidator } from "../types";
 export declare class PrimitiveClaim<T extends JSONPrimitive> extends SessionClaim<T> {
-    fetchValue: (userId: string, userContext: any) => Promise<T | undefined> | T | undefined;
-    constructor(config: { key: string; fetchValue: SessionClaim<T>["fetchValue"] });
+    readonly fetchValue: (userId: string, userContext: any) => Promise<T | undefined> | T | undefined;
+    readonly defaultMaxAgeInSeconds: number;
+    constructor(config: { key: string; fetchValue: SessionClaim<T>["fetchValue"]; defaultMaxAgeInSeconds?: number });
     addToPayload_internal(payload: any, value: T, _userContext: any): any;
     removeFromPayloadByMerge_internal(payload: any, _userContext?: any): any;
     removeFromPayload(payload: any, _userContext?: any): any;
     getValueFromPayload(payload: any, _userContext?: any): T | undefined;
     getLastRefetchTime(payload: any, _userContext?: any): number | undefined;
     validators: {
-        hasValue: (val: T, id?: string | undefined) => SessionClaimValidator;
-        hasFreshValue: (val: T, maxAgeInSeconds: number, id?: string | undefined) => SessionClaimValidator;
+        hasValue: (val: T, maxAgeInSeconds?: number, id?: string | undefined) => SessionClaimValidator;
     };
 }

--- a/lib/build/recipe/session/claimBaseClasses/primitiveClaim.js
+++ b/lib/build/recipe/session/claimBaseClasses/primitiveClaim.js
@@ -36,32 +36,14 @@ class PrimitiveClaim extends types_1.SessionClaim {
     constructor(config) {
         super(config.key);
         this.validators = {
-            hasValue: (val, id) => {
+            hasValue: (val, maxAgeInSeconds = this.defaultMaxAgeInSeconds, id) => {
                 return {
                     claim: this,
                     id: id !== null && id !== void 0 ? id : this.key,
-                    shouldRefetch: (payload, ctx) => this.getValueFromPayload(payload, ctx) === undefined,
-                    validate: (payload, ctx) =>
-                        __awaiter(this, void 0, void 0, function* () {
-                            const claimVal = this.getValueFromPayload(payload, ctx);
-                            const isValid = claimVal === val;
-                            return isValid
-                                ? { isValid: isValid }
-                                : {
-                                      isValid,
-                                      reason: { message: "wrong value", expectedValue: val, actualValue: claimVal },
-                                  };
-                        }),
-                };
-            },
-            hasFreshValue: (val, maxAgeInSeconds, id) => {
-                return {
-                    claim: this,
-                    id: id !== null && id !== void 0 ? id : this.key + "-fresh-val",
                     shouldRefetch: (payload, ctx) =>
                         this.getValueFromPayload(payload, ctx) === undefined ||
-                        // We know payload[this.id] is defined since the value is not undefined in this branch
-                        payload[this.key].t < Date.now() - maxAgeInSeconds * 1000,
+                        (maxAgeInSeconds !== undefined && // We know payload[this.id] is defined since the value is not undefined in this branch
+                            payload[this.key].t < Date.now() - maxAgeInSeconds * 1000),
                     validate: (payload, ctx) =>
                         __awaiter(this, void 0, void 0, function* () {
                             const claimVal = this.getValueFromPayload(payload, ctx);
@@ -76,7 +58,7 @@ class PrimitiveClaim extends types_1.SessionClaim {
                                 };
                             }
                             const ageInSeconds = (Date.now() - this.getLastRefetchTime(payload, ctx)) / 1000;
-                            if (ageInSeconds > maxAgeInSeconds) {
+                            if (maxAgeInSeconds !== undefined && ageInSeconds > maxAgeInSeconds) {
                                 return {
                                     isValid: false,
                                     reason: {
@@ -98,6 +80,7 @@ class PrimitiveClaim extends types_1.SessionClaim {
             },
         };
         this.fetchValue = config.fetchValue;
+        this.defaultMaxAgeInSeconds = config.defaultMaxAgeInSeconds === undefined ? 300 : config.defaultMaxAgeInSeconds;
     }
     addToPayload_internal(payload, value, _userContext) {
         return Object.assign(Object.assign({}, payload), {

--- a/lib/build/recipe/session/with-jwt/recipeImplementation.js
+++ b/lib/build/recipe/session/with-jwt/recipeImplementation.js
@@ -165,6 +165,9 @@ function default_1(originalImplementation, openIdRecipeImplementation, config) {
         mergeIntoAccessTokenPayload: function ({ sessionHandle, accessTokenPayloadUpdate, userContext }) {
             return __awaiter(this, void 0, void 0, function* () {
                 let sessionInformation = yield this.getSessionInformation({ sessionHandle, userContext });
+                if (!sessionInformation) {
+                    return false;
+                }
                 let newAccessTokenPayload = Object.assign(
                     Object.assign({}, sessionInformation.accessTokenPayload),
                     accessTokenPayloadUpdate
@@ -185,6 +188,9 @@ function default_1(originalImplementation, openIdRecipeImplementation, config) {
                 newAccessTokenPayload =
                     newAccessTokenPayload === null || newAccessTokenPayload === undefined ? {} : newAccessTokenPayload;
                 const sessionInformation = yield this.getSessionInformation({ sessionHandle, userContext });
+                if (!sessionInformation) {
+                    return false;
+                }
                 return jwtAwareUpdateAccessTokenPayload(sessionInformation, newAccessTokenPayload, userContext);
             });
         },

--- a/lib/ts/recipe/emailverification/emailVerificationClaim.ts
+++ b/lib/ts/recipe/emailverification/emailVerificationClaim.ts
@@ -27,7 +27,7 @@ export class EmailVerificationClaimClass extends BooleanClaim {
         this.validators = {
             ...this.validators,
             isVerified: (refetchTimeOnFalseInSeconds: number = 10) => ({
-                ...this.validators.hasValue(true, "st-ev-isVerified"),
+                ...this.validators.hasValue(true),
                 shouldRefetch: (payload, userContext) => {
                     const value = this.getValueFromPayload(payload, userContext);
                     return (

--- a/lib/ts/recipe/session/claimBaseClasses/booleanClaim.ts
+++ b/lib/ts/recipe/session/claimBaseClasses/booleanClaim.ts
@@ -2,23 +2,17 @@ import { SessionClaim, SessionClaimValidator } from "../types";
 import { PrimitiveClaim } from "./primitiveClaim";
 
 export class BooleanClaim extends PrimitiveClaim<boolean> {
-    constructor(conf: { key: string; fetchValue: SessionClaim<boolean>["fetchValue"] }) {
+    constructor(conf: {
+        key: string;
+        fetchValue: SessionClaim<boolean>["fetchValue"];
+        defaultMaxAgeInSeconds?: number;
+    }) {
         super(conf);
 
         this.validators = {
             ...this.validators,
-            isTrue: (maxAge?: number): SessionClaimValidator => {
-                if (maxAge) {
-                    return this.validators.hasFreshValue(true, maxAge);
-                }
-                return this.validators.hasValue(true);
-            },
-            isFalse: (maxAge?: number): SessionClaimValidator => {
-                if (maxAge) {
-                    return this.validators.hasFreshValue(false, maxAge);
-                }
-                return this.validators.hasValue(false);
-            },
+            isTrue: (maxAge?: number): SessionClaimValidator => this.validators.hasValue(true, maxAge),
+            isFalse: (maxAge?: number): SessionClaimValidator => this.validators.hasValue(false, maxAge),
         };
     }
 

--- a/lib/ts/recipe/session/claimBaseClasses/booleanClaim.ts
+++ b/lib/ts/recipe/session/claimBaseClasses/booleanClaim.ts
@@ -11,13 +11,14 @@ export class BooleanClaim extends PrimitiveClaim<boolean> {
 
         this.validators = {
             ...this.validators,
-            isTrue: (maxAge?: number): SessionClaimValidator => this.validators.hasValue(true, maxAge),
-            isFalse: (maxAge?: number): SessionClaimValidator => this.validators.hasValue(false, maxAge),
+            isTrue: (maxAge?: number, id?: string): SessionClaimValidator => this.validators.hasValue(true, maxAge, id),
+            isFalse: (maxAge?: number, id?: string): SessionClaimValidator =>
+                this.validators.hasValue(false, maxAge, id),
         };
     }
 
     validators!: PrimitiveClaim<boolean>["validators"] & {
-        isTrue: (maxAge?: number) => SessionClaimValidator;
-        isFalse: (maxAge?: number) => SessionClaimValidator;
+        isTrue: (maxAge?: number, id?: string) => SessionClaimValidator;
+        isFalse: (maxAge?: number, id?: string) => SessionClaimValidator;
     };
 }

--- a/lib/ts/recipe/session/claimBaseClasses/primitiveArrayClaim.ts
+++ b/lib/ts/recipe/session/claimBaseClasses/primitiveArrayClaim.ts
@@ -2,11 +2,13 @@ import { JSONPrimitive } from "../../../types";
 import { SessionClaim, SessionClaimValidator } from "../types";
 
 export class PrimitiveArrayClaim<T extends JSONPrimitive> extends SessionClaim<T[]> {
-    public fetchValue: (userId: string, userContext: any) => Promise<T[] | undefined> | T[] | undefined;
+    public readonly fetchValue: (userId: string, userContext: any) => Promise<T[] | undefined> | T[] | undefined;
+    public readonly defaultMaxAgeInSeconds: number;
 
-    constructor(config: { key: string; fetchValue: SessionClaim<T[]>["fetchValue"] }) {
+    constructor(config: { key: string; fetchValue: SessionClaim<T[]>["fetchValue"]; defaultMaxAgeInSeconds?: number }) {
         super(config.key);
         this.fetchValue = config.fetchValue;
+        this.defaultMaxAgeInSeconds = config.defaultMaxAgeInSeconds === undefined ? 300 : config.defaultMaxAgeInSeconds;
     }
 
     addToPayload_internal(payload: any, value: T[], _userContext: any): any {
@@ -45,10 +47,14 @@ export class PrimitiveArrayClaim<T extends JSONPrimitive> extends SessionClaim<T
     }
 
     validators = {
-        includes: (val: T, maxAgeInSeconds?: number, id?: string): SessionClaimValidator => {
+        includes: (
+            val: T,
+            maxAgeInSeconds: number = this.defaultMaxAgeInSeconds,
+            id?: string
+        ): SessionClaimValidator => {
             return {
                 claim: this,
-                id: id ?? this.key + "-includes",
+                id: id ?? this.key,
                 shouldRefetch: (payload, ctx) =>
                     this.getValueFromPayload(payload, ctx) === undefined ||
                     // We know payload[this.id] is defined since the value is not undefined in this branch
@@ -82,10 +88,14 @@ export class PrimitiveArrayClaim<T extends JSONPrimitive> extends SessionClaim<T
                 },
             };
         },
-        excludes: (val: T, maxAgeInSeconds?: number, id?: string): SessionClaimValidator => {
+        excludes: (
+            val: T,
+            maxAgeInSeconds: number = this.defaultMaxAgeInSeconds,
+            id?: string
+        ): SessionClaimValidator => {
             return {
                 claim: this,
-                id: id ?? this.key + "-excludes",
+                id: id ?? this.key,
                 shouldRefetch: (payload, ctx) =>
                     this.getValueFromPayload(payload, ctx) === undefined ||
                     // We know payload[this.id] is defined since the value is not undefined in this branch
@@ -123,10 +133,14 @@ export class PrimitiveArrayClaim<T extends JSONPrimitive> extends SessionClaim<T
                 },
             };
         },
-        includesAll: (val: T[], maxAgeInSeconds: number, id?: string): SessionClaimValidator => {
+        includesAll: (
+            val: T[],
+            maxAgeInSeconds: number = this.defaultMaxAgeInSeconds,
+            id?: string
+        ): SessionClaimValidator => {
             return {
                 claim: this,
-                id: id ?? this.key + "-includesAll",
+                id: id ?? this.key,
                 shouldRefetch: (payload, ctx) =>
                     this.getValueFromPayload(payload, ctx) === undefined ||
                     // We know payload[this.id] is defined since the value is not undefined in this branch
@@ -161,10 +175,14 @@ export class PrimitiveArrayClaim<T extends JSONPrimitive> extends SessionClaim<T
                 },
             };
         },
-        excludesAll: (val: T[], maxAgeInSeconds: number, id?: string): SessionClaimValidator => {
+        excludesAll: (
+            val: T[],
+            maxAgeInSeconds: number = this.defaultMaxAgeInSeconds,
+            id?: string
+        ): SessionClaimValidator => {
             return {
                 claim: this,
-                id: id ?? this.key + "excludesAll",
+                id: id ?? this.key,
                 shouldRefetch: (payload, ctx) =>
                     this.getValueFromPayload(payload, ctx) === undefined ||
                     // We know payload[this.id] is defined since the value is not undefined in this branch

--- a/lib/ts/recipe/session/with-jwt/recipeImplementation.ts
+++ b/lib/ts/recipe/session/with-jwt/recipeImplementation.ts
@@ -141,17 +141,20 @@ export default function (
 
             return new SessionClassWithJWT(sessionContainer, openIdRecipeImplementation);
         },
-        getSession: async function ({
-            req,
-            res,
-            options,
-            userContext,
-        }: {
-            req: BaseRequest;
-            res: BaseResponse;
-            options?: VerifySessionOptions;
-            userContext: any;
-        }): Promise<SessionContainerInterface | undefined> {
+        getSession: async function (
+            this: RecipeInterface,
+            {
+                req,
+                res,
+                options,
+                userContext,
+            }: {
+                req: BaseRequest;
+                res: BaseResponse;
+                options?: VerifySessionOptions;
+                userContext: any;
+            }
+        ): Promise<SessionContainerInterface | undefined> {
             let sessionContainer = await originalImplementation.getSession({ req, res, options, userContext });
 
             if (sessionContainer === undefined) {
@@ -160,15 +163,18 @@ export default function (
 
             return new SessionClassWithJWT(sessionContainer, openIdRecipeImplementation);
         },
-        refreshSession: async function ({
-            req,
-            res,
-            userContext,
-        }: {
-            req: BaseRequest;
-            res: BaseResponse;
-            userContext: any;
-        }): Promise<SessionContainerInterface> {
+        refreshSession: async function (
+            this: RecipeInterface,
+            {
+                req,
+                res,
+                userContext,
+            }: {
+                req: BaseRequest;
+                res: BaseResponse;
+                userContext: any;
+            }
+        ): Promise<SessionContainerInterface> {
             let accessTokenValidityInSeconds = Math.ceil((await this.getAccessTokenLifeTimeMS({ userContext })) / 1000);
 
             // Refresh session first because this will create a new access token
@@ -189,16 +195,23 @@ export default function (
             return new SessionClassWithJWT(newSession, openIdRecipeImplementation);
         },
 
-        mergeIntoAccessTokenPayload: async function ({
-            sessionHandle,
-            accessTokenPayloadUpdate,
-            userContext,
-        }: {
-            sessionHandle: string;
-            accessTokenPayloadUpdate: JSONObject;
-            userContext: any;
-        }): Promise<boolean> {
+        mergeIntoAccessTokenPayload: async function (
+            this: RecipeInterface,
+            {
+                sessionHandle,
+                accessTokenPayloadUpdate,
+                userContext,
+            }: {
+                sessionHandle: string;
+                accessTokenPayloadUpdate: JSONObject;
+                userContext: any;
+            }
+        ): Promise<boolean> {
             let sessionInformation = await this.getSessionInformation({ sessionHandle, userContext });
+
+            if (!sessionInformation) {
+                return false;
+            }
 
             let newAccessTokenPayload = { ...sessionInformation.accessTokenPayload, ...accessTokenPayloadUpdate };
             for (const key of Object.keys(accessTokenPayloadUpdate)) {
@@ -213,19 +226,26 @@ export default function (
         /**
          * @deprecated use mergeIntoAccessTokenPayload instead
          */
-        updateAccessTokenPayload: async function ({
-            sessionHandle,
-            newAccessTokenPayload,
-            userContext,
-        }: {
-            sessionHandle: string;
-            newAccessTokenPayload: any;
-            userContext: any;
-        }): Promise<boolean> {
+        updateAccessTokenPayload: async function (
+            this: RecipeInterface,
+            {
+                sessionHandle,
+                newAccessTokenPayload,
+                userContext,
+            }: {
+                sessionHandle: string;
+                newAccessTokenPayload: any;
+                userContext: any;
+            }
+        ): Promise<boolean> {
             newAccessTokenPayload =
                 newAccessTokenPayload === null || newAccessTokenPayload === undefined ? {} : newAccessTokenPayload;
 
             const sessionInformation = await this.getSessionInformation({ sessionHandle, userContext });
+
+            if (!sessionInformation) {
+                return false;
+            }
 
             return jwtAwareUpdateAccessTokenPayload(sessionInformation, newAccessTokenPayload, userContext);
         },

--- a/test/session/claims/validateClaimsForSessionHandle.test.js
+++ b/test/session/claims/validateClaimsForSessionHandle.test.js
@@ -86,7 +86,7 @@ describe(`sessionClaims/validateClaimsForSessionHandle: ${printPath(
                             reason: {
                                 actualValue: undefined,
                                 expectedValue: true,
-                                message: "wrong value",
+                                message: "value does not exist",
                             },
                         },
                     ],

--- a/test/session/claims/verifySession.test.js
+++ b/test/session/claims/verifySession.test.js
@@ -134,7 +134,15 @@ describe(`sessionClaims/verifySession: ${printPath("[test/session/claims/verifyS
                 const session = await createSession(app);
                 const resp = await testGet(app, session, "/default-claims", 403);
 
-                validateErrorResp(resp, [{ id: "st-undef", reason: { message: "wrong value", expectedValue: true } }]);
+                validateErrorResp(resp, [
+                    {
+                        id: "st-undef",
+                        reason: {
+                            message: "value does not exist",
+                            expectedValue: true,
+                        },
+                    },
+                ]);
             });
 
             it("should allow with custom validator returning true", async function () {

--- a/test/session/claims/withJWT.test.js
+++ b/test/session/claims/withJWT.test.js
@@ -122,7 +122,7 @@ describe(`sessionClaims/withJWT: ${printPath("[test/session/claims/withJWT.test.
             const failingValidator = UndefinedClaim.validators.hasValue(true);
             assert.deepStrictEqual(
                 await Session.validateClaimsInJWTPayload(sessionInfo.userId, decodedJWT, () => [
-                    TrueClaim.validators.hasFreshValue(true, 2),
+                    TrueClaim.validators.hasValue(true, 2),
                     failingValidator,
                 ]),
                 {
@@ -133,7 +133,7 @@ describe(`sessionClaims/withJWT: ${printPath("[test/session/claims/withJWT.test.
                             reason: {
                                 actualValue: undefined,
                                 expectedValue: true,
-                                message: "wrong value",
+                                message: "value does not exist",
                             },
                         },
                     ],


### PR DESCRIPTION
## Summary of change

Changes discussed yesterday + comments on the PR:
- merged `hasFreshValue` into `hasValue`
- using id from claim for validators as well
- added `defaultMaxAge` to claims/validators
- checking `getSessionInformation` for undefined return value + fixed typing

## Related issues

-   

## Test Plan

Updated&added tests

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
