### PR TITLE
adds session object as input / output to some of the api functions in session recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Removed `getResetPasswordURL`, `getEmailVerificationURL`, `getLinkDomainAndPath`. Changing these urls can be done in the email delivery configs instead.
 -   Removed `unverifyEmail`, `revokeEmailVerificationTokens`, `isEmailVerified`, `verifyEmailUsingToken` and `createEmailVerificationToken` from auth recipes. These should be called on the `EmailVerification` recipe instead.
 -   Changed function signature for email verification APIs to accept a session as an input.
+-   Changed Session API interface functions:
+    -   `refreshPOST` now returns a Session container object.
+    -   `signOutPOST` now takes in an optional session object as a parameter.
 
 ### Migration
 

--- a/lib/build/recipe/session/api/implementation.js
+++ b/lib/build/recipe/session/api/implementation.js
@@ -31,7 +31,6 @@ var __awaiter =
         });
     };
 Object.defineProperty(exports, "__esModule", { value: true });
-const error_1 = require("../error");
 const utils_1 = require("../../../utils");
 const normalisedURLPath_1 = require("../../../normalisedURLPath");
 const utils_2 = require("../utils");
@@ -39,7 +38,11 @@ function getAPIInterface() {
     return {
         refreshPOST: function ({ options, userContext }) {
             return __awaiter(this, void 0, void 0, function* () {
-                yield options.recipeImplementation.refreshSession({ req: options.req, res: options.res, userContext });
+                return yield options.recipeImplementation.refreshSession({
+                    req: options.req,
+                    res: options.res,
+                    userContext,
+                });
             });
         },
         verifySession: function ({ verifySessionOptions, options, userContext }) {
@@ -77,31 +80,11 @@ function getAPIInterface() {
                 }
             });
         },
-        signOutPOST: function ({ options, userContext }) {
+        signOutPOST: function ({ session, userContext }) {
             return __awaiter(this, void 0, void 0, function* () {
-                let session;
-                try {
-                    session = yield options.recipeImplementation.getSession({
-                        req: options.req,
-                        res: options.res,
-                        options: {
-                            overrideGlobalClaimValidators: () => [],
-                        },
-                        userContext,
-                    });
-                } catch (err) {
-                    if (error_1.default.isErrorFromSuperTokens(err) && err.type === error_1.default.UNAUTHORISED) {
-                        // The session is expired / does not exist anyway. So we return OK
-                        return {
-                            status: "OK",
-                        };
-                    }
-                    throw err;
+                if (session !== undefined) {
+                    yield session.revokeSession(userContext);
                 }
-                if (session === undefined) {
-                    throw new Error("Session is undefined. Should not come here.");
-                }
-                yield session.revokeSession(userContext);
                 return {
                     status: "OK",
                 };

--- a/lib/build/recipe/session/api/signout.js
+++ b/lib/build/recipe/session/api/signout.js
@@ -53,9 +53,20 @@ function signOutAPI(apiImplementation, options) {
         if (apiImplementation.signOutPOST === undefined) {
             return false;
         }
+        let defaultUserContext = utils_2.makeDefaultUserContextFromAPI(options.req);
+        const session = yield options.recipeImplementation.getSession({
+            req: options.req,
+            res: options.res,
+            options: {
+                sessionRequired: false,
+                overrideGlobalClaimValidators: () => [],
+            },
+            userContext: defaultUserContext,
+        });
         let result = yield apiImplementation.signOutPOST({
             options,
-            userContext: utils_2.makeDefaultUserContextFromAPI(options.req),
+            session,
+            userContext: defaultUserContext,
         });
         utils_1.send200Response(options.res, result);
         return true;

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -320,11 +320,12 @@ export declare type APIInterface = {
      * since it's not something that is directly called by the user on the
      * frontend anyway
      */
-    refreshPOST: undefined | ((input: { options: APIOptions; userContext: any }) => Promise<void>);
+    refreshPOST: undefined | ((input: { options: APIOptions; userContext: any }) => Promise<SessionContainerInterface>);
     signOutPOST:
         | undefined
         | ((input: {
               options: APIOptions;
+              session: SessionContainerInterface | undefined;
               userContext: any;
           }) => Promise<
               | {

--- a/lib/ts/recipe/session/api/signout.ts
+++ b/lib/ts/recipe/session/api/signout.ts
@@ -24,9 +24,22 @@ export default async function signOutAPI(apiImplementation: APIInterface, option
         return false;
     }
 
+    let defaultUserContext = makeDefaultUserContextFromAPI(options.req);
+
+    const session = await options.recipeImplementation.getSession({
+        req: options.req,
+        res: options.res,
+        options: {
+            sessionRequired: false,
+            overrideGlobalClaimValidators: () => [],
+        },
+        userContext: defaultUserContext,
+    });
+
     let result = await apiImplementation.signOutPOST({
         options,
-        userContext: makeDefaultUserContextFromAPI(options.req),
+        session,
+        userContext: defaultUserContext,
     });
 
     send200Response(options.res, result);

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -379,12 +379,17 @@ export type APIInterface = {
      * since it's not something that is directly called by the user on the
      * frontend anyway
      */
-    refreshPOST: undefined | ((input: { options: APIOptions; userContext: any }) => Promise<void>);
+    refreshPOST: undefined | ((input: { options: APIOptions; userContext: any }) => Promise<SessionContainerInterface>);
 
     signOutPOST:
         | undefined
         | ((input: {
               options: APIOptions;
+              // the reason we make this optional is cause it allows users to do something in
+              // case a session does not exist and the sign out button is pressed. It is
+              // rare that something needs to be done in this case, but making it like this
+              // has little disadvantages.
+              session: SessionContainerInterface | undefined;
               userContext: any;
           }) => Promise<
               | {


### PR DESCRIPTION
## Summary of change
Just like how we changed the email verification API interface to accept session as input to the some of its functions, we should make similar changes to other APIs as well that "require" a session. So I have changed the signOut API in the session recipe to have this.

I also returned the session object from the refresh session API, since we are following a pattern that the API interface functions should return everything that it creates in it.
