### PR TITLE
fix: fix the returned status of revokeEmailVerificationTokens for pwless users

### DIFF
--- a/lib/build/recipe/emailverification/index.js
+++ b/lib/build/recipe/emailverification/index.js
@@ -102,13 +102,19 @@ class Wrapper {
     static revokeEmailVerificationTokens(userId, email, userContext) {
         return __awaiter(this, void 0, void 0, function* () {
             const recipeInstance = recipe_1.default.getInstanceOrThrowError();
+            // If the dev wants to delete the tokens for an old email address of the user they can pass the address
+            // but redeeming those tokens would have no effect on isEmailVerified called without the old address
+            // so in general that is not necessary either.
             if (email === undefined) {
                 const emailInfo = yield recipeInstance.getEmailForUserId(userId, userContext);
                 if (emailInfo.status === "OK") {
                     email = emailInfo.email;
                 } else if (emailInfo.status === "EMAIL_DOES_NOT_EXIST_ERROR") {
+                    // This only happens for phone based passwordless users (or if the user added a custom getEmailForUserId)
+                    // We can return OK here, since there is no way to create an email verification token
+                    // if getEmailForUserId returns EMAIL_DOES_NOT_EXIST_ERROR.
                     return {
-                        status: "EMAIL_ALREADY_VERIFIED",
+                        status: "OK",
                     };
                 } else {
                     throw new global.Error("Unknown User ID provided without email");

--- a/lib/ts/recipe/emailverification/index.ts
+++ b/lib/ts/recipe/emailverification/index.ts
@@ -89,13 +89,19 @@ export default class Wrapper {
     static async revokeEmailVerificationTokens(userId: string, email?: string, userContext?: any) {
         const recipeInstance = Recipe.getInstanceOrThrowError();
 
+        // If the dev wants to delete the tokens for an old email address of the user they can pass the address
+        // but redeeming those tokens would have no effect on isEmailVerified called without the old address
+        // so in general that is not necessary either.
         if (email === undefined) {
             const emailInfo = await recipeInstance.getEmailForUserId(userId, userContext);
             if (emailInfo.status === "OK") {
                 email = emailInfo.email;
             } else if (emailInfo.status === "EMAIL_DOES_NOT_EXIST_ERROR") {
+                // This only happens for phone based passwordless users (or if the user added a custom getEmailForUserId)
+                // We can return OK here, since there is no way to create an email verification token
+                // if getEmailForUserId returns EMAIL_DOES_NOT_EXIST_ERROR.
                 return {
-                    status: "EMAIL_ALREADY_VERIFIED",
+                    status: "OK",
                 };
             } else {
                 throw new global.Error("Unknown User ID provided without email");


### PR DESCRIPTION
## Summary of change

Fixing comment on the base PR

## Related issues

-   #278 

## Test Plan

Added test 


## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
