### PR TITLE
fix: adds missing force param to userIdMapping functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Bug fix:
+
+-   Adds missing `force` param from `createUserIdMapping` and `deleteUserIdMapping` functions
+
 ## [11.1.0] - 2022-08-11
 
 ### Adds:

--- a/lib/build/index.d.ts
+++ b/lib/build/index.d.ts
@@ -37,6 +37,7 @@ export default class SuperTokensWrapper {
         superTokensUserId: string;
         externalUserId: string;
         externalUserIdInfo?: string;
+        force?: boolean;
     }): Promise<
         | {
               status: "OK" | "UNKNOWN_SUPERTOKENS_USER_ID_ERROR";
@@ -64,6 +65,7 @@ export default class SuperTokensWrapper {
     static deleteUserIdMapping(input: {
         userId: string;
         userIdType?: "SUPERTOKENS" | "EXTERNAL" | "ANY";
+        force?: boolean;
     }): Promise<{
         status: "OK";
         didMappingExist: boolean;

--- a/lib/build/supertokens.d.ts
+++ b/lib/build/supertokens.d.ts
@@ -46,6 +46,7 @@ export default class SuperTokens {
         superTokensUserId: string;
         externalUserId: string;
         externalUserIdInfo?: string | undefined;
+        force?: boolean | undefined;
     }) => Promise<
         | {
               status: "OK" | "UNKNOWN_SUPERTOKENS_USER_ID_ERROR";
@@ -73,6 +74,7 @@ export default class SuperTokens {
     deleteUserIdMapping: (input: {
         userId: string;
         userIdType?: "SUPERTOKENS" | "EXTERNAL" | "ANY" | undefined;
+        force?: boolean | undefined;
     }) => Promise<{
         status: "OK";
         didMappingExist: boolean;

--- a/lib/build/supertokens.js
+++ b/lib/build/supertokens.js
@@ -163,6 +163,7 @@ class SuperTokens {
                         superTokensUserId: input.superTokensUserId,
                         externalUserId: input.externalUserId,
                         externalUserIdInfo: input.externalUserIdInfo,
+                        force: input.force,
                     });
                 } else {
                     throw new global.Error("Please upgrade the SuperTokens core to >= 3.15.0");
@@ -193,6 +194,7 @@ class SuperTokens {
                     return yield querier.sendPostRequest(new normalisedURLPath_1.default("/recipe/userid/map/remove"), {
                         userId: input.userId,
                         userIdType: input.userIdType,
+                        force: input.force,
                     });
                 } else {
                     throw new global.Error("Please upgrade the SuperTokens core to >= 3.15.0");

--- a/lib/ts/index.ts
+++ b/lib/ts/index.ts
@@ -68,6 +68,7 @@ export default class SuperTokensWrapper {
         superTokensUserId: string;
         externalUserId: string;
         externalUserIdInfo?: string;
+        force?: boolean;
     }) {
         return SuperTokens.getInstanceOrThrowError().createUserIdMapping(input);
     }
@@ -76,7 +77,11 @@ export default class SuperTokensWrapper {
         return SuperTokens.getInstanceOrThrowError().getUserIdMapping(input);
     }
 
-    static deleteUserIdMapping(input: { userId: string; userIdType?: "SUPERTOKENS" | "EXTERNAL" | "ANY" }) {
+    static deleteUserIdMapping(input: {
+        userId: string;
+        userIdType?: "SUPERTOKENS" | "EXTERNAL" | "ANY";
+        force?: boolean;
+    }) {
         return SuperTokens.getInstanceOrThrowError().deleteUserIdMapping(input);
     }
 

--- a/lib/ts/supertokens.ts
+++ b/lib/ts/supertokens.ts
@@ -227,6 +227,7 @@ export default class SuperTokens {
         superTokensUserId: string;
         externalUserId: string;
         externalUserIdInfo?: string;
+        force?: boolean;
     }): Promise<
         | {
               status: "OK" | "UNKNOWN_SUPERTOKENS_USER_ID_ERROR";
@@ -245,6 +246,7 @@ export default class SuperTokens {
                 superTokensUserId: input.superTokensUserId,
                 externalUserId: input.externalUserId,
                 externalUserIdInfo: input.externalUserIdInfo,
+                force: input.force,
             });
         } else {
             throw new global.Error("Please upgrade the SuperTokens core to >= 3.15.0");
@@ -282,6 +284,7 @@ export default class SuperTokens {
     deleteUserIdMapping = async function (input: {
         userId: string;
         userIdType?: "SUPERTOKENS" | "EXTERNAL" | "ANY";
+        force?: boolean;
     }): Promise<{
         status: "OK";
         didMappingExist: boolean;
@@ -292,6 +295,7 @@ export default class SuperTokens {
             return await querier.sendPostRequest(new NormalisedURLPath("/recipe/userid/map/remove"), {
                 userId: input.userId,
                 userIdType: input.userIdType,
+                force: input.force,
             });
         } else {
             throw new global.Error("Please upgrade the SuperTokens core to >= 3.15.0");


### PR DESCRIPTION

## Summary of change

Adds missing `force` param to `createUserIdMapping` and `deleteUserIdMapping` functions

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
