### PR TITLE
fix: backwards compatibility

### DIFF
--- a/lib/build/supertokens.js
+++ b/lib/build/supertokens.js
@@ -261,6 +261,21 @@ class SuperTokens {
                     logger_1.logDebugMessage("middleware: Matched with recipe ID: " + matchedRecipe.getRecipeId());
                     let id = matchedRecipe.returnAPIIdIfCanHandleRequest(path, method);
                     if (id === undefined) {
+                        // test that it doesn't fail if EV is not initialized
+                        // This part is only necessary while we support FDI < 1.15
+                        // Using rid manually copied here to avoid circular dependencies
+                        const emailVerificationRecipe = this.recipeModules.find(
+                            (r) => r.getRecipeId() === "emailverification"
+                        );
+                        if (emailVerificationRecipe) {
+                            logger_1.logDebugMessage(
+                                "middleware: recipe matched by rid didn't handle this path, falling back to email verification for backwards compatibility"
+                            );
+                            matchedRecipe = emailVerificationRecipe;
+                            id = emailVerificationRecipe.returnAPIIdIfCanHandleRequest(path, method);
+                        }
+                    }
+                    if (id === undefined) {
                         logger_1.logDebugMessage(
                             "middleware: Not handling because recipe doesn't handle request path or method. Request path: " +
                                 path.getAsStringDangerous() +

--- a/lib/ts/supertokens.ts
+++ b/lib/ts/supertokens.ts
@@ -373,6 +373,20 @@ export default class SuperTokens {
 
             let id = matchedRecipe.returnAPIIdIfCanHandleRequest(path, method);
             if (id === undefined) {
+                // test that it doesn't fail if EV is not initialized
+                // This part is only necessary while we support FDI < 1.15
+                // Using rid manually copied here to avoid circular dependencies
+                const emailVerificationRecipe = this.recipeModules.find((r) => r.getRecipeId() === "emailverification");
+                if (emailVerificationRecipe) {
+                    logDebugMessage(
+                        "middleware: recipe matched by rid didn't handle this path, falling back to email verification for backwards compatibility"
+                    );
+                    matchedRecipe = emailVerificationRecipe;
+                    id = emailVerificationRecipe.returnAPIIdIfCanHandleRequest(path, method);
+                }
+            }
+
+            if (id === undefined) {
                 logDebugMessage(
                     "middleware: Not handling because recipe doesn't handle request path or method. Request path: " +
                         path.getAsStringDangerous() +


### PR DESCRIPTION
## Summary of change

- updated auth-react test server
- added a fallback mechanism if email verification is called with the wrong `rid`

## Related issues


## Test Plan

Added a testcase 

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
