### PR TITLE
chore: remove support for fdi 1.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+-   Support for FDI 1.15
 -   Added support for session claims with related interfaces and classes.
 -   Added `onInvalidClaim` optional error handler to send InvalidClaim error responses.
 -   Added `INVALID_CLAIMS` to `SessionErrors`.
@@ -34,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
+-   Removes support for FDI < 1.15
 -   Changed `signInUp` third party recipe function to accept an email string instead of an object that takes `{id: string, isVerified: boolean}`.
 -   Renames `STMP` to `SMTP` everywhere (typo).
 -   The frontend SDK should be updated to a version supporting session claims!

--- a/frontendDriverInterfaceSupported.json
+++ b/frontendDriverInterfaceSupported.json
@@ -1,4 +1,4 @@
 {
     "_comment": "contains a list of frontend-driver interfaces branch names that this core supports",
-    "versions": ["1.14", "1.15"]
+    "versions": ["1.15"]
 }


### PR DESCRIPTION
## Summary of change

Removed support for FDI 1.14

## Related issues

## Test Plan

N/A

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
