### PR TITLE
test: fix tests old cdis

### DIFF
--- a/test/session/claims/createNewSession.test.js
+++ b/test/session/claims/createNewSession.test.js
@@ -168,6 +168,7 @@ describe(`sessionClaims/createNewSession: ${printPath("[test/session/claims/crea
             if (maxVersion(apiVersion, "2.12") === "2.12") {
                 return;
             }
+            const includesNullInPayload = maxVersion(apiVersion, "2.14") !== "2.14";
             const response = mockResponse();
             const res = await Session.createNewSession(response, "someId", payloadParam);
 
@@ -175,7 +176,7 @@ describe(`sessionClaims/createNewSession: ${printPath("[test/session/claims/crea
             assert.strictEqual(Object.keys(payloadParam).length, 1);
 
             const payload = res.getAccessTokenPayload();
-            assert.strictEqual(Object.keys(payload).length, 5);
+            assert.strictEqual(Object.keys(payload).length, includesNullInPayload ? 5 : 4);
             // We have the prop from the payload param
             assert.strictEqual(payload["initial"], true);
             // We have the boolean claim
@@ -185,11 +186,18 @@ describe(`sessionClaims/createNewSession: ${printPath("[test/session/claims/crea
             // We have the custom claim
             // The resulting payload is different from the input: it doesn't container undefined
             assert.deepStrictEqual(payload["user-custom"], "asdf");
-            assert.deepStrictEqual(payload["user-custom2"], {
-                inner: "asdf",
-                nullProp: null,
-            });
-            assert.deepStrictEqual(payload["user-custom3"], null);
+            if (includesNullInPayload) {
+                assert.deepStrictEqual(payload["user-custom2"], {
+                    inner: "asdf",
+                    nullProp: null,
+                });
+                assert.deepStrictEqual(payload["user-custom3"], null);
+            } else {
+                assert.deepStrictEqual(payload["user-custom2"], {
+                    inner: "asdf",
+                });
+                assert.deepStrictEqual(payload["user-custom3"], undefined);
+            }
         });
     });
 });


### PR DESCRIPTION
## Summary of change

Fixes running access token payload tests for older CDIs (which do not include null props in the payload)

## Related issues

-   

## Test Plan

N/A test only change

## Documentation changes

N/A test only change

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
