### PR TITLE
fix: rethrow generic errors in isEmailVerifiedGET and verifyEmailPOST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Bug fix:
+
+-   Properly rethrowing generic errors in email verification endpoints.
+
 ## [12.0.1] - 2022-09-22
 
 ### Changed

--- a/lib/build/recipe/emailverification/api/implementation.js
+++ b/lib/build/recipe/emailverification/api/implementation.js
@@ -45,12 +45,13 @@ function getAPIInterface() {
                         yield session.fetchAndSetClaim(emailVerificationClaim_1.EmailVerificationClaim, userContext);
                     } catch (err) {
                         // This should never happen, since we've just set the status above.
-                        if (err && err.message === "UNKNOWN_USER_ID") {
+                        if (err.message === "UNKNOWN_USER_ID") {
                             throw new error_1.default({
                                 type: error_1.default.UNAUTHORISED,
                                 message: "Unknown User ID provided",
                             });
                         }
+                        throw err;
                     }
                 }
                 return res;
@@ -64,12 +65,13 @@ function getAPIInterface() {
                 try {
                     yield session.fetchAndSetClaim(emailVerificationClaim_1.EmailVerificationClaim, userContext);
                 } catch (err) {
-                    if (err && err.message === "UNKNOWN_USER_ID") {
+                    if (err.message === "UNKNOWN_USER_ID") {
                         throw new error_1.default({
                             type: error_1.default.UNAUTHORISED,
                             message: "Unknown User ID provided",
                         });
                     }
+                    throw err;
                 }
                 const isVerified = yield session.getClaimValue(
                     emailVerificationClaim_1.EmailVerificationClaim,

--- a/lib/ts/recipe/emailverification/api/implementation.ts
+++ b/lib/ts/recipe/emailverification/api/implementation.ts
@@ -22,12 +22,13 @@ export default function getAPIInterface(): APIInterface {
                     await session.fetchAndSetClaim(EmailVerificationClaim, userContext);
                 } catch (err) {
                     // This should never happen, since we've just set the status above.
-                    if (err && (err as Error).message === "UNKNOWN_USER_ID") {
+                    if ((err as Error).message === "UNKNOWN_USER_ID") {
                         throw new SessionError({
                             type: SessionError.UNAUTHORISED,
                             message: "Unknown User ID provided",
                         });
                     }
+                    throw err;
                 }
             }
             return res;
@@ -50,12 +51,13 @@ export default function getAPIInterface(): APIInterface {
             try {
                 await session.fetchAndSetClaim(EmailVerificationClaim, userContext);
             } catch (err) {
-                if (err && (err as Error).message === "UNKNOWN_USER_ID") {
+                if ((err as Error).message === "UNKNOWN_USER_ID") {
                     throw new SessionError({
                         type: SessionError.UNAUTHORISED,
                         message: "Unknown User ID provided",
                     });
                 }
+                throw err;
             }
             const isVerified = await session.getClaimValue(EmailVerificationClaim, userContext);
 


### PR DESCRIPTION
## Summary of change

rethrow generic errors in isEmailVerifiedGET and verifyEmailPOST

## Related issues

-   
## Test Plan

-

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
