### PR TITLE
feat(sessionrework): remove id refresh token

### DIFF
--- a/lib/build/constants.d.ts
+++ b/lib/build/constants.d.ts
@@ -1,4 +1,3 @@
 // @ts-nocheck
 export declare const HEADER_RID = "rid";
-export declare const HEADER_AUTH_MODE = "st-auth-mode";
 export declare const HEADER_FDI = "fdi-version";

--- a/lib/build/constants.js
+++ b/lib/build/constants.js
@@ -15,5 +15,4 @@
  */
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.HEADER_RID = "rid";
-exports.HEADER_AUTH_MODE = "st-auth-mode";
 exports.HEADER_FDI = "fdi-version";

--- a/lib/build/recipe/session/accessToken.d.ts
+++ b/lib/build/recipe/session/accessToken.d.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
+import { ParsedJWTInfo } from "./jwt";
 export declare function getInfoFromAccessToken(
-    token: string,
+    jwtInfo: ParsedJWTInfo,
     jwtSigningPublicKey: string,
     doAntiCsrfCheck: boolean
 ): Promise<{
@@ -13,4 +14,5 @@ export declare function getInfoFromAccessToken(
     expiryTime: number;
     timeCreated: number;
 }>;
+export declare function validateAccessTokenStructure(payload: any): void;
 export declare function sanitizeNumberInput(field: any): number | undefined;

--- a/lib/build/recipe/session/accessToken.js
+++ b/lib/build/recipe/session/accessToken.js
@@ -47,10 +47,13 @@ var __awaiter =
 Object.defineProperty(exports, "__esModule", { value: true });
 const error_1 = require("./error");
 const jwt_1 = require("./jwt");
-function getInfoFromAccessToken(token, jwtSigningPublicKey, doAntiCsrfCheck) {
+function getInfoFromAccessToken(jwtInfo, jwtSigningPublicKey, doAntiCsrfCheck) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            let payload = jwt_1.verifyJWTAndGetPayload(token, jwtSigningPublicKey);
+            let payload = jwt_1.verifyJWT(jwtInfo, jwtSigningPublicKey);
+            // This should be called before this function, but the check is very quick, so we can also do them here
+            validateAccessTokenStructure(payload);
+            // We can mark these as defined (the ! after the calls), since validateAccessTokenPayload checks this
             let sessionHandle = sanitizeStringInput(payload.sessionHandle);
             let userId = sanitizeStringInput(payload.userId);
             let refreshTokenHash1 = sanitizeStringInput(payload.refreshTokenHash1);
@@ -59,17 +62,8 @@ function getInfoFromAccessToken(token, jwtSigningPublicKey, doAntiCsrfCheck) {
             let antiCsrfToken = sanitizeStringInput(payload.antiCsrfToken);
             let expiryTime = sanitizeNumberInput(payload.expiryTime);
             let timeCreated = sanitizeNumberInput(payload.timeCreated);
-            if (
-                sessionHandle === undefined ||
-                userId === undefined ||
-                refreshTokenHash1 === undefined ||
-                userData === undefined ||
-                (antiCsrfToken === undefined && doAntiCsrfCheck) ||
-                expiryTime === undefined ||
-                timeCreated === undefined
-            ) {
-                // it would come here if we change the structure of the JWT.
-                throw Error("Access token does not contain all the information. Maybe the structure has changed?");
+            if (antiCsrfToken === undefined && doAntiCsrfCheck) {
+                throw Error("Access token does not contain the anti-csrf token.");
             }
             if (expiryTime < Date.now()) {
                 throw Error("Access token expired");
@@ -93,6 +87,20 @@ function getInfoFromAccessToken(token, jwtSigningPublicKey, doAntiCsrfCheck) {
     });
 }
 exports.getInfoFromAccessToken = getInfoFromAccessToken;
+function validateAccessTokenStructure(payload) {
+    if (
+        typeof payload.sessionHandle !== "string" ||
+        typeof payload.userId !== "string" ||
+        typeof payload.refreshTokenHash1 !== "string" ||
+        payload.userData === undefined ||
+        typeof payload.expiryTime !== "number" ||
+        typeof payload.timeCreated !== "number"
+    ) {
+        // it would come here if we change the structure of the JWT.
+        throw Error("Access token does not contain all the information. Maybe the structure has changed?");
+    }
+}
+exports.validateAccessTokenStructure = validateAccessTokenStructure;
 function sanitizeStringInput(field) {
     if (field === "") {
         return "";

--- a/lib/build/recipe/session/constants.d.ts
+++ b/lib/build/recipe/session/constants.d.ts
@@ -1,3 +1,5 @@
 // @ts-nocheck
+import { TokenTransferMethod } from "./types";
 export declare const REFRESH_API_PATH = "/session/refresh";
 export declare const SIGNOUT_API_PATH = "/signout";
+export declare const availableTokenTransferMethods: TokenTransferMethod[];

--- a/lib/build/recipe/session/constants.js
+++ b/lib/build/recipe/session/constants.js
@@ -16,3 +16,4 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.REFRESH_API_PATH = "/session/refresh";
 exports.SIGNOUT_API_PATH = "/signout";
+exports.availableTokenTransferMethods = ["cookie", "header"];

--- a/lib/build/recipe/session/cookieAndHeaders.d.ts
+++ b/lib/build/recipe/session/cookieAndHeaders.d.ts
@@ -1,14 +1,13 @@
 // @ts-nocheck
 import { BaseRequest, BaseResponse } from "../../framework";
-import { TokenType, TypeNormalisedInput } from "./types";
+import { TokenTransferMethod, TokenType, TypeNormalisedInput } from "./types";
 /**
  * @description clears all the auth cookies from the response
  */
 export declare function clearSession(
     config: TypeNormalisedInput,
-    req: BaseRequest,
     res: BaseResponse,
-    userContext: any
+    transferMethod: TokenTransferMethod
 ): void;
 export declare function getAntiCsrfTokenFromHeaders(req: BaseRequest): string | undefined;
 export declare function setAntiCsrfTokenInHeaders(res: BaseResponse, antiCsrfToken: string): void;
@@ -19,23 +18,18 @@ export declare function setFrontTokenInHeaders(
     accessTokenPayload: any
 ): void;
 export declare function getCORSAllowedHeaders(): string[];
-export declare function isTokenInCookies(req: BaseRequest, tokenType: TokenType): boolean;
 export declare function getToken(
-    config: TypeNormalisedInput,
     req: BaseRequest,
     tokenType: TokenType,
-    userContext: any,
-    transferMethod?: "cookie" | "header"
+    transferMethod: TokenTransferMethod
 ): string | undefined;
 export declare function setToken(
     config: TypeNormalisedInput,
-    req: BaseRequest,
     res: BaseResponse,
     tokenType: TokenType,
     value: string,
     expires: number,
-    userContext: any,
-    transferMethod?: "cookie" | "header"
+    transferMethod: TokenTransferMethod
 ): void;
 export declare function setHeader(res: BaseResponse, name: string, value: string, expires: number): void;
 /**
@@ -57,3 +51,4 @@ export declare function setCookie(
     expires: number,
     pathType: "refreshTokenPath" | "accessTokenPath"
 ): void;
+export declare function getAuthModeFromHeader(req: BaseRequest): string | undefined;

--- a/lib/build/recipe/session/cookieAndHeaders.js
+++ b/lib/build/recipe/session/cookieAndHeaders.js
@@ -20,9 +20,6 @@ const accessTokenCookieKey = "sAccessToken";
 const accessTokenheaderKey = "st-access-token";
 const refreshTokenCookieKey = "sRefreshToken";
 const refreshTokenHeaderKey = "st-refresh-token";
-// there are two of them because one is used by the server to check if the user is logged in and the other is checked by the frontend to see if the user is logged in.
-const idRefreshTokenCookieKey = "sIdRefreshToken";
-const idRefreshTokenHeaderKey = "st-id-refresh-token";
 const antiCsrfHeaderKey = "anti-csrf";
 const frontTokenHeaderKey = "front-token";
 /**
@@ -30,7 +27,7 @@ const frontTokenHeaderKey = "front-token";
  */
 function clearSession(config, req, res, userContext) {
     const transferMethod = config.getTokenTransferMethod({ req, userContext });
-    const tokenTypes = ["access", "refresh", "idRefresh"];
+    const tokenTypes = ["access", "refresh"];
     for (const token of tokenTypes) {
         setToken(config, req, res, token, "", 0, userContext, transferMethod);
         // This is to ensure we clear the cookies as well if the user has migrated to headers,
@@ -39,6 +36,8 @@ function clearSession(config, req, res, userContext) {
             setToken(config, req, res, token, "", 0, userContext, "cookie");
         }
     }
+    res.setHeader(frontTokenHeaderKey, "remove", false);
+    res.setHeader("Access-Control-Expose-Headers", frontTokenHeaderKey, true);
 }
 exports.clearSession = clearSession;
 function getAntiCsrfTokenFromHeaders(req) {
@@ -61,21 +60,13 @@ function setFrontTokenInHeaders(res, userId, atExpiry, accessTokenPayload) {
 }
 exports.setFrontTokenInHeaders = setFrontTokenInHeaders;
 function getCORSAllowedHeaders() {
-    return [
-        antiCsrfHeaderKey,
-        constants_1.HEADER_RID,
-        authorizationHeaderKey,
-        refreshTokenHeaderKey,
-        idRefreshTokenHeaderKey,
-    ];
+    return [antiCsrfHeaderKey, constants_1.HEADER_RID, authorizationHeaderKey, refreshTokenHeaderKey];
 }
 exports.getCORSAllowedHeaders = getCORSAllowedHeaders;
 function getCookieNameFromTokenType(tokenType) {
     switch (tokenType) {
         case "access":
             return accessTokenCookieKey;
-        case "idRefresh":
-            return idRefreshTokenCookieKey;
         case "refresh":
             return refreshTokenCookieKey;
         default:
@@ -86,8 +77,6 @@ function getHeaderNameFromTokenType(tokenType) {
     switch (tokenType) {
         case "access":
             return accessTokenheaderKey;
-        case "idRefresh":
-            return idRefreshTokenHeaderKey;
         case "refresh":
             return refreshTokenHeaderKey;
         default:
@@ -132,16 +121,8 @@ function setToken(config, req, res, tokenType, value, expires, userContext, tran
             expires,
             tokenType === "refresh" ? "refreshTokenPath" : "accessTokenPath"
         );
-        // If we are saving the idRefresh token we want to also add it as a header
-        if (tokenType === "idRefresh") {
-            setHeader(res, idRefreshTokenHeaderKey, value === "" ? "remove" : value, expires);
-        }
     } else if (transferMethod === "header") {
-        if (tokenType === "idRefresh" && value === "") {
-            setHeader(res, getHeaderNameFromTokenType(tokenType), "remove", expires);
-        } else {
-            setHeader(res, getHeaderNameFromTokenType(tokenType), value, expires);
-        }
+        setHeader(res, getHeaderNameFromTokenType(tokenType), value, expires);
     }
 }
 exports.setToken = setToken;

--- a/lib/build/recipe/session/cookieAndHeaders.js
+++ b/lib/build/recipe/session/cookieAndHeaders.js
@@ -112,7 +112,6 @@ function setToken(config, req, res, tokenType, value, expires, userContext, tran
         transferMethod = config.getTokenTransferMethod({ req, userContext });
     }
     if (transferMethod === "cookie") {
-        // We intentionally use accessTokenPath for idRefresh tokens
         setCookie(
             config,
             res,

--- a/lib/build/recipe/session/cookieAndHeaders.js
+++ b/lib/build/recipe/session/cookieAndHeaders.js
@@ -17,24 +17,20 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const constants_1 = require("../../constants");
 const authorizationHeaderKey = "authorization";
 const accessTokenCookieKey = "sAccessToken";
-const accessTokenheaderKey = "st-access-token";
+const accessTokenHeaderKey = "st-access-token";
 const refreshTokenCookieKey = "sRefreshToken";
 const refreshTokenHeaderKey = "st-refresh-token";
 const antiCsrfHeaderKey = "anti-csrf";
 const frontTokenHeaderKey = "front-token";
+const authModeHeaderKey = "st-auth-mode";
 /**
  * @description clears all the auth cookies from the response
  */
-function clearSession(config, req, res, userContext) {
-    const transferMethod = config.getTokenTransferMethod({ req, userContext });
+function clearSession(config, res, transferMethod) {
+    // If we can tell it's a cookie based session we are not clearing using headers
     const tokenTypes = ["access", "refresh"];
     for (const token of tokenTypes) {
-        setToken(config, req, res, token, "", 0, userContext, transferMethod);
-        // This is to ensure we clear the cookies as well if the user has migrated to headers,
-        // because this can't be done on the client side
-        if (transferMethod === "header" && isTokenInCookies(req, token)) {
-            setToken(config, req, res, token, "", 0, userContext, "cookie");
-        }
+        setToken(config, res, token, "", 0, transferMethod);
     }
     res.setHeader(frontTokenHeaderKey, "remove", false);
     res.setHeader("Access-Control-Expose-Headers", frontTokenHeaderKey, true);
@@ -60,7 +56,7 @@ function setFrontTokenInHeaders(res, userId, atExpiry, accessTokenPayload) {
 }
 exports.setFrontTokenInHeaders = setFrontTokenInHeaders;
 function getCORSAllowedHeaders() {
-    return [antiCsrfHeaderKey, constants_1.HEADER_RID, authorizationHeaderKey, refreshTokenHeaderKey];
+    return [antiCsrfHeaderKey, constants_1.HEADER_RID, authorizationHeaderKey, authModeHeaderKey];
 }
 exports.getCORSAllowedHeaders = getCORSAllowedHeaders;
 function getCookieNameFromTokenType(tokenType) {
@@ -73,44 +69,31 @@ function getCookieNameFromTokenType(tokenType) {
             throw new Error("Unknown token type, should never happen.");
     }
 }
-function getHeaderNameFromTokenType(tokenType) {
+function getResponseHeaderNameForTokenType(tokenType) {
     switch (tokenType) {
         case "access":
-            return accessTokenheaderKey;
+            return accessTokenHeaderKey;
         case "refresh":
             return refreshTokenHeaderKey;
         default:
             throw new Error("Unknown token type, should never happen.");
     }
 }
-function isTokenInCookies(req, tokenType) {
-    return req.getCookieValue(getCookieNameFromTokenType(tokenType)) !== undefined;
-}
-exports.isTokenInCookies = isTokenInCookies;
-function getToken(config, req, tokenType, userContext, transferMethod) {
-    if (transferMethod === undefined) {
-        transferMethod = config.getTokenTransferMethod({ req, userContext });
-    }
+function getToken(req, tokenType, transferMethod) {
     if (transferMethod === "cookie") {
         return req.getCookieValue(getCookieNameFromTokenType(tokenType));
     } else if (transferMethod === "header") {
-        if (tokenType === "access") {
-            const value = req.getHeaderValue(authorizationHeaderKey);
-            if (value === undefined || !value.startsWith("Bearer ")) {
-                return undefined;
-            }
-            return value.replace(/^Bearer /, "");
+        const value = req.getHeaderValue(authorizationHeaderKey);
+        if (value === undefined || !value.startsWith("Bearer ")) {
+            return undefined;
         }
-        return req.getHeaderValue(getHeaderNameFromTokenType(tokenType));
+        return value.replace(/^Bearer /, "");
     } else {
         throw new Error("Should never happen: Unknown transferMethod: " + transferMethod);
     }
 }
 exports.getToken = getToken;
-function setToken(config, req, res, tokenType, value, expires, userContext, transferMethod) {
-    if (transferMethod === undefined) {
-        transferMethod = config.getTokenTransferMethod({ req, userContext });
-    }
+function setToken(config, res, tokenType, value, expires, transferMethod) {
     if (transferMethod === "cookie") {
         setCookie(
             config,
@@ -121,16 +104,12 @@ function setToken(config, req, res, tokenType, value, expires, userContext, tran
             tokenType === "refresh" ? "refreshTokenPath" : "accessTokenPath"
         );
     } else if (transferMethod === "header") {
-        setHeader(res, getHeaderNameFromTokenType(tokenType), value, expires);
+        setHeader(res, getResponseHeaderNameForTokenType(tokenType), value, expires);
     }
 }
 exports.setToken = setToken;
 function setHeader(res, name, value, expires) {
-    if (value === "remove") {
-        res.setHeader(name, value, false);
-    } else {
-        res.setHeader(name, `${value};${expires}`, false);
-    }
+    res.setHeader(name, `${value};${expires}`, false);
     res.setHeader("Access-Control-Expose-Headers", name, true);
 }
 exports.setHeader = setHeader;
@@ -159,3 +138,8 @@ function setCookie(config, res, name, value, expires, pathType) {
     return res.setCookie(name, value, domain, secure, httpOnly, expires, path, sameSite);
 }
 exports.setCookie = setCookie;
+function getAuthModeFromHeader(req) {
+    var _a;
+    return (_a = req.getHeaderValue(authModeHeaderKey)) === null || _a === void 0 ? void 0 : _a.toLowerCase();
+}
+exports.getAuthModeFromHeader = getAuthModeFromHeader;

--- a/lib/build/recipe/session/jwt.d.ts
+++ b/lib/build/recipe/session/jwt.d.ts
@@ -1,12 +1,14 @@
 // @ts-nocheck
-export declare function verifyJWTAndGetPayload(
-    jwt: string,
-    jwtSigningPublicKey: string
-): {
-    [key: string]: any;
+export declare type ParsedJWTInfo = {
+    rawTokenString: string;
+    header: string;
+    payload: any;
+    signature: string;
 };
-export declare function getPayloadWithoutVerifiying(
-    jwt: string
+export declare function parseJWTWithoutSignatureVerification(jwt: string): ParsedJWTInfo;
+export declare function verifyJWT(
+    { header, payload, signature }: ParsedJWTInfo,
+    jwtSigningPublicKey: string
 ): {
     [key: string]: any;
 };

--- a/lib/build/recipe/session/jwt.js
+++ b/lib/build/recipe/session/jwt.js
@@ -31,7 +31,7 @@ const HEADERS = new Set([
         })
     ).toString("base64"),
 ]);
-function verifyJWTAndGetPayload(jwt, jwtSigningPublicKey) {
+function parseJWTWithoutSignatureVerification(jwt) {
     const splittedInput = jwt.split(".");
     if (splittedInput.length !== 3) {
         throw new Error("Invalid JWT");
@@ -40,31 +40,29 @@ function verifyJWTAndGetPayload(jwt, jwtSigningPublicKey) {
     if (!HEADERS.has(splittedInput[0])) {
         throw new Error("JWT header mismatch");
     }
-    let payload = splittedInput[1];
+    return {
+        rawTokenString: jwt,
+        header: splittedInput[0],
+        // Ideally we would only parse this after the signature verification is done.
+        // We do this at the start, since we want to check if a token can be a supertokens access token or not
+        payload: JSON.parse(Buffer.from(splittedInput[1], "base64").toString()),
+        signature: splittedInput[2],
+    };
+}
+exports.parseJWTWithoutSignatureVerification = parseJWTWithoutSignatureVerification;
+function verifyJWT({ header, payload, signature }, jwtSigningPublicKey) {
     let verifier = crypto.createVerify("sha256");
     // convert the jwtSigningPublicKey into .pem format
-    verifier.update(splittedInput[0] + "." + payload);
+    verifier.update(header + "." + payload);
     if (
         !verifier.verify(
             "-----BEGIN PUBLIC KEY-----\n" + jwtSigningPublicKey + "\n-----END PUBLIC KEY-----",
-            splittedInput[2],
+            signature,
             "base64"
         )
     ) {
         throw new Error("JWT verification failed");
     }
-    // sending payload
-    payload = Buffer.from(payload, "base64").toString();
     return JSON.parse(payload);
 }
-exports.verifyJWTAndGetPayload = verifyJWTAndGetPayload;
-function getPayloadWithoutVerifiying(jwt) {
-    const splittedInput = jwt.split(".");
-    if (splittedInput.length !== 3) {
-        throw new Error("Invalid JWT");
-    }
-    let payload = splittedInput[1];
-    payload = Buffer.from(payload, "base64").toString();
-    return JSON.parse(payload);
-}
-exports.getPayloadWithoutVerifiying = getPayloadWithoutVerifiying;
+exports.verifyJWT = verifyJWT;

--- a/lib/build/recipe/session/recipeImplementation.js
+++ b/lib/build/recipe/session/recipeImplementation.js
@@ -145,26 +145,26 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                 logger_1.logDebugMessage("getSession: request method: " + req.getMethod());
                 let doAntiCsrfCheck = options !== undefined ? options.antiCsrfCheck : undefined;
                 const transferMethod = config.getTokenTransferMethod({ req, userContext });
-                let idRefreshToken = cookieAndHeaders_1.getToken(config, req, "idRefresh", userContext, transferMethod);
-                if (idRefreshToken === undefined) {
+                let accessToken = cookieAndHeaders_1.getToken(config, req, "access", userContext, transferMethod);
+                if (accessToken === undefined) {
                     // We are checking if we could've gone ahead with validation if the transferMethod was different
                     // However, we don't want to do the fallback here, but force a call to refresh
                     // This is done to ensure that the browsers update the transfermethod in a timely manner (basically on the next API call)
                     // instead of waiting for the session to expire
-                    idRefreshToken = cookieAndHeaders_1.getToken(
+                    accessToken = cookieAndHeaders_1.getToken(
                         config,
                         req,
-                        "idRefresh",
+                        "access",
                         userContext,
                         transferMethod === "cookie" ? "header" : "cookie"
                     );
-                    if (idRefreshToken !== undefined) {
+                    if (accessToken !== undefined) {
                         logger_1.logDebugMessage(
-                            "getSession: Returning try refresh token because idRefresh token were not sent as a " +
+                            "getSession: Returning try refresh token because the access token was not sent as a " +
                                 transferMethod
                         );
                         throw new error_1.default({
-                            message: "idRefreshToken sent with the wrong method. Please call the refresh API",
+                            message: "access token sent with the wrong method. Please call the refresh API",
                             type: error_1.default.TRY_REFRESH_TOKEN,
                         });
                     }
@@ -172,22 +172,19 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                     // race condition mentioned here: https://github.com/supertokens/supertokens-node/issues/17
                     if (options !== undefined && typeof options !== "boolean" && options.sessionRequired === false) {
                         logger_1.logDebugMessage(
-                            "getSession: returning undefined because idRefreshToken is undefined and sessionRequired is false"
+                            "getSession: returning undefined because accessToken is undefined and sessionRequired is false"
                         );
                         // there is no session that exists here, and the user wants session verification
                         // to be optional. So we return undefined.
                         return undefined;
                     }
-                    logger_1.logDebugMessage(
-                        "getSession: UNAUTHORISED because idRefreshToken from cookies is undefined"
-                    );
+                    logger_1.logDebugMessage("getSession: UNAUTHORISED because accessToken from cookies is undefined");
                     throw new error_1.default({
                         message:
                             "Session does not exist. Are you sending the session tokens in the request as cookies?",
                         type: error_1.default.UNAUTHORISED,
                     });
                 }
-                let accessToken = cookieAndHeaders_1.getToken(config, req, "access", userContext, transferMethod);
                 if (accessToken === undefined) {
                     // maybe the access token has expired.
                     /**
@@ -239,7 +236,10 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                             res,
                             "access",
                             response.accessToken.token,
-                            response.accessToken.expiry,
+                            // We set the expiration to 10 years, because we can't really access the expiration of the refresh token here.
+                            // This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
+                            // Even if the token is expired the presence of the token indicates that the user could have a valid refresh token
+                            Date.now() + 315360000000,
                             userContext
                         );
                         accessToken = response.accessToken.token;
@@ -332,43 +332,24 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                 // We only use it here and not while getting/validating sessions, because we want to "force" clients to upgrade
                 const outputTransferMethod = config.getTokenTransferMethod({ req, userContext });
                 let inputTransferMethod = outputTransferMethod;
-                let inputIdRefreshToken = cookieAndHeaders_1.getToken(
+                let inputRefreshToken = cookieAndHeaders_1.getToken(
                     config,
                     req,
-                    "idRefresh",
+                    "refresh",
                     userContext,
                     inputTransferMethod
                 );
-                if (inputIdRefreshToken === undefined) {
+                if (inputRefreshToken === undefined) {
                     inputTransferMethod = inputTransferMethod === "cookie" ? "header" : "cookie";
-                    inputIdRefreshToken = cookieAndHeaders_1.getToken(
-                        config,
-                        req,
-                        "idRefresh",
-                        userContext,
-                        inputTransferMethod
-                    );
-                }
-                if (inputIdRefreshToken === undefined) {
-                    logger_1.logDebugMessage(
-                        "refreshSession: UNAUTHORISED because idRefreshToken from cookies is undefined"
-                    );
-                    // we do not clear cookies here because of a
-                    // race condition mentioned here: https://github.com/supertokens/supertokens-node/issues/17
-                    throw new error_1.default({
-                        message:
-                            "Session does not exist. Are you sending the session tokens in the request as cookies?",
-                        type: error_1.default.UNAUTHORISED,
-                    });
-                }
-                try {
-                    let inputRefreshToken = cookieAndHeaders_1.getToken(
+                    inputRefreshToken = cookieAndHeaders_1.getToken(
                         config,
                         req,
                         "refresh",
                         userContext,
                         inputTransferMethod
                     );
+                }
+                try {
                     if (inputRefreshToken === undefined) {
                         logger_1.logDebugMessage(
                             "refreshSession: UNAUTHORISED because refresh token from cookies is undefined"

--- a/lib/build/recipe/session/recipeImplementation.js
+++ b/lib/build/recipe/session/recipeImplementation.js
@@ -236,11 +236,11 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                             res,
                             "access",
                             response.accessToken.token,
-                            // We set the expiration to 10 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
+                            // We set the expiration to 100 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
                             // This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
                             // Even if the token is expired the presence of the token indicates that the user could have a valid refresh
                             // Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
-                            Date.now() + 315360000000,
+                            Date.now() + 3153600000000,
                             userContext
                         );
                         accessToken = response.accessToken.token;

--- a/lib/build/recipe/session/recipeImplementation.js
+++ b/lib/build/recipe/session/recipeImplementation.js
@@ -236,9 +236,10 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                             res,
                             "access",
                             response.accessToken.token,
-                            // We set the expiration to 10 years, because we can't really access the expiration of the refresh token here.
+                            // We set the expiration to 10 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
                             // This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
-                            // Even if the token is expired the presence of the token indicates that the user could have a valid refresh token
+                            // Even if the token is expired the presence of the token indicates that the user could have a valid refresh
+                            // Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
                             Date.now() + 315360000000,
                             userContext
                         );

--- a/lib/build/recipe/session/recipeImplementation.js
+++ b/lib/build/recipe/session/recipeImplementation.js
@@ -40,6 +40,9 @@ const utils_2 = require("../../utils");
 const processState_1 = require("../../processState");
 const normalisedURLPath_1 = require("../../normalisedURLPath");
 const logger_1 = require("../../logger");
+const constants_1 = require("./constants");
+const jwt_1 = require("./jwt");
+const accessToken_1 = require("./accessToken");
 class HandshakeInfo {
     constructor(
         antiCsrf,
@@ -71,6 +74,8 @@ class HandshakeInfo {
     }
 }
 exports.HandshakeInfo = HandshakeInfo;
+// We are defining this here to reduce the scope of legacy code
+const LEGACY_ID_REFRESH_TOKEN_COOKIE_NAME = "sIdRefreshToken";
 function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverrides) {
     let handshakeInfo;
     function getHandshakeInfo(forceRefetch = false) {
@@ -113,7 +118,17 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
     let obj = {
         createNewSession: function ({ req, res, userId, accessTokenPayload = {}, sessionData = {}, userContext }) {
             return __awaiter(this, void 0, void 0, function* () {
-                const disableAntiCSRF = config.getTokenTransferMethod({ req, userContext }) === "header";
+                logger_1.logDebugMessage("createNewSession: Started");
+                let outputTransferMethod = config.getTokenTransferMethod({
+                    req,
+                    forCreateNewSession: true,
+                    userContext,
+                });
+                if (outputTransferMethod === "any") {
+                    outputTransferMethod = "header";
+                }
+                logger_1.logDebugMessage("createNewSession: using transfer method " + outputTransferMethod);
+                const disableAntiCSRF = outputTransferMethod === "header";
                 let response = yield SessionFunctions.createNewSession(
                     helpers,
                     userId,
@@ -121,7 +136,15 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                     accessTokenPayload,
                     sessionData
                 );
-                utils_1.attachCreateOrRefreshSessionResponseToExpressRes(config, req, res, response, userContext);
+                for (const transferMethod of constants_1.availableTokenTransferMethods) {
+                    if (
+                        transferMethod !== outputTransferMethod &&
+                        cookieAndHeaders_1.getToken(req, "access", transferMethod) !== undefined
+                    ) {
+                        cookieAndHeaders_1.clearSession(config, res, transferMethod);
+                    }
+                }
+                utils_1.attachCreateOrRefreshSessionResponseToExpressRes(config, res, response, outputTransferMethod);
                 return new sessionClass_1.default(
                     helpers,
                     response.accessToken.token,
@@ -129,7 +152,8 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                     response.session.userId,
                     response.session.userDataInJWT,
                     res,
-                    req
+                    req,
+                    outputTransferMethod
                 );
             });
         },
@@ -138,39 +162,65 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                 return input.claimValidatorsAddedByOtherRecipes;
             });
         },
+        /* In all cases if sIdRefreshToken token exists (so it's a legacy session) we return TRY_REFRESH_TOKEN. The refresh endpoint will clear this cookie and try to upgrade the session.
+           Check https://supertokens.com/docs/contribute/decisions/session/0007 for further details and a table of expected behaviours
+         */
         getSession: function ({ req, res, options, userContext }) {
             return __awaiter(this, void 0, void 0, function* () {
                 logger_1.logDebugMessage("getSession: Started");
-                logger_1.logDebugMessage("getSession: rid in header: " + utils_2.frontendHasInterceptor(req));
-                logger_1.logDebugMessage("getSession: request method: " + req.getMethod());
-                let doAntiCsrfCheck = options !== undefined ? options.antiCsrfCheck : undefined;
-                const transferMethod = config.getTokenTransferMethod({ req, userContext });
-                let accessToken = cookieAndHeaders_1.getToken(config, req, "access", userContext, transferMethod);
-                if (accessToken === undefined) {
-                    // We are checking if we could've gone ahead with validation if the transferMethod was different
-                    // However, we don't want to do the fallback here, but force a call to refresh
-                    // This is done to ensure that the browsers update the transfermethod in a timely manner (basically on the next API call)
-                    // instead of waiting for the session to expire
-                    accessToken = cookieAndHeaders_1.getToken(
-                        config,
-                        req,
-                        "access",
-                        userContext,
-                        transferMethod === "cookie" ? "header" : "cookie"
-                    );
-                    if (accessToken !== undefined) {
-                        logger_1.logDebugMessage(
-                            "getSession: Returning try refresh token because the access token was not sent as a " +
-                                transferMethod
-                        );
-                        throw new error_1.default({
-                            message: "access token sent with the wrong method. Please call the refresh API",
-                            type: error_1.default.TRY_REFRESH_TOKEN,
-                        });
+                // This token isn't handled by getToken to limit the scope of this legacy/migration code
+                if (req.getCookieValue(LEGACY_ID_REFRESH_TOKEN_COOKIE_NAME) !== undefined) {
+                    // This could create a spike on refresh calls during the update of the backend SDK
+                    throw new error_1.default({
+                        message: "using legacy session, please call the refresh API",
+                        type: error_1.default.TRY_REFRESH_TOKEN,
+                    });
+                }
+                const sessionOptional =
+                    (options === null || options === void 0 ? void 0 : options.sessionRequired) === false;
+                logger_1.logDebugMessage("getSession: optional validation: " + sessionOptional);
+                const accessTokens = {};
+                // We check all token transfer methods for available access tokens
+                for (const transferMethod of constants_1.availableTokenTransferMethods) {
+                    const tokenString = cookieAndHeaders_1.getToken(req, "access", transferMethod);
+                    if (tokenString !== undefined) {
+                        try {
+                            const info = jwt_1.parseJWTWithoutSignatureVerification(tokenString);
+                            accessToken_1.validateAccessTokenStructure(info.payload);
+                            logger_1.logDebugMessage("getSession: got access token from " + transferMethod);
+                            accessTokens[transferMethod] = info;
+                        } catch (_a) {
+                            logger_1.logDebugMessage(
+                                `getSession: ignoring token in ${transferMethod}, because it doesn't match our access token structure`
+                            );
+                        }
                     }
+                }
+                const allowedTransferMethod = config.getTokenTransferMethod({
+                    req,
+                    forCreateNewSession: false,
+                    userContext,
+                });
+                let requestTransferMethod;
+                let accessToken;
+                if (
+                    (allowedTransferMethod === "any" || allowedTransferMethod === "header") &&
+                    accessTokens["header"] !== undefined
+                ) {
+                    logger_1.logDebugMessage("getSession: using header transfer method");
+                    requestTransferMethod = "header";
+                    accessToken = accessTokens["header"];
+                } else if (
+                    (allowedTransferMethod === "any" || allowedTransferMethod === "cookie") &&
+                    accessTokens["cookie"] !== undefined
+                ) {
+                    logger_1.logDebugMessage("getSession: using header transfer method");
+                    requestTransferMethod = "cookie";
+                    accessToken = accessTokens["cookie"];
+                } else {
                     // we do not clear cookies here because of a
                     // race condition mentioned here: https://github.com/supertokens/supertokens-node/issues/17
-                    if (options !== undefined && typeof options !== "boolean" && options.sessionRequired === false) {
+                    if (sessionOptional) {
                         logger_1.logDebugMessage(
                             "getSession: returning undefined because accessToken is undefined and sessionRequired is false"
                         );
@@ -178,51 +228,31 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                         // to be optional. So we return undefined.
                         return undefined;
                     }
-                    logger_1.logDebugMessage("getSession: UNAUTHORISED because accessToken from cookies is undefined");
+                    logger_1.logDebugMessage("getSession: UNAUTHORISED because accessToken in request is undefined");
                     throw new error_1.default({
                         message:
-                            "Session does not exist. Are you sending the session tokens in the request as cookies?",
+                            "Session does not exist. Are you sending the session tokens in the request as with the appropriate token transfer method?",
                         type: error_1.default.UNAUTHORISED,
                     });
                 }
-                if (accessToken === undefined) {
-                    // maybe the access token has expired.
-                    /**
-                     * Based on issue: #156 (spertokens-node)
-                     * we throw TRY_REFRESH_TOKEN only if
-                     * options.sessionRequired === true || (frontendHasInterceptor or request method is get),
-                     * else we should return undefined
-                     */
-                    if (
-                        options === undefined ||
-                        (options !== undefined && options.sessionRequired === true) ||
-                        utils_2.frontendHasInterceptor(req) ||
-                        utils_2.normaliseHttpMethod(req.getMethod()) === "get"
-                    ) {
-                        logger_1.logDebugMessage(
-                            "getSession: Returning try refresh token because access token from cookies is undefined"
-                        );
-                        throw new error_1.default({
-                            message: "Access token has expired. Please call the refresh API",
-                            type: error_1.default.TRY_REFRESH_TOKEN,
-                        });
-                    }
-                    return undefined;
-                }
                 try {
                     let antiCsrfToken = cookieAndHeaders_1.getAntiCsrfTokenFromHeaders(req);
-                    const disableAntiCSRF = transferMethod === "header";
+                    let doAntiCsrfCheck = options !== undefined ? options.antiCsrfCheck : undefined;
                     if (doAntiCsrfCheck === undefined) {
                         doAntiCsrfCheck = utils_2.normaliseHttpMethod(req.getMethod()) !== "get";
+                    }
+                    if (requestTransferMethod === "header") {
+                        doAntiCsrfCheck = false;
                     }
                     logger_1.logDebugMessage("getSession: Value of doAntiCsrfCheck is: " + doAntiCsrfCheck);
                     let response = yield SessionFunctions.getSession(
                         helpers,
                         accessToken,
                         antiCsrfToken,
-                        !disableAntiCSRF && doAntiCsrfCheck,
+                        doAntiCsrfCheck,
                         utils_2.getRidFromHeader(req) !== undefined
                     );
+                    let accessTokenString = accessToken.rawTokenString;
                     if (response.accessToken !== undefined) {
                         cookieAndHeaders_1.setFrontTokenInHeaders(
                             res,
@@ -232,7 +262,6 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                         );
                         cookieAndHeaders_1.setToken(
                             config,
-                            req,
                             res,
                             "access",
                             response.accessToken.token,
@@ -241,25 +270,28 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                             // Even if the token is expired the presence of the token indicates that the user could have a valid refresh
                             // Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
                             Date.now() + 3153600000000,
-                            userContext
+                            requestTransferMethod
                         );
-                        accessToken = response.accessToken.token;
+                        accessTokenString = response.accessToken.token;
                     }
                     logger_1.logDebugMessage("getSession: Success!");
                     const session = new sessionClass_1.default(
                         helpers,
-                        accessToken,
+                        accessTokenString,
                         response.session.handle,
                         response.session.userId,
                         response.session.userDataInJWT,
                         res,
-                        req
+                        req,
+                        requestTransferMethod
                     );
                     return session;
                 } catch (err) {
                     if (err.type === error_1.default.UNAUTHORISED) {
-                        logger_1.logDebugMessage("getSession: Clearing cookies because of UNAUTHORISED response");
-                        cookieAndHeaders_1.clearSession(config, req, res, userContext);
+                        logger_1.logDebugMessage(
+                            `getSession: Clearing ${requestTransferMethod} because of UNAUTHORISED response from getSession`
+                        );
+                        cookieAndHeaders_1.clearSession(config, res, requestTransferMethod);
                     }
                     throw err;
                 }
@@ -326,53 +358,88 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                 return SessionFunctions.getSessionInformation(helpers, sessionHandle);
             });
         },
+        /*
+            In all cases: if sIdRefreshToken token exists (so it's a legacy session) we clear it.
+            Check http://localhost:3002/docs/contribute/decisions/session/0008 for further details and a table of expected behaviours
+         */
         refreshSession: function ({ req, res, userContext }) {
             return __awaiter(this, void 0, void 0, function* () {
                 logger_1.logDebugMessage("refreshSession: Started");
-                // We use a fallback mechanism here, to ensure there is a smooth upgrade path when switching transfer methods
-                // We only use it here and not while getting/validating sessions, because we want to "force" clients to upgrade
-                const outputTransferMethod = config.getTokenTransferMethod({ req, userContext });
-                let inputTransferMethod = outputTransferMethod;
-                let inputRefreshToken = cookieAndHeaders_1.getToken(
-                    config,
-                    req,
-                    "refresh",
-                    userContext,
-                    inputTransferMethod
-                );
-                if (inputRefreshToken === undefined) {
-                    inputTransferMethod = inputTransferMethod === "cookie" ? "header" : "cookie";
-                    inputRefreshToken = cookieAndHeaders_1.getToken(
+                // This token isn't handled by getToken/setToken to limit the scope of this legacy/migration code
+                if (req.getCookieValue(LEGACY_ID_REFRESH_TOKEN_COOKIE_NAME) !== undefined) {
+                    cookieAndHeaders_1.setCookie(
                         config,
-                        req,
-                        "refresh",
-                        userContext,
-                        inputTransferMethod
+                        res,
+                        LEGACY_ID_REFRESH_TOKEN_COOKIE_NAME,
+                        "",
+                        0,
+                        "accessTokenPath"
                     );
                 }
-                try {
-                    if (inputRefreshToken === undefined) {
-                        logger_1.logDebugMessage(
-                            "refreshSession: UNAUTHORISED because refresh token from cookies is undefined"
-                        );
-                        throw new error_1.default({
-                            message:
-                                "Refresh token not found. Are you sending the refresh token in the request as a cookie?",
-                            type: error_1.default.UNAUTHORISED,
-                        });
+                const refreshTokens = {};
+                // We check all token transfer methods for available refresh tokens
+                // We do this so that we can later clear all we are not overwriting
+                for (const transferMethod of constants_1.availableTokenTransferMethods) {
+                    refreshTokens[transferMethod] = cookieAndHeaders_1.getToken(req, "refresh", transferMethod);
+                    if (refreshTokens[transferMethod] !== undefined) {
+                        logger_1.logDebugMessage("refreshSession: got refresh token from " + transferMethod);
                     }
+                }
+                const allowedTransferMethod = config.getTokenTransferMethod({
+                    req,
+                    forCreateNewSession: false,
+                    userContext,
+                });
+                let requestTransferMethod;
+                let refreshToken;
+                if (
+                    (allowedTransferMethod === "any" || allowedTransferMethod === "header") &&
+                    refreshTokens["header"] !== undefined
+                ) {
+                    logger_1.logDebugMessage("refreshSession: using header transfer method");
+                    requestTransferMethod = "header";
+                    refreshToken = refreshTokens["header"];
+                } else if (
+                    (allowedTransferMethod === "any" || allowedTransferMethod === "cookie") &&
+                    refreshTokens["cookie"]
+                ) {
+                    logger_1.logDebugMessage("refreshSession: using header transfer method");
+                    requestTransferMethod = "cookie";
+                    refreshToken = refreshTokens["cookie"];
+                } else {
+                    logger_1.logDebugMessage(
+                        "refreshSession: UNAUTHORISED because refresh token in request is undefined"
+                    );
+                    throw new error_1.default({
+                        message:
+                            "Refresh token not found. Are you sending the refresh token in the request as a cookie?",
+                        type: error_1.default.UNAUTHORISED,
+                    });
+                }
+                try {
                     let antiCsrfToken = cookieAndHeaders_1.getAntiCsrfTokenFromHeaders(req);
                     let response = yield SessionFunctions.refreshSession(
                         helpers,
-                        inputRefreshToken,
+                        refreshToken,
                         antiCsrfToken,
                         utils_2.getRidFromHeader(req) !== undefined,
-                        inputTransferMethod,
-                        outputTransferMethod
+                        requestTransferMethod
                     );
-                    // This will get the preferred transfer method again, and intentionally not use the fallback
-                    // See above for the reasoning
-                    utils_1.attachCreateOrRefreshSessionResponseToExpressRes(config, req, res, response, userContext);
+                    logger_1.logDebugMessage(
+                        "refreshSession: Attaching refreshed session info as " + requestTransferMethod
+                    );
+                    // We clear the tokens in all token transfer methods we are not going to overwrite
+                    for (const transferMethod of constants_1.availableTokenTransferMethods) {
+                        if (transferMethod !== requestTransferMethod && refreshTokens[transferMethod] !== undefined) {
+                            cookieAndHeaders_1.clearSession(config, res, transferMethod);
+                        }
+                    }
+                    utils_1.attachCreateOrRefreshSessionResponseToExpressRes(
+                        config,
+                        res,
+                        response,
+                        requestTransferMethod
+                    );
                     logger_1.logDebugMessage("refreshSession: Success!");
                     return new sessionClass_1.default(
                         helpers,
@@ -381,7 +448,8 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                         response.session.userId,
                         response.session.userDataInJWT,
                         res,
-                        req
+                        req,
+                        requestTransferMethod
                     );
                 } catch (err) {
                     if (
@@ -391,7 +459,7 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                         logger_1.logDebugMessage(
                             "refreshSession: Clearing cookies because of UNAUTHORISED or TOKEN_THEFT_DETECTED response"
                         );
-                        cookieAndHeaders_1.clearSession(config, req, res, userContext);
+                        cookieAndHeaders_1.clearSession(config, res, requestTransferMethod);
                     }
                     throw err;
                 }

--- a/lib/build/recipe/session/sessionClass.d.ts
+++ b/lib/build/recipe/session/sessionClass.d.ts
@@ -1,15 +1,16 @@
 // @ts-nocheck
 import { BaseRequest, BaseResponse } from "../../framework";
-import { SessionClaim, SessionClaimValidator, SessionContainerInterface } from "./types";
+import { SessionClaim, SessionClaimValidator, SessionContainerInterface, TokenTransferMethod } from "./types";
 import { Helpers } from "./recipeImplementation";
 export default class Session implements SessionContainerInterface {
+    protected helpers: Helpers;
+    protected accessToken: string;
     protected sessionHandle: string;
     protected userId: string;
     protected userDataInAccessToken: any;
-    protected readonly req: BaseRequest;
     protected res: BaseResponse;
-    protected accessToken: string;
-    protected helpers: Helpers;
+    protected readonly req: BaseRequest;
+    protected readonly transferMethod: TokenTransferMethod;
     constructor(
         helpers: Helpers,
         accessToken: string,
@@ -17,7 +18,8 @@ export default class Session implements SessionContainerInterface {
         userId: string,
         userDataInAccessToken: any,
         res: BaseResponse,
-        req: BaseRequest
+        req: BaseRequest,
+        transferMethod: TokenTransferMethod
     );
     revokeSession: (userContext?: any) => Promise<void>;
     getSessionData: (userContext?: any) => Promise<any>;

--- a/lib/build/recipe/session/sessionClass.js
+++ b/lib/build/recipe/session/sessionClass.js
@@ -203,9 +203,10 @@ class Session {
                         this.res,
                         "access",
                         response.accessToken.token,
-                        // We set the expiration to 10 years, because we can't really access the expiration of the refresh token here.
+                        // We set the expiration to 10 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
                         // This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
-                        // Even if the token is expired the presence of the token indicates that the user could have a valid refresh token
+                        // Even if the token is expired the presence of the token indicates that the user could have a valid refresh
+                        // Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
                         Date.now() + 315360000000,
                         userContext
                     );

--- a/lib/build/recipe/session/sessionClass.js
+++ b/lib/build/recipe/session/sessionClass.js
@@ -203,7 +203,10 @@ class Session {
                         this.res,
                         "access",
                         response.accessToken.token,
-                        response.accessToken.expiry,
+                        // We set the expiration to 10 years, because we can't really access the expiration of the refresh token here.
+                        // This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
+                        // Even if the token is expired the presence of the token indicates that the user could have a valid refresh token
+                        Date.now() + 315360000000,
                         userContext
                     );
                 }

--- a/lib/build/recipe/session/sessionClass.js
+++ b/lib/build/recipe/session/sessionClass.js
@@ -203,11 +203,11 @@ class Session {
                         this.res,
                         "access",
                         response.accessToken.token,
-                        // We set the expiration to 10 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
+                        // We set the expiration to 100 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
                         // This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
                         // Even if the token is expired the presence of the token indicates that the user could have a valid refresh
                         // Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
-                        Date.now() + 315360000000,
+                        Date.now() + 3153600000000,
                         userContext
                     );
                 }

--- a/lib/build/recipe/session/sessionClass.js
+++ b/lib/build/recipe/session/sessionClass.js
@@ -34,7 +34,15 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const cookieAndHeaders_1 = require("./cookieAndHeaders");
 const error_1 = require("./error");
 class Session {
-    constructor(helpers, accessToken, sessionHandle, userId, userDataInAccessToken, res, req) {
+    constructor(helpers, accessToken, sessionHandle, userId, userDataInAccessToken, res, req, transferMethod) {
+        this.helpers = helpers;
+        this.accessToken = accessToken;
+        this.sessionHandle = sessionHandle;
+        this.userId = userId;
+        this.userDataInAccessToken = userDataInAccessToken;
+        this.res = res;
+        this.req = req;
+        this.transferMethod = transferMethod;
         this.revokeSession = (userContext) =>
             __awaiter(this, void 0, void 0, function* () {
                 yield this.helpers.getRecipeImpl().revokeSession({
@@ -47,7 +55,7 @@ class Session {
                 // If we instead clear the cookies only when revokeSession
                 // returns true, it can cause this kind of a bug:
                 // https://github.com/supertokens/supertokens-node/issues/343
-                cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, userContext);
+                cookieAndHeaders_1.clearSession(this.helpers.config, this.res, this.transferMethod);
             });
         this.getSessionData = (userContext) =>
             __awaiter(this, void 0, void 0, function* () {
@@ -56,7 +64,7 @@ class Session {
                     userContext: userContext === undefined ? {} : userContext,
                 });
                 if (sessionInfo === undefined) {
-                    cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, userContext);
+                    cookieAndHeaders_1.clearSession(this.helpers.config, this.res, this.transferMethod);
                     throw new error_1.default({
                         message: "Session does not exist anymore",
                         type: error_1.default.UNAUTHORISED,
@@ -73,7 +81,7 @@ class Session {
                         userContext: userContext === undefined ? {} : userContext,
                     }))
                 ) {
-                    cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, userContext);
+                    cookieAndHeaders_1.clearSession(this.helpers.config, this.res, this.transferMethod);
                     throw new error_1.default({
                         message: "Session does not exist anymore",
                         type: error_1.default.UNAUTHORISED,
@@ -112,7 +120,7 @@ class Session {
                     userContext: userContext === undefined ? {} : userContext,
                 });
                 if (sessionInfo === undefined) {
-                    cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, userContext);
+                    cookieAndHeaders_1.clearSession(this.helpers.config, this.res, this.transferMethod);
                     throw new error_1.default({
                         message: "Session does not exist anymore",
                         type: error_1.default.UNAUTHORISED,
@@ -127,7 +135,7 @@ class Session {
                     userContext: userContext === undefined ? {} : userContext,
                 });
                 if (sessionInfo === undefined) {
-                    cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, userContext);
+                    cookieAndHeaders_1.clearSession(this.helpers.config, this.res, this.transferMethod);
                     throw new error_1.default({
                         message: "Session does not exist anymore",
                         type: error_1.default.UNAUTHORISED,
@@ -182,7 +190,7 @@ class Session {
                     userContext: userContext === undefined ? {} : userContext,
                 });
                 if (response === undefined) {
-                    cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, userContext);
+                    cookieAndHeaders_1.clearSession(this.helpers.config, this.res, this.transferMethod);
                     throw new error_1.default({
                         message: "Session does not exist anymore",
                         type: error_1.default.UNAUTHORISED,
@@ -199,7 +207,6 @@ class Session {
                     );
                     cookieAndHeaders_1.setToken(
                         this.helpers.config,
-                        this.req,
                         this.res,
                         "access",
                         response.accessToken.token,
@@ -208,17 +215,10 @@ class Session {
                         // Even if the token is expired the presence of the token indicates that the user could have a valid refresh
                         // Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
                         Date.now() + 3153600000000,
-                        userContext
+                        this.transferMethod
                     );
                 }
             });
-        this.sessionHandle = sessionHandle;
-        this.userId = userId;
-        this.userDataInAccessToken = userDataInAccessToken;
-        this.req = req;
-        this.res = res;
-        this.accessToken = accessToken;
-        this.helpers = helpers;
     }
 }
 exports.default = Session;

--- a/lib/build/recipe/session/sessionFunctions.d.ts
+++ b/lib/build/recipe/session/sessionFunctions.d.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
-import { CreateOrRefreshAPIResponse, SessionInformation } from "./types";
+import { ParsedJWTInfo } from "./jwt";
+import { CreateOrRefreshAPIResponse, SessionInformation, TokenTransferMethod } from "./types";
 import { Helpers } from "./recipeImplementation";
 /**
  * @description call this to "login" a user.
@@ -16,7 +17,7 @@ export declare function createNewSession(
  */
 export declare function getSession(
     helpers: Helpers,
-    accessToken: string,
+    parsedAccessToken: ParsedJWTInfo,
     antiCsrfToken: string | undefined,
     doAntiCsrfCheck: boolean,
     containsCustomHeader: boolean
@@ -49,8 +50,7 @@ export declare function refreshSession(
     refreshToken: string,
     antiCsrfToken: string | undefined,
     containsCustomHeader: boolean,
-    inputTransferMethod: "header" | "cookie",
-    outputTransferMethod: "header" | "cookie"
+    transferMethod: TokenTransferMethod
 ): Promise<CreateOrRefreshAPIResponse>;
 /**
  * @description deletes session info of a user from db. This only invalidates the refresh token. Not the access token.

--- a/lib/build/recipe/session/sessionFunctions.js
+++ b/lib/build/recipe/session/sessionFunctions.js
@@ -46,7 +46,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * under the License.
  */
 const accessToken_1 = require("./accessToken");
-const jwt_1 = require("./jwt");
 const error_1 = require("./error");
 const processState_1 = require("../../processState");
 const normalisedURLPath_1 = require("../../normalisedURLPath");
@@ -103,7 +102,7 @@ exports.createNewSession = createNewSession;
 /**
  * @description authenticates a session. To be used in APIs that require authentication
  */
-function getSession(helpers, accessToken, antiCsrfToken, doAntiCsrfCheck, containsCustomHeader) {
+function getSession(helpers, parsedAccessToken, antiCsrfToken, doAntiCsrfCheck, containsCustomHeader) {
     return __awaiter(this, void 0, void 0, function* () {
         let handShakeInfo = yield helpers.getHandshakeInfo();
         let accessTokenInfo;
@@ -115,7 +114,7 @@ function getSession(helpers, accessToken, antiCsrfToken, doAntiCsrfCheck, contai
                  * get access token info using existing signingKey
                  */
                 accessTokenInfo = yield accessToken_1.getInfoFromAccessToken(
-                    accessToken,
+                    parsedAccessToken,
                     key.publicKey,
                     handShakeInfo.antiCsrf === "VIA_TOKEN" && doAntiCsrfCheck
                 );
@@ -146,15 +145,7 @@ function getSession(helpers, accessToken, antiCsrfToken, doAntiCsrfCheck, contai
                  * so if foundASigningKeyThatIsOlderThanTheAccessToken is still false after
                  * the loop we just return TRY_REFRESH_TOKEN
                  */
-                let payload;
-                try {
-                    payload = jwt_1.getPayloadWithoutVerifiying(accessToken);
-                } catch (_) {
-                    throw err;
-                }
-                if (payload === undefined) {
-                    throw err;
-                }
+                let payload = parsedAccessToken.payload;
                 const timeCreated = accessToken_1.sanitizeNumberInput(payload.timeCreated);
                 const expiryTime = accessToken_1.sanitizeNumberInput(payload.expiryTime);
                 if (expiryTime === undefined || expiryTime < Date.now()) {
@@ -237,7 +228,7 @@ function getSession(helpers, accessToken, antiCsrfToken, doAntiCsrfCheck, contai
         }
         processState_1.ProcessState.getInstance().addState(processState_1.PROCESS_STATE.CALLING_SERVICE_IN_VERIFY);
         let requestBody = {
-            accessToken,
+            accessToken: parsedAccessToken.rawTokenString,
             antiCsrfToken,
             doAntiCsrfCheck,
             enableAntiCsrf: handShakeInfo.antiCsrf === "VIA_TOKEN",
@@ -278,7 +269,7 @@ function getSession(helpers, accessToken, antiCsrfToken, doAntiCsrfCheck, contai
                 // we force update the signing keys...
                 yield helpers.getHandshakeInfo(true);
             }
-            logger_1.logDebugMessage("getSession: Returning TRY_REFRESH_TOKEN because of core response");
+            logger_1.logDebugMessage("getSession: Returning TRY_REFRESH_TOKEN because of core response.");
             throw new error_1.default({
                 message: response.message,
                 type: error_1.default.TRY_REFRESH_TOKEN,
@@ -317,22 +308,15 @@ exports.getSessionInformation = getSessionInformation;
  * @description generates new access and refresh tokens for a given refresh token. Called when client's access token has expired.
  * @sideEffects calls onTokenTheftDetection if token theft is detected.
  */
-function refreshSession(
-    helpers,
-    refreshToken,
-    antiCsrfToken,
-    containsCustomHeader,
-    inputTransferMethod,
-    outputTransferMethod
-) {
+function refreshSession(helpers, refreshToken, antiCsrfToken, containsCustomHeader, transferMethod) {
     return __awaiter(this, void 0, void 0, function* () {
         let handShakeInfo = yield helpers.getHandshakeInfo();
         let requestBody = {
             refreshToken,
             antiCsrfToken,
-            enableAntiCsrf: outputTransferMethod === "cookie" && handShakeInfo.antiCsrf === "VIA_TOKEN",
+            enableAntiCsrf: transferMethod === "cookie" && handShakeInfo.antiCsrf === "VIA_TOKEN",
         };
-        if (handShakeInfo.antiCsrf === "VIA_CUSTOM_HEADER" && inputTransferMethod === "cookie") {
+        if (handShakeInfo.antiCsrf === "VIA_CUSTOM_HEADER" && transferMethod === "cookie") {
             if (!containsCustomHeader) {
                 logger_1.logDebugMessage(
                     "refreshSession: Returning UNAUTHORISED because custom header (rid) was not passed"

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -43,11 +43,6 @@ export declare type CreateOrRefreshAPIResponse = {
         expiry: number;
         createdTime: number;
     };
-    idRefreshToken: {
-        token: string;
-        expiry: number;
-        createdTime: number;
-    };
     antiCsrfToken: string | undefined;
 };
 export interface ErrorHandlers {

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -51,13 +51,18 @@ export interface ErrorHandlers {
     onInvalidClaim?: InvalidClaimErrorHandlerMiddleware;
 }
 export declare type TokenType = "access" | "refresh";
+export declare type TokenTransferMethod = "header" | "cookie";
 export declare type TypeInput = {
     sessionExpiredStatusCode?: number;
     invalidClaimStatusCode?: number;
     cookieSecure?: boolean;
     cookieSameSite?: "strict" | "lax" | "none";
     cookieDomain?: string;
-    getTokenTransferMethod?: (input: { req: BaseRequest; userContext: any }) => "cookie" | "header";
+    getTokenTransferMethod?: (input: {
+        req: BaseRequest;
+        forCreateNewSession: boolean;
+        userContext: any;
+    }) => TokenTransferMethod | "any";
     errorHandlers?: ErrorHandlers;
     antiCsrf?: "VIA_TOKEN" | "VIA_CUSTOM_HEADER" | "NONE";
     jwt?:
@@ -105,7 +110,11 @@ export declare type TypeNormalisedInput = {
     sessionExpiredStatusCode: number;
     errorHandlers: NormalisedErrorHandlers;
     antiCsrf: "VIA_TOKEN" | "VIA_CUSTOM_HEADER" | "NONE";
-    getTokenTransferMethod: (input: { req: BaseRequest; userContext: any }) => "cookie" | "header";
+    getTokenTransferMethod: (input: {
+        req: BaseRequest;
+        forCreateNewSession: boolean;
+        userContext: any;
+    }) => TokenTransferMethod | "any";
     invalidClaimStatusCode: number;
     jwt: {
         enable: boolean;

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -55,7 +55,7 @@ export interface ErrorHandlers {
     onTokenTheftDetected?: TokenTheftErrorHandlerMiddleware;
     onInvalidClaim?: InvalidClaimErrorHandlerMiddleware;
 }
-export declare type TokenType = "access" | "refresh" | "idRefresh";
+export declare type TokenType = "access" | "refresh";
 export declare type TypeInput = {
     sessionExpiredStatusCode?: number;
     invalidClaimStatusCode?: number;

--- a/lib/build/recipe/session/utils.d.ts
+++ b/lib/build/recipe/session/utils.d.ts
@@ -7,6 +7,7 @@ import {
     SessionClaimValidator,
     SessionContainerInterface,
     VerifySessionOptions,
+    TokenTransferMethod,
 } from "./types";
 import SessionRecipe from "./recipe";
 import { NormalisedAppinfo } from "../../types";
@@ -46,10 +47,9 @@ export declare function validateAndNormaliseUserInput(
 export declare function normaliseSameSiteOrThrowError(sameSite: string): "strict" | "lax" | "none";
 export declare function attachCreateOrRefreshSessionResponseToExpressRes(
     config: TypeNormalisedInput,
-    req: BaseRequest,
     res: BaseResponse,
     response: CreateOrRefreshAPIResponse,
-    userContext: any
+    transferMethod: TokenTransferMethod
 ): void;
 export declare function getRequiredClaimValidators(
     session: SessionContainerInterface,

--- a/lib/build/recipe/session/utils.js
+++ b/lib/build/recipe/session/utils.js
@@ -262,11 +262,11 @@ function attachCreateOrRefreshSessionResponseToExpressRes(config, req, res, resp
         res,
         "access",
         accessToken.token,
-        // We set the expiration to 10 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
+        // We set the expiration to 100 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
         // This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
         // Even if the token is expired the presence of the token indicates that the user could have a valid refresh
         // Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
-        Date.now() + 315360000000,
+        Date.now() + 3153600000000,
         userContext
     );
     cookieAndHeaders_1.setToken(config, req, res, "refresh", refreshToken.token, refreshToken.expiry, userContext);

--- a/lib/build/recipe/session/utils.js
+++ b/lib/build/recipe/session/utils.js
@@ -262,9 +262,10 @@ function attachCreateOrRefreshSessionResponseToExpressRes(config, req, res, resp
         res,
         "access",
         accessToken.token,
-        // We set the expiration to 10 years, because in other places we set it we can't really access the expiration of the refresh token.
+        // We set the expiration to 10 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
         // This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
-        // Even if the token is expired the presence of the token indicates that the user could have a valid refresh token
+        // Even if the token is expired the presence of the token indicates that the user could have a valid refresh
+        // Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
         Date.now() + 315360000000,
         userContext
     );

--- a/lib/build/recipe/session/utils.js
+++ b/lib/build/recipe/session/utils.js
@@ -247,7 +247,7 @@ function normaliseSameSiteOrThrowError(sameSite) {
     return sameSite;
 }
 exports.normaliseSameSiteOrThrowError = normaliseSameSiteOrThrowError;
-function attachCreateOrRefreshSessionResponseToExpressRes(config, req, res, response, userContext) {
+function attachCreateOrRefreshSessionResponseToExpressRes(config, res, response, transferMethod) {
     let accessToken = response.accessToken;
     let refreshToken = response.refreshToken;
     cookieAndHeaders_1.setFrontTokenInHeaders(
@@ -258,7 +258,6 @@ function attachCreateOrRefreshSessionResponseToExpressRes(config, req, res, resp
     );
     cookieAndHeaders_1.setToken(
         config,
-        req,
         res,
         "access",
         accessToken.token,
@@ -267,9 +266,9 @@ function attachCreateOrRefreshSessionResponseToExpressRes(config, req, res, resp
         // Even if the token is expired the presence of the token indicates that the user could have a valid refresh
         // Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
         Date.now() + 3153600000000,
-        userContext
+        transferMethod
     );
-    cookieAndHeaders_1.setToken(config, req, res, "refresh", refreshToken.token, refreshToken.expiry, userContext);
+    cookieAndHeaders_1.setToken(config, res, "refresh", refreshToken.token, refreshToken.expiry, transferMethod);
     if (response.antiCsrfToken !== undefined) {
         cookieAndHeaders_1.setAntiCsrfTokenInHeaders(res, response.antiCsrfToken);
     }
@@ -312,6 +311,18 @@ function validateClaimsInPayload(claimValidators, newAccessTokenPayload, userCon
     });
 }
 exports.validateClaimsInPayload = validateClaimsInPayload;
-function defaultGetTokenTransferMethod({ req }) {
-    return utils_1.getAuthModeFromHeader(req) === "header" ? "header" : "cookie";
+function defaultGetTokenTransferMethod({ req, forCreateNewSession }) {
+    // We allow fallback (checking headers then cookies) by default when validating
+    if (!forCreateNewSession) {
+        return "any";
+    }
+    // In create new session we respect the frontend preference by default
+    switch (cookieAndHeaders_1.getAuthModeFromHeader(req)) {
+        case "header":
+            return "header";
+        case "cookie":
+            return "cookie";
+        default:
+            return "any";
+    }
 }

--- a/lib/build/recipe/session/utils.js
+++ b/lib/build/recipe/session/utils.js
@@ -313,6 +313,5 @@ function validateClaimsInPayload(claimValidators, newAccessTokenPayload, userCon
 }
 exports.validateClaimsInPayload = validateClaimsInPayload;
 function defaultGetTokenTransferMethod({ req }) {
-    console.log("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", utils_1.getAuthModeFromHeader(req));
     return utils_1.getAuthModeFromHeader(req) === "header" ? "header" : "cookie";
 }

--- a/lib/build/recipe/session/utils.js
+++ b/lib/build/recipe/session/utils.js
@@ -250,24 +250,25 @@ exports.normaliseSameSiteOrThrowError = normaliseSameSiteOrThrowError;
 function attachCreateOrRefreshSessionResponseToExpressRes(config, req, res, response, userContext) {
     let accessToken = response.accessToken;
     let refreshToken = response.refreshToken;
-    let idRefreshToken = response.idRefreshToken;
     cookieAndHeaders_1.setFrontTokenInHeaders(
         res,
         response.session.userId,
         response.accessToken.expiry,
         response.session.userDataInJWT
     );
-    cookieAndHeaders_1.setToken(config, req, res, "access", accessToken.token, accessToken.expiry, userContext);
-    cookieAndHeaders_1.setToken(config, req, res, "refresh", refreshToken.token, refreshToken.expiry, userContext);
     cookieAndHeaders_1.setToken(
         config,
         req,
         res,
-        "idRefresh",
-        idRefreshToken.token,
-        idRefreshToken.expiry,
+        "access",
+        accessToken.token,
+        // We set the expiration to 10 years, because in other places we set it we can't really access the expiration of the refresh token.
+        // This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
+        // Even if the token is expired the presence of the token indicates that the user could have a valid refresh token
+        Date.now() + 315360000000,
         userContext
     );
+    cookieAndHeaders_1.setToken(config, req, res, "refresh", refreshToken.token, refreshToken.expiry, userContext);
     if (response.antiCsrfToken !== undefined) {
         cookieAndHeaders_1.setAntiCsrfTokenInHeaders(res, response.antiCsrfToken);
     }

--- a/lib/build/supertokens.js
+++ b/lib/build/supertokens.js
@@ -88,7 +88,6 @@ class SuperTokens {
             let headerSet = new Set();
             headerSet.add(constants_1.HEADER_RID);
             headerSet.add(constants_1.HEADER_FDI);
-            headerSet.add(constants_1.HEADER_AUTH_MODE);
             this.recipeModules.forEach((recipe) => {
                 let headers = recipe.getAllCORSHeaders();
                 headers.forEach((h) => {

--- a/lib/build/utils.d.ts
+++ b/lib/build/utils.d.ts
@@ -9,7 +9,6 @@ export declare function sendNon200ResponseWithMessage(res: BaseResponse, message
 export declare function sendNon200Response(res: BaseResponse, statusCode: number, body: JSONObject): void;
 export declare function send200Response(res: BaseResponse, responseJson: any): void;
 export declare function isAnIpAddress(ipaddress: string): boolean;
-export declare function getAuthModeFromHeader(req: BaseRequest): string | undefined;
 export declare function getRidFromHeader(req: BaseRequest): string | undefined;
 export declare function frontendHasInterceptor(req: BaseRequest): boolean;
 export declare function humaniseMilliseconds(ms: number): string;

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -5,6 +5,7 @@ const normalisedURLDomain_1 = require("./normalisedURLDomain");
 const normalisedURLPath_1 = require("./normalisedURLPath");
 const logger_1 = require("./logger");
 const constants_1 = require("./constants");
+const url_1 = require("url");
 function getLargestVersionFromIntersection(v1, v2) {
     let intersection = v1.filter((value) => v2.indexOf(value) !== -1);
     if (intersection.length === 0) {
@@ -156,7 +157,7 @@ function makeDefaultUserContextFromAPI(request) {
 }
 exports.makeDefaultUserContextFromAPI = makeDefaultUserContextFromAPI;
 function getTopLevelDomainForSameSiteResolution(url) {
-    let urlObj = new URL(url);
+    let urlObj = new url_1.URL(url);
     let hostname = urlObj.hostname;
     if (hostname.startsWith("localhost") || hostname.startsWith("localhost.org") || isAnIpAddress(hostname)) {
         // we treat these as the same TLDs since we can use sameSite lax for all of them.

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -105,10 +105,6 @@ function isAnIpAddress(ipaddress) {
     );
 }
 exports.isAnIpAddress = isAnIpAddress;
-function getAuthModeFromHeader(req) {
-    return req.getHeaderValue(constants_1.HEADER_AUTH_MODE);
-}
-exports.getAuthModeFromHeader = getAuthModeFromHeader;
 function getRidFromHeader(req) {
     return req.getHeaderValue(constants_1.HEADER_RID);
 }

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -4,7 +4,6 @@ const psl = require("psl");
 const normalisedURLDomain_1 = require("./normalisedURLDomain");
 const normalisedURLPath_1 = require("./normalisedURLPath");
 const logger_1 = require("./logger");
-const url_1 = require("url");
 const constants_1 = require("./constants");
 function getLargestVersionFromIntersection(v1, v2) {
     let intersection = v1.filter((value) => v2.indexOf(value) !== -1);
@@ -144,7 +143,7 @@ function makeDefaultUserContextFromAPI(request) {
 }
 exports.makeDefaultUserContextFromAPI = makeDefaultUserContextFromAPI;
 function getTopLevelDomainForSameSiteResolution(url) {
-    let urlObj = new url_1.URL(url);
+    let urlObj = new URL(url);
     let hostname = urlObj.hostname;
     if (hostname.startsWith("localhost") || hostname.startsWith("localhost.org") || isAnIpAddress(hostname)) {
         // we treat these as the same TLDs since we can use sameSite lax for all of them.

--- a/lib/ts/constants.ts
+++ b/lib/ts/constants.ts
@@ -14,5 +14,4 @@
  */
 
 export const HEADER_RID = "rid";
-export const HEADER_AUTH_MODE = "st-auth-mode";
 export const HEADER_FDI = "fdi-version";

--- a/lib/ts/recipe/session/accessToken.ts
+++ b/lib/ts/recipe/session/accessToken.ts
@@ -14,10 +14,10 @@
  */
 
 import STError from "./error";
-import { verifyJWTAndGetPayload } from "./jwt";
+import { ParsedJWTInfo, verifyJWT } from "./jwt";
 
 export async function getInfoFromAccessToken(
-    token: string,
+    jwtInfo: ParsedJWTInfo,
     jwtSigningPublicKey: string,
     doAntiCsrfCheck: boolean
 ): Promise<{
@@ -31,28 +31,25 @@ export async function getInfoFromAccessToken(
     timeCreated: number;
 }> {
     try {
-        let payload = verifyJWTAndGetPayload(token, jwtSigningPublicKey);
+        let payload = verifyJWT(jwtInfo, jwtSigningPublicKey);
 
-        let sessionHandle = sanitizeStringInput(payload.sessionHandle);
-        let userId = sanitizeStringInput(payload.userId);
-        let refreshTokenHash1 = sanitizeStringInput(payload.refreshTokenHash1);
+        // This should be called before this function, but the check is very quick, so we can also do them here
+        validateAccessTokenStructure(payload);
+
+        // We can mark these as defined (the ! after the calls), since validateAccessTokenPayload checks this
+        let sessionHandle = sanitizeStringInput(payload.sessionHandle)!;
+        let userId = sanitizeStringInput(payload.userId)!;
+        let refreshTokenHash1 = sanitizeStringInput(payload.refreshTokenHash1)!;
         let parentRefreshTokenHash1 = sanitizeStringInput(payload.parentRefreshTokenHash1);
         let userData = payload.userData;
         let antiCsrfToken = sanitizeStringInput(payload.antiCsrfToken);
-        let expiryTime = sanitizeNumberInput(payload.expiryTime);
-        let timeCreated = sanitizeNumberInput(payload.timeCreated);
-        if (
-            sessionHandle === undefined ||
-            userId === undefined ||
-            refreshTokenHash1 === undefined ||
-            userData === undefined ||
-            (antiCsrfToken === undefined && doAntiCsrfCheck) ||
-            expiryTime === undefined ||
-            timeCreated === undefined
-        ) {
-            // it would come here if we change the structure of the JWT.
-            throw Error("Access token does not contain all the information. Maybe the structure has changed?");
+        let expiryTime = sanitizeNumberInput(payload.expiryTime)!;
+        let timeCreated = sanitizeNumberInput(payload.timeCreated)!;
+
+        if (antiCsrfToken === undefined && doAntiCsrfCheck) {
+            throw Error("Access token does not contain the anti-csrf token.");
         }
+
         if (expiryTime < Date.now()) {
             throw Error("Access token expired");
         }
@@ -71,6 +68,20 @@ export async function getInfoFromAccessToken(
             message: "Failed to verify access token",
             type: STError.TRY_REFRESH_TOKEN,
         });
+    }
+}
+
+export function validateAccessTokenStructure(payload: any) {
+    if (
+        typeof payload.sessionHandle !== "string" ||
+        typeof payload.userId !== "string" ||
+        typeof payload.refreshTokenHash1 !== "string" ||
+        payload.userData === undefined ||
+        typeof payload.expiryTime !== "number" ||
+        typeof payload.timeCreated !== "number"
+    ) {
+        // it would come here if we change the structure of the JWT.
+        throw Error("Access token does not contain all the information. Maybe the structure has changed?");
     }
 }
 

--- a/lib/ts/recipe/session/constants.ts
+++ b/lib/ts/recipe/session/constants.ts
@@ -13,5 +13,9 @@
  * under the License.
  */
 
+import { TokenTransferMethod } from "./types";
+
 export const REFRESH_API_PATH = "/session/refresh";
 export const SIGNOUT_API_PATH = "/signout";
+
+export const availableTokenTransferMethods: TokenTransferMethod[] = ["cookie", "header"];

--- a/lib/ts/recipe/session/cookieAndHeaders.ts
+++ b/lib/ts/recipe/session/cookieAndHeaders.ts
@@ -137,7 +137,6 @@ export function setToken(
     }
 
     if (transferMethod === "cookie") {
-        // We intentionally use accessTokenPath for idRefresh tokens
         setCookie(
             config,
             res,

--- a/lib/ts/recipe/session/jwt.ts
+++ b/lib/ts/recipe/session/jwt.ts
@@ -31,7 +31,14 @@ const HEADERS = new Set([
     ).toString("base64"),
 ]);
 
-export function verifyJWTAndGetPayload(jwt: string, jwtSigningPublicKey: string): { [key: string]: any } {
+export type ParsedJWTInfo = {
+    rawTokenString: string;
+    header: string;
+    payload: any;
+    signature: string;
+};
+
+export function parseJWTWithoutSignatureVerification(jwt: string): ParsedJWTInfo {
     const splittedInput = jwt.split(".");
     if (splittedInput.length !== 3) {
         throw new Error("Invalid JWT");
@@ -42,33 +49,33 @@ export function verifyJWTAndGetPayload(jwt: string, jwtSigningPublicKey: string)
         throw new Error("JWT header mismatch");
     }
 
-    let payload = splittedInput[1];
+    return {
+        rawTokenString: jwt,
+        header: splittedInput[0],
+        // Ideally we would only parse this after the signature verification is done.
+        // We do this at the start, since we want to check if a token can be a supertokens access token or not
+        payload: JSON.parse(Buffer.from(splittedInput[1], "base64").toString()),
+        signature: splittedInput[2],
+    };
+}
 
+export function verifyJWT(
+    { header, payload, signature }: ParsedJWTInfo,
+    jwtSigningPublicKey: string
+): { [key: string]: any } {
     let verifier = crypto.createVerify("sha256");
     // convert the jwtSigningPublicKey into .pem format
 
-    verifier.update(splittedInput[0] + "." + payload);
+    verifier.update(header + "." + payload);
     if (
         !verifier.verify(
             "-----BEGIN PUBLIC KEY-----\n" + jwtSigningPublicKey + "\n-----END PUBLIC KEY-----",
-            splittedInput[2],
+            signature,
             "base64"
         )
     ) {
         throw new Error("JWT verification failed");
     }
-    // sending payload
-    payload = Buffer.from(payload, "base64").toString();
-    return JSON.parse(payload);
-}
 
-export function getPayloadWithoutVerifiying(jwt: string): { [key: string]: any } {
-    const splittedInput = jwt.split(".");
-    if (splittedInput.length !== 3) {
-        throw new Error("Invalid JWT");
-    }
-
-    let payload = splittedInput[1];
-    payload = Buffer.from(payload, "base64").toString();
     return JSON.parse(payload);
 }

--- a/lib/ts/recipe/session/recipeImplementation.ts
+++ b/lib/ts/recipe/session/recipeImplementation.ts
@@ -261,9 +261,10 @@ export default function getRecipeInterface(
                         res,
                         "access",
                         response.accessToken.token,
-                        // We set the expiration to 10 years, because we can't really access the expiration of the refresh token here.
+                        // We set the expiration to 10 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
                         // This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
-                        // Even if the token is expired the presence of the token indicates that the user could have a valid refresh token
+                        // Even if the token is expired the presence of the token indicates that the user could have a valid refresh
+                        // Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
                         Date.now() + 315360000000,
                         userContext
                     );

--- a/lib/ts/recipe/session/recipeImplementation.ts
+++ b/lib/ts/recipe/session/recipeImplementation.ts
@@ -261,11 +261,11 @@ export default function getRecipeInterface(
                         res,
                         "access",
                         response.accessToken.token,
-                        // We set the expiration to 10 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
+                        // We set the expiration to 100 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
                         // This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
                         // Even if the token is expired the presence of the token indicates that the user could have a valid refresh
                         // Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
-                        Date.now() + 315360000000,
+                        Date.now() + 3153600000000,
                         userContext
                     );
                     accessToken = response.accessToken.token;

--- a/lib/ts/recipe/session/recipeImplementation.ts
+++ b/lib/ts/recipe/session/recipeImplementation.ts
@@ -8,6 +8,7 @@ import {
     SessionClaimValidator,
     SessionClaim,
     ClaimValidationError,
+    TokenTransferMethod,
 } from "./types";
 import * as SessionFunctions from "./sessionFunctions";
 import {
@@ -16,11 +17,12 @@ import {
     setFrontTokenInHeaders,
     getToken,
     setToken,
+    setCookie,
 } from "./cookieAndHeaders";
 import { attachCreateOrRefreshSessionResponseToExpressRes, validateClaimsInPayload } from "./utils";
 import Session from "./sessionClass";
 import STError from "./error";
-import { normaliseHttpMethod, frontendHasInterceptor, getRidFromHeader } from "../../utils";
+import { normaliseHttpMethod, getRidFromHeader } from "../../utils";
 import { Querier } from "../../querier";
 import { PROCESS_STATE, ProcessState } from "../../processState";
 import NormalisedURLPath from "../../normalisedURLPath";
@@ -28,6 +30,9 @@ import { JSONObject, NormalisedAppinfo } from "../../types";
 import { logDebugMessage } from "../../logger";
 import { BaseResponse } from "../../framework/response";
 import { BaseRequest } from "../../framework/request";
+import { availableTokenTransferMethods } from "./constants";
+import { ParsedJWTInfo, parseJWTWithoutSignatureVerification } from "./jwt";
+import { validateAccessTokenStructure } from "./accessToken";
 
 export class HandshakeInfo {
     constructor(
@@ -65,6 +70,9 @@ export type Helpers = {
     appInfo: NormalisedAppinfo;
     getRecipeImpl: () => RecipeInterface;
 };
+
+// We are defining this here to reduce the scope of legacy code
+const LEGACY_ID_REFRESH_TOKEN_COOKIE_NAME = "sIdRefreshToken";
 
 export default function getRecipeInterface(
     querier: Querier,
@@ -124,7 +132,14 @@ export default function getRecipeInterface(
             sessionData?: any;
             userContext: any;
         }): Promise<Session> {
-            const disableAntiCSRF = config.getTokenTransferMethod({ req, userContext }) === "header";
+            logDebugMessage("createNewSession: Started");
+            let outputTransferMethod = config.getTokenTransferMethod({ req, forCreateNewSession: true, userContext });
+            if (outputTransferMethod === "any") {
+                outputTransferMethod = "header";
+            }
+            logDebugMessage("createNewSession: using transfer method " + outputTransferMethod);
+
+            const disableAntiCSRF = outputTransferMethod === "header";
             let response = await SessionFunctions.createNewSession(
                 helpers,
                 userId,
@@ -132,7 +147,14 @@ export default function getRecipeInterface(
                 accessTokenPayload,
                 sessionData
             );
-            attachCreateOrRefreshSessionResponseToExpressRes(config, req, res, response, userContext);
+
+            for (const transferMethod of availableTokenTransferMethods) {
+                if (transferMethod !== outputTransferMethod && getToken(req, "access", transferMethod) !== undefined) {
+                    clearSession(config, res, transferMethod);
+                }
+            }
+
+            attachCreateOrRefreshSessionResponseToExpressRes(config, res, response, outputTransferMethod);
             return new Session(
                 helpers,
                 response.accessToken.token,
@@ -140,7 +162,8 @@ export default function getRecipeInterface(
                 response.session.userId,
                 response.session.userDataInJWT,
                 res,
-                req
+                req,
+                outputTransferMethod
             );
         },
 
@@ -150,6 +173,9 @@ export default function getRecipeInterface(
             return input.claimValidatorsAddedByOtherRecipes;
         },
 
+        /* In all cases if sIdRefreshToken token exists (so it's a legacy session) we return TRY_REFRESH_TOKEN. The refresh endpoint will clear this cookie and try to upgrade the session.
+           Check https://supertokens.com/docs/contribute/decisions/session/0007 for further details and a table of expected behaviours
+         */
         getSession: async function ({
             req,
             res,
@@ -162,38 +188,66 @@ export default function getRecipeInterface(
             userContext: any;
         }): Promise<Session | undefined> {
             logDebugMessage("getSession: Started");
-            logDebugMessage("getSession: rid in header: " + frontendHasInterceptor(req));
-            logDebugMessage("getSession: request method: " + req.getMethod());
-            let doAntiCsrfCheck = options !== undefined ? options.antiCsrfCheck : undefined;
-            const transferMethod = config.getTokenTransferMethod({ req, userContext });
 
-            let accessToken = getToken(config, req, "access", userContext, transferMethod);
-            if (accessToken === undefined) {
-                // We are checking if we could've gone ahead with validation if the transferMethod was different
-                // However, we don't want to do the fallback here, but force a call to refresh
-                // This is done to ensure that the browsers update the transfermethod in a timely manner (basically on the next API call)
-                // instead of waiting for the session to expire
-                accessToken = getToken(
-                    config,
-                    req,
-                    "access",
-                    userContext,
-                    transferMethod === "cookie" ? "header" : "cookie"
-                );
-                if (accessToken !== undefined) {
-                    logDebugMessage(
-                        "getSession: Returning try refresh token because the access token was not sent as a " +
-                            transferMethod
-                    );
-                    throw new STError({
-                        message: "access token sent with the wrong method. Please call the refresh API",
-                        type: STError.TRY_REFRESH_TOKEN,
-                    });
+            // This token isn't handled by getToken to limit the scope of this legacy/migration code
+            if (req.getCookieValue(LEGACY_ID_REFRESH_TOKEN_COOKIE_NAME) !== undefined) {
+                // This could create a spike on refresh calls during the update of the backend SDK
+                throw new STError({
+                    message: "using legacy session, please call the refresh API",
+                    type: STError.TRY_REFRESH_TOKEN,
+                });
+            }
+
+            const sessionOptional = options?.sessionRequired === false;
+            logDebugMessage("getSession: optional validation: " + sessionOptional);
+
+            const accessTokens: {
+                [key in TokenTransferMethod]?: ParsedJWTInfo;
+            } = {};
+
+            // We check all token transfer methods for available access tokens
+            for (const transferMethod of availableTokenTransferMethods) {
+                const tokenString = getToken(req, "access", transferMethod);
+                if (tokenString !== undefined) {
+                    try {
+                        const info = parseJWTWithoutSignatureVerification(tokenString);
+                        validateAccessTokenStructure(info.payload);
+                        logDebugMessage("getSession: got access token from " + transferMethod);
+                        accessTokens[transferMethod] = info;
+                    } catch {
+                        logDebugMessage(
+                            `getSession: ignoring token in ${transferMethod}, because it doesn't match our access token structure`
+                        );
+                    }
                 }
+            }
+
+            const allowedTransferMethod = config.getTokenTransferMethod({
+                req,
+                forCreateNewSession: false,
+                userContext,
+            });
+            let requestTransferMethod: TokenTransferMethod;
+            let accessToken: ParsedJWTInfo | undefined;
+
+            if (
+                (allowedTransferMethod === "any" || allowedTransferMethod === "header") &&
+                accessTokens["header"] !== undefined
+            ) {
+                logDebugMessage("getSession: using header transfer method");
+                requestTransferMethod = "header";
+                accessToken = accessTokens["header"];
+            } else if (
+                (allowedTransferMethod === "any" || allowedTransferMethod === "cookie") &&
+                accessTokens["cookie"] !== undefined
+            ) {
+                logDebugMessage("getSession: using header transfer method");
+                requestTransferMethod = "cookie";
+                accessToken = accessTokens["cookie"];
+            } else {
                 // we do not clear cookies here because of a
                 // race condition mentioned here: https://github.com/supertokens/supertokens-node/issues/17
-
-                if (options !== undefined && typeof options !== "boolean" && options.sessionRequired === false) {
+                if (sessionOptional) {
                     logDebugMessage(
                         "getSession: returning undefined because accessToken is undefined and sessionRequired is false"
                     );
@@ -202,52 +256,36 @@ export default function getRecipeInterface(
                     return undefined;
                 }
 
-                logDebugMessage("getSession: UNAUTHORISED because accessToken from cookies is undefined");
+                logDebugMessage("getSession: UNAUTHORISED because accessToken in request is undefined");
                 throw new STError({
-                    message: "Session does not exist. Are you sending the session tokens in the request as cookies?",
+                    message:
+                        "Session does not exist. Are you sending the session tokens in the request as with the appropriate token transfer method?",
                     type: STError.UNAUTHORISED,
                 });
             }
-            if (accessToken === undefined) {
-                // maybe the access token has expired.
-                /**
-                 * Based on issue: #156 (spertokens-node)
-                 * we throw TRY_REFRESH_TOKEN only if
-                 * options.sessionRequired === true || (frontendHasInterceptor or request method is get),
-                 * else we should return undefined
-                 */
-                if (
-                    options === undefined ||
-                    (options !== undefined && options.sessionRequired === true) ||
-                    frontendHasInterceptor(req) ||
-                    normaliseHttpMethod(req.getMethod()) === "get"
-                ) {
-                    logDebugMessage(
-                        "getSession: Returning try refresh token because access token from cookies is undefined"
-                    );
-                    throw new STError({
-                        message: "Access token has expired. Please call the refresh API",
-                        type: STError.TRY_REFRESH_TOKEN,
-                    });
-                }
-                return undefined;
-            }
+
             try {
                 let antiCsrfToken = getAntiCsrfTokenFromHeaders(req);
-                const disableAntiCSRF = transferMethod === "header";
+                let doAntiCsrfCheck = options !== undefined ? options.antiCsrfCheck : undefined;
 
                 if (doAntiCsrfCheck === undefined) {
                     doAntiCsrfCheck = normaliseHttpMethod(req.getMethod()) !== "get";
                 }
+
+                if (requestTransferMethod === "header") {
+                    doAntiCsrfCheck = false;
+                }
+
                 logDebugMessage("getSession: Value of doAntiCsrfCheck is: " + doAntiCsrfCheck);
 
                 let response = await SessionFunctions.getSession(
                     helpers,
                     accessToken,
                     antiCsrfToken,
-                    !disableAntiCSRF && doAntiCsrfCheck,
+                    doAntiCsrfCheck,
                     getRidFromHeader(req) !== undefined
                 );
+                let accessTokenString = accessToken.rawTokenString;
                 if (response.accessToken !== undefined) {
                     setFrontTokenInHeaders(
                         res,
@@ -257,7 +295,6 @@ export default function getRecipeInterface(
                     );
                     setToken(
                         config,
-                        req,
                         res,
                         "access",
                         response.accessToken.token,
@@ -266,26 +303,29 @@ export default function getRecipeInterface(
                         // Even if the token is expired the presence of the token indicates that the user could have a valid refresh
                         // Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
                         Date.now() + 3153600000000,
-                        userContext
+                        requestTransferMethod
                     );
-                    accessToken = response.accessToken.token;
+                    accessTokenString = response.accessToken.token;
                 }
                 logDebugMessage("getSession: Success!");
                 const session = new Session(
                     helpers,
-                    accessToken,
+                    accessTokenString,
                     response.session.handle,
                     response.session.userId,
                     response.session.userDataInJWT,
                     res,
-                    req
+                    req,
+                    requestTransferMethod
                 );
 
                 return session;
             } catch (err) {
                 if (err.type === STError.UNAUTHORISED) {
-                    logDebugMessage("getSession: Clearing cookies because of UNAUTHORISED response");
-                    clearSession(config, req, res, userContext);
+                    logDebugMessage(
+                        `getSession: Clearing ${requestTransferMethod} because of UNAUTHORISED response from getSession`
+                    );
+                    clearSession(config, res, requestTransferMethod);
                 }
                 throw err;
             }
@@ -375,43 +415,85 @@ export default function getRecipeInterface(
             return SessionFunctions.getSessionInformation(helpers, sessionHandle);
         },
 
+        /*
+            In all cases: if sIdRefreshToken token exists (so it's a legacy session) we clear it.
+            Check http://localhost:3002/docs/contribute/decisions/session/0008 for further details and a table of expected behaviours
+         */
         refreshSession: async function (
             this: RecipeInterface,
             { req, res, userContext }: { req: BaseRequest; res: BaseResponse; userContext: any }
         ): Promise<Session> {
             logDebugMessage("refreshSession: Started");
-            // We use a fallback mechanism here, to ensure there is a smooth upgrade path when switching transfer methods
-            // We only use it here and not while getting/validating sessions, because we want to "force" clients to upgrade
-            const outputTransferMethod = config.getTokenTransferMethod({ req, userContext });
-            let inputTransferMethod = outputTransferMethod;
 
-            let inputRefreshToken = getToken(config, req, "refresh", userContext, inputTransferMethod);
-            if (inputRefreshToken === undefined) {
-                inputTransferMethod = inputTransferMethod === "cookie" ? "header" : "cookie";
-                inputRefreshToken = getToken(config, req, "refresh", userContext, inputTransferMethod);
+            // This token isn't handled by getToken/setToken to limit the scope of this legacy/migration code
+            if (req.getCookieValue(LEGACY_ID_REFRESH_TOKEN_COOKIE_NAME) !== undefined) {
+                setCookie(config, res, LEGACY_ID_REFRESH_TOKEN_COOKIE_NAME, "", 0, "accessTokenPath");
+            }
+
+            const refreshTokens: {
+                [key in TokenTransferMethod]?: string;
+            } = {};
+
+            // We check all token transfer methods for available refresh tokens
+            // We do this so that we can later clear all we are not overwriting
+            for (const transferMethod of availableTokenTransferMethods) {
+                refreshTokens[transferMethod] = getToken(req, "refresh", transferMethod);
+                if (refreshTokens[transferMethod] !== undefined) {
+                    logDebugMessage("refreshSession: got refresh token from " + transferMethod);
+                }
+            }
+
+            const allowedTransferMethod = config.getTokenTransferMethod({
+                req,
+                forCreateNewSession: false,
+                userContext,
+            });
+
+            let requestTransferMethod: TokenTransferMethod;
+            let refreshToken: string | undefined;
+
+            if (
+                (allowedTransferMethod === "any" || allowedTransferMethod === "header") &&
+                refreshTokens["header"] !== undefined
+            ) {
+                logDebugMessage("refreshSession: using header transfer method");
+                requestTransferMethod = "header";
+                refreshToken = refreshTokens["header"];
+            } else if (
+                (allowedTransferMethod === "any" || allowedTransferMethod === "cookie") &&
+                refreshTokens["cookie"]
+            ) {
+                logDebugMessage("refreshSession: using header transfer method");
+                requestTransferMethod = "cookie";
+                refreshToken = refreshTokens["cookie"];
+            } else {
+                logDebugMessage("refreshSession: UNAUTHORISED because refresh token in request is undefined");
+                throw new STError({
+                    message: "Refresh token not found. Are you sending the refresh token in the request as a cookie?",
+                    type: STError.UNAUTHORISED,
+                });
             }
 
             try {
-                if (inputRefreshToken === undefined) {
-                    logDebugMessage("refreshSession: UNAUTHORISED because refresh token from cookies is undefined");
-                    throw new STError({
-                        message:
-                            "Refresh token not found. Are you sending the refresh token in the request as a cookie?",
-                        type: STError.UNAUTHORISED,
-                    });
-                }
                 let antiCsrfToken = getAntiCsrfTokenFromHeaders(req);
                 let response = await SessionFunctions.refreshSession(
                     helpers,
-                    inputRefreshToken,
+                    refreshToken,
                     antiCsrfToken,
                     getRidFromHeader(req) !== undefined,
-                    inputTransferMethod,
-                    outputTransferMethod
+                    requestTransferMethod
                 );
-                // This will get the preferred transfer method again, and intentionally not use the fallback
-                // See above for the reasoning
-                attachCreateOrRefreshSessionResponseToExpressRes(config, req, res, response, userContext);
+                logDebugMessage("refreshSession: Attaching refreshed session info as " + requestTransferMethod);
+
+                // We clear the tokens in all token transfer methods we are not going to overwrite
+                for (const transferMethod of availableTokenTransferMethods) {
+                    if (transferMethod !== requestTransferMethod && refreshTokens[transferMethod] !== undefined) {
+                        clearSession(config, res, transferMethod);
+                    }
+                }
+
+                attachCreateOrRefreshSessionResponseToExpressRes(config, res, response, requestTransferMethod);
+
                 logDebugMessage("refreshSession: Success!");
                 return new Session(
                     helpers,
@@ -420,7 +502,8 @@ export default function getRecipeInterface(
                     response.session.userId,
                     response.session.userDataInJWT,
                     res,
-                    req
+                    req,
+                    requestTransferMethod
                 );
             } catch (err) {
                 if (
@@ -430,7 +513,7 @@ export default function getRecipeInterface(
                     logDebugMessage(
                         "refreshSession: Clearing cookies because of UNAUTHORISED or TOKEN_THEFT_DETECTED response"
                     );
-                    clearSession(config, req, res, userContext);
+                    clearSession(config, res, requestTransferMethod);
                 }
                 throw err;
             }

--- a/lib/ts/recipe/session/sessionClass.ts
+++ b/lib/ts/recipe/session/sessionClass.ts
@@ -219,7 +219,10 @@ export default class Session implements SessionContainerInterface {
                 this.res,
                 "access",
                 response.accessToken.token,
-                response.accessToken.expiry,
+                // We set the expiration to 10 years, because we can't really access the expiration of the refresh token here.
+                // This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
+                // Even if the token is expired the presence of the token indicates that the user could have a valid refresh token
+                Date.now() + 315360000000,
                 userContext
             );
         }

--- a/lib/ts/recipe/session/sessionClass.ts
+++ b/lib/ts/recipe/session/sessionClass.ts
@@ -219,9 +219,10 @@ export default class Session implements SessionContainerInterface {
                 this.res,
                 "access",
                 response.accessToken.token,
-                // We set the expiration to 10 years, because we can't really access the expiration of the refresh token here.
+                // We set the expiration to 10 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
                 // This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
-                // Even if the token is expired the presence of the token indicates that the user could have a valid refresh token
+                // Even if the token is expired the presence of the token indicates that the user could have a valid refresh
+                // Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
                 Date.now() + 315360000000,
                 userContext
             );

--- a/lib/ts/recipe/session/sessionClass.ts
+++ b/lib/ts/recipe/session/sessionClass.ts
@@ -219,11 +219,11 @@ export default class Session implements SessionContainerInterface {
                 this.res,
                 "access",
                 response.accessToken.token,
-                // We set the expiration to 10 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
+                // We set the expiration to 100 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
                 // This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
                 // Even if the token is expired the presence of the token indicates that the user could have a valid refresh
                 // Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
-                Date.now() + 315360000000,
+                Date.now() + 3153600000000,
                 userContext
             );
         }

--- a/lib/ts/recipe/session/sessionClass.ts
+++ b/lib/ts/recipe/session/sessionClass.ts
@@ -15,35 +15,20 @@
 import { BaseRequest, BaseResponse } from "../../framework";
 import { clearSession, setFrontTokenInHeaders, setToken } from "./cookieAndHeaders";
 import STError from "./error";
-import { SessionClaim, SessionClaimValidator, SessionContainerInterface } from "./types";
+import { SessionClaim, SessionClaimValidator, SessionContainerInterface, TokenTransferMethod } from "./types";
 import { Helpers } from "./recipeImplementation";
 
 export default class Session implements SessionContainerInterface {
-    protected sessionHandle: string;
-    protected userId: string;
-    protected userDataInAccessToken: any;
-    protected readonly req: BaseRequest;
-    protected res: BaseResponse;
-    protected accessToken: string;
-    protected helpers: Helpers;
-
     constructor(
-        helpers: Helpers,
-        accessToken: string,
-        sessionHandle: string,
-        userId: string,
-        userDataInAccessToken: any,
-        res: BaseResponse,
-        req: BaseRequest
-    ) {
-        this.sessionHandle = sessionHandle;
-        this.userId = userId;
-        this.userDataInAccessToken = userDataInAccessToken;
-        this.req = req;
-        this.res = res;
-        this.accessToken = accessToken;
-        this.helpers = helpers;
-    }
+        protected helpers: Helpers,
+        protected accessToken: string,
+        protected sessionHandle: string,
+        protected userId: string,
+        protected userDataInAccessToken: any,
+        protected res: BaseResponse,
+        protected readonly req: BaseRequest,
+        protected readonly transferMethod: TokenTransferMethod
+    ) {}
 
     revokeSession = async (userContext?: any) => {
         await this.helpers.getRecipeImpl().revokeSession({
@@ -57,7 +42,7 @@ export default class Session implements SessionContainerInterface {
         // If we instead clear the cookies only when revokeSession
         // returns true, it can cause this kind of a bug:
         // https://github.com/supertokens/supertokens-node/issues/343
-        clearSession(this.helpers.config, this.req, this.res, userContext);
+        clearSession(this.helpers.config, this.res, this.transferMethod);
     };
 
     getSessionData = async (userContext?: any): Promise<any> => {
@@ -66,7 +51,7 @@ export default class Session implements SessionContainerInterface {
             userContext: userContext === undefined ? {} : userContext,
         });
         if (sessionInfo === undefined) {
-            clearSession(this.helpers.config, this.req, this.res, userContext);
+            clearSession(this.helpers.config, this.res, this.transferMethod);
             throw new STError({
                 message: "Session does not exist anymore",
                 type: STError.UNAUTHORISED,
@@ -83,7 +68,7 @@ export default class Session implements SessionContainerInterface {
                 userContext: userContext === undefined ? {} : userContext,
             }))
         ) {
-            clearSession(this.helpers.config, this.req, this.res, userContext);
+            clearSession(this.helpers.config, this.res, this.transferMethod);
             throw new STError({
                 message: "Session does not exist anymore",
                 type: STError.UNAUTHORISED,
@@ -124,7 +109,7 @@ export default class Session implements SessionContainerInterface {
             userContext: userContext === undefined ? {} : userContext,
         });
         if (sessionInfo === undefined) {
-            clearSession(this.helpers.config, this.req, this.res, userContext);
+            clearSession(this.helpers.config, this.res, this.transferMethod);
             throw new STError({
                 message: "Session does not exist anymore",
                 type: STError.UNAUTHORISED,
@@ -139,7 +124,7 @@ export default class Session implements SessionContainerInterface {
             userContext: userContext === undefined ? {} : userContext,
         });
         if (sessionInfo === undefined) {
-            clearSession(this.helpers.config, this.req, this.res, userContext);
+            clearSession(this.helpers.config, this.res, this.transferMethod);
             throw new STError({
                 message: "Session does not exist anymore",
                 type: STError.UNAUTHORISED,
@@ -198,7 +183,7 @@ export default class Session implements SessionContainerInterface {
             userContext: userContext === undefined ? {} : userContext,
         });
         if (response === undefined) {
-            clearSession(this.helpers.config, this.req, this.res, userContext);
+            clearSession(this.helpers.config, this.res, this.transferMethod);
             throw new STError({
                 message: "Session does not exist anymore",
                 type: STError.UNAUTHORISED,
@@ -215,7 +200,6 @@ export default class Session implements SessionContainerInterface {
             );
             setToken(
                 this.helpers.config,
-                this.req,
                 this.res,
                 "access",
                 response.accessToken.token,
@@ -224,7 +208,7 @@ export default class Session implements SessionContainerInterface {
                 // Even if the token is expired the presence of the token indicates that the user could have a valid refresh
                 // Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
                 Date.now() + 3153600000000,
-                userContext
+                this.transferMethod
             );
         }
     };

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -61,11 +61,6 @@ export type CreateOrRefreshAPIResponse = {
         expiry: number;
         createdTime: number;
     };
-    idRefreshToken: {
-        token: string;
-        expiry: number;
-        createdTime: number;
-    };
     antiCsrfToken: string | undefined;
 };
 

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -72,6 +72,9 @@ export interface ErrorHandlers {
 
 export type TokenType = "access" | "refresh";
 
+// When adding a new token transfer method, it's also necessary to update the related constant (availableTokenTransferMethods)
+export type TokenTransferMethod = "header" | "cookie";
+
 export type TypeInput = {
     sessionExpiredStatusCode?: number;
     invalidClaimStatusCode?: number;
@@ -80,7 +83,11 @@ export type TypeInput = {
     cookieSameSite?: "strict" | "lax" | "none";
     cookieDomain?: string;
 
-    getTokenTransferMethod?: (input: { req: BaseRequest; userContext: any }) => "cookie" | "header";
+    getTokenTransferMethod?: (input: {
+        req: BaseRequest;
+        forCreateNewSession: boolean;
+        userContext: any;
+    }) => TokenTransferMethod | "any";
 
     errorHandlers?: ErrorHandlers;
     antiCsrf?: "VIA_TOKEN" | "VIA_CUSTOM_HEADER" | "NONE";
@@ -129,7 +136,11 @@ export type TypeNormalisedInput = {
     errorHandlers: NormalisedErrorHandlers;
     antiCsrf: "VIA_TOKEN" | "VIA_CUSTOM_HEADER" | "NONE";
 
-    getTokenTransferMethod: (input: { req: BaseRequest; userContext: any }) => "cookie" | "header";
+    getTokenTransferMethod: (input: {
+        req: BaseRequest;
+        forCreateNewSession: boolean;
+        userContext: any;
+    }) => TokenTransferMethod | "any";
 
     invalidClaimStatusCode: number;
     jwt: {

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -75,7 +75,7 @@ export interface ErrorHandlers {
     onInvalidClaim?: InvalidClaimErrorHandlerMiddleware;
 }
 
-export type TokenType = "access" | "refresh" | "idRefresh";
+export type TokenType = "access" | "refresh";
 
 export type TypeInput = {
     sessionExpiredStatusCode?: number;

--- a/lib/ts/recipe/session/utils.ts
+++ b/lib/ts/recipe/session/utils.ts
@@ -273,11 +273,11 @@ export function attachCreateOrRefreshSessionResponseToExpressRes(
         res,
         "access",
         accessToken.token,
-        // We set the expiration to 10 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
+        // We set the expiration to 100 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
         // This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
         // Even if the token is expired the presence of the token indicates that the user could have a valid refresh
         // Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
-        Date.now() + 315360000000,
+        Date.now() + 3153600000000,
         userContext
     );
     setToken(config, req, res, "refresh", refreshToken.token, refreshToken.expiry, userContext);

--- a/lib/ts/recipe/session/utils.ts
+++ b/lib/ts/recipe/session/utils.ts
@@ -266,11 +266,20 @@ export function attachCreateOrRefreshSessionResponseToExpressRes(
 ) {
     let accessToken = response.accessToken;
     let refreshToken = response.refreshToken;
-    let idRefreshToken = response.idRefreshToken;
     setFrontTokenInHeaders(res, response.session.userId, response.accessToken.expiry, response.session.userDataInJWT);
-    setToken(config, req, res, "access", accessToken.token, accessToken.expiry, userContext);
+    setToken(
+        config,
+        req,
+        res,
+        "access",
+        accessToken.token,
+        // We set the expiration to 10 years, because in other places we set it we can't really access the expiration of the refresh token.
+        // This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
+        // Even if the token is expired the presence of the token indicates that the user could have a valid refresh token
+        Date.now() + 315360000000,
+        userContext
+    );
     setToken(config, req, res, "refresh", refreshToken.token, refreshToken.expiry, userContext);
-    setToken(config, req, res, "idRefresh", idRefreshToken.token, idRefreshToken.expiry, userContext);
     if (response.antiCsrfToken !== undefined) {
         setAntiCsrfTokenInHeaders(res, response.antiCsrfToken);
     }

--- a/lib/ts/recipe/session/utils.ts
+++ b/lib/ts/recipe/session/utils.ts
@@ -327,6 +327,5 @@ export async function validateClaimsInPayload(
 }
 
 function defaultGetTokenTransferMethod({ req }: { req: BaseRequest }): "cookie" | "header" {
-    console.log("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", getAuthModeFromHeader(req));
     return getAuthModeFromHeader(req) === "header" ? "header" : "cookie";
 }

--- a/lib/ts/recipe/session/utils.ts
+++ b/lib/ts/recipe/session/utils.ts
@@ -273,9 +273,10 @@ export function attachCreateOrRefreshSessionResponseToExpressRes(
         res,
         "access",
         accessToken.token,
-        // We set the expiration to 10 years, because in other places we set it we can't really access the expiration of the refresh token.
+        // We set the expiration to 10 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
         // This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
-        // Even if the token is expired the presence of the token indicates that the user could have a valid refresh token
+        // Even if the token is expired the presence of the token indicates that the user could have a valid refresh
+        // Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
         Date.now() + 315360000000,
         userContext
     );

--- a/lib/ts/supertokens.ts
+++ b/lib/ts/supertokens.ts
@@ -24,7 +24,7 @@ import {
 } from "./utils";
 import { Querier } from "./querier";
 import RecipeModule from "./recipeModule";
-import { HEADER_RID, HEADER_FDI, HEADER_AUTH_MODE } from "./constants";
+import { HEADER_RID, HEADER_FDI } from "./constants";
 import NormalisedURLDomain from "./normalisedURLDomain";
 import NormalisedURLPath from "./normalisedURLPath";
 import { BaseRequest, BaseResponse } from "./framework";
@@ -158,7 +158,6 @@ export default class SuperTokens {
         let headerSet = new Set<string>();
         headerSet.add(HEADER_RID);
         headerSet.add(HEADER_FDI);
-        headerSet.add(HEADER_AUTH_MODE);
         this.recipeModules.forEach((recipe) => {
             let headers = recipe.getAllCORSHeaders();
             headers.forEach((h) => {

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -5,7 +5,6 @@ import NormalisedURLDomain from "./normalisedURLDomain";
 import NormalisedURLPath from "./normalisedURLPath";
 import type { BaseRequest, BaseResponse } from "./framework";
 import { logDebugMessage } from "./logger";
-import { URL } from "url";
 import { HEADER_AUTH_MODE, HEADER_RID } from "./constants";
 
 export function getLargestVersionFromIntersection(v1: string[], v2: string[]): string | undefined {

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -5,7 +5,7 @@ import NormalisedURLDomain from "./normalisedURLDomain";
 import NormalisedURLPath from "./normalisedURLPath";
 import type { BaseRequest, BaseResponse } from "./framework";
 import { logDebugMessage } from "./logger";
-import { HEADER_AUTH_MODE, HEADER_RID } from "./constants";
+import { HEADER_RID } from "./constants";
 
 export function getLargestVersionFromIntersection(v1: string[], v2: string[]): string | undefined {
     let intersection = v1.filter((value) => v2.indexOf(value) !== -1);
@@ -107,10 +107,6 @@ export function isAnIpAddress(ipaddress: string) {
     return /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(
         ipaddress
     );
-}
-
-export function getAuthModeFromHeader(req: BaseRequest): string | undefined {
-    return req.getHeaderValue(HEADER_AUTH_MODE);
 }
 
 export function getRidFromHeader(req: BaseRequest): string | undefined {

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -6,6 +6,7 @@ import NormalisedURLPath from "./normalisedURLPath";
 import type { BaseRequest, BaseResponse } from "./framework";
 import { logDebugMessage } from "./logger";
 import { HEADER_RID } from "./constants";
+import { URL } from "url";
 
 export function getLargestVersionFromIntersection(v1: string[], v2: string[]): string | undefined {
     let intersection = v1.filter((value) => v2.indexOf(value) !== -1);


### PR DESCRIPTION
## Summary of change

- Removed id-refresh-token
- Setting access token with unlimited cookie lifetime
- Sending "remove" for front-token to signal we are clearing the session 

## Related issues

-   

## Test Plan

We have extensive tests to make sure sessions work.

## Documentation changes

N/A internal change

## Checklist for important updates

-   [ ] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
