### PR TITLE
Email verification post session claim update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [12.0.6] - 2022-11-09
+
+### Fixes
+
+-   Adds updating of session claims in email verification token generation API in case the session claims are outdated.
+
 ## [12.0.5] - 2022-10-17
 
 -   Updated google token endpoint.

--- a/lib/build/recipe/emailverification/api/implementation.js
+++ b/lib/build/recipe/emailverification/api/implementation.js
@@ -109,10 +109,25 @@ function getAPIInterface() {
                         userContext,
                     });
                     if (response.status === "EMAIL_ALREADY_VERIFIED_ERROR") {
+                        if ((yield session.getClaimValue(emailVerificationClaim_1.EmailVerificationClaim)) !== true) {
+                            // this can happen if the email was verified in another browser
+                            // and this session is still outdated - and the user has not
+                            // called the get email verification API yet.
+                            yield session.fetchAndSetClaim(
+                                emailVerificationClaim_1.EmailVerificationClaim,
+                                userContext
+                            );
+                        }
                         logger_1.logDebugMessage(
                             `Email verification email not sent to ${emailInfo.email} because it is already verified.`
                         );
                         return response;
+                    }
+                    if ((yield session.getClaimValue(emailVerificationClaim_1.EmailVerificationClaim)) !== false) {
+                        // this can happen if the email was unverified in another browser
+                        // and this session is still outdated - and the user has not
+                        // called the get email verification API yet.
+                        yield session.fetchAndSetClaim(emailVerificationClaim_1.EmailVerificationClaim, userContext);
                     }
                     let emailVerifyLink =
                         options.appInfo.websiteDomain.getAsStringDangerous() +

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "12.0.5";
+export declare const version = "12.0.6";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.1";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -14,7 +14,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "12.0.5";
+exports.version = "12.0.6";
 exports.cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.1";

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "12.0.5";
+export const version = "12.0.6";
 
 export const cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "12.0.5",
+    "version": "12.0.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "12.0.5",
+    "version": "12.0.6",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {

--- a/test/emailpassword/emailverify.test.js
+++ b/test/emailpassword/emailverify.test.js
@@ -1455,4 +1455,104 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         assert.ok(caughtError);
         assert.strictEqual(caughtError.message, "Unknown User ID provided without email");
     });
+
+    it("test that generate email verification token API updates session claims", async function () {
+        await startST();
+
+        STExpress.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                EmailPassword.init(),
+                EmailVerification.init({
+                    mode: "OPTIONAL",
+                    createAndSendCustomEmail: (user, emailVerificationURLWithToken) => {},
+                }),
+                Session.init({
+                    antiCsrf: "VIA_TOKEN",
+                }),
+            ],
+        });
+
+        const app = express();
+
+        app.use(middleware());
+
+        app.use(errorHandler());
+
+        const querier = Querier.getNewInstanceOrThrowError(undefined);
+        const apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.10") !== apiVersion) {
+            return this.skip();
+        }
+
+        let response = await signUPRequest(app, "test@gmail.com", "testPass123");
+        assert.strictEqual(response.body.status, "OK");
+        assert.strictEqual(response.status, 200);
+
+        let userId = response.body.user.id;
+        let infoFromResponse = extractInfoFromResponse(response);
+        let antiCsrfToken = infoFromResponse.antiCsrf;
+        let token = await EmailVerification.createEmailVerificationToken(userId);
+        await EmailVerification.verifyEmailUsingToken(token.token);
+        response = await emailVerifyTokenRequest(
+            app,
+            infoFromResponse.accessToken,
+            infoFromResponse.idRefreshTokenFromCookie,
+            antiCsrfToken,
+            userId
+        );
+        infoFromResponse = extractInfoFromResponse(response);
+        assert.strictEqual(response.statusCode, 200);
+        assert.deepStrictEqual(response.body.status, "EMAIL_ALREADY_VERIFIED_ERROR");
+        let frontendInfo = JSON.parse(new Buffer.from(infoFromResponse.frontToken, "base64").toString());
+        assert.strictEqual(frontendInfo.up["st-ev"].v, true);
+
+        // calling the API again should not modify the access token again
+        response = await emailVerifyTokenRequest(
+            app,
+            infoFromResponse.accessToken,
+            infoFromResponse.idRefreshTokenFromCookie,
+            antiCsrfToken,
+            userId
+        );
+        let infoFromResponse2 = extractInfoFromResponse(response);
+        assert.strictEqual(response.statusCode, 200);
+        assert.deepStrictEqual(response.body.status, "EMAIL_ALREADY_VERIFIED_ERROR");
+        assert.strictEqual(infoFromResponse2.frontToken, undefined);
+
+        // now we mark the email as unverified and try again
+        await EmailVerification.unverifyEmail(userId);
+        response = await emailVerifyTokenRequest(
+            app,
+            infoFromResponse.accessToken,
+            infoFromResponse.idRefreshTokenFromCookie,
+            antiCsrfToken,
+            userId
+        );
+        infoFromResponse = extractInfoFromResponse(response);
+        assert.strictEqual(response.statusCode, 200);
+        assert.deepStrictEqual(response.body.status, "OK");
+        frontendInfo = JSON.parse(new Buffer.from(infoFromResponse.frontToken, "base64").toString());
+        assert.strictEqual(frontendInfo.up["st-ev"].v, false);
+
+        // calling the API again should not modify the access token again
+        response = await emailVerifyTokenRequest(
+            app,
+            infoFromResponse.accessToken,
+            infoFromResponse.idRefreshTokenFromCookie,
+            antiCsrfToken,
+            userId
+        );
+        infoFromResponse2 = extractInfoFromResponse(response);
+        assert.strictEqual(response.statusCode, 200);
+        assert.deepStrictEqual(response.body.status, "OK");
+        assert.strictEqual(infoFromResponse2.frontToken, undefined);
+    });
 });


### PR DESCRIPTION
## Summary of change

Updates session claims related to email verification in email verification token generation API as well - so that if someone is building a custom UI without our SDK on the frontend and they forget to call the get email verification API, then claims will still be updated correctly for them.

## Related issues

-   https://github.com/supertokens/supertokens-node/issues/419

## Test Plan

Added test to query API and check if tokens are updated in the response

## Documentation changes

No change required

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

