### PR TITLE
fix: make mergeIntoAccessTokenPayload properly update the jwt payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [12.0.6] - 2022-11-16
+
+### Fixed:
+
+-   Fixed mergeIntoAccessTokenPayload not updating the JWT payload
+
 ## [12.0.5] - 2022-10-17
 
 -   Updated google token endpoint.

--- a/lib/build/recipe/session/sessionClass.d.ts
+++ b/lib/build/recipe/session/sessionClass.d.ts
@@ -17,23 +17,23 @@ export default class Session implements SessionContainerInterface {
         userDataInAccessToken: any,
         res: BaseResponse
     );
-    revokeSession: (userContext?: any) => Promise<void>;
-    getSessionData: (userContext?: any) => Promise<any>;
-    updateSessionData: (newSessionData: any, userContext?: any) => Promise<void>;
-    getUserId: (_userContext?: any) => string;
-    getAccessTokenPayload: (_userContext?: any) => any;
-    getHandle: () => string;
-    getAccessToken: () => string;
-    mergeIntoAccessTokenPayload: (accessTokenPayloadUpdate: any, userContext?: any) => Promise<void>;
-    getTimeCreated: (userContext?: any) => Promise<number>;
-    getExpiry: (userContext?: any) => Promise<number>;
-    assertClaims: (claimValidators: SessionClaimValidator[], userContext?: any) => Promise<void>;
-    fetchAndSetClaim: <T>(claim: SessionClaim<T>, userContext?: any) => Promise<void>;
-    setClaimValue: <T>(claim: SessionClaim<T>, value: T, userContext?: any) => Promise<void>;
-    getClaimValue: <T>(claim: SessionClaim<T>, userContext?: any) => Promise<T | undefined>;
-    removeClaim: (claim: SessionClaim<any>, userContext?: any) => Promise<void>;
+    revokeSession(userContext?: any): Promise<void>;
+    getSessionData(userContext?: any): Promise<any>;
+    updateSessionData(newSessionData: any, userContext?: any): Promise<void>;
+    getUserId(_userContext?: any): string;
+    getAccessTokenPayload(_userContext?: any): any;
+    getHandle(): string;
+    getAccessToken(): string;
+    mergeIntoAccessTokenPayload(accessTokenPayloadUpdate: any, userContext?: any): Promise<void>;
+    getTimeCreated(userContext?: any): Promise<number>;
+    getExpiry(userContext?: any): Promise<number>;
+    assertClaims(claimValidators: SessionClaimValidator[], userContext?: any): Promise<void>;
+    fetchAndSetClaim<T>(claim: SessionClaim<T>, userContext?: any): Promise<void>;
+    setClaimValue<T>(claim: SessionClaim<T>, value: T, userContext?: any): Promise<void>;
+    getClaimValue<T>(claim: SessionClaim<T>, userContext?: any): Promise<T | undefined>;
+    removeClaim(claim: SessionClaim<any>, userContext?: any): Promise<void>;
     /**
      * @deprecated Use mergeIntoAccessTokenPayload
      */
-    updateAccessTokenPayload: (newAccessTokenPayload: any, userContext: any) => Promise<void>;
+    updateAccessTokenPayload(newAccessTokenPayload: any, userContext: any): Promise<void>;
 }

--- a/lib/build/recipe/session/sessionClass.js
+++ b/lib/build/recipe/session/sessionClass.js
@@ -35,177 +35,193 @@ const cookieAndHeaders_1 = require("./cookieAndHeaders");
 const error_1 = require("./error");
 class Session {
     constructor(helpers, accessToken, sessionHandle, userId, userDataInAccessToken, res) {
-        this.revokeSession = (userContext) =>
-            __awaiter(this, void 0, void 0, function* () {
-                yield this.helpers.getRecipeImpl().revokeSession({
-                    sessionHandle: this.sessionHandle,
-                    userContext: userContext === undefined ? {} : userContext,
-                });
-                // we do not check the output of calling revokeSession
-                // before clearing the cookies because we are revoking the
-                // current API request's session.
-                // If we instead clear the cookies only when revokeSession
-                // returns true, it can cause this kind of a bug:
-                // https://github.com/supertokens/supertokens-node/issues/343
-                cookieAndHeaders_1.clearSessionFromCookie(this.helpers.config, this.res);
-            });
-        this.getSessionData = (userContext) =>
-            __awaiter(this, void 0, void 0, function* () {
-                let sessionInfo = yield this.helpers.getRecipeImpl().getSessionInformation({
-                    sessionHandle: this.sessionHandle,
-                    userContext: userContext === undefined ? {} : userContext,
-                });
-                if (sessionInfo === undefined) {
-                    throw new error_1.default({
-                        message: "Session does not exist anymore",
-                        type: error_1.default.UNAUTHORISED,
-                    });
-                }
-                return sessionInfo.sessionData;
-            });
-        this.updateSessionData = (newSessionData, userContext) =>
-            __awaiter(this, void 0, void 0, function* () {
-                if (
-                    !(yield this.helpers.getRecipeImpl().updateSessionData({
-                        sessionHandle: this.sessionHandle,
-                        newSessionData,
-                        userContext: userContext === undefined ? {} : userContext,
-                    }))
-                ) {
-                    throw new error_1.default({
-                        message: "Session does not exist anymore",
-                        type: error_1.default.UNAUTHORISED,
-                    });
-                }
-            });
-        this.getUserId = (_userContext) => {
-            return this.userId;
-        };
-        this.getAccessTokenPayload = (_userContext) => {
-            return this.userDataInAccessToken;
-        };
-        this.getHandle = () => {
-            return this.sessionHandle;
-        };
-        this.getAccessToken = () => {
-            return this.accessToken;
-        };
-        this.mergeIntoAccessTokenPayload = (accessTokenPayloadUpdate, userContext) =>
-            __awaiter(this, void 0, void 0, function* () {
-                const updatedPayload = Object.assign(
-                    Object.assign({}, this.getAccessTokenPayload(userContext)),
-                    accessTokenPayloadUpdate
-                );
-                for (const key of Object.keys(accessTokenPayloadUpdate)) {
-                    if (accessTokenPayloadUpdate[key] === null) {
-                        delete updatedPayload[key];
-                    }
-                }
-                yield this.updateAccessTokenPayload(updatedPayload, userContext);
-            });
-        this.getTimeCreated = (userContext) =>
-            __awaiter(this, void 0, void 0, function* () {
-                let sessionInfo = yield this.helpers.getRecipeImpl().getSessionInformation({
-                    sessionHandle: this.sessionHandle,
-                    userContext: userContext === undefined ? {} : userContext,
-                });
-                if (sessionInfo === undefined) {
-                    throw new error_1.default({
-                        message: "Session does not exist anymore",
-                        type: error_1.default.UNAUTHORISED,
-                    });
-                }
-                return sessionInfo.timeCreated;
-            });
-        this.getExpiry = (userContext) =>
-            __awaiter(this, void 0, void 0, function* () {
-                let sessionInfo = yield this.helpers.getRecipeImpl().getSessionInformation({
-                    sessionHandle: this.sessionHandle,
-                    userContext: userContext === undefined ? {} : userContext,
-                });
-                if (sessionInfo === undefined) {
-                    throw new error_1.default({
-                        message: "Session does not exist anymore",
-                        type: error_1.default.UNAUTHORISED,
-                    });
-                }
-                return sessionInfo.expiry;
-            });
-        this.assertClaims = (claimValidators, userContext) =>
-            __awaiter(this, void 0, void 0, function* () {
-                let validateClaimResponse = yield this.helpers.getRecipeImpl().validateClaims({
-                    accessTokenPayload: this.getAccessTokenPayload(userContext),
-                    userId: this.getUserId(userContext),
-                    claimValidators,
-                    userContext,
-                });
-                if (validateClaimResponse.accessTokenPayloadUpdate !== undefined) {
-                    yield this.mergeIntoAccessTokenPayload(validateClaimResponse.accessTokenPayloadUpdate, userContext);
-                }
-                if (validateClaimResponse.invalidClaims.length !== 0) {
-                    throw new error_1.default({
-                        type: "INVALID_CLAIMS",
-                        message: "INVALID_CLAIMS",
-                        payload: validateClaimResponse.invalidClaims,
-                    });
-                }
-            });
-        this.fetchAndSetClaim = (claim, userContext) =>
-            __awaiter(this, void 0, void 0, function* () {
-                const update = yield claim.build(this.getUserId(userContext), userContext);
-                return this.mergeIntoAccessTokenPayload(update, userContext);
-            });
-        this.setClaimValue = (claim, value, userContext) => {
-            const update = claim.addToPayload_internal({}, value, userContext);
-            return this.mergeIntoAccessTokenPayload(update, userContext);
-        };
-        this.getClaimValue = (claim, userContext) =>
-            __awaiter(this, void 0, void 0, function* () {
-                return claim.getValueFromPayload(yield this.getAccessTokenPayload(userContext), userContext);
-            });
-        this.removeClaim = (claim, userContext) => {
-            const update = claim.removeFromPayloadByMerge_internal({}, userContext);
-            return this.mergeIntoAccessTokenPayload(update, userContext);
-        };
-        /**
-         * @deprecated Use mergeIntoAccessTokenPayload
-         */
-        this.updateAccessTokenPayload = (newAccessTokenPayload, userContext) =>
-            __awaiter(this, void 0, void 0, function* () {
-                let response = yield this.helpers.getRecipeImpl().regenerateAccessToken({
-                    accessToken: this.getAccessToken(),
-                    newAccessTokenPayload,
-                    userContext: userContext === undefined ? {} : userContext,
-                });
-                if (response === undefined) {
-                    throw new error_1.default({
-                        message: "Session does not exist anymore",
-                        type: error_1.default.UNAUTHORISED,
-                    });
-                }
-                this.userDataInAccessToken = response.session.userDataInJWT;
-                if (response.accessToken !== undefined) {
-                    this.accessToken = response.accessToken.token;
-                    cookieAndHeaders_1.setFrontTokenInHeaders(
-                        this.res,
-                        response.session.userId,
-                        response.accessToken.expiry,
-                        response.session.userDataInJWT
-                    );
-                    cookieAndHeaders_1.attachAccessTokenToCookie(
-                        this.helpers.config,
-                        this.res,
-                        response.accessToken.token,
-                        response.accessToken.expiry
-                    );
-                }
-            });
         this.sessionHandle = sessionHandle;
         this.userId = userId;
         this.userDataInAccessToken = userDataInAccessToken;
         this.res = res;
         this.accessToken = accessToken;
         this.helpers = helpers;
+    }
+    revokeSession(userContext) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield this.helpers.getRecipeImpl().revokeSession({
+                sessionHandle: this.sessionHandle,
+                userContext: userContext === undefined ? {} : userContext,
+            });
+            // we do not check the output of calling revokeSession
+            // before clearing the cookies because we are revoking the
+            // current API request's session.
+            // If we instead clear the cookies only when revokeSession
+            // returns true, it can cause this kind of a bug:
+            // https://github.com/supertokens/supertokens-node/issues/343
+            cookieAndHeaders_1.clearSessionFromCookie(this.helpers.config, this.res);
+        });
+    }
+    getSessionData(userContext) {
+        return __awaiter(this, void 0, void 0, function* () {
+            let sessionInfo = yield this.helpers.getRecipeImpl().getSessionInformation({
+                sessionHandle: this.sessionHandle,
+                userContext: userContext === undefined ? {} : userContext,
+            });
+            if (sessionInfo === undefined) {
+                throw new error_1.default({
+                    message: "Session does not exist anymore",
+                    type: error_1.default.UNAUTHORISED,
+                });
+            }
+            return sessionInfo.sessionData;
+        });
+    }
+    updateSessionData(newSessionData, userContext) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (
+                !(yield this.helpers.getRecipeImpl().updateSessionData({
+                    sessionHandle: this.sessionHandle,
+                    newSessionData,
+                    userContext: userContext === undefined ? {} : userContext,
+                }))
+            ) {
+                throw new error_1.default({
+                    message: "Session does not exist anymore",
+                    type: error_1.default.UNAUTHORISED,
+                });
+            }
+        });
+    }
+    getUserId(_userContext) {
+        return this.userId;
+    }
+    getAccessTokenPayload(_userContext) {
+        return this.userDataInAccessToken;
+    }
+    getHandle() {
+        return this.sessionHandle;
+    }
+    getAccessToken() {
+        return this.accessToken;
+    }
+    // Any update to this function should also be reflected in the respective JWT version
+    mergeIntoAccessTokenPayload(accessTokenPayloadUpdate, userContext) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const updatedPayload = Object.assign(
+                Object.assign({}, this.getAccessTokenPayload(userContext)),
+                accessTokenPayloadUpdate
+            );
+            for (const key of Object.keys(accessTokenPayloadUpdate)) {
+                if (accessTokenPayloadUpdate[key] === null) {
+                    delete updatedPayload[key];
+                }
+            }
+            yield this.updateAccessTokenPayload(updatedPayload, userContext);
+        });
+    }
+    getTimeCreated(userContext) {
+        return __awaiter(this, void 0, void 0, function* () {
+            let sessionInfo = yield this.helpers.getRecipeImpl().getSessionInformation({
+                sessionHandle: this.sessionHandle,
+                userContext: userContext === undefined ? {} : userContext,
+            });
+            if (sessionInfo === undefined) {
+                throw new error_1.default({
+                    message: "Session does not exist anymore",
+                    type: error_1.default.UNAUTHORISED,
+                });
+            }
+            return sessionInfo.timeCreated;
+        });
+    }
+    getExpiry(userContext) {
+        return __awaiter(this, void 0, void 0, function* () {
+            let sessionInfo = yield this.helpers.getRecipeImpl().getSessionInformation({
+                sessionHandle: this.sessionHandle,
+                userContext: userContext === undefined ? {} : userContext,
+            });
+            if (sessionInfo === undefined) {
+                throw new error_1.default({
+                    message: "Session does not exist anymore",
+                    type: error_1.default.UNAUTHORISED,
+                });
+            }
+            return sessionInfo.expiry;
+        });
+    }
+    // Any update to this function should also be reflected in the respective JWT version
+    assertClaims(claimValidators, userContext) {
+        return __awaiter(this, void 0, void 0, function* () {
+            let validateClaimResponse = yield this.helpers.getRecipeImpl().validateClaims({
+                accessTokenPayload: this.getAccessTokenPayload(userContext),
+                userId: this.getUserId(userContext),
+                claimValidators,
+                userContext,
+            });
+            if (validateClaimResponse.accessTokenPayloadUpdate !== undefined) {
+                yield this.mergeIntoAccessTokenPayload(validateClaimResponse.accessTokenPayloadUpdate, userContext);
+            }
+            if (validateClaimResponse.invalidClaims.length !== 0) {
+                throw new error_1.default({
+                    type: "INVALID_CLAIMS",
+                    message: "INVALID_CLAIMS",
+                    payload: validateClaimResponse.invalidClaims,
+                });
+            }
+        });
+    }
+    // Any update to this function should also be reflected in the respective JWT version
+    fetchAndSetClaim(claim, userContext) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const update = yield claim.build(this.getUserId(userContext), userContext);
+            return this.mergeIntoAccessTokenPayload(update, userContext);
+        });
+    }
+    // Any update to this function should also be reflected in the respective JWT version
+    setClaimValue(claim, value, userContext) {
+        const update = claim.addToPayload_internal({}, value, userContext);
+        return this.mergeIntoAccessTokenPayload(update, userContext);
+    }
+    // Any update to this function should also be reflected in the respective JWT version
+    getClaimValue(claim, userContext) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return claim.getValueFromPayload(yield this.getAccessTokenPayload(userContext), userContext);
+        });
+    }
+    // Any update to this function should also be reflected in the respective JWT version
+    removeClaim(claim, userContext) {
+        const update = claim.removeFromPayloadByMerge_internal({}, userContext);
+        return this.mergeIntoAccessTokenPayload(update, userContext);
+    }
+    /**
+     * @deprecated Use mergeIntoAccessTokenPayload
+     */
+    updateAccessTokenPayload(newAccessTokenPayload, userContext) {
+        return __awaiter(this, void 0, void 0, function* () {
+            let response = yield this.helpers.getRecipeImpl().regenerateAccessToken({
+                accessToken: this.getAccessToken(),
+                newAccessTokenPayload,
+                userContext: userContext === undefined ? {} : userContext,
+            });
+            if (response === undefined) {
+                throw new error_1.default({
+                    message: "Session does not exist anymore",
+                    type: error_1.default.UNAUTHORISED,
+                });
+            }
+            this.userDataInAccessToken = response.session.userDataInJWT;
+            if (response.accessToken !== undefined) {
+                this.accessToken = response.accessToken.token;
+                cookieAndHeaders_1.setFrontTokenInHeaders(
+                    this.res,
+                    response.session.userId,
+                    response.accessToken.expiry,
+                    response.session.userDataInJWT
+                );
+                cookieAndHeaders_1.attachAccessTokenToCookie(
+                    this.helpers.config,
+                    this.res,
+                    response.accessToken.token,
+                    response.accessToken.expiry
+                );
+            }
+        });
     }
 }
 exports.default = Session;

--- a/lib/build/recipe/session/with-jwt/sessionClass.d.ts
+++ b/lib/build/recipe/session/with-jwt/sessionClass.d.ts
@@ -2,26 +2,34 @@
 import { RecipeInterface as OpenIdRecipeInterface } from "../../openid/types";
 import { SessionClaim, SessionClaimValidator, SessionContainerInterface } from "../types";
 export default class SessionClassWithJWT implements SessionContainerInterface {
-    private openIdRecipeImplementation;
-    private originalSessionClass;
+    private readonly originalSessionClass;
+    private readonly openIdRecipeImplementation;
     constructor(originalSessionClass: SessionContainerInterface, openIdRecipeImplementation: OpenIdRecipeInterface);
-    revokeSession: (userContext?: any) => Promise<void>;
-    getSessionData: (userContext?: any) => Promise<any>;
-    updateSessionData: (newSessionData: any, userContext?: any) => Promise<any>;
-    getUserId: (userContext?: any) => string;
-    getAccessTokenPayload: (userContext?: any) => any;
-    getHandle: (userContext?: any) => string;
-    getAccessToken: (userContext?: any) => string;
-    getTimeCreated: (userContext?: any) => Promise<number>;
-    getExpiry: (userContext?: any) => Promise<number>;
+    revokeSession(userContext?: any): Promise<void>;
+    getSessionData(userContext?: any): Promise<any>;
+    updateSessionData(newSessionData: any, userContext?: any): Promise<any>;
+    getUserId(userContext?: any): string;
+    getAccessTokenPayload(userContext?: any): any;
+    getHandle(userContext?: any): string;
+    getAccessToken(userContext?: any): string;
+    getTimeCreated(userContext?: any): Promise<number>;
+    getExpiry(userContext?: any): Promise<number>;
     assertClaims(claimValidators: SessionClaimValidator[], userContext?: any): Promise<void>;
-    fetchAndSetClaim: <T>(claim: SessionClaim<T>, userContext?: any) => Promise<void>;
-    setClaimValue: <T>(claim: SessionClaim<T>, value: T, userContext?: any) => Promise<void>;
-    getClaimValue: <T>(claim: SessionClaim<T>, userContext?: any) => Promise<T | undefined>;
-    removeClaim: (claim: SessionClaim<any>, userContext?: any) => Promise<void>;
-    mergeIntoAccessTokenPayload: (accessTokenPayloadUpdate: any, userContext?: any) => Promise<void>;
+    fetchAndSetClaim<T>(this: SessionClassWithJWT, claim: SessionClaim<T>, userContext?: any): Promise<void>;
+    setClaimValue<T>(this: SessionClassWithJWT, claim: SessionClaim<T>, value: T, userContext?: any): Promise<void>;
+    getClaimValue<T>(this: SessionClassWithJWT, claim: SessionClaim<T>, userContext?: any): Promise<T | undefined>;
+    removeClaim(this: SessionClassWithJWT, claim: SessionClaim<any>, userContext?: any): Promise<void>;
+    mergeIntoAccessTokenPayload(
+        this: SessionClassWithJWT,
+        accessTokenPayloadUpdate: any,
+        userContext?: any
+    ): Promise<void>;
     /**
      * @deprecated use mergeIntoAccessTokenPayload instead
      */
-    updateAccessTokenPayload: (newAccessTokenPayload: any, userContext?: any) => Promise<void>;
+    updateAccessTokenPayload(
+        this: SessionClassWithJWT,
+        newAccessTokenPayload: any | undefined,
+        userContext?: any
+    ): Promise<void>;
 }

--- a/lib/build/recipe/session/with-jwt/sessionClass.js
+++ b/lib/build/recipe/session/with-jwt/sessionClass.js
@@ -49,97 +49,140 @@ const JsonWebToken = require("jsonwebtoken");
 const assert = require("assert");
 const constants_1 = require("./constants");
 const utils_1 = require("./utils");
+const error_1 = require("../error");
+const recipe_1 = require("../recipe");
 class SessionClassWithJWT {
     constructor(originalSessionClass, openIdRecipeImplementation) {
-        this.revokeSession = (userContext) => {
-            return this.originalSessionClass.revokeSession(userContext);
-        };
-        this.getSessionData = (userContext) => {
-            return this.originalSessionClass.getSessionData(userContext);
-        };
-        this.updateSessionData = (newSessionData, userContext) => {
-            return this.originalSessionClass.updateSessionData(newSessionData, userContext);
-        };
-        this.getUserId = (userContext) => {
-            return this.originalSessionClass.getUserId(userContext);
-        };
-        this.getAccessTokenPayload = (userContext) => {
-            return this.originalSessionClass.getAccessTokenPayload(userContext);
-        };
-        this.getHandle = (userContext) => {
-            return this.originalSessionClass.getHandle(userContext);
-        };
-        this.getAccessToken = (userContext) => {
-            return this.originalSessionClass.getAccessToken(userContext);
-        };
-        this.getTimeCreated = (userContext) => {
-            return this.originalSessionClass.getTimeCreated(userContext);
-        };
-        this.getExpiry = (userContext) => {
-            return this.originalSessionClass.getExpiry(userContext);
-        };
-        this.fetchAndSetClaim = (claim, userContext) => {
-            return this.originalSessionClass.fetchAndSetClaim.bind(this)(claim, userContext);
-        };
-        this.setClaimValue = (claim, value, userContext) => {
-            return this.originalSessionClass.setClaimValue.bind(this)(claim, value, userContext);
-        };
-        this.getClaimValue = (claim, userContext) => {
-            return this.originalSessionClass.getClaimValue.bind(this)(claim, userContext);
-        };
-        this.removeClaim = (claim, userContext) => {
-            return this.originalSessionClass.removeClaim.bind(this)(claim, userContext);
-        };
-        this.mergeIntoAccessTokenPayload = (accessTokenPayloadUpdate, userContext) =>
-            __awaiter(this, void 0, void 0, function* () {
-                return this.originalSessionClass.mergeIntoAccessTokenPayload.bind(this)(
-                    accessTokenPayloadUpdate,
-                    userContext
-                );
-            });
-        /**
-         * @deprecated use mergeIntoAccessTokenPayload instead
-         */
-        this.updateAccessTokenPayload = (newAccessTokenPayload, userContext) =>
-            __awaiter(this, void 0, void 0, function* () {
-                newAccessTokenPayload =
-                    newAccessTokenPayload === null || newAccessTokenPayload === undefined ? {} : newAccessTokenPayload;
-                let accessTokenPayload = this.getAccessTokenPayload(userContext);
-                let jwtPropertyName = accessTokenPayload[constants_1.ACCESS_TOKEN_PAYLOAD_JWT_PROPERTY_NAME_KEY];
-                if (jwtPropertyName === undefined) {
-                    return this.originalSessionClass.updateAccessTokenPayload(newAccessTokenPayload, userContext);
-                }
-                let existingJWT = accessTokenPayload[jwtPropertyName];
-                assert.notStrictEqual(existingJWT, undefined);
-                let currentTimeInSeconds = Date.now() / 1000;
-                let decodedPayload = JsonWebToken.decode(existingJWT, { json: true });
-                // JsonWebToken.decode possibly returns null
-                if (decodedPayload === null) {
-                    throw new Error("Error reading JWT from session");
-                }
-                let jwtExpiry = decodedPayload.exp - currentTimeInSeconds;
-                if (jwtExpiry <= 0) {
-                    // it can come here if someone calls this function well after
-                    // the access token and the jwt payload have expired (which can happen if an API takes a VERY long time). In this case, we still want the jwt payload to update, but the resulting JWT should
-                    // not be alive for too long (since it's expired already). So we set it to
-                    // 1 second lifetime.
-                    jwtExpiry = 1;
-                }
-                newAccessTokenPayload = yield utils_1.addJWTToAccessTokenPayload({
-                    accessTokenPayload: newAccessTokenPayload,
-                    jwtExpiry,
-                    userId: this.getUserId(),
-                    jwtPropertyName,
-                    openIdRecipeImplementation: this.openIdRecipeImplementation,
+        this.originalSessionClass = originalSessionClass;
+        this.openIdRecipeImplementation = openIdRecipeImplementation;
+    }
+    revokeSession(userContext) {
+        return this.originalSessionClass.revokeSession(userContext);
+    }
+    getSessionData(userContext) {
+        return this.originalSessionClass.getSessionData(userContext);
+    }
+    updateSessionData(newSessionData, userContext) {
+        return this.originalSessionClass.updateSessionData(newSessionData, userContext);
+    }
+    getUserId(userContext) {
+        return this.originalSessionClass.getUserId(userContext);
+    }
+    getAccessTokenPayload(userContext) {
+        return this.originalSessionClass.getAccessTokenPayload(userContext);
+    }
+    getHandle(userContext) {
+        return this.originalSessionClass.getHandle(userContext);
+    }
+    getAccessToken(userContext) {
+        return this.originalSessionClass.getAccessToken(userContext);
+    }
+    getTimeCreated(userContext) {
+        return this.originalSessionClass.getTimeCreated(userContext);
+    }
+    getExpiry(userContext) {
+        return this.originalSessionClass.getExpiry(userContext);
+    }
+    // We copy the implementation here, since we want to override updateAccessTokenPayload
+    assertClaims(claimValidators, userContext) {
+        return __awaiter(this, void 0, void 0, function* () {
+            let validateClaimResponse = yield recipe_1.default
+                .getInstanceOrThrowError()
+                .recipeInterfaceImpl.validateClaims({
+                    accessTokenPayload: this.getAccessTokenPayload(userContext),
+                    userId: this.getUserId(userContext),
+                    claimValidators,
                     userContext,
                 });
-                yield this.originalSessionClass.updateAccessTokenPayload(newAccessTokenPayload, userContext);
-            });
-        this.openIdRecipeImplementation = openIdRecipeImplementation;
-        this.originalSessionClass = originalSessionClass;
+            if (validateClaimResponse.accessTokenPayloadUpdate !== undefined) {
+                yield this.mergeIntoAccessTokenPayload(validateClaimResponse.accessTokenPayloadUpdate, userContext);
+            }
+            if (validateClaimResponse.invalidClaims.length !== 0) {
+                throw new error_1.default({
+                    type: "INVALID_CLAIMS",
+                    message: "INVALID_CLAIMS",
+                    payload: validateClaimResponse.invalidClaims,
+                });
+            }
+        });
     }
-    assertClaims(claimValidators, userContext) {
-        return this.originalSessionClass.assertClaims.bind(this)(claimValidators, userContext);
+    // We copy the implementation here, since we want to override updateAccessTokenPayload
+    fetchAndSetClaim(claim, userContext) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const update = yield claim.build(this.getUserId(userContext), userContext);
+            return this.mergeIntoAccessTokenPayload(update, userContext);
+        });
+    }
+    // We copy the implementation here, since we want to override updateAccessTokenPayload
+    setClaimValue(claim, value, userContext) {
+        const update = claim.addToPayload_internal({}, value, userContext);
+        return this.mergeIntoAccessTokenPayload(update, userContext);
+    }
+    // We copy the implementation here, since we want to override updateAccessTokenPayload
+    getClaimValue(claim, userContext) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return claim.getValueFromPayload(yield this.getAccessTokenPayload(userContext), userContext);
+        });
+    }
+    // We copy the implementation here, since we want to override updateAccessTokenPayload
+    removeClaim(claim, userContext) {
+        const update = claim.removeFromPayloadByMerge_internal({}, userContext);
+        return this.mergeIntoAccessTokenPayload(update, userContext);
+    }
+    // We copy the implementation here, since we want to override updateAccessTokenPayload
+    mergeIntoAccessTokenPayload(accessTokenPayloadUpdate, userContext) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const updatedPayload = Object.assign(
+                Object.assign({}, this.getAccessTokenPayload(userContext)),
+                accessTokenPayloadUpdate
+            );
+            for (const key of Object.keys(accessTokenPayloadUpdate)) {
+                if (accessTokenPayloadUpdate[key] === null) {
+                    delete updatedPayload[key];
+                }
+            }
+            yield this.updateAccessTokenPayload(updatedPayload, userContext);
+        });
+    }
+    // TODO: figure out a proper way to override just this function
+    /**
+     * @deprecated use mergeIntoAccessTokenPayload instead
+     */
+    updateAccessTokenPayload(newAccessTokenPayload, userContext) {
+        return __awaiter(this, void 0, void 0, function* () {
+            newAccessTokenPayload =
+                newAccessTokenPayload === null || newAccessTokenPayload === undefined ? {} : newAccessTokenPayload;
+            let accessTokenPayload = this.getAccessTokenPayload(userContext);
+            let jwtPropertyName = accessTokenPayload[constants_1.ACCESS_TOKEN_PAYLOAD_JWT_PROPERTY_NAME_KEY];
+            if (jwtPropertyName === undefined) {
+                return this.originalSessionClass.updateAccessTokenPayload(newAccessTokenPayload, userContext);
+            }
+            let existingJWT = accessTokenPayload[jwtPropertyName];
+            assert.notStrictEqual(existingJWT, undefined);
+            let currentTimeInSeconds = Date.now() / 1000;
+            let decodedPayload = JsonWebToken.decode(existingJWT, { json: true });
+            // JsonWebToken.decode possibly returns null
+            if (decodedPayload === null) {
+                throw new Error("Error reading JWT from session");
+            }
+            let jwtExpiry = decodedPayload.exp - currentTimeInSeconds;
+            if (jwtExpiry <= 0) {
+                // it can come here if someone calls this function well after
+                // the access token and the jwt payload have expired (which can happen if an API takes a VERY long time). In this case, we still want the jwt payload to update, but the resulting JWT should
+                // not be alive for too long (since it's expired already). So we set it to
+                // 1 second lifetime.
+                jwtExpiry = 1;
+            }
+            newAccessTokenPayload = yield utils_1.addJWTToAccessTokenPayload({
+                accessTokenPayload: newAccessTokenPayload,
+                jwtExpiry,
+                userId: this.getUserId(),
+                jwtPropertyName,
+                openIdRecipeImplementation: this.openIdRecipeImplementation,
+                userContext,
+            });
+            yield this.originalSessionClass.updateAccessTokenPayload(newAccessTokenPayload, userContext);
+        });
     }
 }
 exports.default = SessionClassWithJWT;

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "12.0.5";
+export declare const version = "12.0.6";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.1";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -14,7 +14,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "12.0.5";
+exports.version = "12.0.6";
 exports.cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.1";

--- a/lib/ts/recipe/session/sessionClass.ts
+++ b/lib/ts/recipe/session/sessionClass.ts
@@ -42,7 +42,7 @@ export default class Session implements SessionContainerInterface {
         this.helpers = helpers;
     }
 
-    revokeSession = async (userContext?: any) => {
+    async revokeSession(userContext?: any) {
         await this.helpers.getRecipeImpl().revokeSession({
             sessionHandle: this.sessionHandle,
             userContext: userContext === undefined ? {} : userContext,
@@ -55,9 +55,9 @@ export default class Session implements SessionContainerInterface {
         // returns true, it can cause this kind of a bug:
         // https://github.com/supertokens/supertokens-node/issues/343
         clearSessionFromCookie(this.helpers.config, this.res);
-    };
+    }
 
-    getSessionData = async (userContext?: any): Promise<any> => {
+    async getSessionData(userContext?: any): Promise<any> {
         let sessionInfo = await this.helpers.getRecipeImpl().getSessionInformation({
             sessionHandle: this.sessionHandle,
             userContext: userContext === undefined ? {} : userContext,
@@ -69,9 +69,9 @@ export default class Session implements SessionContainerInterface {
             });
         }
         return sessionInfo.sessionData;
-    };
+    }
 
-    updateSessionData = async (newSessionData: any, userContext?: any) => {
+    async updateSessionData(newSessionData: any, userContext?: any) {
         if (
             !(await this.helpers.getRecipeImpl().updateSessionData({
                 sessionHandle: this.sessionHandle,
@@ -84,25 +84,26 @@ export default class Session implements SessionContainerInterface {
                 type: STError.UNAUTHORISED,
             });
         }
-    };
+    }
 
-    getUserId = (_userContext?: any) => {
+    getUserId(_userContext?: any) {
         return this.userId;
-    };
+    }
 
-    getAccessTokenPayload = (_userContext?: any) => {
+    getAccessTokenPayload(_userContext?: any) {
         return this.userDataInAccessToken;
-    };
+    }
 
-    getHandle = () => {
+    getHandle() {
         return this.sessionHandle;
-    };
+    }
 
-    getAccessToken = () => {
+    getAccessToken() {
         return this.accessToken;
-    };
+    }
 
-    mergeIntoAccessTokenPayload = async (accessTokenPayloadUpdate: any, userContext?: any) => {
+    // Any update to this function should also be reflected in the respective JWT version
+    async mergeIntoAccessTokenPayload(accessTokenPayloadUpdate: any, userContext?: any): Promise<void> {
         const updatedPayload = { ...this.getAccessTokenPayload(userContext), ...accessTokenPayloadUpdate };
         for (const key of Object.keys(accessTokenPayloadUpdate)) {
             if (accessTokenPayloadUpdate[key] === null) {
@@ -111,9 +112,9 @@ export default class Session implements SessionContainerInterface {
         }
 
         await this.updateAccessTokenPayload(updatedPayload, userContext);
-    };
+    }
 
-    getTimeCreated = async (userContext?: any): Promise<number> => {
+    async getTimeCreated(userContext?: any): Promise<number> {
         let sessionInfo = await this.helpers.getRecipeImpl().getSessionInformation({
             sessionHandle: this.sessionHandle,
             userContext: userContext === undefined ? {} : userContext,
@@ -125,9 +126,9 @@ export default class Session implements SessionContainerInterface {
             });
         }
         return sessionInfo.timeCreated;
-    };
+    }
 
-    getExpiry = async (userContext?: any): Promise<number> => {
+    async getExpiry(userContext?: any): Promise<number> {
         let sessionInfo = await this.helpers.getRecipeImpl().getSessionInformation({
             sessionHandle: this.sessionHandle,
             userContext: userContext === undefined ? {} : userContext,
@@ -139,9 +140,10 @@ export default class Session implements SessionContainerInterface {
             });
         }
         return sessionInfo.expiry;
-    };
+    }
 
-    assertClaims = async (claimValidators: SessionClaimValidator[], userContext?: any): Promise<void> => {
+    // Any update to this function should also be reflected in the respective JWT version
+    async assertClaims(claimValidators: SessionClaimValidator[], userContext?: any): Promise<void> {
         let validateClaimResponse = await this.helpers.getRecipeImpl().validateClaims({
             accessTokenPayload: this.getAccessTokenPayload(userContext),
             userId: this.getUserId(userContext),
@@ -160,31 +162,35 @@ export default class Session implements SessionContainerInterface {
                 payload: validateClaimResponse.invalidClaims,
             });
         }
-    };
+    }
 
-    fetchAndSetClaim = async <T>(claim: SessionClaim<T>, userContext?: any) => {
+    // Any update to this function should also be reflected in the respective JWT version
+    async fetchAndSetClaim<T>(claim: SessionClaim<T>, userContext?: any): Promise<void> {
         const update = await claim.build(this.getUserId(userContext), userContext);
         return this.mergeIntoAccessTokenPayload(update, userContext);
-    };
+    }
 
-    setClaimValue = <T>(claim: SessionClaim<T>, value: T, userContext?: any) => {
+    // Any update to this function should also be reflected in the respective JWT version
+    setClaimValue<T>(claim: SessionClaim<T>, value: T, userContext?: any): Promise<void> {
         const update = claim.addToPayload_internal({}, value, userContext);
         return this.mergeIntoAccessTokenPayload(update, userContext);
-    };
+    }
 
-    getClaimValue = async <T>(claim: SessionClaim<T>, userContext?: any) => {
+    // Any update to this function should also be reflected in the respective JWT version
+    async getClaimValue<T>(claim: SessionClaim<T>, userContext?: any) {
         return claim.getValueFromPayload(await this.getAccessTokenPayload(userContext), userContext);
-    };
+    }
 
-    removeClaim = (claim: SessionClaim<any>, userContext?: any) => {
+    // Any update to this function should also be reflected in the respective JWT version
+    removeClaim(claim: SessionClaim<any>, userContext?: any): Promise<void> {
         const update = claim.removeFromPayloadByMerge_internal({}, userContext);
         return this.mergeIntoAccessTokenPayload(update, userContext);
-    };
+    }
 
     /**
      * @deprecated Use mergeIntoAccessTokenPayload
      */
-    updateAccessTokenPayload = async (newAccessTokenPayload: any, userContext: any) => {
+    async updateAccessTokenPayload(newAccessTokenPayload: any, userContext: any): Promise<void> {
         let response = await this.helpers.getRecipeImpl().regenerateAccessToken({
             accessToken: this.getAccessToken(),
             newAccessTokenPayload,
@@ -212,5 +218,5 @@ export default class Session implements SessionContainerInterface {
                 response.accessToken.expiry
             );
         }
-    };
+    }
 }

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "12.0.5";
+export const version = "12.0.6";
 
 export const cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "12.0.5",
+    "version": "12.0.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "12.0.5",
+            "version": "12.0.6",
             "license": "Apache-2.0",
             "dependencies": {
                 "axios": "0.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "12.0.5",
+    "version": "12.0.6",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {

--- a/test/session/with-jwt/sessionClass.test.js
+++ b/test/session/with-jwt/sessionClass.test.js
@@ -24,6 +24,7 @@ let { ProcessState } = require("../../../lib/build/processState");
 let SuperTokens = require("../../../");
 let Session = require("../../../recipe/session");
 let { middleware, errorHandler } = require("../../../framework/express");
+const { TrueClaim } = require("../claims/testClaims");
 
 describe(`session-jwt-functions: ${printPath("[test/session/with-jwt/sessionClass.test.js]")}`, function () {
     beforeEach(async function () {
@@ -118,6 +119,91 @@ describe(`session-jwt-functions: ${printPath("[test/session/with-jwt/sessionClas
         assert.strictEqual(decodedJWT["sub"], "userId");
         assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io/auth");
         assert.strictEqual(decodedJWT._jwtPName, undefined);
+        assert.strictEqual(decodedJWT.newKey, "newValue");
+    });
+
+    it("Test that updating access token payload by mergeIntoAccessTokenPayload works", async function () {
+        await startST();
+        SuperTokens.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                Session.init({
+                    jwt: { enable: true },
+                    override: {
+                        functions: function (oi) {
+                            return {
+                                ...oi,
+                                createNewSession: async function ({ res, userId, accessTokenPayload, sessionData }) {
+                                    accessTokenPayload = {
+                                        ...accessTokenPayload,
+                                        customKey: "customValue",
+                                        customKey2: "customValue2",
+                                    };
+
+                                    return await oi.createNewSession({ res, userId, accessTokenPayload, sessionData });
+                                },
+                            };
+                        },
+                    },
+                }),
+            ],
+        });
+
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
+
+        let app = express();
+
+        app.use(middleware());
+        app.use(express.json());
+
+        app.post("/create", async (req, res) => {
+            let session = await Session.createNewSession(res, "userId", {}, {});
+
+            await session.mergeIntoAccessTokenPayload({ newKey: "newValue" });
+
+            res.status(200).json({ accessTokenPayload: session.getAccessTokenPayload() });
+        });
+
+        app.use(errorHandler());
+
+        let createJWTResponse = await new Promise((resolve) =>
+            request(app)
+                .post("/create")
+                .expect(200)
+                .end((err, res) => {
+                    if (err) {
+                        resolve(undefined);
+                    } else {
+                        resolve(res);
+                    }
+                })
+        );
+
+        let accessTokenPayload = createJWTResponse.body.accessTokenPayload;
+        assert.strictEqual(accessTokenPayload.sub, undefined);
+        assert.strictEqual(accessTokenPayload.iss, undefined);
+        assert.strictEqual(accessTokenPayload.newKey, "newValue");
+        assert.notStrictEqual(accessTokenPayload.jwt, undefined);
+        assert.strictEqual(accessTokenPayload._jwtPName, "jwt");
+
+        let decodedJWT = JsonWebToken.decode(accessTokenPayload.jwt);
+        assert.notStrictEqual(decodedJWT, null);
+        assert.strictEqual(decodedJWT["sub"], "userId");
+        assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io/auth");
+        assert.strictEqual(decodedJWT._jwtPName, undefined);
+        assert.strictEqual(decodedJWT.newKey, "newValue");
     });
 
     it("Test that both access token payload and JWT have valid claims when calling update with a undefined payload", async function () {
@@ -201,5 +287,258 @@ describe(`session-jwt-functions: ${printPath("[test/session/with-jwt/sessionClas
         assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io/auth");
         assert.strictEqual(decodedJWT._jwtPName, undefined);
         assert.strictEqual(decodedJWT.customClaim, undefined);
+    });
+
+    it("should update JWT when setting claim value by fetchAndSetClaim", async function () {
+        await startST();
+        SuperTokens.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                Session.init({
+                    jwt: { enable: true },
+                    override: {
+                        functions: function (oi) {
+                            return {
+                                ...oi,
+                                createNewSession: async function ({ res, userId, accessTokenPayload, sessionData }) {
+                                    accessTokenPayload = {
+                                        ...accessTokenPayload,
+                                        customKey: "customValue",
+                                        customKey2: "customValue2",
+                                    };
+
+                                    return await oi.createNewSession({ res, userId, accessTokenPayload, sessionData });
+                                },
+                            };
+                        },
+                    },
+                }),
+            ],
+        });
+
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
+
+        let app = express();
+
+        app.use(middleware());
+        app.use(express.json());
+
+        app.post("/create", async (req, res) => {
+            let session = await Session.createNewSession(res, "userId", {}, {});
+
+            await session.fetchAndSetClaim(TrueClaim);
+
+            res.status(200).json({ accessTokenPayload: session.getAccessTokenPayload() });
+        });
+
+        app.use(errorHandler());
+
+        let createJWTResponse = await new Promise((resolve) =>
+            request(app)
+                .post("/create")
+                .expect(200)
+                .end((err, res) => {
+                    if (err) {
+                        resolve(undefined);
+                    } else {
+                        resolve(res);
+                    }
+                })
+        );
+
+        let accessTokenPayload = createJWTResponse.body.accessTokenPayload;
+        assert.strictEqual(accessTokenPayload.sub, undefined);
+        assert.strictEqual(accessTokenPayload.iss, undefined);
+        assert.strictEqual(TrueClaim.getValueFromPayload(accessTokenPayload), true);
+        assert.notStrictEqual(accessTokenPayload.jwt, undefined);
+        assert.strictEqual(accessTokenPayload._jwtPName, "jwt");
+
+        let decodedJWT = JsonWebToken.decode(accessTokenPayload.jwt);
+        assert.notStrictEqual(decodedJWT, null);
+        assert.strictEqual(decodedJWT["sub"], "userId");
+        assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io/auth");
+        assert.strictEqual(decodedJWT._jwtPName, undefined);
+        assert.strictEqual(TrueClaim.getValueFromPayload(decodedJWT), true);
+    });
+
+    it("should update JWT when setting claim value by setClaimValue", async function () {
+        await startST();
+        SuperTokens.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                Session.init({
+                    jwt: { enable: true },
+                    override: {
+                        functions: function (oi) {
+                            return {
+                                ...oi,
+                                createNewSession: async function ({ res, userId, accessTokenPayload, sessionData }) {
+                                    accessTokenPayload = {
+                                        ...accessTokenPayload,
+                                        customKey: "customValue",
+                                        customKey2: "customValue2",
+                                    };
+
+                                    return await oi.createNewSession({ res, userId, accessTokenPayload, sessionData });
+                                },
+                            };
+                        },
+                    },
+                }),
+            ],
+        });
+
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
+
+        let app = express();
+
+        app.use(middleware());
+        app.use(express.json());
+
+        app.post("/create", async (req, res) => {
+            let session = await Session.createNewSession(res, "userId", {}, {});
+
+            await session.setClaimValue(TrueClaim, false);
+
+            res.status(200).json({ accessTokenPayload: session.getAccessTokenPayload() });
+        });
+
+        app.use(errorHandler());
+
+        let createJWTResponse = await new Promise((resolve) =>
+            request(app)
+                .post("/create")
+                .expect(200)
+                .end((err, res) => {
+                    if (err) {
+                        resolve(undefined);
+                    } else {
+                        resolve(res);
+                    }
+                })
+        );
+
+        let accessTokenPayload = createJWTResponse.body.accessTokenPayload;
+        assert.strictEqual(accessTokenPayload.sub, undefined);
+        assert.strictEqual(accessTokenPayload.iss, undefined);
+        assert.strictEqual(TrueClaim.getValueFromPayload(accessTokenPayload), false);
+        assert.notStrictEqual(accessTokenPayload.jwt, undefined);
+        assert.strictEqual(accessTokenPayload._jwtPName, "jwt");
+
+        let decodedJWT = JsonWebToken.decode(accessTokenPayload.jwt);
+        assert.notStrictEqual(decodedJWT, null);
+        assert.strictEqual(decodedJWT["sub"], "userId");
+        assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io/auth");
+        assert.strictEqual(decodedJWT._jwtPName, undefined);
+        assert.strictEqual(TrueClaim.getValueFromPayload(decodedJWT), false);
+    });
+
+    it("should update JWT when removing claim", async function () {
+        await startST();
+        SuperTokens.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                Session.init({
+                    jwt: { enable: true },
+                    override: {
+                        functions: function (oi) {
+                            return {
+                                ...oi,
+                                createNewSession: async function ({ res, userId, accessTokenPayload, sessionData }) {
+                                    accessTokenPayload = {
+                                        ...accessTokenPayload,
+                                        customKey: "customValue",
+                                        customKey2: "customValue2",
+                                    };
+
+                                    return await oi.createNewSession({ res, userId, accessTokenPayload, sessionData });
+                                },
+                            };
+                        },
+                    },
+                }),
+            ],
+        });
+
+        // Only run for version >= 2.9
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        let apiVersion = await querier.getAPIVersion();
+        if (maxVersion(apiVersion, "2.8") === "2.8") {
+            return;
+        }
+
+        let app = express();
+
+        app.use(middleware());
+        app.use(express.json());
+
+        app.post("/create", async (req, res) => {
+            let session = await Session.createNewSession(res, "userId", {}, {});
+
+            await session.setClaimValue(TrueClaim, true);
+            await session.removeClaim(TrueClaim);
+
+            res.status(200).json({ accessTokenPayload: session.getAccessTokenPayload() });
+        });
+
+        app.use(errorHandler());
+
+        let createJWTResponse = await new Promise((resolve) =>
+            request(app)
+                .post("/create")
+                .expect(200)
+                .end((err, res) => {
+                    if (err) {
+                        resolve(undefined);
+                    } else {
+                        resolve(res);
+                    }
+                })
+        );
+
+        let accessTokenPayload = createJWTResponse.body.accessTokenPayload;
+        assert.strictEqual(accessTokenPayload.sub, undefined);
+        assert.strictEqual(accessTokenPayload.iss, undefined);
+        assert.strictEqual(TrueClaim.getValueFromPayload(accessTokenPayload), undefined);
+        assert.notStrictEqual(accessTokenPayload.jwt, undefined);
+        assert.strictEqual(accessTokenPayload._jwtPName, "jwt");
+
+        let decodedJWT = JsonWebToken.decode(accessTokenPayload.jwt);
+        assert.notStrictEqual(decodedJWT, null);
+        assert.strictEqual(decodedJWT["sub"], "userId");
+        assert.strictEqual(decodedJWT.iss, "https://api.supertokens.io/auth");
+        assert.strictEqual(decodedJWT._jwtPName, undefined);
+        assert.strictEqual(TrueClaim.getValueFromPayload(decodedJWT), undefined);
     });
 });


### PR DESCRIPTION
## Summary of change

- make mergeIntoAccessTokenPayload properly update the jwt payload
- use class methods instead of arrow functions defined on the instance

## Related issues

-   #423 

## Test Plan

Added test cases:
- `SessionContainer.mergeIntoAccessTokenPayload ` should update JWT
- `SessionContainer.fetchAndSetClaim` should update JWT when setting claim value
- `SessionContainer.setClaimValue` should update JWT when setting claim value
- `SessionContainer.removeClaim` should update JWT when removing claim
- `Session.mergeIntoAccessTokenPayload` updates JWT (passed originally)

## Documentation changes

N/A, fix change

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
