### PR TITLE
feat(session rework): fallback auth method

### DIFF
--- a/lib/build/constants.d.ts
+++ b/lib/build/constants.d.ts
@@ -1,4 +1,3 @@
 // @ts-nocheck
 export declare const HEADER_RID = "rid";
-export declare const HEADER_AUTH_MODE = "st-auth-mode";
 export declare const HEADER_FDI = "fdi-version";

--- a/lib/build/constants.js
+++ b/lib/build/constants.js
@@ -15,5 +15,4 @@
  */
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.HEADER_RID = "rid";
-exports.HEADER_AUTH_MODE = "st-auth-mode";
 exports.HEADER_FDI = "fdi-version";

--- a/lib/build/recipe/session/accessToken.d.ts
+++ b/lib/build/recipe/session/accessToken.d.ts
@@ -14,5 +14,5 @@ export declare function getInfoFromAccessToken(
     expiryTime: number;
     timeCreated: number;
 }>;
-export declare function validateAccessTokenPayload(payload: { [key: string]: any }): void;
+export declare function validateAccessTokenStructure(payload: any): void;
 export declare function sanitizeNumberInput(field: any): number | undefined;

--- a/lib/build/recipe/session/accessToken.d.ts
+++ b/lib/build/recipe/session/accessToken.d.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
+import { ParsedJWTInfo } from "./jwt";
 export declare function getInfoFromAccessToken(
-    token: string,
+    jwtInfo: ParsedJWTInfo,
     jwtSigningPublicKey: string,
     doAntiCsrfCheck: boolean
 ): Promise<{
@@ -13,4 +14,5 @@ export declare function getInfoFromAccessToken(
     expiryTime: number;
     timeCreated: number;
 }>;
+export declare function validateAccessTokenPayload(payload: { [key: string]: any }): void;
 export declare function sanitizeNumberInput(field: any): number | undefined;

--- a/lib/build/recipe/session/accessToken.js
+++ b/lib/build/recipe/session/accessToken.js
@@ -52,7 +52,7 @@ function getInfoFromAccessToken(jwtInfo, jwtSigningPublicKey, doAntiCsrfCheck) {
         try {
             let payload = jwt_1.verifyJWT(jwtInfo, jwtSigningPublicKey);
             // This should be called before this function, but the check is very quick, so we can also do them here
-            validateAccessTokenPayload(payload);
+            validateAccessTokenStructure(payload);
             // We can mark these as defined (the ! after the calls), since validateAccessTokenPayload checks this
             let sessionHandle = sanitizeStringInput(payload.sessionHandle);
             let userId = sanitizeStringInput(payload.userId);
@@ -87,7 +87,7 @@ function getInfoFromAccessToken(jwtInfo, jwtSigningPublicKey, doAntiCsrfCheck) {
     });
 }
 exports.getInfoFromAccessToken = getInfoFromAccessToken;
-function validateAccessTokenPayload(payload) {
+function validateAccessTokenStructure(payload) {
     if (
         typeof payload.sessionHandle !== "string" ||
         typeof payload.userId !== "string" ||
@@ -100,7 +100,7 @@ function validateAccessTokenPayload(payload) {
         throw Error("Access token does not contain all the information. Maybe the structure has changed?");
     }
 }
-exports.validateAccessTokenPayload = validateAccessTokenPayload;
+exports.validateAccessTokenStructure = validateAccessTokenStructure;
 function sanitizeStringInput(field) {
     if (field === "") {
         return "";

--- a/lib/build/recipe/session/accessToken.js
+++ b/lib/build/recipe/session/accessToken.js
@@ -47,10 +47,13 @@ var __awaiter =
 Object.defineProperty(exports, "__esModule", { value: true });
 const error_1 = require("./error");
 const jwt_1 = require("./jwt");
-function getInfoFromAccessToken(token, jwtSigningPublicKey, doAntiCsrfCheck) {
+function getInfoFromAccessToken(jwtInfo, jwtSigningPublicKey, doAntiCsrfCheck) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            let payload = jwt_1.verifyJWTAndGetPayload(token, jwtSigningPublicKey);
+            let payload = jwt_1.verifyJWT(jwtInfo, jwtSigningPublicKey);
+            // This should be called before this function, but the check is very quick, so we can also do them here
+            validateAccessTokenPayload(payload);
+            // We can mark these as defined (the ! after the calls), since validateAccessTokenPayload checks this
             let sessionHandle = sanitizeStringInput(payload.sessionHandle);
             let userId = sanitizeStringInput(payload.userId);
             let refreshTokenHash1 = sanitizeStringInput(payload.refreshTokenHash1);
@@ -59,17 +62,8 @@ function getInfoFromAccessToken(token, jwtSigningPublicKey, doAntiCsrfCheck) {
             let antiCsrfToken = sanitizeStringInput(payload.antiCsrfToken);
             let expiryTime = sanitizeNumberInput(payload.expiryTime);
             let timeCreated = sanitizeNumberInput(payload.timeCreated);
-            if (
-                sessionHandle === undefined ||
-                userId === undefined ||
-                refreshTokenHash1 === undefined ||
-                userData === undefined ||
-                (antiCsrfToken === undefined && doAntiCsrfCheck) ||
-                expiryTime === undefined ||
-                timeCreated === undefined
-            ) {
-                // it would come here if we change the structure of the JWT.
-                throw Error("Access token does not contain all the information. Maybe the structure has changed?");
+            if (antiCsrfToken === undefined && doAntiCsrfCheck) {
+                throw Error("Access token does not contain the anti-csrf token.");
             }
             if (expiryTime < Date.now()) {
                 throw Error("Access token expired");
@@ -93,6 +87,20 @@ function getInfoFromAccessToken(token, jwtSigningPublicKey, doAntiCsrfCheck) {
     });
 }
 exports.getInfoFromAccessToken = getInfoFromAccessToken;
+function validateAccessTokenPayload(payload) {
+    if (
+        typeof payload.sessionHandle !== "string" ||
+        typeof payload.userId !== "string" ||
+        typeof payload.refreshTokenHash1 !== "string" ||
+        payload.userData === undefined ||
+        typeof payload.expiryTime !== "number" ||
+        typeof payload.timeCreated !== "number"
+    ) {
+        // it would come here if we change the structure of the JWT.
+        throw Error("Access token does not contain all the information. Maybe the structure has changed?");
+    }
+}
+exports.validateAccessTokenPayload = validateAccessTokenPayload;
 function sanitizeStringInput(field) {
     if (field === "") {
         return "";

--- a/lib/build/recipe/session/constants.d.ts
+++ b/lib/build/recipe/session/constants.d.ts
@@ -1,3 +1,5 @@
 // @ts-nocheck
+import { TokenTransferMethod } from "./types";
 export declare const REFRESH_API_PATH = "/session/refresh";
 export declare const SIGNOUT_API_PATH = "/signout";
+export declare const availableTokenTransferMethods: TokenTransferMethod[];

--- a/lib/build/recipe/session/constants.js
+++ b/lib/build/recipe/session/constants.js
@@ -16,3 +16,4 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.REFRESH_API_PATH = "/session/refresh";
 exports.SIGNOUT_API_PATH = "/signout";
+exports.availableTokenTransferMethods = ["cookie", "header"];

--- a/lib/build/recipe/session/cookieAndHeaders.d.ts
+++ b/lib/build/recipe/session/cookieAndHeaders.d.ts
@@ -21,21 +21,17 @@ export declare function setFrontTokenInHeaders(
 export declare function getCORSAllowedHeaders(): string[];
 export declare function isTokenInCookies(req: BaseRequest, tokenType: TokenType): boolean;
 export declare function getToken(
-    config: TypeNormalisedInput,
     req: BaseRequest,
     tokenType: TokenType,
-    userContext: any,
-    transferMethod?: "cookie" | "header"
+    transferMethod: "cookie" | "header"
 ): string | undefined;
 export declare function setToken(
     config: TypeNormalisedInput,
-    req: BaseRequest,
     res: BaseResponse,
     tokenType: TokenType,
     value: string,
     expires: number,
-    userContext: any,
-    transferMethod?: "cookie" | "header"
+    transferMethod: "cookie" | "header"
 ): void;
 export declare function setHeader(res: BaseResponse, name: string, value: string, expires: number): void;
 /**

--- a/lib/build/recipe/session/cookieAndHeaders.d.ts
+++ b/lib/build/recipe/session/cookieAndHeaders.d.ts
@@ -6,7 +6,6 @@ import { TokenTransferMethod, TokenType, TypeNormalisedInput } from "./types";
  */
 export declare function clearSession(
     config: TypeNormalisedInput,
-    req: BaseRequest,
     res: BaseResponse,
     transferMethod: TokenTransferMethod
 ): void;
@@ -19,7 +18,6 @@ export declare function setFrontTokenInHeaders(
     accessTokenPayload: any
 ): void;
 export declare function getCORSAllowedHeaders(): string[];
-export declare function isTokenInCookies(req: BaseRequest, tokenType: TokenType): boolean;
 export declare function getToken(
     req: BaseRequest,
     tokenType: TokenType,

--- a/lib/build/recipe/session/cookieAndHeaders.d.ts
+++ b/lib/build/recipe/session/cookieAndHeaders.d.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { BaseRequest, BaseResponse } from "../../framework";
-import { TokenType, TypeNormalisedInput } from "./types";
+import { TokenTransferMethod, TokenType, TypeNormalisedInput } from "./types";
+export declare const availableTokenTransferMethods: TokenTransferMethod[];
 /**
  * @description clears all the auth cookies from the response
  */
@@ -8,7 +9,8 @@ export declare function clearSession(
     config: TypeNormalisedInput,
     req: BaseRequest,
     res: BaseResponse,
-    userContext: any
+    userContext: any,
+    transferMethod?: TokenTransferMethod | "missing_auth_header"
 ): void;
 export declare function getAntiCsrfTokenFromHeaders(req: BaseRequest): string | undefined;
 export declare function setAntiCsrfTokenInHeaders(res: BaseResponse, antiCsrfToken: string): void;
@@ -23,7 +25,7 @@ export declare function isTokenInCookies(req: BaseRequest, tokenType: TokenType)
 export declare function getToken(
     req: BaseRequest,
     tokenType: TokenType,
-    transferMethod: "cookie" | "header"
+    transferMethod: TokenTransferMethod
 ): string | undefined;
 export declare function setToken(
     config: TypeNormalisedInput,
@@ -31,7 +33,7 @@ export declare function setToken(
     tokenType: TokenType,
     value: string,
     expires: number,
-    transferMethod: "cookie" | "header"
+    transferMethod: TokenTransferMethod
 ): void;
 export declare function setHeader(res: BaseResponse, name: string, value: string, expires: number): void;
 /**
@@ -53,3 +55,4 @@ export declare function setCookie(
     expires: number,
     pathType: "refreshTokenPath" | "accessTokenPath"
 ): void;
+export declare function getAuthModeFromHeader(req: BaseRequest): string | undefined;

--- a/lib/build/recipe/session/cookieAndHeaders.d.ts
+++ b/lib/build/recipe/session/cookieAndHeaders.d.ts
@@ -1,7 +1,6 @@
 // @ts-nocheck
 import { BaseRequest, BaseResponse } from "../../framework";
 import { TokenTransferMethod, TokenType, TypeNormalisedInput } from "./types";
-export declare const availableTokenTransferMethods: TokenTransferMethod[];
 /**
  * @description clears all the auth cookies from the response
  */
@@ -9,8 +8,7 @@ export declare function clearSession(
     config: TypeNormalisedInput,
     req: BaseRequest,
     res: BaseResponse,
-    userContext: any,
-    transferMethod?: TokenTransferMethod | "missing_auth_header"
+    transferMethod: TokenTransferMethod
 ): void;
 export declare function getAntiCsrfTokenFromHeaders(req: BaseRequest): string | undefined;
 export declare function setAntiCsrfTokenInHeaders(res: BaseResponse, antiCsrfToken: string): void;

--- a/lib/build/recipe/session/cookieAndHeaders.js
+++ b/lib/build/recipe/session/cookieAndHeaders.js
@@ -56,13 +56,7 @@ function setFrontTokenInHeaders(res, userId, atExpiry, accessTokenPayload) {
 }
 exports.setFrontTokenInHeaders = setFrontTokenInHeaders;
 function getCORSAllowedHeaders() {
-    return [
-        antiCsrfHeaderKey,
-        constants_1.HEADER_RID,
-        authorizationHeaderKey,
-        refreshTokenHeaderKey,
-        authModeHeaderKey,
-    ];
+    return [antiCsrfHeaderKey, constants_1.HEADER_RID, authorizationHeaderKey, authModeHeaderKey];
 }
 exports.getCORSAllowedHeaders = getCORSAllowedHeaders;
 function getCookieNameFromTokenType(tokenType) {
@@ -115,11 +109,7 @@ function setToken(config, res, tokenType, value, expires, transferMethod) {
 }
 exports.setToken = setToken;
 function setHeader(res, name, value, expires) {
-    if (value === "remove") {
-        res.setHeader(name, value, false);
-    } else {
-        res.setHeader(name, `${value};${expires}`, false);
-    }
+    res.setHeader(name, `${value};${expires}`, false);
     res.setHeader("Access-Control-Expose-Headers", name, true);
 }
 exports.setHeader = setHeader;

--- a/lib/build/recipe/session/cookieAndHeaders.js
+++ b/lib/build/recipe/session/cookieAndHeaders.js
@@ -22,21 +22,23 @@ const refreshTokenCookieKey = "sRefreshToken";
 const refreshTokenHeaderKey = "st-refresh-token";
 const antiCsrfHeaderKey = "anti-csrf";
 const frontTokenHeaderKey = "front-token";
+const authModeHeaderKey = "st-auth-mode";
+exports.availableTokenTransferMethods = ["cookie", "header"];
 /**
  * @description clears all the auth cookies from the response
  */
-function clearSession(config, req, res, userContext) {
+function clearSession(config, req, res, userContext, transferMethod) {
     // If we can tell it's a cookie based session we are not clearing using headers
-    let transferMethod = config.getTokenTransferMethod({ req, userContext });
-    if (transferMethod === "MISSING_AUTH_HEADER") {
-        transferMethod = "header";
+    let outputTransferMethod = transferMethod || config.getTokenTransferMethod({ req, userContext });
+    if (outputTransferMethod === "missing_auth_header") {
+        outputTransferMethod = "header";
     }
     const tokenTypes = ["access", "refresh"];
     for (const token of tokenTypes) {
-        setToken(config, res, token, "", 0, transferMethod);
+        setToken(config, res, token, "", 0, outputTransferMethod);
         // This is to ensure we clear the cookies as well if the user has migrated to headers,
         // because this can't be done on the client side
-        if (transferMethod === "header" && isTokenInCookies(req, token)) {
+        if (outputTransferMethod === "header" && isTokenInCookies(req, token)) {
             setToken(config, res, token, "", 0, "cookie");
         }
     }
@@ -64,7 +66,13 @@ function setFrontTokenInHeaders(res, userId, atExpiry, accessTokenPayload) {
 }
 exports.setFrontTokenInHeaders = setFrontTokenInHeaders;
 function getCORSAllowedHeaders() {
-    return [antiCsrfHeaderKey, constants_1.HEADER_RID, authorizationHeaderKey, refreshTokenHeaderKey];
+    return [
+        antiCsrfHeaderKey,
+        constants_1.HEADER_RID,
+        authorizationHeaderKey,
+        refreshTokenHeaderKey,
+        authModeHeaderKey,
+    ];
 }
 exports.getCORSAllowedHeaders = getCORSAllowedHeaders;
 function getCookieNameFromTokenType(tokenType) {
@@ -77,7 +85,7 @@ function getCookieNameFromTokenType(tokenType) {
             throw new Error("Unknown token type, should never happen.");
     }
 }
-function getHeaderNameFromTokenType(tokenType) {
+function getResponseHeaderNameForTokenType(tokenType) {
     switch (tokenType) {
         case "access":
             // We are getting the access token from the authorization header during verification.
@@ -97,14 +105,11 @@ function getToken(req, tokenType, transferMethod) {
     if (transferMethod === "cookie") {
         return req.getCookieValue(getCookieNameFromTokenType(tokenType));
     } else if (transferMethod === "header") {
-        if (tokenType === "access") {
-            const value = req.getHeaderValue(authorizationHeaderKey);
-            if (value === undefined || !value.startsWith("Bearer ")) {
-                return undefined;
-            }
-            return value.replace(/^Bearer /, "");
+        const value = req.getHeaderValue(authorizationHeaderKey);
+        if (value === undefined || !value.startsWith("Bearer ")) {
+            return undefined;
         }
-        return req.getHeaderValue(getHeaderNameFromTokenType(tokenType));
+        return value.replace(/^Bearer /, "");
     } else {
         throw new Error("Should never happen: Unknown transferMethod: " + transferMethod);
     }
@@ -121,7 +126,7 @@ function setToken(config, res, tokenType, value, expires, transferMethod) {
             tokenType === "refresh" ? "refreshTokenPath" : "accessTokenPath"
         );
     } else if (transferMethod === "header") {
-        setHeader(res, getHeaderNameFromTokenType(tokenType), value, expires);
+        setHeader(res, getResponseHeaderNameForTokenType(tokenType), value, expires);
     }
 }
 exports.setToken = setToken;
@@ -159,3 +164,7 @@ function setCookie(config, res, name, value, expires, pathType) {
     return res.setCookie(name, value, domain, secure, httpOnly, expires, path, sameSite);
 }
 exports.setCookie = setCookie;
+function getAuthModeFromHeader(req) {
+    return req.getHeaderValue(authModeHeaderKey);
+}
+exports.getAuthModeFromHeader = getAuthModeFromHeader;

--- a/lib/build/recipe/session/cookieAndHeaders.js
+++ b/lib/build/recipe/session/cookieAndHeaders.js
@@ -17,7 +17,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const constants_1 = require("../../constants");
 const authorizationHeaderKey = "authorization";
 const accessTokenCookieKey = "sAccessToken";
-const accessTokenheaderKey = "st-access-token";
+const accessTokenHeaderKey = "st-access-token";
 const refreshTokenCookieKey = "sRefreshToken";
 const refreshTokenHeaderKey = "st-refresh-token";
 const antiCsrfHeaderKey = "anti-csrf";
@@ -26,14 +26,18 @@ const frontTokenHeaderKey = "front-token";
  * @description clears all the auth cookies from the response
  */
 function clearSession(config, req, res, userContext) {
-    const transferMethod = config.getTokenTransferMethod({ req, userContext });
+    // If we can tell it's a cookie based session we are not clearing using headers
+    let transferMethod = config.getTokenTransferMethod({ req, userContext });
+    if (transferMethod === "MISSING_AUTH_HEADER") {
+        transferMethod = "header";
+    }
     const tokenTypes = ["access", "refresh"];
     for (const token of tokenTypes) {
-        setToken(config, req, res, token, "", 0, userContext, transferMethod);
+        setToken(config, res, token, "", 0, transferMethod);
         // This is to ensure we clear the cookies as well if the user has migrated to headers,
         // because this can't be done on the client side
         if (transferMethod === "header" && isTokenInCookies(req, token)) {
-            setToken(config, req, res, token, "", 0, userContext, "cookie");
+            setToken(config, res, token, "", 0, "cookie");
         }
     }
     res.setHeader(frontTokenHeaderKey, "remove", false);
@@ -76,7 +80,9 @@ function getCookieNameFromTokenType(tokenType) {
 function getHeaderNameFromTokenType(tokenType) {
     switch (tokenType) {
         case "access":
-            return accessTokenheaderKey;
+            // We are getting the access token from the authorization header during verification.
+            // This case is handled in the getToken fn below.
+            return accessTokenHeaderKey;
         case "refresh":
             return refreshTokenHeaderKey;
         default:
@@ -87,10 +93,7 @@ function isTokenInCookies(req, tokenType) {
     return req.getCookieValue(getCookieNameFromTokenType(tokenType)) !== undefined;
 }
 exports.isTokenInCookies = isTokenInCookies;
-function getToken(config, req, tokenType, userContext, transferMethod) {
-    if (transferMethod === undefined) {
-        transferMethod = config.getTokenTransferMethod({ req, userContext });
-    }
+function getToken(req, tokenType, transferMethod) {
     if (transferMethod === "cookie") {
         return req.getCookieValue(getCookieNameFromTokenType(tokenType));
     } else if (transferMethod === "header") {
@@ -107,10 +110,7 @@ function getToken(config, req, tokenType, userContext, transferMethod) {
     }
 }
 exports.getToken = getToken;
-function setToken(config, req, res, tokenType, value, expires, userContext, transferMethod) {
-    if (transferMethod === undefined) {
-        transferMethod = config.getTokenTransferMethod({ req, userContext });
-    }
+function setToken(config, res, tokenType, value, expires, transferMethod) {
     if (transferMethod === "cookie") {
         // We intentionally use accessTokenPath for idRefresh tokens
         setCookie(

--- a/lib/build/recipe/session/cookieAndHeaders.js
+++ b/lib/build/recipe/session/cookieAndHeaders.js
@@ -23,22 +23,17 @@ const refreshTokenHeaderKey = "st-refresh-token";
 const antiCsrfHeaderKey = "anti-csrf";
 const frontTokenHeaderKey = "front-token";
 const authModeHeaderKey = "st-auth-mode";
-exports.availableTokenTransferMethods = ["cookie", "header"];
 /**
  * @description clears all the auth cookies from the response
  */
-function clearSession(config, req, res, userContext, transferMethod) {
+function clearSession(config, req, res, transferMethod) {
     // If we can tell it's a cookie based session we are not clearing using headers
-    let outputTransferMethod = transferMethod || config.getTokenTransferMethod({ req, userContext });
-    if (outputTransferMethod === "missing_auth_header") {
-        outputTransferMethod = "header";
-    }
     const tokenTypes = ["access", "refresh"];
     for (const token of tokenTypes) {
-        setToken(config, res, token, "", 0, outputTransferMethod);
+        setToken(config, res, token, "", 0, transferMethod);
         // This is to ensure we clear the cookies as well if the user has migrated to headers,
         // because this can't be done on the client side
-        if (outputTransferMethod === "header" && isTokenInCookies(req, token)) {
+        if (transferMethod === "header" && isTokenInCookies(req, token)) {
             setToken(config, res, token, "", 0, "cookie");
         }
     }
@@ -88,8 +83,6 @@ function getCookieNameFromTokenType(tokenType) {
 function getResponseHeaderNameForTokenType(tokenType) {
     switch (tokenType) {
         case "access":
-            // We are getting the access token from the authorization header during verification.
-            // This case is handled in the getToken fn below.
             return accessTokenHeaderKey;
         case "refresh":
             return refreshTokenHeaderKey;

--- a/lib/build/recipe/session/cookieAndHeaders.js
+++ b/lib/build/recipe/session/cookieAndHeaders.js
@@ -26,16 +26,11 @@ const authModeHeaderKey = "st-auth-mode";
 /**
  * @description clears all the auth cookies from the response
  */
-function clearSession(config, req, res, transferMethod) {
+function clearSession(config, res, transferMethod) {
     // If we can tell it's a cookie based session we are not clearing using headers
     const tokenTypes = ["access", "refresh"];
     for (const token of tokenTypes) {
         setToken(config, res, token, "", 0, transferMethod);
-        // This is to ensure we clear the cookies as well if the user has migrated to headers,
-        // because this can't be done on the client side
-        if (transferMethod === "header" && isTokenInCookies(req, token)) {
-            setToken(config, res, token, "", 0, "cookie");
-        }
     }
     res.setHeader(frontTokenHeaderKey, "remove", false);
     res.setHeader("Access-Control-Expose-Headers", frontTokenHeaderKey, true);
@@ -90,10 +85,6 @@ function getResponseHeaderNameForTokenType(tokenType) {
             throw new Error("Unknown token type, should never happen.");
     }
 }
-function isTokenInCookies(req, tokenType) {
-    return req.getCookieValue(getCookieNameFromTokenType(tokenType)) !== undefined;
-}
-exports.isTokenInCookies = isTokenInCookies;
 function getToken(req, tokenType, transferMethod) {
     if (transferMethod === "cookie") {
         return req.getCookieValue(getCookieNameFromTokenType(tokenType));
@@ -158,6 +149,7 @@ function setCookie(config, res, name, value, expires, pathType) {
 }
 exports.setCookie = setCookie;
 function getAuthModeFromHeader(req) {
-    return req.getHeaderValue(authModeHeaderKey);
+    var _a;
+    return (_a = req.getHeaderValue(authModeHeaderKey)) === null || _a === void 0 ? void 0 : _a.toLowerCase();
 }
 exports.getAuthModeFromHeader = getAuthModeFromHeader;

--- a/lib/build/recipe/session/jwt.d.ts
+++ b/lib/build/recipe/session/jwt.d.ts
@@ -5,7 +5,7 @@ export declare type ParsedJWTInfo = {
     payload: any;
     signature: string;
 };
-export declare function parseJWT(jwt: string): ParsedJWTInfo;
+export declare function parseJWTWithoutSignatureVerification(jwt: string): ParsedJWTInfo;
 export declare function verifyJWT(
     { header, payload, signature }: ParsedJWTInfo,
     jwtSigningPublicKey: string

--- a/lib/build/recipe/session/jwt.d.ts
+++ b/lib/build/recipe/session/jwt.d.ts
@@ -1,12 +1,14 @@
 // @ts-nocheck
-export declare function verifyJWTAndGetPayload(
-    jwt: string,
-    jwtSigningPublicKey: string
-): {
-    [key: string]: any;
+export declare type ParsedJWTInfo = {
+    rawTokenString: string;
+    header: string;
+    payload: any;
+    signature: string;
 };
-export declare function getPayloadWithoutVerifiying(
-    jwt: string
+export declare function parseJWT(jwt: string): ParsedJWTInfo;
+export declare function verifyJWT(
+    { header, payload, signature }: ParsedJWTInfo,
+    jwtSigningPublicKey: string
 ): {
     [key: string]: any;
 };

--- a/lib/build/recipe/session/jwt.js
+++ b/lib/build/recipe/session/jwt.js
@@ -31,7 +31,7 @@ const HEADERS = new Set([
         })
     ).toString("base64"),
 ]);
-function verifyJWTAndGetPayload(jwt, jwtSigningPublicKey) {
+function parseJWT(jwt) {
     const splittedInput = jwt.split(".");
     if (splittedInput.length !== 3) {
         throw new Error("Invalid JWT");
@@ -40,31 +40,29 @@ function verifyJWTAndGetPayload(jwt, jwtSigningPublicKey) {
     if (!HEADERS.has(splittedInput[0])) {
         throw new Error("JWT header mismatch");
     }
-    let payload = splittedInput[1];
+    return {
+        rawTokenString: jwt,
+        header: splittedInput[0],
+        // Ideally we would only parse this after the signature verification is done.
+        // We do this at the start, since we want to check if a token can be a supertokens access token or not
+        payload: JSON.parse(Buffer.from(splittedInput[1], "base64").toString()),
+        signature: splittedInput[2],
+    };
+}
+exports.parseJWT = parseJWT;
+function verifyJWT({ header, payload, signature }, jwtSigningPublicKey) {
     let verifier = crypto.createVerify("sha256");
     // convert the jwtSigningPublicKey into .pem format
-    verifier.update(splittedInput[0] + "." + payload);
+    verifier.update(header + "." + payload);
     if (
         !verifier.verify(
             "-----BEGIN PUBLIC KEY-----\n" + jwtSigningPublicKey + "\n-----END PUBLIC KEY-----",
-            splittedInput[2],
+            signature,
             "base64"
         )
     ) {
         throw new Error("JWT verification failed");
     }
-    // sending payload
-    payload = Buffer.from(payload, "base64").toString();
     return JSON.parse(payload);
 }
-exports.verifyJWTAndGetPayload = verifyJWTAndGetPayload;
-function getPayloadWithoutVerifiying(jwt) {
-    const splittedInput = jwt.split(".");
-    if (splittedInput.length !== 3) {
-        throw new Error("Invalid JWT");
-    }
-    let payload = splittedInput[1];
-    payload = Buffer.from(payload, "base64").toString();
-    return JSON.parse(payload);
-}
-exports.getPayloadWithoutVerifiying = getPayloadWithoutVerifiying;
+exports.verifyJWT = verifyJWT;

--- a/lib/build/recipe/session/jwt.js
+++ b/lib/build/recipe/session/jwt.js
@@ -31,7 +31,7 @@ const HEADERS = new Set([
         })
     ).toString("base64"),
 ]);
-function parseJWT(jwt) {
+function parseJWTWithoutSignatureVerification(jwt) {
     const splittedInput = jwt.split(".");
     if (splittedInput.length !== 3) {
         throw new Error("Invalid JWT");
@@ -49,7 +49,7 @@ function parseJWT(jwt) {
         signature: splittedInput[2],
     };
 }
-exports.parseJWT = parseJWT;
+exports.parseJWTWithoutSignatureVerification = parseJWTWithoutSignatureVerification;
 function verifyJWT({ header, payload, signature }, jwtSigningPublicKey) {
     let verifier = crypto.createVerify("sha256");
     // convert the jwtSigningPublicKey into .pem format

--- a/lib/build/recipe/session/recipeImplementation.js
+++ b/lib/build/recipe/session/recipeImplementation.js
@@ -71,6 +71,8 @@ class HandshakeInfo {
     }
 }
 exports.HandshakeInfo = HandshakeInfo;
+// We are defining this here to reduce the scope of legacy code
+const LEGACY_ID_REFRESH_TOKEN_COOKIE_NAME = "sIdRefreshToken";
 function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverrides) {
     let handshakeInfo;
     function getHandshakeInfo(forceRefetch = false) {
@@ -114,13 +116,13 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
         createNewSession: function ({ req, res, userId, accessTokenPayload = {}, sessionData = {}, userContext }) {
             return __awaiter(this, void 0, void 0, function* () {
                 logger_1.logDebugMessage("createNewSession: Started");
-                let transferMethod = config.getTokenTransferMethod({ req, userContext });
-                logger_1.logDebugMessage("createNewSession: got transfer method " + transferMethod);
-                if (transferMethod === "MISSING_AUTH_HEADER") {
-                    transferMethod = "header";
+                let outputTransferMethod = config.getTokenTransferMethod({ req, userContext });
+                logger_1.logDebugMessage("createNewSession: got transfer method " + outputTransferMethod);
+                if (outputTransferMethod === "missing_auth_header") {
+                    outputTransferMethod = "header";
                 }
-                logger_1.logDebugMessage("createNewSession: using transfer method " + transferMethod);
-                const disableAntiCSRF = transferMethod === "header";
+                logger_1.logDebugMessage("createNewSession: using transfer method " + outputTransferMethod);
+                const disableAntiCSRF = outputTransferMethod === "header";
                 let response = yield SessionFunctions.createNewSession(
                     helpers,
                     userId,
@@ -128,7 +130,12 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                     accessTokenPayload,
                     sessionData
                 );
-                utils_1.attachCreateOrRefreshSessionResponseToExpressRes(config, res, response, transferMethod);
+                for (const transferMethod of cookieAndHeaders_1.availableTokenTransferMethods) {
+                    if (transferMethod !== outputTransferMethod) {
+                        cookieAndHeaders_1.clearSession(config, req, res, userContext, transferMethod);
+                    }
+                }
+                utils_1.attachCreateOrRefreshSessionResponseToExpressRes(config, res, response, outputTransferMethod);
                 return new sessionClass_1.default(
                     helpers,
                     response.accessToken.token,
@@ -137,7 +144,7 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                     response.session.userDataInJWT,
                     res,
                     req,
-                    transferMethod
+                    outputTransferMethod
                 );
             });
         },
@@ -146,30 +153,34 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                 return input.claimValidatorsAddedByOtherRecipes;
             });
         },
+        /* In all cases if sIdRefreshToken token exists (so it's a legacy session) we return TRY_REFRESH_TOKEN. The refresh endpoint will clear this cookie and try to upgrade the session.
+           Check https://supertokens.com/docs/contribute/decisions/session/0007 for further details and a table of expected behaviours
+         */
         getSession: function ({ req, res, options, userContext }) {
             return __awaiter(this, void 0, void 0, function* () {
                 logger_1.logDebugMessage("getSession: Started");
+                // This token isn't handled by getToken to limit the scope of this legacy/migration code
+                if (req.getCookieValue(LEGACY_ID_REFRESH_TOKEN_COOKIE_NAME) !== undefined) {
+                    // This could create a spike on refresh calls during the update of the backend SDK
+                    throw new error_1.default({
+                        message: "using legacy session, please call the refresh API",
+                        type: error_1.default.TRY_REFRESH_TOKEN,
+                    });
+                }
                 const sessionOptional =
-                    options !== undefined && typeof options !== "boolean" && options.sessionRequired === false;
-                const gotRID = utils_2.frontendHasInterceptor(req);
-                const method = req.getMethod();
+                    (options === null || options === void 0 ? void 0 : options.sessionRequired) === false;
                 logger_1.logDebugMessage("getSession: optional validation: " + sessionOptional);
-                logger_1.logDebugMessage("getSession: rid in header: " + gotRID);
-                logger_1.logDebugMessage("getSession: request method: " + method);
-                let doAntiCsrfCheck = options !== undefined ? options.antiCsrfCheck : undefined;
                 const preferredTransferMethod = config.getTokenTransferMethod({ req, userContext });
                 let transferMethod =
-                    preferredTransferMethod === "MISSING_AUTH_HEADER" ? "header" : preferredTransferMethod;
+                    preferredTransferMethod === "missing_auth_header" ? "header" : preferredTransferMethod;
                 let accessToken = cookieAndHeaders_1.getToken(req, "access", transferMethod);
                 if (accessToken === undefined) {
                     const fallbackMethod = transferMethod === "cookie" ? "header" : "cookie";
-                    // We are checking if we could've gone ahead with validation if the transferMethod was different
-                    // However, we don't want to do the fallback here, but force a call to refresh
-                    // This is done to ensure that the browsers update the transfermethod in a timely manner (basically on the next API call)
-                    // instead of waiting for the session to expire
+                    // We are checking if we could go ahead with validation if the transferMethod was different
+                    // However, we don't want to allow fallback here if there is an up-to-date frontend SDK that sends the auth-mode header.
                     accessToken = cookieAndHeaders_1.getToken(req, "access", fallbackMethod);
                     if (accessToken !== undefined) {
-                        if (preferredTransferMethod === "MISSING_AUTH_HEADER") {
+                        if (preferredTransferMethod === "missing_auth_header") {
                             transferMethod = fallbackMethod;
                             logger_1.logDebugMessage(
                                 `getSession: falling back to use ${fallbackMethod} as an authentication-method`
@@ -186,14 +197,6 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                     }
                 }
                 if (accessToken === undefined) {
-                    // This is done here to ensure smooth migration of sessions started before removing the id-refresh-token
-                    // This token isn't handled by getToken to limit the scope of this legacy/migration code
-                    if (req.getCookieValue("sIRTFrontend") !== undefined) {
-                        throw new error_1.default({
-                            message: "access token expired, please call the refresh API",
-                            type: error_1.default.TRY_REFRESH_TOKEN,
-                        });
-                    }
                     // we do not clear cookies here because of a
                     // race condition mentioned here: https://github.com/supertokens/supertokens-node/issues/17
                     if (sessionOptional) {
@@ -213,16 +216,19 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                 }
                 try {
                     let antiCsrfToken = cookieAndHeaders_1.getAntiCsrfTokenFromHeaders(req);
-                    const disableAntiCSRF = transferMethod === "header";
+                    let doAntiCsrfCheck = options !== undefined ? options.antiCsrfCheck : undefined;
                     if (doAntiCsrfCheck === undefined) {
                         doAntiCsrfCheck = utils_2.normaliseHttpMethod(req.getMethod()) !== "get";
+                    }
+                    if (transferMethod === "header") {
+                        doAntiCsrfCheck = false;
                     }
                     logger_1.logDebugMessage("getSession: Value of doAntiCsrfCheck is: " + doAntiCsrfCheck);
                     let response = yield SessionFunctions.getSession(
                         helpers,
                         accessToken,
                         antiCsrfToken,
-                        !disableAntiCSRF && doAntiCsrfCheck,
+                        doAntiCsrfCheck,
                         utils_2.getRidFromHeader(req) !== undefined
                     );
                     if (response.accessToken !== undefined) {
@@ -259,14 +265,6 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                     );
                     return session;
                 } catch (err) {
-                    if (
-                        err.type === error_1.default.TRY_REFRESH_TOKEN &&
-                        sessionOptional &&
-                        !gotRID &&
-                        method !== "get"
-                    ) {
-                        return undefined;
-                    }
                     if (err.type === error_1.default.UNAUTHORISED) {
                         logger_1.logDebugMessage("getSession: Clearing cookies because of UNAUTHORISED response");
                         cookieAndHeaders_1.clearSession(config, req, res, userContext);
@@ -336,26 +334,41 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                 return SessionFunctions.getSessionInformation(helpers, sessionHandle);
             });
         },
+        /*
+            In all cases: if sIdRefreshToken token exists (so it's a legacy session) we clear it.
+            Check http://localhost:3002/docs/contribute/decisions/session/0008 for further details and a table of expected behaviours
+         */
         refreshSession: function ({ req, res, userContext }) {
             return __awaiter(this, void 0, void 0, function* () {
                 logger_1.logDebugMessage("refreshSession: Started");
-                // We use a fallback mechanism here, to ensure there is a smooth upgrade path when switching transfer methods
-                // We only use it here and not while getting/validating sessions, because we want to "force" clients to upgrade
-                let outputTransferMethod = config.getTokenTransferMethod({ req, userContext });
-                logger_1.logDebugMessage("refreshSession: Preferred transfer method: " + outputTransferMethod);
-                let inputTransferMethod = outputTransferMethod;
-                if (inputTransferMethod === "MISSING_AUTH_HEADER") {
-                    inputTransferMethod = "header";
+                // This token isn't handled by getToken/setToken to limit the scope of this legacy/migration code
+                if (req.getCookieValue(LEGACY_ID_REFRESH_TOKEN_COOKIE_NAME) !== undefined) {
+                    cookieAndHeaders_1.setCookie(
+                        config,
+                        res,
+                        LEGACY_ID_REFRESH_TOKEN_COOKIE_NAME,
+                        "",
+                        0,
+                        "accessTokenPath"
+                    );
                 }
-                let inputRefreshToken = cookieAndHeaders_1.getToken(req, "refresh", inputTransferMethod);
-                if (inputRefreshToken === undefined) {
-                    inputTransferMethod = inputTransferMethod === "cookie" ? "header" : "cookie";
-                    inputRefreshToken = cookieAndHeaders_1.getToken(req, "refresh", inputTransferMethod);
+                const refreshTokens = {};
+                // We check all token transfer methods for available refresh tokens
+                // We do this so that we can later clear all we are not overwrite
+                for (const transferMethod of cookieAndHeaders_1.availableTokenTransferMethods) {
+                    refreshTokens[transferMethod] = cookieAndHeaders_1.getToken(req, "refresh", transferMethod);
+                    if (refreshTokens[transferMethod] !== undefined) {
+                        logger_1.logDebugMessage("refreshSession: got refresh token from " + transferMethod);
+                    }
                 }
-                if (outputTransferMethod === "MISSING_AUTH_HEADER") {
-                    outputTransferMethod = inputTransferMethod;
-                }
-                if (inputRefreshToken === undefined) {
+                let requestTransferMethod;
+                if (refreshTokens["header"] !== undefined) {
+                    logger_1.logDebugMessage("refreshSession: using header transfer method");
+                    requestTransferMethod = "header";
+                } else if (refreshTokens["cookie"]) {
+                    logger_1.logDebugMessage("refreshSession: using header transfer method");
+                    requestTransferMethod = "cookie";
+                } else {
                     logger_1.logDebugMessage(
                         "refreshSession: UNAUTHORISED because refresh token in request is undefined"
                     );
@@ -365,27 +378,29 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                         type: error_1.default.UNAUTHORISED,
                     });
                 }
-                logger_1.logDebugMessage("refreshSession: Request used transfer method: " + inputRefreshToken);
                 try {
                     let antiCsrfToken = cookieAndHeaders_1.getAntiCsrfTokenFromHeaders(req);
                     let response = yield SessionFunctions.refreshSession(
                         helpers,
-                        inputRefreshToken,
+                        requestTransferMethod,
                         antiCsrfToken,
                         utils_2.getRidFromHeader(req) !== undefined,
-                        inputTransferMethod,
-                        outputTransferMethod
+                        requestTransferMethod
                     );
                     logger_1.logDebugMessage(
-                        "refreshSession: Attaching refreshed session info as " + outputTransferMethod
+                        "refreshSession: Attaching refreshed session info as " + requestTransferMethod
                     );
-                    // This will get the preferred transfer method again, and intentionally not use the fallback
-                    // See above for the reasoning
+                    // We clear the tokens in all token transfer methods we are not going to overwrite
+                    for (const transferMethod of cookieAndHeaders_1.availableTokenTransferMethods) {
+                        if (transferMethod !== requestTransferMethod && refreshTokens[transferMethod] !== undefined) {
+                            cookieAndHeaders_1.clearSession(config, req, res, userContext, transferMethod);
+                        }
+                    }
                     utils_1.attachCreateOrRefreshSessionResponseToExpressRes(
                         config,
                         res,
                         response,
-                        outputTransferMethod
+                        requestTransferMethod
                     );
                     logger_1.logDebugMessage("refreshSession: Success!");
                     return new sessionClass_1.default(
@@ -396,7 +411,7 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                         response.session.userDataInJWT,
                         res,
                         req,
-                        outputTransferMethod
+                        requestTransferMethod
                     );
                 } catch (err) {
                     if (
@@ -406,7 +421,7 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                         logger_1.logDebugMessage(
                             "refreshSession: Clearing cookies because of UNAUTHORISED or TOKEN_THEFT_DETECTED response"
                         );
-                        cookieAndHeaders_1.clearSession(config, req, res, userContext);
+                        cookieAndHeaders_1.clearSession(config, req, res, userContext, requestTransferMethod);
                     }
                     throw err;
                 }

--- a/lib/build/recipe/session/recipeImplementation.js
+++ b/lib/build/recipe/session/recipeImplementation.js
@@ -40,6 +40,9 @@ const utils_2 = require("../../utils");
 const processState_1 = require("../../processState");
 const normalisedURLPath_1 = require("../../normalisedURLPath");
 const logger_1 = require("../../logger");
+const constants_1 = require("./constants");
+const jwt_1 = require("./jwt");
+const accessToken_1 = require("./accessToken");
 class HandshakeInfo {
     constructor(
         antiCsrf,
@@ -116,9 +119,12 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
         createNewSession: function ({ req, res, userId, accessTokenPayload = {}, sessionData = {}, userContext }) {
             return __awaiter(this, void 0, void 0, function* () {
                 logger_1.logDebugMessage("createNewSession: Started");
-                let outputTransferMethod = config.getTokenTransferMethod({ req, userContext });
-                logger_1.logDebugMessage("createNewSession: got transfer method " + outputTransferMethod);
-                if (outputTransferMethod === "missing_auth_header") {
+                let outputTransferMethod = config.getTokenTransferMethod({
+                    req,
+                    forCreateNewSession: true,
+                    userContext,
+                });
+                if (outputTransferMethod === "any") {
                     outputTransferMethod = "header";
                 }
                 logger_1.logDebugMessage("createNewSession: using transfer method " + outputTransferMethod);
@@ -130,9 +136,9 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                     accessTokenPayload,
                     sessionData
                 );
-                for (const transferMethod of cookieAndHeaders_1.availableTokenTransferMethods) {
+                for (const transferMethod of constants_1.availableTokenTransferMethods) {
                     if (transferMethod !== outputTransferMethod) {
-                        cookieAndHeaders_1.clearSession(config, req, res, userContext, transferMethod);
+                        cookieAndHeaders_1.clearSession(config, req, res, transferMethod);
                     }
                 }
                 utils_1.attachCreateOrRefreshSessionResponseToExpressRes(config, res, response, outputTransferMethod);
@@ -170,33 +176,45 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                 const sessionOptional =
                     (options === null || options === void 0 ? void 0 : options.sessionRequired) === false;
                 logger_1.logDebugMessage("getSession: optional validation: " + sessionOptional);
-                const preferredTransferMethod = config.getTokenTransferMethod({ req, userContext });
-                let transferMethod =
-                    preferredTransferMethod === "missing_auth_header" ? "header" : preferredTransferMethod;
-                let accessToken = cookieAndHeaders_1.getToken(req, "access", transferMethod);
-                if (accessToken === undefined) {
-                    const fallbackMethod = transferMethod === "cookie" ? "header" : "cookie";
-                    // We are checking if we could go ahead with validation if the transferMethod was different
-                    // However, we don't want to allow fallback here if there is an up-to-date frontend SDK that sends the auth-mode header.
-                    accessToken = cookieAndHeaders_1.getToken(req, "access", fallbackMethod);
-                    if (accessToken !== undefined) {
-                        if (preferredTransferMethod === "missing_auth_header") {
-                            transferMethod = fallbackMethod;
+                const accessTokens = {};
+                // We check all token transfer methods for available access tokens
+                for (const transferMethod of constants_1.availableTokenTransferMethods) {
+                    const tokenString = cookieAndHeaders_1.getToken(req, "access", transferMethod);
+                    if (tokenString !== undefined) {
+                        try {
+                            const info = jwt_1.parseJWT(tokenString);
+                            accessToken_1.validateAccessTokenPayload(info.payload);
+                            logger_1.logDebugMessage("getSession: got access token from " + transferMethod);
+                            accessTokens[transferMethod] = info;
+                        } catch (_a) {
                             logger_1.logDebugMessage(
-                                `getSession: falling back to use ${fallbackMethod} as an authentication-method`
+                                `getSession: ignoring token in ${transferMethod}, because it doesn't match our access token structure`
                             );
-                        } else {
-                            logger_1.logDebugMessage(
-                                `getSession: returning TRY_REFRESH_TOKEN because preferred auth-mode doesn't allow fallback and access token was sent with the wrong method`
-                            );
-                            throw new error_1.default({
-                                message: "access token sent with the wrong method. Please call the refresh API",
-                                type: error_1.default.TRY_REFRESH_TOKEN,
-                            });
                         }
                     }
                 }
-                if (accessToken === undefined) {
+                const allowedTransferMethod = config.getTokenTransferMethod({
+                    req,
+                    forCreateNewSession: false,
+                    userContext,
+                });
+                let requestTransferMethod;
+                let accessToken;
+                if (
+                    (allowedTransferMethod === "any" || allowedTransferMethod === "header") &&
+                    accessTokens["header"] !== undefined
+                ) {
+                    logger_1.logDebugMessage("getSession: using header transfer method");
+                    requestTransferMethod = "header";
+                    accessToken = accessTokens["header"];
+                } else if (
+                    (allowedTransferMethod === "any" || allowedTransferMethod === "cookie") &&
+                    accessTokens["cookie"] !== undefined
+                ) {
+                    logger_1.logDebugMessage("getSession: using header transfer method");
+                    requestTransferMethod = "cookie";
+                    accessToken = accessTokens["cookie"];
+                } else {
                     // we do not clear cookies here because of a
                     // race condition mentioned here: https://github.com/supertokens/supertokens-node/issues/17
                     if (sessionOptional) {
@@ -210,7 +228,7 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                     logger_1.logDebugMessage("getSession: UNAUTHORISED because accessToken in request is undefined");
                     throw new error_1.default({
                         message:
-                            "Session does not exist. Are you sending the session tokens in the request as cookies?",
+                            "Session does not exist. Are you sending the session tokens in the request as with the appropriate token transfer method?",
                         type: error_1.default.UNAUTHORISED,
                     });
                 }
@@ -220,7 +238,7 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                     if (doAntiCsrfCheck === undefined) {
                         doAntiCsrfCheck = utils_2.normaliseHttpMethod(req.getMethod()) !== "get";
                     }
-                    if (transferMethod === "header") {
+                    if (requestTransferMethod === "header") {
                         doAntiCsrfCheck = false;
                     }
                     logger_1.logDebugMessage("getSession: Value of doAntiCsrfCheck is: " + doAntiCsrfCheck);
@@ -231,6 +249,7 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                         doAntiCsrfCheck,
                         utils_2.getRidFromHeader(req) !== undefined
                     );
+                    let accessTokenString = accessToken.rawTokenString;
                     if (response.accessToken !== undefined) {
                         cookieAndHeaders_1.setFrontTokenInHeaders(
                             res,
@@ -248,26 +267,28 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                             // Even if the token is expired the presence of the token indicates that the user could have a valid refresh
                             // Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
                             Date.now() + 3153600000000,
-                            transferMethod
+                            requestTransferMethod
                         );
-                        accessToken = response.accessToken.token;
+                        accessTokenString = response.accessToken.token;
                     }
                     logger_1.logDebugMessage("getSession: Success!");
                     const session = new sessionClass_1.default(
                         helpers,
-                        accessToken,
+                        accessTokenString,
                         response.session.handle,
                         response.session.userId,
                         response.session.userDataInJWT,
                         res,
                         req,
-                        transferMethod
+                        requestTransferMethod
                     );
                     return session;
                 } catch (err) {
                     if (err.type === error_1.default.UNAUTHORISED) {
-                        logger_1.logDebugMessage("getSession: Clearing cookies because of UNAUTHORISED response");
-                        cookieAndHeaders_1.clearSession(config, req, res, userContext);
+                        logger_1.logDebugMessage(
+                            "getSession: Clearing cookies because of UNAUTHORISED response from getSession"
+                        );
+                        cookieAndHeaders_1.clearSession(config, req, res, requestTransferMethod);
                     }
                     throw err;
                 }
@@ -338,7 +359,7 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
             In all cases: if sIdRefreshToken token exists (so it's a legacy session) we clear it.
             Check http://localhost:3002/docs/contribute/decisions/session/0008 for further details and a table of expected behaviours
          */
-        refreshSession: function ({ req, res, userContext }) {
+        refreshSession: function ({ req, res }) {
             return __awaiter(this, void 0, void 0, function* () {
                 logger_1.logDebugMessage("refreshSession: Started");
                 // This token isn't handled by getToken/setToken to limit the scope of this legacy/migration code
@@ -355,7 +376,7 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                 const refreshTokens = {};
                 // We check all token transfer methods for available refresh tokens
                 // We do this so that we can later clear all we are not overwrite
-                for (const transferMethod of cookieAndHeaders_1.availableTokenTransferMethods) {
+                for (const transferMethod of constants_1.availableTokenTransferMethods) {
                     refreshTokens[transferMethod] = cookieAndHeaders_1.getToken(req, "refresh", transferMethod);
                     if (refreshTokens[transferMethod] !== undefined) {
                         logger_1.logDebugMessage("refreshSession: got refresh token from " + transferMethod);
@@ -391,9 +412,9 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                         "refreshSession: Attaching refreshed session info as " + requestTransferMethod
                     );
                     // We clear the tokens in all token transfer methods we are not going to overwrite
-                    for (const transferMethod of cookieAndHeaders_1.availableTokenTransferMethods) {
+                    for (const transferMethod of constants_1.availableTokenTransferMethods) {
                         if (transferMethod !== requestTransferMethod && refreshTokens[transferMethod] !== undefined) {
-                            cookieAndHeaders_1.clearSession(config, req, res, userContext, transferMethod);
+                            cookieAndHeaders_1.clearSession(config, req, res, transferMethod);
                         }
                     }
                     utils_1.attachCreateOrRefreshSessionResponseToExpressRes(
@@ -421,7 +442,7 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                         logger_1.logDebugMessage(
                             "refreshSession: Clearing cookies because of UNAUTHORISED or TOKEN_THEFT_DETECTED response"
                         );
-                        cookieAndHeaders_1.clearSession(config, req, res, userContext, requestTransferMethod);
+                        cookieAndHeaders_1.clearSession(config, req, res, requestTransferMethod);
                     }
                     throw err;
                 }

--- a/lib/build/recipe/session/recipeImplementation.js
+++ b/lib/build/recipe/session/recipeImplementation.js
@@ -113,7 +113,14 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
     let obj = {
         createNewSession: function ({ req, res, userId, accessTokenPayload = {}, sessionData = {}, userContext }) {
             return __awaiter(this, void 0, void 0, function* () {
-                const disableAntiCSRF = config.getTokenTransferMethod({ req, userContext }) === "header";
+                logger_1.logDebugMessage("createNewSession: Started");
+                let transferMethod = config.getTokenTransferMethod({ req, userContext });
+                logger_1.logDebugMessage("createNewSession: got transfer method " + transferMethod);
+                if (transferMethod === "MISSING_AUTH_HEADER") {
+                    transferMethod = "header";
+                }
+                logger_1.logDebugMessage("createNewSession: using transfer method " + transferMethod);
+                const disableAntiCSRF = transferMethod === "header";
                 let response = yield SessionFunctions.createNewSession(
                     helpers,
                     userId,
@@ -121,7 +128,7 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                     accessTokenPayload,
                     sessionData
                 );
-                utils_1.attachCreateOrRefreshSessionResponseToExpressRes(config, req, res, response, userContext);
+                utils_1.attachCreateOrRefreshSessionResponseToExpressRes(config, res, response, transferMethod);
                 return new sessionClass_1.default(
                     helpers,
                     response.accessToken.token,
@@ -129,7 +136,8 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                     response.session.userId,
                     response.session.userDataInJWT,
                     res,
-                    req
+                    req,
+                    transferMethod
                 );
             });
         },
@@ -141,36 +149,54 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
         getSession: function ({ req, res, options, userContext }) {
             return __awaiter(this, void 0, void 0, function* () {
                 logger_1.logDebugMessage("getSession: Started");
-                logger_1.logDebugMessage("getSession: rid in header: " + utils_2.frontendHasInterceptor(req));
-                logger_1.logDebugMessage("getSession: request method: " + req.getMethod());
+                const sessionOptional =
+                    options !== undefined && typeof options !== "boolean" && options.sessionRequired === false;
+                const gotRID = utils_2.frontendHasInterceptor(req);
+                const method = req.getMethod();
+                logger_1.logDebugMessage("getSession: optional validation: " + sessionOptional);
+                logger_1.logDebugMessage("getSession: rid in header: " + gotRID);
+                logger_1.logDebugMessage("getSession: request method: " + method);
                 let doAntiCsrfCheck = options !== undefined ? options.antiCsrfCheck : undefined;
-                const transferMethod = config.getTokenTransferMethod({ req, userContext });
-                let accessToken = cookieAndHeaders_1.getToken(config, req, "access", userContext, transferMethod);
+                const preferredTransferMethod = config.getTokenTransferMethod({ req, userContext });
+                let transferMethod =
+                    preferredTransferMethod === "MISSING_AUTH_HEADER" ? "header" : preferredTransferMethod;
+                let accessToken = cookieAndHeaders_1.getToken(req, "access", transferMethod);
                 if (accessToken === undefined) {
+                    const fallbackMethod = transferMethod === "cookie" ? "header" : "cookie";
                     // We are checking if we could've gone ahead with validation if the transferMethod was different
                     // However, we don't want to do the fallback here, but force a call to refresh
                     // This is done to ensure that the browsers update the transfermethod in a timely manner (basically on the next API call)
                     // instead of waiting for the session to expire
-                    accessToken = cookieAndHeaders_1.getToken(
-                        config,
-                        req,
-                        "access",
-                        userContext,
-                        transferMethod === "cookie" ? "header" : "cookie"
-                    );
+                    accessToken = cookieAndHeaders_1.getToken(req, "access", fallbackMethod);
                     if (accessToken !== undefined) {
-                        logger_1.logDebugMessage(
-                            "getSession: Returning try refresh token because the access token was not sent as a " +
-                                transferMethod
-                        );
+                        if (preferredTransferMethod === "MISSING_AUTH_HEADER") {
+                            transferMethod = fallbackMethod;
+                            logger_1.logDebugMessage(
+                                `getSession: falling back to use ${fallbackMethod} as an authentication-method`
+                            );
+                        } else {
+                            logger_1.logDebugMessage(
+                                `getSession: returning TRY_REFRESH_TOKEN because preferred auth-mode doesn't allow fallback and access token was sent with the wrong method`
+                            );
+                            throw new error_1.default({
+                                message: "access token sent with the wrong method. Please call the refresh API",
+                                type: error_1.default.TRY_REFRESH_TOKEN,
+                            });
+                        }
+                    }
+                }
+                if (accessToken === undefined) {
+                    // This is done here to ensure smooth migration of sessions started before removing the id-refresh-token
+                    // This token isn't handled by getToken to limit the scope of this legacy/migration code
+                    if (req.getCookieValue("sIRTFrontend") !== undefined) {
                         throw new error_1.default({
-                            message: "access token sent with the wrong method. Please call the refresh API",
+                            message: "access token expired, please call the refresh API",
                             type: error_1.default.TRY_REFRESH_TOKEN,
                         });
                     }
                     // we do not clear cookies here because of a
                     // race condition mentioned here: https://github.com/supertokens/supertokens-node/issues/17
-                    if (options !== undefined && typeof options !== "boolean" && options.sessionRequired === false) {
+                    if (sessionOptional) {
                         logger_1.logDebugMessage(
                             "getSession: returning undefined because accessToken is undefined and sessionRequired is false"
                         );
@@ -178,36 +204,12 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                         // to be optional. So we return undefined.
                         return undefined;
                     }
-                    logger_1.logDebugMessage("getSession: UNAUTHORISED because accessToken from cookies is undefined");
+                    logger_1.logDebugMessage("getSession: UNAUTHORISED because accessToken in request is undefined");
                     throw new error_1.default({
                         message:
                             "Session does not exist. Are you sending the session tokens in the request as cookies?",
                         type: error_1.default.UNAUTHORISED,
                     });
-                }
-                if (accessToken === undefined) {
-                    // maybe the access token has expired.
-                    /**
-                     * Based on issue: #156 (spertokens-node)
-                     * we throw TRY_REFRESH_TOKEN only if
-                     * options.sessionRequired === true || (frontendHasInterceptor or request method is get),
-                     * else we should return undefined
-                     */
-                    if (
-                        options === undefined ||
-                        (options !== undefined && options.sessionRequired === true) ||
-                        utils_2.frontendHasInterceptor(req) ||
-                        utils_2.normaliseHttpMethod(req.getMethod()) === "get"
-                    ) {
-                        logger_1.logDebugMessage(
-                            "getSession: Returning try refresh token because access token from cookies is undefined"
-                        );
-                        throw new error_1.default({
-                            message: "Access token has expired. Please call the refresh API",
-                            type: error_1.default.TRY_REFRESH_TOKEN,
-                        });
-                    }
-                    return undefined;
                 }
                 try {
                     let antiCsrfToken = cookieAndHeaders_1.getAntiCsrfTokenFromHeaders(req);
@@ -232,7 +234,6 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                         );
                         cookieAndHeaders_1.setToken(
                             config,
-                            req,
                             res,
                             "access",
                             response.accessToken.token,
@@ -241,7 +242,7 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                             // Even if the token is expired the presence of the token indicates that the user could have a valid refresh
                             // Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
                             Date.now() + 315360000000,
-                            userContext
+                            transferMethod
                         );
                         accessToken = response.accessToken.token;
                     }
@@ -253,10 +254,19 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                         response.session.userId,
                         response.session.userDataInJWT,
                         res,
-                        req
+                        req,
+                        transferMethod
                     );
                     return session;
                 } catch (err) {
+                    if (
+                        err.type === error_1.default.TRY_REFRESH_TOKEN &&
+                        sessionOptional &&
+                        !gotRID &&
+                        method !== "get"
+                    ) {
+                        return undefined;
+                    }
                     if (err.type === error_1.default.UNAUTHORISED) {
                         logger_1.logDebugMessage("getSession: Clearing cookies because of UNAUTHORISED response");
                         cookieAndHeaders_1.clearSession(config, req, res, userContext);
@@ -331,36 +341,32 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                 logger_1.logDebugMessage("refreshSession: Started");
                 // We use a fallback mechanism here, to ensure there is a smooth upgrade path when switching transfer methods
                 // We only use it here and not while getting/validating sessions, because we want to "force" clients to upgrade
-                const outputTransferMethod = config.getTokenTransferMethod({ req, userContext });
+                let outputTransferMethod = config.getTokenTransferMethod({ req, userContext });
+                logger_1.logDebugMessage("refreshSession: Preferred transfer method: " + outputTransferMethod);
                 let inputTransferMethod = outputTransferMethod;
-                let inputRefreshToken = cookieAndHeaders_1.getToken(
-                    config,
-                    req,
-                    "refresh",
-                    userContext,
-                    inputTransferMethod
-                );
+                if (inputTransferMethod === "MISSING_AUTH_HEADER") {
+                    inputTransferMethod = "header";
+                }
+                let inputRefreshToken = cookieAndHeaders_1.getToken(req, "refresh", inputTransferMethod);
                 if (inputRefreshToken === undefined) {
                     inputTransferMethod = inputTransferMethod === "cookie" ? "header" : "cookie";
-                    inputRefreshToken = cookieAndHeaders_1.getToken(
-                        config,
-                        req,
-                        "refresh",
-                        userContext,
-                        inputTransferMethod
-                    );
+                    inputRefreshToken = cookieAndHeaders_1.getToken(req, "refresh", inputTransferMethod);
                 }
+                if (outputTransferMethod === "MISSING_AUTH_HEADER") {
+                    outputTransferMethod = inputTransferMethod;
+                }
+                if (inputRefreshToken === undefined) {
+                    logger_1.logDebugMessage(
+                        "refreshSession: UNAUTHORISED because refresh token in request is undefined"
+                    );
+                    throw new error_1.default({
+                        message:
+                            "Refresh token not found. Are you sending the refresh token in the request as a cookie?",
+                        type: error_1.default.UNAUTHORISED,
+                    });
+                }
+                logger_1.logDebugMessage("refreshSession: Request used transfer method: " + inputRefreshToken);
                 try {
-                    if (inputRefreshToken === undefined) {
-                        logger_1.logDebugMessage(
-                            "refreshSession: UNAUTHORISED because refresh token from cookies is undefined"
-                        );
-                        throw new error_1.default({
-                            message:
-                                "Refresh token not found. Are you sending the refresh token in the request as a cookie?",
-                            type: error_1.default.UNAUTHORISED,
-                        });
-                    }
                     let antiCsrfToken = cookieAndHeaders_1.getAntiCsrfTokenFromHeaders(req);
                     let response = yield SessionFunctions.refreshSession(
                         helpers,
@@ -370,9 +376,17 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                         inputTransferMethod,
                         outputTransferMethod
                     );
+                    logger_1.logDebugMessage(
+                        "refreshSession: Attaching refreshed session info as " + outputTransferMethod
+                    );
                     // This will get the preferred transfer method again, and intentionally not use the fallback
                     // See above for the reasoning
-                    utils_1.attachCreateOrRefreshSessionResponseToExpressRes(config, req, res, response, userContext);
+                    utils_1.attachCreateOrRefreshSessionResponseToExpressRes(
+                        config,
+                        res,
+                        response,
+                        outputTransferMethod
+                    );
                     logger_1.logDebugMessage("refreshSession: Success!");
                     return new sessionClass_1.default(
                         helpers,
@@ -381,7 +395,8 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                         response.session.userId,
                         response.session.userDataInJWT,
                         res,
-                        req
+                        req,
+                        outputTransferMethod
                     );
                 } catch (err) {
                     if (

--- a/lib/build/recipe/session/recipeImplementation.js
+++ b/lib/build/recipe/session/recipeImplementation.js
@@ -137,8 +137,11 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                     sessionData
                 );
                 for (const transferMethod of constants_1.availableTokenTransferMethods) {
-                    if (transferMethod !== outputTransferMethod) {
-                        cookieAndHeaders_1.clearSession(config, req, res, transferMethod);
+                    if (
+                        transferMethod !== outputTransferMethod &&
+                        cookieAndHeaders_1.getToken(req, "access", transferMethod) !== undefined
+                    ) {
+                        cookieAndHeaders_1.clearSession(config, res, transferMethod);
                     }
                 }
                 utils_1.attachCreateOrRefreshSessionResponseToExpressRes(config, res, response, outputTransferMethod);
@@ -182,8 +185,8 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                     const tokenString = cookieAndHeaders_1.getToken(req, "access", transferMethod);
                     if (tokenString !== undefined) {
                         try {
-                            const info = jwt_1.parseJWT(tokenString);
-                            accessToken_1.validateAccessTokenPayload(info.payload);
+                            const info = jwt_1.parseJWTWithoutSignatureVerification(tokenString);
+                            accessToken_1.validateAccessTokenStructure(info.payload);
                             logger_1.logDebugMessage("getSession: got access token from " + transferMethod);
                             accessTokens[transferMethod] = info;
                         } catch (_a) {
@@ -286,9 +289,9 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                 } catch (err) {
                     if (err.type === error_1.default.UNAUTHORISED) {
                         logger_1.logDebugMessage(
-                            "getSession: Clearing cookies because of UNAUTHORISED response from getSession"
+                            `getSession: Clearing ${requestTransferMethod} because of UNAUTHORISED response from getSession`
                         );
-                        cookieAndHeaders_1.clearSession(config, req, res, requestTransferMethod);
+                        cookieAndHeaders_1.clearSession(config, res, requestTransferMethod);
                     }
                     throw err;
                 }
@@ -359,7 +362,7 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
             In all cases: if sIdRefreshToken token exists (so it's a legacy session) we clear it.
             Check http://localhost:3002/docs/contribute/decisions/session/0008 for further details and a table of expected behaviours
          */
-        refreshSession: function ({ req, res }) {
+        refreshSession: function ({ req, res, userContext }) {
             return __awaiter(this, void 0, void 0, function* () {
                 logger_1.logDebugMessage("refreshSession: Started");
                 // This token isn't handled by getToken/setToken to limit the scope of this legacy/migration code
@@ -375,20 +378,34 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                 }
                 const refreshTokens = {};
                 // We check all token transfer methods for available refresh tokens
-                // We do this so that we can later clear all we are not overwrite
+                // We do this so that we can later clear all we are not overwriting
                 for (const transferMethod of constants_1.availableTokenTransferMethods) {
                     refreshTokens[transferMethod] = cookieAndHeaders_1.getToken(req, "refresh", transferMethod);
                     if (refreshTokens[transferMethod] !== undefined) {
                         logger_1.logDebugMessage("refreshSession: got refresh token from " + transferMethod);
                     }
                 }
+                const allowedTransferMethod = config.getTokenTransferMethod({
+                    req,
+                    forCreateNewSession: false,
+                    userContext,
+                });
                 let requestTransferMethod;
-                if (refreshTokens["header"] !== undefined) {
+                let refreshToken;
+                if (
+                    (allowedTransferMethod === "any" || allowedTransferMethod === "header") &&
+                    refreshTokens["header"] !== undefined
+                ) {
                     logger_1.logDebugMessage("refreshSession: using header transfer method");
                     requestTransferMethod = "header";
-                } else if (refreshTokens["cookie"]) {
+                    refreshToken = refreshTokens["header"];
+                } else if (
+                    (allowedTransferMethod === "any" || allowedTransferMethod === "cookie") &&
+                    refreshTokens["cookie"]
+                ) {
                     logger_1.logDebugMessage("refreshSession: using header transfer method");
                     requestTransferMethod = "cookie";
+                    refreshToken = refreshTokens["cookie"];
                 } else {
                     logger_1.logDebugMessage(
                         "refreshSession: UNAUTHORISED because refresh token in request is undefined"
@@ -403,7 +420,7 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                     let antiCsrfToken = cookieAndHeaders_1.getAntiCsrfTokenFromHeaders(req);
                     let response = yield SessionFunctions.refreshSession(
                         helpers,
-                        requestTransferMethod,
+                        refreshToken,
                         antiCsrfToken,
                         utils_2.getRidFromHeader(req) !== undefined,
                         requestTransferMethod
@@ -414,7 +431,7 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                     // We clear the tokens in all token transfer methods we are not going to overwrite
                     for (const transferMethod of constants_1.availableTokenTransferMethods) {
                         if (transferMethod !== requestTransferMethod && refreshTokens[transferMethod] !== undefined) {
-                            cookieAndHeaders_1.clearSession(config, req, res, transferMethod);
+                            cookieAndHeaders_1.clearSession(config, res, transferMethod);
                         }
                     }
                     utils_1.attachCreateOrRefreshSessionResponseToExpressRes(
@@ -442,7 +459,7 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                         logger_1.logDebugMessage(
                             "refreshSession: Clearing cookies because of UNAUTHORISED or TOKEN_THEFT_DETECTED response"
                         );
-                        cookieAndHeaders_1.clearSession(config, req, res, requestTransferMethod);
+                        cookieAndHeaders_1.clearSession(config, res, requestTransferMethod);
                     }
                     throw err;
                 }

--- a/lib/build/recipe/session/sessionClass.d.ts
+++ b/lib/build/recipe/session/sessionClass.d.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { BaseRequest, BaseResponse } from "../../framework";
-import { SessionClaim, SessionClaimValidator, SessionContainerInterface } from "./types";
+import { SessionClaim, SessionClaimValidator, SessionContainerInterface, TokenTransferMethod } from "./types";
 import { Helpers } from "./recipeImplementation";
 export default class Session implements SessionContainerInterface {
     protected helpers: Helpers;
@@ -10,7 +10,7 @@ export default class Session implements SessionContainerInterface {
     protected userDataInAccessToken: any;
     protected res: BaseResponse;
     protected readonly req: BaseRequest;
-    protected readonly transferMethod: "cookie" | "header";
+    protected readonly transferMethod: TokenTransferMethod;
     constructor(
         helpers: Helpers,
         accessToken: string,
@@ -19,7 +19,7 @@ export default class Session implements SessionContainerInterface {
         userDataInAccessToken: any,
         res: BaseResponse,
         req: BaseRequest,
-        transferMethod: "cookie" | "header"
+        transferMethod: TokenTransferMethod
     );
     revokeSession: (userContext?: any) => Promise<void>;
     getSessionData: (userContext?: any) => Promise<any>;

--- a/lib/build/recipe/session/sessionClass.d.ts
+++ b/lib/build/recipe/session/sessionClass.d.ts
@@ -3,13 +3,14 @@ import { BaseRequest, BaseResponse } from "../../framework";
 import { SessionClaim, SessionClaimValidator, SessionContainerInterface } from "./types";
 import { Helpers } from "./recipeImplementation";
 export default class Session implements SessionContainerInterface {
+    protected helpers: Helpers;
+    protected accessToken: string;
     protected sessionHandle: string;
     protected userId: string;
     protected userDataInAccessToken: any;
-    protected readonly req: BaseRequest;
     protected res: BaseResponse;
-    protected accessToken: string;
-    protected helpers: Helpers;
+    protected readonly req: BaseRequest;
+    protected readonly transferMethod: "cookie" | "header";
     constructor(
         helpers: Helpers,
         accessToken: string,
@@ -17,7 +18,8 @@ export default class Session implements SessionContainerInterface {
         userId: string,
         userDataInAccessToken: any,
         res: BaseResponse,
-        req: BaseRequest
+        req: BaseRequest,
+        transferMethod: "cookie" | "header"
     );
     revokeSession: (userContext?: any) => Promise<void>;
     getSessionData: (userContext?: any) => Promise<any>;

--- a/lib/build/recipe/session/sessionClass.js
+++ b/lib/build/recipe/session/sessionClass.js
@@ -55,7 +55,7 @@ class Session {
                 // If we instead clear the cookies only when revokeSession
                 // returns true, it can cause this kind of a bug:
                 // https://github.com/supertokens/supertokens-node/issues/343
-                cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, userContext);
+                cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
             });
         this.getSessionData = (userContext) =>
             __awaiter(this, void 0, void 0, function* () {
@@ -64,7 +64,7 @@ class Session {
                     userContext: userContext === undefined ? {} : userContext,
                 });
                 if (sessionInfo === undefined) {
-                    cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, userContext);
+                    cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
                     throw new error_1.default({
                         message: "Session does not exist anymore",
                         type: error_1.default.UNAUTHORISED,
@@ -81,7 +81,7 @@ class Session {
                         userContext: userContext === undefined ? {} : userContext,
                     }))
                 ) {
-                    cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, userContext);
+                    cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
                     throw new error_1.default({
                         message: "Session does not exist anymore",
                         type: error_1.default.UNAUTHORISED,
@@ -120,7 +120,7 @@ class Session {
                     userContext: userContext === undefined ? {} : userContext,
                 });
                 if (sessionInfo === undefined) {
-                    cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, userContext);
+                    cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
                     throw new error_1.default({
                         message: "Session does not exist anymore",
                         type: error_1.default.UNAUTHORISED,
@@ -135,7 +135,7 @@ class Session {
                     userContext: userContext === undefined ? {} : userContext,
                 });
                 if (sessionInfo === undefined) {
-                    cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, userContext);
+                    cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
                     throw new error_1.default({
                         message: "Session does not exist anymore",
                         type: error_1.default.UNAUTHORISED,
@@ -190,7 +190,7 @@ class Session {
                     userContext: userContext === undefined ? {} : userContext,
                 });
                 if (response === undefined) {
-                    cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, userContext);
+                    cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
                     throw new error_1.default({
                         message: "Session does not exist anymore",
                         type: error_1.default.UNAUTHORISED,

--- a/lib/build/recipe/session/sessionClass.js
+++ b/lib/build/recipe/session/sessionClass.js
@@ -55,7 +55,7 @@ class Session {
                 // If we instead clear the cookies only when revokeSession
                 // returns true, it can cause this kind of a bug:
                 // https://github.com/supertokens/supertokens-node/issues/343
-                cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
+                cookieAndHeaders_1.clearSession(this.helpers.config, this.res, this.transferMethod);
             });
         this.getSessionData = (userContext) =>
             __awaiter(this, void 0, void 0, function* () {
@@ -64,7 +64,7 @@ class Session {
                     userContext: userContext === undefined ? {} : userContext,
                 });
                 if (sessionInfo === undefined) {
-                    cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
+                    cookieAndHeaders_1.clearSession(this.helpers.config, this.res, this.transferMethod);
                     throw new error_1.default({
                         message: "Session does not exist anymore",
                         type: error_1.default.UNAUTHORISED,
@@ -81,7 +81,7 @@ class Session {
                         userContext: userContext === undefined ? {} : userContext,
                     }))
                 ) {
-                    cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
+                    cookieAndHeaders_1.clearSession(this.helpers.config, this.res, this.transferMethod);
                     throw new error_1.default({
                         message: "Session does not exist anymore",
                         type: error_1.default.UNAUTHORISED,
@@ -120,7 +120,7 @@ class Session {
                     userContext: userContext === undefined ? {} : userContext,
                 });
                 if (sessionInfo === undefined) {
-                    cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
+                    cookieAndHeaders_1.clearSession(this.helpers.config, this.res, this.transferMethod);
                     throw new error_1.default({
                         message: "Session does not exist anymore",
                         type: error_1.default.UNAUTHORISED,
@@ -135,7 +135,7 @@ class Session {
                     userContext: userContext === undefined ? {} : userContext,
                 });
                 if (sessionInfo === undefined) {
-                    cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
+                    cookieAndHeaders_1.clearSession(this.helpers.config, this.res, this.transferMethod);
                     throw new error_1.default({
                         message: "Session does not exist anymore",
                         type: error_1.default.UNAUTHORISED,
@@ -190,7 +190,7 @@ class Session {
                     userContext: userContext === undefined ? {} : userContext,
                 });
                 if (response === undefined) {
-                    cookieAndHeaders_1.clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
+                    cookieAndHeaders_1.clearSession(this.helpers.config, this.res, this.transferMethod);
                     throw new error_1.default({
                         message: "Session does not exist anymore",
                         type: error_1.default.UNAUTHORISED,

--- a/lib/build/recipe/session/sessionClass.js
+++ b/lib/build/recipe/session/sessionClass.js
@@ -34,7 +34,15 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const cookieAndHeaders_1 = require("./cookieAndHeaders");
 const error_1 = require("./error");
 class Session {
-    constructor(helpers, accessToken, sessionHandle, userId, userDataInAccessToken, res, req) {
+    constructor(helpers, accessToken, sessionHandle, userId, userDataInAccessToken, res, req, transferMethod) {
+        this.helpers = helpers;
+        this.accessToken = accessToken;
+        this.sessionHandle = sessionHandle;
+        this.userId = userId;
+        this.userDataInAccessToken = userDataInAccessToken;
+        this.res = res;
+        this.req = req;
+        this.transferMethod = transferMethod;
         this.revokeSession = (userContext) =>
             __awaiter(this, void 0, void 0, function* () {
                 yield this.helpers.getRecipeImpl().revokeSession({
@@ -199,7 +207,6 @@ class Session {
                     );
                     cookieAndHeaders_1.setToken(
                         this.helpers.config,
-                        this.req,
                         this.res,
                         "access",
                         response.accessToken.token,
@@ -208,17 +215,10 @@ class Session {
                         // Even if the token is expired the presence of the token indicates that the user could have a valid refresh
                         // Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
                         Date.now() + 315360000000,
-                        userContext
+                        this.transferMethod
                     );
                 }
             });
-        this.sessionHandle = sessionHandle;
-        this.userId = userId;
-        this.userDataInAccessToken = userDataInAccessToken;
-        this.req = req;
-        this.res = res;
-        this.accessToken = accessToken;
-        this.helpers = helpers;
     }
 }
 exports.default = Session;

--- a/lib/build/recipe/session/sessionFunctions.d.ts
+++ b/lib/build/recipe/session/sessionFunctions.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { CreateOrRefreshAPIResponse, SessionInformation } from "./types";
+import { CreateOrRefreshAPIResponse, SessionInformation, TokenTransferMethod } from "./types";
 import { Helpers } from "./recipeImplementation";
 /**
  * @description call this to "login" a user.
@@ -49,8 +49,7 @@ export declare function refreshSession(
     refreshToken: string,
     antiCsrfToken: string | undefined,
     containsCustomHeader: boolean,
-    inputTransferMethod: "header" | "cookie",
-    outputTransferMethod: "header" | "cookie"
+    transferMethod: TokenTransferMethod
 ): Promise<CreateOrRefreshAPIResponse>;
 /**
  * @description deletes session info of a user from db. This only invalidates the refresh token. Not the access token.

--- a/lib/build/recipe/session/sessionFunctions.d.ts
+++ b/lib/build/recipe/session/sessionFunctions.d.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+import { ParsedJWTInfo } from "./jwt";
 import { CreateOrRefreshAPIResponse, SessionInformation, TokenTransferMethod } from "./types";
 import { Helpers } from "./recipeImplementation";
 /**
@@ -16,7 +17,7 @@ export declare function createNewSession(
  */
 export declare function getSession(
     helpers: Helpers,
-    accessToken: string,
+    parsedAccessToken: ParsedJWTInfo,
     antiCsrfToken: string | undefined,
     doAntiCsrfCheck: boolean,
     containsCustomHeader: boolean

--- a/lib/build/recipe/session/sessionFunctions.js
+++ b/lib/build/recipe/session/sessionFunctions.js
@@ -278,7 +278,7 @@ function getSession(helpers, accessToken, antiCsrfToken, doAntiCsrfCheck, contai
                 // we force update the signing keys...
                 yield helpers.getHandshakeInfo(true);
             }
-            logger_1.logDebugMessage("getSession: Returning TRY_REFRESH_TOKEN because of core response");
+            logger_1.logDebugMessage("getSession: Returning TRY_REFRESH_TOKEN because of core response.");
             throw new error_1.default({
                 message: response.message,
                 type: error_1.default.TRY_REFRESH_TOKEN,

--- a/lib/build/recipe/session/sessionFunctions.js
+++ b/lib/build/recipe/session/sessionFunctions.js
@@ -46,7 +46,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * under the License.
  */
 const accessToken_1 = require("./accessToken");
-const jwt_1 = require("./jwt");
 const error_1 = require("./error");
 const processState_1 = require("../../processState");
 const normalisedURLPath_1 = require("../../normalisedURLPath");
@@ -103,7 +102,7 @@ exports.createNewSession = createNewSession;
 /**
  * @description authenticates a session. To be used in APIs that require authentication
  */
-function getSession(helpers, accessToken, antiCsrfToken, doAntiCsrfCheck, containsCustomHeader) {
+function getSession(helpers, parsedAccessToken, antiCsrfToken, doAntiCsrfCheck, containsCustomHeader) {
     return __awaiter(this, void 0, void 0, function* () {
         let handShakeInfo = yield helpers.getHandshakeInfo();
         let accessTokenInfo;
@@ -115,7 +114,7 @@ function getSession(helpers, accessToken, antiCsrfToken, doAntiCsrfCheck, contai
                  * get access token info using existing signingKey
                  */
                 accessTokenInfo = yield accessToken_1.getInfoFromAccessToken(
-                    accessToken,
+                    parsedAccessToken,
                     key.publicKey,
                     handShakeInfo.antiCsrf === "VIA_TOKEN" && doAntiCsrfCheck
                 );
@@ -146,15 +145,7 @@ function getSession(helpers, accessToken, antiCsrfToken, doAntiCsrfCheck, contai
                  * so if foundASigningKeyThatIsOlderThanTheAccessToken is still false after
                  * the loop we just return TRY_REFRESH_TOKEN
                  */
-                let payload;
-                try {
-                    payload = jwt_1.getPayloadWithoutVerifiying(accessToken);
-                } catch (_) {
-                    throw err;
-                }
-                if (payload === undefined) {
-                    throw err;
-                }
+                let payload = parsedAccessToken.payload;
                 const timeCreated = accessToken_1.sanitizeNumberInput(payload.timeCreated);
                 const expiryTime = accessToken_1.sanitizeNumberInput(payload.expiryTime);
                 if (expiryTime === undefined || expiryTime < Date.now()) {
@@ -237,7 +228,7 @@ function getSession(helpers, accessToken, antiCsrfToken, doAntiCsrfCheck, contai
         }
         processState_1.ProcessState.getInstance().addState(processState_1.PROCESS_STATE.CALLING_SERVICE_IN_VERIFY);
         let requestBody = {
-            accessToken,
+            accessToken: parsedAccessToken.rawTokenString,
             antiCsrfToken,
             doAntiCsrfCheck,
             enableAntiCsrf: handShakeInfo.antiCsrf === "VIA_TOKEN",

--- a/lib/build/recipe/session/sessionFunctions.js
+++ b/lib/build/recipe/session/sessionFunctions.js
@@ -317,22 +317,15 @@ exports.getSessionInformation = getSessionInformation;
  * @description generates new access and refresh tokens for a given refresh token. Called when client's access token has expired.
  * @sideEffects calls onTokenTheftDetection if token theft is detected.
  */
-function refreshSession(
-    helpers,
-    refreshToken,
-    antiCsrfToken,
-    containsCustomHeader,
-    inputTransferMethod,
-    outputTransferMethod
-) {
+function refreshSession(helpers, refreshToken, antiCsrfToken, containsCustomHeader, transferMethod) {
     return __awaiter(this, void 0, void 0, function* () {
         let handShakeInfo = yield helpers.getHandshakeInfo();
         let requestBody = {
             refreshToken,
             antiCsrfToken,
-            enableAntiCsrf: outputTransferMethod === "cookie" && handShakeInfo.antiCsrf === "VIA_TOKEN",
+            enableAntiCsrf: transferMethod === "cookie" && handShakeInfo.antiCsrf === "VIA_TOKEN",
         };
-        if (handShakeInfo.antiCsrf === "VIA_CUSTOM_HEADER" && inputTransferMethod === "cookie") {
+        if (handShakeInfo.antiCsrf === "VIA_CUSTOM_HEADER" && transferMethod === "cookie") {
             if (!containsCustomHeader) {
                 logger_1.logDebugMessage(
                     "refreshSession: Returning UNAUTHORISED because custom header (rid) was not passed"

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -51,13 +51,14 @@ export interface ErrorHandlers {
     onInvalidClaim?: InvalidClaimErrorHandlerMiddleware;
 }
 export declare type TokenType = "access" | "refresh";
+export declare type TokenTransferMethod = "header" | "cookie";
 export declare type TypeInput = {
     sessionExpiredStatusCode?: number;
     invalidClaimStatusCode?: number;
     cookieSecure?: boolean;
     cookieSameSite?: "strict" | "lax" | "none";
     cookieDomain?: string;
-    getTokenTransferMethod?: (input: { req: BaseRequest; userContext: any }) => "cookie" | "header";
+    getTokenTransferMethod?: (input: { req: BaseRequest; userContext: any }) => TokenTransferMethod;
     errorHandlers?: ErrorHandlers;
     antiCsrf?: "VIA_TOKEN" | "VIA_CUSTOM_HEADER" | "NONE";
     jwt?:
@@ -108,7 +109,7 @@ export declare type TypeNormalisedInput = {
     getTokenTransferMethod: (input: {
         req: BaseRequest;
         userContext: any;
-    }) => "cookie" | "header" | "MISSING_AUTH_HEADER";
+    }) => TokenTransferMethod | "missing_auth_header";
     invalidClaimStatusCode: number;
     jwt: {
         enable: boolean;

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -43,11 +43,6 @@ export declare type CreateOrRefreshAPIResponse = {
         expiry: number;
         createdTime: number;
     };
-    idRefreshToken: {
-        token: string;
-        expiry: number;
-        createdTime: number;
-    };
     antiCsrfToken: string | undefined;
 };
 export interface ErrorHandlers {
@@ -110,7 +105,10 @@ export declare type TypeNormalisedInput = {
     sessionExpiredStatusCode: number;
     errorHandlers: NormalisedErrorHandlers;
     antiCsrf: "VIA_TOKEN" | "VIA_CUSTOM_HEADER" | "NONE";
-    getTokenTransferMethod: (input: { req: BaseRequest; userContext: any }) => "cookie" | "header";
+    getTokenTransferMethod: (input: {
+        req: BaseRequest;
+        userContext: any;
+    }) => "cookie" | "header" | "MISSING_AUTH_HEADER";
     invalidClaimStatusCode: number;
     jwt: {
         enable: boolean;

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -58,7 +58,11 @@ export declare type TypeInput = {
     cookieSecure?: boolean;
     cookieSameSite?: "strict" | "lax" | "none";
     cookieDomain?: string;
-    getTokenTransferMethod?: (input: { req: BaseRequest; userContext: any }) => TokenTransferMethod;
+    getTokenTransferMethod?: (input: {
+        req: BaseRequest;
+        forCreateNewSession: boolean;
+        userContext: any;
+    }) => TokenTransferMethod | "any";
     errorHandlers?: ErrorHandlers;
     antiCsrf?: "VIA_TOKEN" | "VIA_CUSTOM_HEADER" | "NONE";
     jwt?:
@@ -108,8 +112,9 @@ export declare type TypeNormalisedInput = {
     antiCsrf: "VIA_TOKEN" | "VIA_CUSTOM_HEADER" | "NONE";
     getTokenTransferMethod: (input: {
         req: BaseRequest;
+        forCreateNewSession: boolean;
         userContext: any;
-    }) => TokenTransferMethod | "missing_auth_header";
+    }) => TokenTransferMethod | "any";
     invalidClaimStatusCode: number;
     jwt: {
         enable: boolean;

--- a/lib/build/recipe/session/utils.d.ts
+++ b/lib/build/recipe/session/utils.d.ts
@@ -7,6 +7,7 @@ import {
     SessionClaimValidator,
     SessionContainerInterface,
     VerifySessionOptions,
+    TokenTransferMethod,
 } from "./types";
 import SessionRecipe from "./recipe";
 import { NormalisedAppinfo } from "../../types";
@@ -48,7 +49,7 @@ export declare function attachCreateOrRefreshSessionResponseToExpressRes(
     config: TypeNormalisedInput,
     res: BaseResponse,
     response: CreateOrRefreshAPIResponse,
-    transferMethod: "cookie" | "header"
+    transferMethod: TokenTransferMethod
 ): void;
 export declare function getRequiredClaimValidators(
     session: SessionContainerInterface,

--- a/lib/build/recipe/session/utils.d.ts
+++ b/lib/build/recipe/session/utils.d.ts
@@ -46,10 +46,9 @@ export declare function validateAndNormaliseUserInput(
 export declare function normaliseSameSiteOrThrowError(sameSite: string): "strict" | "lax" | "none";
 export declare function attachCreateOrRefreshSessionResponseToExpressRes(
     config: TypeNormalisedInput,
-    req: BaseRequest,
     res: BaseResponse,
     response: CreateOrRefreshAPIResponse,
-    userContext: any
+    transferMethod: "cookie" | "header"
 ): void;
 export declare function getRequiredClaimValidators(
     session: SessionContainerInterface,

--- a/lib/build/recipe/session/utils.js
+++ b/lib/build/recipe/session/utils.js
@@ -312,12 +312,12 @@ function validateClaimsInPayload(claimValidators, newAccessTokenPayload, userCon
 }
 exports.validateClaimsInPayload = validateClaimsInPayload;
 function defaultGetTokenTransferMethod({ req }) {
-    switch (utils_1.getAuthModeFromHeader(req)) {
+    switch (cookieAndHeaders_1.getAuthModeFromHeader(req)) {
         case "header":
             return "header";
         case "cookie":
             return "cookie";
         default:
-            return "MISSING_AUTH_HEADER";
+            return "missing_auth_header";
     }
 }

--- a/lib/build/recipe/session/utils.js
+++ b/lib/build/recipe/session/utils.js
@@ -311,13 +311,18 @@ function validateClaimsInPayload(claimValidators, newAccessTokenPayload, userCon
     });
 }
 exports.validateClaimsInPayload = validateClaimsInPayload;
-function defaultGetTokenTransferMethod({ req }) {
+function defaultGetTokenTransferMethod({ req, forCreateNewSession }) {
+    // We allow fallback (checking headers then cookies) by default when validating
+    if (!forCreateNewSession) {
+        return "any";
+    }
+    // In create new session we respect the frontend preference by default
     switch (cookieAndHeaders_1.getAuthModeFromHeader(req)) {
         case "header":
             return "header";
         case "cookie":
             return "cookie";
         default:
-            return "missing_auth_header";
+            return "any";
     }
 }

--- a/lib/build/recipe/session/utils.js
+++ b/lib/build/recipe/session/utils.js
@@ -247,7 +247,7 @@ function normaliseSameSiteOrThrowError(sameSite) {
     return sameSite;
 }
 exports.normaliseSameSiteOrThrowError = normaliseSameSiteOrThrowError;
-function attachCreateOrRefreshSessionResponseToExpressRes(config, req, res, response, userContext) {
+function attachCreateOrRefreshSessionResponseToExpressRes(config, res, response, transferMethod) {
     let accessToken = response.accessToken;
     let refreshToken = response.refreshToken;
     cookieAndHeaders_1.setFrontTokenInHeaders(
@@ -258,7 +258,6 @@ function attachCreateOrRefreshSessionResponseToExpressRes(config, req, res, resp
     );
     cookieAndHeaders_1.setToken(
         config,
-        req,
         res,
         "access",
         accessToken.token,
@@ -267,9 +266,9 @@ function attachCreateOrRefreshSessionResponseToExpressRes(config, req, res, resp
         // Even if the token is expired the presence of the token indicates that the user could have a valid refresh
         // Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
         Date.now() + 315360000000,
-        userContext
+        transferMethod
     );
-    cookieAndHeaders_1.setToken(config, req, res, "refresh", refreshToken.token, refreshToken.expiry, userContext);
+    cookieAndHeaders_1.setToken(config, res, "refresh", refreshToken.token, refreshToken.expiry, transferMethod);
     if (response.antiCsrfToken !== undefined) {
         cookieAndHeaders_1.setAntiCsrfTokenInHeaders(res, response.antiCsrfToken);
     }
@@ -313,5 +312,12 @@ function validateClaimsInPayload(claimValidators, newAccessTokenPayload, userCon
 }
 exports.validateClaimsInPayload = validateClaimsInPayload;
 function defaultGetTokenTransferMethod({ req }) {
-    return utils_1.getAuthModeFromHeader(req) === "header" ? "header" : "cookie";
+    switch (utils_1.getAuthModeFromHeader(req)) {
+        case "header":
+            return "header";
+        case "cookie":
+            return "cookie";
+        default:
+            return "MISSING_AUTH_HEADER";
+    }
 }

--- a/lib/build/supertokens.js
+++ b/lib/build/supertokens.js
@@ -88,7 +88,6 @@ class SuperTokens {
             let headerSet = new Set();
             headerSet.add(constants_1.HEADER_RID);
             headerSet.add(constants_1.HEADER_FDI);
-            headerSet.add(constants_1.HEADER_AUTH_MODE);
             this.recipeModules.forEach((recipe) => {
                 let headers = recipe.getAllCORSHeaders();
                 headers.forEach((h) => {

--- a/lib/build/utils.d.ts
+++ b/lib/build/utils.d.ts
@@ -9,7 +9,6 @@ export declare function sendNon200ResponseWithMessage(res: BaseResponse, message
 export declare function sendNon200Response(res: BaseResponse, statusCode: number, body: JSONObject): void;
 export declare function send200Response(res: BaseResponse, responseJson: any): void;
 export declare function isAnIpAddress(ipaddress: string): boolean;
-export declare function getAuthModeFromHeader(req: BaseRequest): string | undefined;
 export declare function getRidFromHeader(req: BaseRequest): string | undefined;
 export declare function frontendHasInterceptor(req: BaseRequest): boolean;
 export declare function humaniseMilliseconds(ms: number): string;

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -105,10 +105,6 @@ function isAnIpAddress(ipaddress) {
     );
 }
 exports.isAnIpAddress = isAnIpAddress;
-function getAuthModeFromHeader(req) {
-    return req.getHeaderValue(constants_1.HEADER_AUTH_MODE);
-}
-exports.getAuthModeFromHeader = getAuthModeFromHeader;
 function getRidFromHeader(req) {
     return req.getHeaderValue(constants_1.HEADER_RID);
 }

--- a/lib/ts/constants.ts
+++ b/lib/ts/constants.ts
@@ -14,5 +14,4 @@
  */
 
 export const HEADER_RID = "rid";
-export const HEADER_AUTH_MODE = "st-auth-mode";
 export const HEADER_FDI = "fdi-version";

--- a/lib/ts/recipe/session/accessToken.ts
+++ b/lib/ts/recipe/session/accessToken.ts
@@ -14,10 +14,10 @@
  */
 
 import STError from "./error";
-import { verifyJWTAndGetPayload } from "./jwt";
+import { ParsedJWTInfo, verifyJWT } from "./jwt";
 
 export async function getInfoFromAccessToken(
-    token: string,
+    jwtInfo: ParsedJWTInfo,
     jwtSigningPublicKey: string,
     doAntiCsrfCheck: boolean
 ): Promise<{
@@ -31,28 +31,25 @@ export async function getInfoFromAccessToken(
     timeCreated: number;
 }> {
     try {
-        let payload = verifyJWTAndGetPayload(token, jwtSigningPublicKey);
+        let payload = verifyJWT(jwtInfo, jwtSigningPublicKey);
 
-        let sessionHandle = sanitizeStringInput(payload.sessionHandle);
-        let userId = sanitizeStringInput(payload.userId);
-        let refreshTokenHash1 = sanitizeStringInput(payload.refreshTokenHash1);
+        // This should be called before this function, but the check is very quick, so we can also do them here
+        validateAccessTokenPayload(payload);
+
+        // We can mark these as defined (the ! after the calls), since validateAccessTokenPayload checks this
+        let sessionHandle = sanitizeStringInput(payload.sessionHandle)!;
+        let userId = sanitizeStringInput(payload.userId)!;
+        let refreshTokenHash1 = sanitizeStringInput(payload.refreshTokenHash1)!;
         let parentRefreshTokenHash1 = sanitizeStringInput(payload.parentRefreshTokenHash1);
         let userData = payload.userData;
         let antiCsrfToken = sanitizeStringInput(payload.antiCsrfToken);
-        let expiryTime = sanitizeNumberInput(payload.expiryTime);
-        let timeCreated = sanitizeNumberInput(payload.timeCreated);
-        if (
-            sessionHandle === undefined ||
-            userId === undefined ||
-            refreshTokenHash1 === undefined ||
-            userData === undefined ||
-            (antiCsrfToken === undefined && doAntiCsrfCheck) ||
-            expiryTime === undefined ||
-            timeCreated === undefined
-        ) {
-            // it would come here if we change the structure of the JWT.
-            throw Error("Access token does not contain all the information. Maybe the structure has changed?");
+        let expiryTime = sanitizeNumberInput(payload.expiryTime)!;
+        let timeCreated = sanitizeNumberInput(payload.timeCreated)!;
+
+        if (antiCsrfToken === undefined && doAntiCsrfCheck) {
+            throw Error("Access token does not contain the anti-csrf token.");
         }
+
         if (expiryTime < Date.now()) {
             throw Error("Access token expired");
         }
@@ -71,6 +68,20 @@ export async function getInfoFromAccessToken(
             message: "Failed to verify access token",
             type: STError.TRY_REFRESH_TOKEN,
         });
+    }
+}
+
+export function validateAccessTokenPayload(payload: { [key: string]: any }) {
+    if (
+        typeof payload.sessionHandle !== "string" ||
+        typeof payload.userId !== "string" ||
+        typeof payload.refreshTokenHash1 !== "string" ||
+        payload.userData === undefined ||
+        typeof payload.expiryTime !== "number" ||
+        typeof payload.timeCreated !== "number"
+    ) {
+        // it would come here if we change the structure of the JWT.
+        throw Error("Access token does not contain all the information. Maybe the structure has changed?");
     }
 }
 

--- a/lib/ts/recipe/session/accessToken.ts
+++ b/lib/ts/recipe/session/accessToken.ts
@@ -34,7 +34,7 @@ export async function getInfoFromAccessToken(
         let payload = verifyJWT(jwtInfo, jwtSigningPublicKey);
 
         // This should be called before this function, but the check is very quick, so we can also do them here
-        validateAccessTokenPayload(payload);
+        validateAccessTokenStructure(payload);
 
         // We can mark these as defined (the ! after the calls), since validateAccessTokenPayload checks this
         let sessionHandle = sanitizeStringInput(payload.sessionHandle)!;
@@ -71,7 +71,7 @@ export async function getInfoFromAccessToken(
     }
 }
 
-export function validateAccessTokenPayload(payload: { [key: string]: any }) {
+export function validateAccessTokenStructure(payload: any) {
     if (
         typeof payload.sessionHandle !== "string" ||
         typeof payload.userId !== "string" ||

--- a/lib/ts/recipe/session/constants.ts
+++ b/lib/ts/recipe/session/constants.ts
@@ -13,5 +13,9 @@
  * under the License.
  */
 
+import { TokenTransferMethod } from "./types";
+
 export const REFRESH_API_PATH = "/session/refresh";
 export const SIGNOUT_API_PATH = "/signout";
+
+export const availableTokenTransferMethods: TokenTransferMethod[] = ["cookie", "header"];

--- a/lib/ts/recipe/session/cookieAndHeaders.ts
+++ b/lib/ts/recipe/session/cookieAndHeaders.ts
@@ -31,23 +31,13 @@ const authModeHeaderKey = "st-auth-mode";
 /**
  * @description clears all the auth cookies from the response
  */
-export function clearSession(
-    config: TypeNormalisedInput,
-    req: BaseRequest,
-    res: BaseResponse,
-    transferMethod: TokenTransferMethod
-) {
+export function clearSession(config: TypeNormalisedInput, res: BaseResponse, transferMethod: TokenTransferMethod) {
     // If we can tell it's a cookie based session we are not clearing using headers
     const tokenTypes: TokenType[] = ["access", "refresh"];
     for (const token of tokenTypes) {
         setToken(config, res, token, "", 0, transferMethod);
-
-        // This is to ensure we clear the cookies as well if the user has migrated to headers,
-        // because this can't be done on the client side
-        if (transferMethod === "header" && isTokenInCookies(req, token)) {
-            setToken(config, res, token, "", 0, "cookie");
-        }
     }
+
     res.setHeader(frontTokenHeaderKey, "remove", false);
     res.setHeader("Access-Control-Expose-Headers", frontTokenHeaderKey, true);
 }
@@ -95,10 +85,6 @@ function getResponseHeaderNameForTokenType(tokenType: TokenType) {
         default:
             throw new Error("Unknown token type, should never happen.");
     }
-}
-
-export function isTokenInCookies(req: BaseRequest, tokenType: TokenType) {
-    return req.getCookieValue(getCookieNameFromTokenType(tokenType)) !== undefined;
 }
 
 export function getToken(req: BaseRequest, tokenType: TokenType, transferMethod: TokenTransferMethod) {
@@ -181,5 +167,5 @@ export function setCookie(
 }
 
 export function getAuthModeFromHeader(req: BaseRequest): string | undefined {
-    return req.getHeaderValue(authModeHeaderKey);
+    return req.getHeaderValue(authModeHeaderKey)?.toLowerCase();
 }

--- a/lib/ts/recipe/session/cookieAndHeaders.ts
+++ b/lib/ts/recipe/session/cookieAndHeaders.ts
@@ -62,7 +62,7 @@ export function setFrontTokenInHeaders(res: BaseResponse, userId: string, atExpi
 }
 
 export function getCORSAllowedHeaders(): string[] {
-    return [antiCsrfHeaderKey, HEADER_RID, authorizationHeaderKey, refreshTokenHeaderKey, authModeHeaderKey];
+    return [antiCsrfHeaderKey, HEADER_RID, authorizationHeaderKey, authModeHeaderKey];
 }
 
 function getCookieNameFromTokenType(tokenType: TokenType) {
@@ -125,11 +125,7 @@ export function setToken(
 }
 
 export function setHeader(res: BaseResponse, name: string, value: string, expires: number) {
-    if (value === "remove") {
-        res.setHeader(name, value, false);
-    } else {
-        res.setHeader(name, `${value};${expires}`, false);
-    }
+    res.setHeader(name, `${value};${expires}`, false);
     res.setHeader("Access-Control-Expose-Headers", name, true);
 }
 

--- a/lib/ts/recipe/session/jwt.ts
+++ b/lib/ts/recipe/session/jwt.ts
@@ -38,7 +38,7 @@ export type ParsedJWTInfo = {
     signature: string;
 };
 
-export function parseJWT(jwt: string): ParsedJWTInfo {
+export function parseJWTWithoutSignatureVerification(jwt: string): ParsedJWTInfo {
     const splittedInput = jwt.split(".");
     if (splittedInput.length !== 3) {
         throw new Error("Invalid JWT");

--- a/lib/ts/recipe/session/sessionClass.ts
+++ b/lib/ts/recipe/session/sessionClass.ts
@@ -15,7 +15,7 @@
 import { BaseRequest, BaseResponse } from "../../framework";
 import { clearSession, setFrontTokenInHeaders, setToken } from "./cookieAndHeaders";
 import STError from "./error";
-import { SessionClaim, SessionClaimValidator, SessionContainerInterface } from "./types";
+import { SessionClaim, SessionClaimValidator, SessionContainerInterface, TokenTransferMethod } from "./types";
 import { Helpers } from "./recipeImplementation";
 
 export default class Session implements SessionContainerInterface {
@@ -27,7 +27,7 @@ export default class Session implements SessionContainerInterface {
         protected userDataInAccessToken: any,
         protected res: BaseResponse,
         protected readonly req: BaseRequest,
-        protected readonly transferMethod: "cookie" | "header"
+        protected readonly transferMethod: TokenTransferMethod
     ) {}
 
     revokeSession = async (userContext?: any) => {

--- a/lib/ts/recipe/session/sessionClass.ts
+++ b/lib/ts/recipe/session/sessionClass.ts
@@ -42,7 +42,7 @@ export default class Session implements SessionContainerInterface {
         // If we instead clear the cookies only when revokeSession
         // returns true, it can cause this kind of a bug:
         // https://github.com/supertokens/supertokens-node/issues/343
-        clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
+        clearSession(this.helpers.config, this.res, this.transferMethod);
     };
 
     getSessionData = async (userContext?: any): Promise<any> => {
@@ -51,7 +51,7 @@ export default class Session implements SessionContainerInterface {
             userContext: userContext === undefined ? {} : userContext,
         });
         if (sessionInfo === undefined) {
-            clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
+            clearSession(this.helpers.config, this.res, this.transferMethod);
             throw new STError({
                 message: "Session does not exist anymore",
                 type: STError.UNAUTHORISED,
@@ -68,7 +68,7 @@ export default class Session implements SessionContainerInterface {
                 userContext: userContext === undefined ? {} : userContext,
             }))
         ) {
-            clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
+            clearSession(this.helpers.config, this.res, this.transferMethod);
             throw new STError({
                 message: "Session does not exist anymore",
                 type: STError.UNAUTHORISED,
@@ -109,7 +109,7 @@ export default class Session implements SessionContainerInterface {
             userContext: userContext === undefined ? {} : userContext,
         });
         if (sessionInfo === undefined) {
-            clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
+            clearSession(this.helpers.config, this.res, this.transferMethod);
             throw new STError({
                 message: "Session does not exist anymore",
                 type: STError.UNAUTHORISED,
@@ -124,7 +124,7 @@ export default class Session implements SessionContainerInterface {
             userContext: userContext === undefined ? {} : userContext,
         });
         if (sessionInfo === undefined) {
-            clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
+            clearSession(this.helpers.config, this.res, this.transferMethod);
             throw new STError({
                 message: "Session does not exist anymore",
                 type: STError.UNAUTHORISED,
@@ -183,7 +183,7 @@ export default class Session implements SessionContainerInterface {
             userContext: userContext === undefined ? {} : userContext,
         });
         if (response === undefined) {
-            clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
+            clearSession(this.helpers.config, this.res, this.transferMethod);
             throw new STError({
                 message: "Session does not exist anymore",
                 type: STError.UNAUTHORISED,

--- a/lib/ts/recipe/session/sessionClass.ts
+++ b/lib/ts/recipe/session/sessionClass.ts
@@ -19,31 +19,16 @@ import { SessionClaim, SessionClaimValidator, SessionContainerInterface } from "
 import { Helpers } from "./recipeImplementation";
 
 export default class Session implements SessionContainerInterface {
-    protected sessionHandle: string;
-    protected userId: string;
-    protected userDataInAccessToken: any;
-    protected readonly req: BaseRequest;
-    protected res: BaseResponse;
-    protected accessToken: string;
-    protected helpers: Helpers;
-
     constructor(
-        helpers: Helpers,
-        accessToken: string,
-        sessionHandle: string,
-        userId: string,
-        userDataInAccessToken: any,
-        res: BaseResponse,
-        req: BaseRequest
-    ) {
-        this.sessionHandle = sessionHandle;
-        this.userId = userId;
-        this.userDataInAccessToken = userDataInAccessToken;
-        this.req = req;
-        this.res = res;
-        this.accessToken = accessToken;
-        this.helpers = helpers;
-    }
+        protected helpers: Helpers,
+        protected accessToken: string,
+        protected sessionHandle: string,
+        protected userId: string,
+        protected userDataInAccessToken: any,
+        protected res: BaseResponse,
+        protected readonly req: BaseRequest,
+        protected readonly transferMethod: "cookie" | "header"
+    ) {}
 
     revokeSession = async (userContext?: any) => {
         await this.helpers.getRecipeImpl().revokeSession({
@@ -215,7 +200,6 @@ export default class Session implements SessionContainerInterface {
             );
             setToken(
                 this.helpers.config,
-                this.req,
                 this.res,
                 "access",
                 response.accessToken.token,
@@ -224,7 +208,7 @@ export default class Session implements SessionContainerInterface {
                 // Even if the token is expired the presence of the token indicates that the user could have a valid refresh
                 // Setting them to infinity would require special case handling on the frontend and just adding 10 years seems enough.
                 Date.now() + 315360000000,
-                userContext
+                this.transferMethod
             );
         }
     };

--- a/lib/ts/recipe/session/sessionClass.ts
+++ b/lib/ts/recipe/session/sessionClass.ts
@@ -42,7 +42,7 @@ export default class Session implements SessionContainerInterface {
         // If we instead clear the cookies only when revokeSession
         // returns true, it can cause this kind of a bug:
         // https://github.com/supertokens/supertokens-node/issues/343
-        clearSession(this.helpers.config, this.req, this.res, userContext);
+        clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
     };
 
     getSessionData = async (userContext?: any): Promise<any> => {
@@ -51,7 +51,7 @@ export default class Session implements SessionContainerInterface {
             userContext: userContext === undefined ? {} : userContext,
         });
         if (sessionInfo === undefined) {
-            clearSession(this.helpers.config, this.req, this.res, userContext);
+            clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
             throw new STError({
                 message: "Session does not exist anymore",
                 type: STError.UNAUTHORISED,
@@ -68,7 +68,7 @@ export default class Session implements SessionContainerInterface {
                 userContext: userContext === undefined ? {} : userContext,
             }))
         ) {
-            clearSession(this.helpers.config, this.req, this.res, userContext);
+            clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
             throw new STError({
                 message: "Session does not exist anymore",
                 type: STError.UNAUTHORISED,
@@ -109,7 +109,7 @@ export default class Session implements SessionContainerInterface {
             userContext: userContext === undefined ? {} : userContext,
         });
         if (sessionInfo === undefined) {
-            clearSession(this.helpers.config, this.req, this.res, userContext);
+            clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
             throw new STError({
                 message: "Session does not exist anymore",
                 type: STError.UNAUTHORISED,
@@ -124,7 +124,7 @@ export default class Session implements SessionContainerInterface {
             userContext: userContext === undefined ? {} : userContext,
         });
         if (sessionInfo === undefined) {
-            clearSession(this.helpers.config, this.req, this.res, userContext);
+            clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
             throw new STError({
                 message: "Session does not exist anymore",
                 type: STError.UNAUTHORISED,
@@ -183,7 +183,7 @@ export default class Session implements SessionContainerInterface {
             userContext: userContext === undefined ? {} : userContext,
         });
         if (response === undefined) {
-            clearSession(this.helpers.config, this.req, this.res, userContext);
+            clearSession(this.helpers.config, this.req, this.res, this.transferMethod);
             throw new STError({
                 message: "Session does not exist anymore",
                 type: STError.UNAUTHORISED,

--- a/lib/ts/recipe/session/sessionFunctions.ts
+++ b/lib/ts/recipe/session/sessionFunctions.ts
@@ -283,7 +283,7 @@ export async function getSession(
             // we force update the signing keys...
             await helpers.getHandshakeInfo(true);
         }
-        logDebugMessage("getSession: Returning TRY_REFRESH_TOKEN because of core response");
+        logDebugMessage("getSession: Returning TRY_REFRESH_TOKEN because of core response.");
         throw new STError({
             message: response.message,
             type: STError.TRY_REFRESH_TOKEN,

--- a/lib/ts/recipe/session/sessionFunctions.ts
+++ b/lib/ts/recipe/session/sessionFunctions.ts
@@ -16,7 +16,7 @@ import { getInfoFromAccessToken, sanitizeNumberInput } from "./accessToken";
 import { getPayloadWithoutVerifiying } from "./jwt";
 import STError from "./error";
 import { PROCESS_STATE, ProcessState } from "../../processState";
-import { CreateOrRefreshAPIResponse, SessionInformation } from "./types";
+import { CreateOrRefreshAPIResponse, SessionInformation, TokenTransferMethod } from "./types";
 import NormalisedURLPath from "../../normalisedURLPath";
 import { Helpers } from "./recipeImplementation";
 import { isAnIpAddress, maxVersion } from "../../utils";
@@ -332,8 +332,7 @@ export async function refreshSession(
     refreshToken: string,
     antiCsrfToken: string | undefined,
     containsCustomHeader: boolean,
-    inputTransferMethod: "header" | "cookie",
-    outputTransferMethod: "header" | "cookie"
+    transferMethod: TokenTransferMethod
 ): Promise<CreateOrRefreshAPIResponse> {
     let handShakeInfo = await helpers.getHandshakeInfo();
 
@@ -344,10 +343,10 @@ export async function refreshSession(
     } = {
         refreshToken,
         antiCsrfToken,
-        enableAntiCsrf: outputTransferMethod === "cookie" && handShakeInfo.antiCsrf === "VIA_TOKEN",
+        enableAntiCsrf: transferMethod === "cookie" && handShakeInfo.antiCsrf === "VIA_TOKEN",
     };
 
-    if (handShakeInfo.antiCsrf === "VIA_CUSTOM_HEADER" && inputTransferMethod === "cookie") {
+    if (handShakeInfo.antiCsrf === "VIA_CUSTOM_HEADER" && transferMethod === "cookie") {
         if (!containsCustomHeader) {
             logDebugMessage("refreshSession: Returning UNAUTHORISED because custom header (rid) was not passed");
             throw new STError({

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -61,11 +61,6 @@ export type CreateOrRefreshAPIResponse = {
         expiry: number;
         createdTime: number;
     };
-    idRefreshToken: {
-        token: string;
-        expiry: number;
-        createdTime: number;
-    };
     antiCsrfToken: string | undefined;
 };
 
@@ -134,7 +129,10 @@ export type TypeNormalisedInput = {
     errorHandlers: NormalisedErrorHandlers;
     antiCsrf: "VIA_TOKEN" | "VIA_CUSTOM_HEADER" | "NONE";
 
-    getTokenTransferMethod: (input: { req: BaseRequest; userContext: any }) => "cookie" | "header";
+    getTokenTransferMethod: (input: {
+        req: BaseRequest;
+        userContext: any;
+    }) => "cookie" | "header" | "MISSING_AUTH_HEADER";
 
     invalidClaimStatusCode: number;
     jwt: {

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -71,6 +71,8 @@ export interface ErrorHandlers {
 }
 
 export type TokenType = "access" | "refresh";
+// When adding a new token transfer method, it's also necessary to update the related constant in cookieAndHeaders
+export type TokenTransferMethod = "header" | "cookie";
 
 export type TypeInput = {
     sessionExpiredStatusCode?: number;
@@ -80,7 +82,7 @@ export type TypeInput = {
     cookieSameSite?: "strict" | "lax" | "none";
     cookieDomain?: string;
 
-    getTokenTransferMethod?: (input: { req: BaseRequest; userContext: any }) => "cookie" | "header";
+    getTokenTransferMethod?: (input: { req: BaseRequest; userContext: any }) => TokenTransferMethod;
 
     errorHandlers?: ErrorHandlers;
     antiCsrf?: "VIA_TOKEN" | "VIA_CUSTOM_HEADER" | "NONE";
@@ -132,7 +134,7 @@ export type TypeNormalisedInput = {
     getTokenTransferMethod: (input: {
         req: BaseRequest;
         userContext: any;
-    }) => "cookie" | "header" | "MISSING_AUTH_HEADER";
+    }) => TokenTransferMethod | "missing_auth_header";
 
     invalidClaimStatusCode: number;
     jwt: {

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -71,7 +71,8 @@ export interface ErrorHandlers {
 }
 
 export type TokenType = "access" | "refresh";
-// When adding a new token transfer method, it's also necessary to update the related constant in cookieAndHeaders
+
+// When adding a new token transfer method, it's also necessary to update the related constant (availableTokenTransferMethods)
 export type TokenTransferMethod = "header" | "cookie";
 
 export type TypeInput = {
@@ -82,7 +83,11 @@ export type TypeInput = {
     cookieSameSite?: "strict" | "lax" | "none";
     cookieDomain?: string;
 
-    getTokenTransferMethod?: (input: { req: BaseRequest; userContext: any }) => TokenTransferMethod;
+    getTokenTransferMethod?: (input: {
+        req: BaseRequest;
+        forCreateNewSession: boolean;
+        userContext: any;
+    }) => TokenTransferMethod | "any";
 
     errorHandlers?: ErrorHandlers;
     antiCsrf?: "VIA_TOKEN" | "VIA_CUSTOM_HEADER" | "NONE";
@@ -133,8 +138,9 @@ export type TypeNormalisedInput = {
 
     getTokenTransferMethod: (input: {
         req: BaseRequest;
+        forCreateNewSession: boolean;
         userContext: any;
-    }) => TokenTransferMethod | "missing_auth_header";
+    }) => TokenTransferMethod | "any";
 
     invalidClaimStatusCode: number;
     jwt: {

--- a/lib/ts/recipe/session/utils.ts
+++ b/lib/ts/recipe/session/utils.ts
@@ -325,13 +325,25 @@ export async function validateClaimsInPayload(
     return validationErrors;
 }
 
-function defaultGetTokenTransferMethod({ req }: { req: BaseRequest }): TokenTransferMethod | "missing_auth_header" {
+function defaultGetTokenTransferMethod({
+    req,
+    forCreateNewSession,
+}: {
+    req: BaseRequest;
+    forCreateNewSession: boolean;
+}): TokenTransferMethod | "any" {
+    // We allow fallback (checking headers then cookies) by default when validating
+    if (!forCreateNewSession) {
+        return "any";
+    }
+
+    // In create new session we respect the frontend preference by default
     switch (getAuthModeFromHeader(req)) {
         case "header":
             return "header";
         case "cookie":
             return "cookie";
         default:
-            return "missing_auth_header";
+            return "any";
     }
 }

--- a/lib/ts/recipe/session/utils.ts
+++ b/lib/ts/recipe/session/utils.ts
@@ -22,14 +22,15 @@ import {
     SessionClaimValidator,
     SessionContainerInterface,
     VerifySessionOptions,
+    TokenTransferMethod,
 } from "./types";
-import { setFrontTokenInHeaders, setAntiCsrfTokenInHeaders, setToken } from "./cookieAndHeaders";
+import { setFrontTokenInHeaders, setAntiCsrfTokenInHeaders, setToken, getAuthModeFromHeader } from "./cookieAndHeaders";
 import { URL } from "url";
 import SessionRecipe from "./recipe";
 import { REFRESH_API_PATH } from "./constants";
 import NormalisedURLPath from "../../normalisedURLPath";
 import { NormalisedAppinfo } from "../../types";
-import { getAuthModeFromHeader, isAnIpAddress } from "../../utils";
+import { isAnIpAddress } from "../../utils";
 import { RecipeInterface, APIInterface } from "./types";
 import { BaseRequest, BaseResponse } from "../../framework";
 import { sendNon200ResponseWithMessage, sendNon200Response } from "../../utils";
@@ -261,7 +262,7 @@ export function attachCreateOrRefreshSessionResponseToExpressRes(
     config: TypeNormalisedInput,
     res: BaseResponse,
     response: CreateOrRefreshAPIResponse,
-    transferMethod: "cookie" | "header"
+    transferMethod: TokenTransferMethod
 ) {
     let accessToken = response.accessToken;
     let refreshToken = response.refreshToken;
@@ -324,13 +325,13 @@ export async function validateClaimsInPayload(
     return validationErrors;
 }
 
-function defaultGetTokenTransferMethod({ req }: { req: BaseRequest }): "cookie" | "header" | "MISSING_AUTH_HEADER" {
+function defaultGetTokenTransferMethod({ req }: { req: BaseRequest }): TokenTransferMethod | "missing_auth_header" {
     switch (getAuthModeFromHeader(req)) {
         case "header":
             return "header";
         case "cookie":
             return "cookie";
         default:
-            return "MISSING_AUTH_HEADER";
+            return "missing_auth_header";
     }
 }

--- a/lib/ts/supertokens.ts
+++ b/lib/ts/supertokens.ts
@@ -24,7 +24,7 @@ import {
 } from "./utils";
 import { Querier } from "./querier";
 import RecipeModule from "./recipeModule";
-import { HEADER_RID, HEADER_FDI, HEADER_AUTH_MODE } from "./constants";
+import { HEADER_RID, HEADER_FDI } from "./constants";
 import NormalisedURLDomain from "./normalisedURLDomain";
 import NormalisedURLPath from "./normalisedURLPath";
 import { BaseRequest, BaseResponse } from "./framework";
@@ -158,7 +158,6 @@ export default class SuperTokens {
         let headerSet = new Set<string>();
         headerSet.add(HEADER_RID);
         headerSet.add(HEADER_FDI);
-        headerSet.add(HEADER_AUTH_MODE);
         this.recipeModules.forEach((recipe) => {
             let headers = recipe.getAllCORSHeaders();
             headers.forEach((h) => {

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -5,7 +5,7 @@ import NormalisedURLDomain from "./normalisedURLDomain";
 import NormalisedURLPath from "./normalisedURLPath";
 import type { BaseRequest, BaseResponse } from "./framework";
 import { logDebugMessage } from "./logger";
-import { HEADER_AUTH_MODE, HEADER_RID } from "./constants";
+import { HEADER_RID } from "./constants";
 
 export function getLargestVersionFromIntersection(v1: string[], v2: string[]): string | undefined {
     let intersection = v1.filter((value) => v2.indexOf(value) !== -1);
@@ -107,10 +107,6 @@ export function isAnIpAddress(ipaddress: string) {
     return /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(
         ipaddress
     );
-}
-
-export function getAuthModeFromHeader(req: BaseRequest): string | undefined {
-    return req.getHeaderValue(HEADER_AUTH_MODE);
 }
 
 export function getRidFromHeader(req: BaseRequest): string | undefined {


### PR DESCRIPTION
## Summary of change

Implement fallback when auth method is not defined in the headers

## Related issues

- https://supertokens.com/docs/contribute/decisions/session/0003
- https://supertokens.com/docs/contribute/decisions/session/0007

## Test Plan

Added separately

## Documentation changes

Added separately

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
