### PR TITLE
fix: Fix user put API importing incorrectly for thirdpartyemailpassword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [12.1.1] - 2022-11-25
+
+-   Fixed an issue with importing the wrong recipe in the dashboard APIs
+
 ## [12.1.0] - 2022-11-17
 
 ### Added:

--- a/lib/build/recipe/dashboard/api/userdetails/userPut.js
+++ b/lib/build/recipe/dashboard/api/userdetails/userPut.js
@@ -33,7 +33,7 @@ var __awaiter =
 Object.defineProperty(exports, "__esModule", { value: true });
 const error_1 = require("../../../../error");
 const recipe_1 = require("../../../emailpassword/recipe");
-const recipe_2 = require("../../../emailpassword/recipe");
+const recipe_2 = require("../../../thirdpartyemailpassword/recipe");
 const recipe_3 = require("../../../passwordless/recipe");
 const recipe_4 = require("../../../thirdpartypasswordless/recipe");
 const emailpassword_1 = require("../../../emailpassword");

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "12.1.0";
+export declare const version = "12.1.1";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.2";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -14,7 +14,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "12.1.0";
+exports.version = "12.1.1";
 exports.cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.2";

--- a/lib/ts/recipe/dashboard/api/userdetails/userPut.ts
+++ b/lib/ts/recipe/dashboard/api/userdetails/userPut.ts
@@ -1,7 +1,7 @@
 import { APIInterface, APIOptions } from "../../types";
 import STError from "../../../../error";
 import EmailPasswordRecipe from "../../../emailpassword/recipe";
-import ThirdPartyEmailPasswordRecipe from "../../../emailpassword/recipe";
+import ThirdPartyEmailPasswordRecipe from "../../../thirdpartyemailpassword/recipe";
 import PasswordlessRecipe from "../../../passwordless/recipe";
 import ThirdPartyPasswordlessRecipe from "../../../thirdpartypasswordless/recipe";
 import EmailPassword from "../../../emailpassword";

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "12.1.0";
+export const version = "12.1.1";
 
 export const cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "12.1.0",
+    "version": "12.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "12.1.0",
+            "version": "12.1.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "axios": "0.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "12.1.0",
+    "version": "12.1.1",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

- User put API had an incorrect import for the thirdpartyemailpassword recipe resulting in a 500

## Related issues

-  

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] 
