### PR TITLE
fixes bug - sendEmail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [12.1.2] - 2022-12-06
+
+-   Fixes issue where if sendEmail is overridden with a different email, it will reset that email.
+
 ## [12.1.1] - 2022-11-25
 
 -   Fixed an issue with importing the wrong recipe in the dashboard APIs

--- a/lib/build/recipe/emailpassword/emaildelivery/services/backwardCompatibility/index.js
+++ b/lib/build/recipe/emailpassword/emaildelivery/services/backwardCompatibility/index.js
@@ -43,6 +43,10 @@ class BackwardCompatibilityService {
                 if (user === undefined) {
                     throw Error("this should never come here");
                 }
+                // we add this here cause the user may have overridden the sendEmail function
+                // to change the input email and if we don't do this, the input email
+                // will get reset by the getUserById call above.
+                user.email = input.user.email;
                 try {
                     if (!this.isInServerlessEnv) {
                         this.resetPasswordUsingTokenFeature

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "12.1.1";
+export declare const version = "12.1.2";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.2";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -14,7 +14,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "12.1.1";
+exports.version = "12.1.2";
 exports.cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.2";

--- a/lib/ts/recipe/emailpassword/emaildelivery/services/backwardCompatibility/index.ts
+++ b/lib/ts/recipe/emailpassword/emaildelivery/services/backwardCompatibility/index.ts
@@ -62,6 +62,10 @@ export default class BackwardCompatibilityService
         if (user === undefined) {
             throw Error("this should never come here");
         }
+        // we add this here cause the user may have overridden the sendEmail function
+        // to change the input email and if we don't do this, the input email
+        // will get reset by the getUserById call above.
+        user.email = input.user.email;
         try {
             if (!this.isInServerlessEnv) {
                 this.resetPasswordUsingTokenFeature

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "12.1.1";
+export const version = "12.1.2";
 
 export const cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "12.1.1",
+    "version": "12.1.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "12.1.1",
+            "version": "12.1.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "axios": "0.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "12.1.1",
+    "version": "12.1.2",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {

--- a/test/emailpassword/emailDelivery.test.js
+++ b/test/emailpassword/emailDelivery.test.js
@@ -764,4 +764,69 @@ describe(`emailDelivery: ${printPath("[test/emailpassword/emailDelivery.test.js]
         assert(sendRawEmailCalled);
         assert.notStrictEqual(emailVerifyURL, undefined);
     });
+
+    it("test backward compatibility: reset password and sendEmail override", async function () {
+        await startST();
+        let email = undefined;
+        let passwordResetURL = undefined;
+        let timeJoined = undefined;
+        STExpress.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                EmailPassword.init({
+                    emailDelivery: {
+                        override: (oI) => {
+                            return {
+                                ...oI,
+                                sendEmail: async function (input) {
+                                    input.user.email = "override@example.com";
+                                    return oI.sendEmail(input);
+                                },
+                            };
+                        },
+                    },
+                    resetPasswordUsingTokenFeature: {
+                        createAndSendCustomEmail: async (input, passwordResetLink) => {
+                            email = input.email;
+                            passwordResetURL = passwordResetLink;
+                            timeJoined = input.timeJoined;
+                        },
+                    },
+                }),
+                Session.init(),
+            ],
+            telemetry: false,
+        });
+
+        const app = express();
+        app.use(middleware());
+        app.use(errorHandler());
+
+        await EmailPassword.signUp("test@example.com", "1234abcd");
+
+        await supertest(app)
+            .post("/auth/user/password/reset/token")
+            .set("rid", "emailpassword")
+            .send({
+                formFields: [
+                    {
+                        id: "email",
+                        value: "test@example.com",
+                    },
+                ],
+            })
+            .expect(200);
+
+        await delay(2);
+        assert.strictEqual(email, "override@example.com");
+        assert.notStrictEqual(passwordResetURL, undefined);
+        assert.notStrictEqual(timeJoined, undefined);
+    });
 });


### PR DESCRIPTION
## Summary of change

If the user is overriding the sendEmail function in emailpassword recipe to change the input email, their change will not get reflected since our implementation calls the getUserById function which will reset their changed email. 

So we reassign the input email to the result of calling getUserById

## Test Plan

Added one test for checking that a different email is mantained

