### PR TITLE
fix: Update dashboard recipe user Get API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
-## [12.1.4] - 2022-12-12
+## [12.1.4] - 2022-12-26
 
 -   Updates dashboard version
--   Updates user GET API for the dashboard
+-   Updates user GET API for the dashboard recipe
 
 ## [12.1.3] - 2022-12-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [12.1.4] - 2022-12-12
+
+-   Updates dashboard version
+-   Updates user GET API for the dashboard
+
 ## [12.1.3] - 2022-12-12
 
 -   Updates some dependencies cause of `npm audit`

--- a/lib/build/recipe/dashboard/api/userdetails/userGet.js
+++ b/lib/build/recipe/dashboard/api/userdetails/userGet.js
@@ -57,6 +57,11 @@ exports.userGet = (_, options) =>
                 type: error_1.default.BAD_INPUT_ERROR,
             });
         }
+        if (!utils_1.isRecipeInitialised(recipeId)) {
+            return {
+                status: "RECIPE_NOT_INITIALISED",
+            };
+        }
         let user = (yield utils_1.getUserForRecipeId(userId, recipeId)).user;
         if (user === undefined) {
             return {

--- a/lib/build/recipe/dashboard/utils.d.ts
+++ b/lib/build/recipe/dashboard/utils.d.ts
@@ -28,3 +28,4 @@ export declare function getUserForRecipeId(
         | "thirdpartypasswordless"
         | undefined;
 }>;
+export declare function isRecipeInitialised(recipeId: RecipeIdForUser): boolean;

--- a/lib/build/recipe/dashboard/utils.js
+++ b/lib/build/recipe/dashboard/utils.js
@@ -265,6 +265,12 @@ function isRecipeInitialised(recipeId) {
                 isRecipeInitialised = true;
             } catch (_) {}
         }
+        if (!isRecipeInitialised) {
+            try {
+                recipe_5.default.getInstanceOrThrowError();
+                isRecipeInitialised = true;
+            } catch (_) {}
+        }
     }
     return isRecipeInitialised;
 }

--- a/lib/build/recipe/dashboard/utils.js
+++ b/lib/build/recipe/dashboard/utils.js
@@ -55,7 +55,9 @@ const emailpassword_1 = require("../emailpassword");
 const thirdparty_1 = require("../thirdparty");
 const passwordless_1 = require("../passwordless");
 const thirdpartyemailpassword_1 = require("../thirdpartyemailpassword");
+const recipe_4 = require("../thirdpartyemailpassword/recipe");
 const thirdpartypasswordless_1 = require("../thirdpartypasswordless");
+const recipe_5 = require("../thirdpartypasswordless/recipe");
 function validateAndNormaliseUserInput(config) {
     if (config.apiKey.trim().length === 0) {
         throw new Error("apiKey provided to Dashboard recipe cannot be empty");
@@ -229,28 +231,41 @@ function getUserForRecipeId(userId, recipeId) {
 }
 exports.getUserForRecipeId = getUserForRecipeId;
 function isRecipeInitialised(recipeId) {
+    let isRecipeInitialised = false;
     if (recipeId === "emailpassword") {
         try {
             recipe_1.default.getInstanceOrThrowError();
-            return true;
-        } catch (_) {
-            return false;
+            isRecipeInitialised = true;
+        } catch (_) {}
+        if (!isRecipeInitialised) {
+            try {
+                recipe_4.default.getInstanceOrThrowError();
+                isRecipeInitialised = true;
+            } catch (_) {}
         }
     } else if (recipeId === "passwordless") {
         try {
             recipe_3.default.getInstanceOrThrowError();
-            return true;
-        } catch (_) {
-            return false;
+            isRecipeInitialised = true;
+        } catch (_) {}
+        if (!isRecipeInitialised) {
+            try {
+                recipe_5.default.getInstanceOrThrowError();
+                isRecipeInitialised = true;
+            } catch (_) {}
         }
     } else if (recipeId === "thirdparty") {
         try {
             recipe_2.default.getInstanceOrThrowError();
-            return true;
-        } catch (_) {
-            return false;
+            isRecipeInitialised = true;
+        } catch (_) {}
+        if (!isRecipeInitialised) {
+            try {
+                recipe_4.default.getInstanceOrThrowError();
+                isRecipeInitialised = true;
+            } catch (_) {}
         }
     }
-    return false;
+    return isRecipeInitialised;
 }
 exports.isRecipeInitialised = isRecipeInitialised;

--- a/lib/build/recipe/dashboard/utils.js
+++ b/lib/build/recipe/dashboard/utils.js
@@ -228,3 +228,29 @@ function getUserForRecipeId(userId, recipeId) {
     });
 }
 exports.getUserForRecipeId = getUserForRecipeId;
+function isRecipeInitialised(recipeId) {
+    if (recipeId === "emailpassword") {
+        try {
+            recipe_1.default.getInstanceOrThrowError();
+            return true;
+        } catch (_) {
+            return false;
+        }
+    } else if (recipeId === "passwordless") {
+        try {
+            recipe_3.default.getInstanceOrThrowError();
+            return true;
+        } catch (_) {
+            return false;
+        }
+    } else if (recipeId === "thirdparty") {
+        try {
+            recipe_2.default.getInstanceOrThrowError();
+            return true;
+        } catch (_) {
+            return false;
+        }
+    }
+    return false;
+}
+exports.isRecipeInitialised = isRecipeInitialised;

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "12.1.3";
+export declare const version = "12.1.4";
 export declare const cdiSupported: string[];
-export declare const dashboardVersion = "0.2";
+export declare const dashboardVersion = "0.3";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -14,7 +14,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "12.1.3";
+exports.version = "12.1.4";
 exports.cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
-exports.dashboardVersion = "0.2";
+exports.dashboardVersion = "0.3";

--- a/lib/ts/recipe/dashboard/api/userdetails/userGet.ts
+++ b/lib/ts/recipe/dashboard/api/userdetails/userGet.ts
@@ -7,13 +7,16 @@ import {
     ThirdPartyUser,
 } from "../../types";
 import STError from "../../../../error";
-import { getUserForRecipeId, isValidRecipeId } from "../../utils";
+import { getUserForRecipeId, isRecipeInitialised, isValidRecipeId } from "../../utils";
 import UserMetaDataRecipe from "../../../usermetadata/recipe";
 import UserMetaData from "../../../usermetadata";
 
 type Response =
     | {
           status: "NO_USER_FOUND_ERROR";
+      }
+    | {
+          status: "RECIPE_NOT_INITIALISED";
       }
     | {
           status: "OK";
@@ -54,6 +57,12 @@ export const userGet: APIFunction = async (_: APIInterface, options: APIOptions)
             message: "Invalid recipe id",
             type: STError.BAD_INPUT_ERROR,
         });
+    }
+
+    if (!isRecipeInitialised(recipeId)) {
+        return {
+            status: "RECIPE_NOT_INITIALISED",
+        };
     }
 
     let user: EmailPasswordUser | ThirdPartyUser | PasswordlessUser | undefined = (

--- a/lib/ts/recipe/dashboard/utils.ts
+++ b/lib/ts/recipe/dashboard/utils.ts
@@ -46,7 +46,9 @@ import EmailPassword from "../emailpassword";
 import ThirdParty from "../thirdparty";
 import Passwordless from "../passwordless";
 import ThirdPartyEmailPassword from "../thirdpartyemailpassword";
+import ThirdPartyEmailPasswordRecipe from "../thirdpartyemailpassword/recipe";
 import ThirdPartyPasswordless from "../thirdpartypasswordless";
+import ThirdPartyPasswordlessRecipe from "../thirdpartypasswordless/recipe";
 
 export function validateAndNormaliseUserInput(config: TypeInput): TypeNormalisedInput {
     if (config.apiKey.trim().length === 0) {
@@ -290,28 +292,45 @@ export async function getUserForRecipeId(
 }
 
 export function isRecipeInitialised(recipeId: RecipeIdForUser): boolean {
+    let isRecipeInitialised = false;
+
     if (recipeId === "emailpassword") {
         try {
             EmailPasswordRecipe.getInstanceOrThrowError();
-            return true;
-        } catch (_) {
-            return false;
+            isRecipeInitialised = true;
+        } catch (_) {}
+
+        if (!isRecipeInitialised) {
+            try {
+                ThirdPartyEmailPasswordRecipe.getInstanceOrThrowError();
+                isRecipeInitialised = true;
+            } catch (_) {}
         }
     } else if (recipeId === "passwordless") {
         try {
             PasswordlessRecipe.getInstanceOrThrowError();
-            return true;
-        } catch (_) {
-            return false;
+            isRecipeInitialised = true;
+        } catch (_) {}
+
+        if (!isRecipeInitialised) {
+            try {
+                ThirdPartyPasswordlessRecipe.getInstanceOrThrowError();
+                isRecipeInitialised = true;
+            } catch (_) {}
         }
     } else if (recipeId === "thirdparty") {
         try {
             ThirdPartyRecipe.getInstanceOrThrowError();
-            return true;
-        } catch (_) {
-            return false;
+            isRecipeInitialised = true;
+        } catch (_) {}
+
+        if (!isRecipeInitialised) {
+            try {
+                ThirdPartyEmailPasswordRecipe.getInstanceOrThrowError();
+                isRecipeInitialised = true;
+            } catch (_) {}
         }
     }
 
-    return false;
+    return isRecipeInitialised;
 }

--- a/lib/ts/recipe/dashboard/utils.ts
+++ b/lib/ts/recipe/dashboard/utils.ts
@@ -330,6 +330,13 @@ export function isRecipeInitialised(recipeId: RecipeIdForUser): boolean {
                 isRecipeInitialised = true;
             } catch (_) {}
         }
+
+        if (!isRecipeInitialised) {
+            try {
+                ThirdPartyPasswordlessRecipe.getInstanceOrThrowError();
+                isRecipeInitialised = true;
+            } catch (_) {}
+        }
     }
 
     return isRecipeInitialised;

--- a/lib/ts/recipe/dashboard/utils.ts
+++ b/lib/ts/recipe/dashboard/utils.ts
@@ -288,3 +288,30 @@ export async function getUserForRecipeId(
         recipe,
     };
 }
+
+export function isRecipeInitialised(recipeId: RecipeIdForUser): boolean {
+    if (recipeId === "emailpassword") {
+        try {
+            EmailPasswordRecipe.getInstanceOrThrowError();
+            return true;
+        } catch (_) {
+            return false;
+        }
+    } else if (recipeId === "passwordless") {
+        try {
+            PasswordlessRecipe.getInstanceOrThrowError();
+            return true;
+        } catch (_) {
+            return false;
+        }
+    } else if (recipeId === "thirdparty") {
+        try {
+            ThirdPartyRecipe.getInstanceOrThrowError();
+            return true;
+        } catch (_) {
+            return false;
+        }
+    }
+
+    return false;
+}

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,9 +12,9 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "12.1.3";
+export const version = "12.1.4";
 
 export const cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15"];
 
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
-export const dashboardVersion = "0.2";
+export const dashboardVersion = "0.3";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "12.1.3",
+    "version": "12.1.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "12.1.3",
+            "version": "12.1.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "axios": "0.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "12.1.3",
+    "version": "12.1.4",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

- Updates dashboard version to 0.3
- Updates user GET API in dashboard recipe to handle if the recipe for the user being fetched was not initialised

## Related issues

-   

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

None

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] ...
