### PR TITLE
fix: clear session fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [13.0.0] - 2023-01-08
+
+### Breaking changes
+
+-   The frontend SDK should be updated to a version supporting the header-based sessions!
+    -   supertokens-auth-react: >= 0.30.0
+    -   supertokens-web-js: >= 0.3.0
+    -   supertokens-website: >= 13.0.0
+    -   supertokens-react-native: >= 4.0.0
+    -   !!!TODO: re-check before release and add mobile SDKs
+-   `createNewSession` now requires passing the request as well as the response.
+    -   This only requires a change if you manually created sessions (e.g.: during testing)
+    -   There is a migration example added below. It uses express, but the same principle applies for other supported frameworks.
+
+### Added
+
+-   Added support for authorizing requests using the `Authorization` header instead of cookies
+    -   Added `getTokenTransferMethod` config option
+    -   Check out https://supertokens.com/docs/thirdpartyemailpassword/common-customizations/sessions/token-transfer-method for more information
+
+### Migration
+
+This example uses express, but the same principle applies for other supported frameworks.
+
+Before:
+
+```
+const app = express();
+app.post("/create", async (req, res) => {
+    await Session.createNewSession(res, "testing-userId", {}, {});
+    res.status(200).json({ message: true });
+});
+```
+
+After the update:
+
+```
+const app = express();
+app.post("/create", async (req, res) => {
+    await Session.createNewSession(req, res, "testing-userId", {}, {});
+    res.status(200).json({ message: true });
+});
+```
+
 ## [12.1.4] - 2022-12-26
 
 -   Updates dashboard version

--- a/lib/build/framework/awsLambda/framework.d.ts
+++ b/lib/build/framework/awsLambda/framework.d.ts
@@ -57,6 +57,7 @@ export declare class AWSResponse extends BaseResponse {
     constructor(event: SupertokensLambdaEvent | SupertokensLambdaEventV2);
     sendHTMLResponse: (html: string) => void;
     setHeader: (key: string, value: string, allowDuplicateKey: boolean) => void;
+    removeHeader: (key: string) => void;
     setCookie: (
         key: string,
         value: string,
@@ -67,6 +68,7 @@ export declare class AWSResponse extends BaseResponse {
         path: string,
         sameSite: "strict" | "lax" | "none"
     ) => void;
+    clearCookie: (key: string) => void;
     /**
      * @param {number} statusCode
      */

--- a/lib/build/framework/awsLambda/framework.d.ts
+++ b/lib/build/framework/awsLambda/framework.d.ts
@@ -68,7 +68,6 @@ export declare class AWSResponse extends BaseResponse {
         path: string,
         sameSite: "strict" | "lax" | "none"
     ) => void;
-    clearCookie: (key: string) => void;
     /**
      * @param {number} statusCode
      */

--- a/lib/build/framework/awsLambda/framework.js
+++ b/lib/build/framework/awsLambda/framework.js
@@ -164,12 +164,6 @@ class AWSResponse extends response_1.BaseResponse {
             );
             this.event.supertokens.response.cookies.push(serialisedCookie);
         };
-        this.clearCookie = (key) => {
-            const prefix = key + "=";
-            this.event.supertokens.response.cookies = this.event.supertokens.response.cookies.filter(
-                (v) => !v.startsWith(prefix)
-            );
-        };
         /**
          * @param {number} statusCode
          */

--- a/lib/build/framework/awsLambda/framework.js
+++ b/lib/build/framework/awsLambda/framework.js
@@ -146,6 +146,11 @@ class AWSResponse extends response_1.BaseResponse {
                 allowDuplicateKey,
             });
         };
+        this.removeHeader = (key) => {
+            this.event.supertokens.response.headers = this.event.supertokens.response.headers.filter(
+                (header) => header.key.toLowerCase() !== key.toLowerCase()
+            );
+        };
         this.setCookie = (key, value, domain, secure, httpOnly, expires, path, sameSite) => {
             let serialisedCookie = utils_2.serializeCookieValue(
                 key,
@@ -158,6 +163,12 @@ class AWSResponse extends response_1.BaseResponse {
                 sameSite
             );
             this.event.supertokens.response.cookies.push(serialisedCookie);
+        };
+        this.clearCookie = (key) => {
+            const prefix = key + "=";
+            this.event.supertokens.response.cookies = this.event.supertokens.response.cookies.filter(
+                (v) => !v.startsWith(prefix)
+            );
         };
         /**
          * @param {number} statusCode

--- a/lib/build/framework/express/framework.d.ts
+++ b/lib/build/framework/express/framework.d.ts
@@ -35,7 +35,6 @@ export declare class ExpressResponse extends BaseResponse {
         path: string,
         sameSite: "strict" | "lax" | "none"
     ) => void;
-    clearCookie: (key: string) => void;
     /**
      * @param {number} statusCode
      */

--- a/lib/build/framework/express/framework.d.ts
+++ b/lib/build/framework/express/framework.d.ts
@@ -24,6 +24,7 @@ export declare class ExpressResponse extends BaseResponse {
     constructor(response: Response);
     sendHTMLResponse: (html: string) => void;
     setHeader: (key: string, value: string, allowDuplicateKey: boolean) => void;
+    removeHeader: (key: string) => void;
     setCookie: (
         key: string,
         value: string,
@@ -34,6 +35,7 @@ export declare class ExpressResponse extends BaseResponse {
         path: string,
         sameSite: "strict" | "lax" | "none"
     ) => void;
+    clearCookie: (key: string) => void;
     /**
      * @param {number} statusCode
      */

--- a/lib/build/framework/express/framework.js
+++ b/lib/build/framework/express/framework.js
@@ -50,6 +50,7 @@ const request_1 = require("../request");
 const response_1 = require("../response");
 const utils_2 = require("../utils");
 const supertokens_1 = require("../../supertokens");
+const constants_1 = require("../constants");
 class ExpressRequest extends request_1.BaseRequest {
     constructor(request) {
         super();
@@ -117,6 +118,9 @@ class ExpressResponse extends response_1.BaseResponse {
         this.setHeader = (key, value, allowDuplicateKey) => {
             utils_2.setHeaderForExpressLikeResponse(this.response, key, value, allowDuplicateKey);
         };
+        this.removeHeader = (key) => {
+            this.response.removeHeader(key);
+        };
         this.setCookie = (key, value, domain, secure, httpOnly, expires, path, sameSite) => {
             utils_2.setCookieForServerResponse(
                 this.response,
@@ -129,6 +133,23 @@ class ExpressResponse extends response_1.BaseResponse {
                 path,
                 sameSite
             );
+        };
+        this.clearCookie = (key) => {
+            let setCookies = this.response.get(constants_1.COOKIE_HEADER);
+            if (setCookies === undefined || setCookies === "") {
+                return;
+            }
+            this.response.removeHeader(constants_1.COOKIE_HEADER);
+            const prefix = key + "=";
+            // Typescript is weird about instanceof
+            if (!(setCookies instanceof Array)) {
+                setCookies = [setCookies];
+            }
+            for (const cookie of setCookies) {
+                if (!cookie.startsWith(prefix)) {
+                    this.response.header(constants_1.COOKIE_HEADER, cookie);
+                }
+            }
         };
         /**
          * @param {number} statusCode

--- a/lib/build/framework/express/framework.js
+++ b/lib/build/framework/express/framework.js
@@ -50,7 +50,6 @@ const request_1 = require("../request");
 const response_1 = require("../response");
 const utils_2 = require("../utils");
 const supertokens_1 = require("../../supertokens");
-const constants_1 = require("../constants");
 class ExpressRequest extends request_1.BaseRequest {
     constructor(request) {
         super();
@@ -133,23 +132,6 @@ class ExpressResponse extends response_1.BaseResponse {
                 path,
                 sameSite
             );
-        };
-        this.clearCookie = (key) => {
-            let setCookies = this.response.get(constants_1.COOKIE_HEADER);
-            if (setCookies === undefined || setCookies === "") {
-                return;
-            }
-            this.response.removeHeader(constants_1.COOKIE_HEADER);
-            const prefix = key + "=";
-            // Typescript is weird about instanceof
-            if (!(setCookies instanceof Array)) {
-                setCookies = [setCookies];
-            }
-            for (const cookie of setCookies) {
-                if (!cookie.startsWith(prefix)) {
-                    this.response.header(constants_1.COOKIE_HEADER, cookie);
-                }
-            }
         };
         /**
          * @param {number} statusCode

--- a/lib/build/framework/fastify/framework.d.ts
+++ b/lib/build/framework/fastify/framework.d.ts
@@ -34,7 +34,6 @@ export declare class FastifyResponse extends BaseResponse {
         path: string,
         sameSite: "strict" | "lax" | "none"
     ) => void;
-    clearCookie: (key: string) => void;
     /**
      * @param {number} statusCode
      */

--- a/lib/build/framework/fastify/framework.d.ts
+++ b/lib/build/framework/fastify/framework.d.ts
@@ -23,6 +23,7 @@ export declare class FastifyResponse extends BaseResponse {
     constructor(response: FastifyReply);
     sendHTMLResponse: (html: string) => void;
     setHeader: (key: string, value: string, allowDuplicateKey: boolean) => void;
+    removeHeader: (key: string) => void;
     setCookie: (
         key: string,
         value: string,
@@ -33,6 +34,7 @@ export declare class FastifyResponse extends BaseResponse {
         path: string,
         sameSite: "strict" | "lax" | "none"
     ) => void;
+    clearCookie: (key: string) => void;
     /**
      * @param {number} statusCode
      */

--- a/lib/build/framework/fastify/framework.js
+++ b/lib/build/framework/fastify/framework.js
@@ -115,6 +115,9 @@ class FastifyResponse extends response_1.BaseResponse {
                 throw new Error("Error while setting header with key: " + key + " and value: " + value);
             }
         };
+        this.removeHeader = (key) => {
+            this.response.removeHeader(key);
+        };
         this.setCookie = (key, value, domain, secure, httpOnly, expires, path, sameSite) => {
             let serialisedCookie = utils_2.serializeCookieValue(
                 key,
@@ -163,6 +166,23 @@ class FastifyResponse extends response_1.BaseResponse {
              * this.response.header(COOKIE_HEADER, cookieValueToSetInHeader);
              */
             this.response.header(constants_1.COOKIE_HEADER, serialisedCookie);
+        };
+        this.clearCookie = (key) => {
+            let setCookies = this.response.getHeader(constants_1.COOKIE_HEADER);
+            if (setCookies === undefined || setCookies === "") {
+                return;
+            }
+            this.response.removeHeader(constants_1.COOKIE_HEADER);
+            const prefix = key + "=";
+            // Typescript is weird about instanceof
+            if (!(setCookies instanceof Array)) {
+                setCookies = [setCookies];
+            }
+            for (const cookie of setCookies) {
+                if (!cookie.startsWith(prefix)) {
+                    this.response.header(constants_1.COOKIE_HEADER, cookie);
+                }
+            }
         };
         /**
          * @param {number} statusCode

--- a/lib/build/framework/fastify/framework.js
+++ b/lib/build/framework/fastify/framework.js
@@ -167,23 +167,6 @@ class FastifyResponse extends response_1.BaseResponse {
              */
             this.response.header(constants_1.COOKIE_HEADER, serialisedCookie);
         };
-        this.clearCookie = (key) => {
-            let setCookies = this.response.getHeader(constants_1.COOKIE_HEADER);
-            if (setCookies === undefined || setCookies === "") {
-                return;
-            }
-            this.response.removeHeader(constants_1.COOKIE_HEADER);
-            const prefix = key + "=";
-            // Typescript is weird about instanceof
-            if (!(setCookies instanceof Array)) {
-                setCookies = [setCookies];
-            }
-            for (const cookie of setCookies) {
-                if (!cookie.startsWith(prefix)) {
-                    this.response.header(constants_1.COOKIE_HEADER, cookie);
-                }
-            }
-        };
         /**
          * @param {number} statusCode
          */

--- a/lib/build/framework/hapi/framework.d.ts
+++ b/lib/build/framework/hapi/framework.d.ts
@@ -17,7 +17,12 @@ export declare class HapiRequest extends BaseRequest {
     getOriginalURL: () => string;
 }
 export interface ExtendedResponseToolkit extends ResponseToolkit {
-    lazyHeaderBindings: (h: ResponseToolkit, key: string, value: string, allowDuplicateKey: boolean) => void;
+    lazyHeaderBindings: (
+        h: ResponseToolkit,
+        key: string,
+        value: string | undefined,
+        allowDuplicateKey: boolean
+    ) => void;
 }
 export declare class HapiResponse extends BaseResponse {
     private response;
@@ -28,6 +33,7 @@ export declare class HapiResponse extends BaseResponse {
     constructor(response: ExtendedResponseToolkit);
     sendHTMLResponse: (html: string) => void;
     setHeader: (key: string, value: string, allowDuplicateKey: boolean) => void;
+    removeHeader: (key: string) => void;
     setCookie: (
         key: string,
         value: string,
@@ -38,6 +44,7 @@ export declare class HapiResponse extends BaseResponse {
         path: string,
         sameSite: "strict" | "lax" | "none"
     ) => void;
+    clearCookie: (key: string) => void;
     /**
      * @param {number} statusCode
      */

--- a/lib/build/framework/hapi/framework.d.ts
+++ b/lib/build/framework/hapi/framework.d.ts
@@ -44,7 +44,6 @@ export declare class HapiResponse extends BaseResponse {
         path: string,
         sameSite: "strict" | "lax" | "none"
     ) => void;
-    clearCookie: (key: string) => void;
     /**
      * @param {number} statusCode
      */

--- a/lib/build/framework/hapi/framework.js
+++ b/lib/build/framework/hapi/framework.js
@@ -124,9 +124,6 @@ class HapiResponse extends response_1.BaseResponse {
                 this.response.unstate(key);
             }
         };
-        this.clearCookie = (key) => {
-            this.response.unstate(key);
-        };
         /**
          * @param {number} statusCode
          */

--- a/lib/build/framework/hapi/framework.js
+++ b/lib/build/framework/hapi/framework.js
@@ -106,6 +106,9 @@ class HapiResponse extends response_1.BaseResponse {
                 throw new Error("Error while setting header with key: " + key + " and value: " + value);
             }
         };
+        this.removeHeader = (key) => {
+            this.response.lazyHeaderBindings(this.response, key, undefined, false);
+        };
         this.setCookie = (key, value, domain, secure, httpOnly, expires, path, sameSite) => {
             let now = Date.now();
             if (expires > now) {
@@ -120,6 +123,9 @@ class HapiResponse extends response_1.BaseResponse {
             } else {
                 this.response.unstate(key);
             }
+        };
+        this.clearCookie = (key) => {
+            this.response.unstate(key);
         };
         /**
          * @param {number} statusCode
@@ -203,8 +209,15 @@ const plugin = {
                 })
             );
             server.decorate("toolkit", "lazyHeaderBindings", function (h, key, value, allowDuplicateKey) {
-                h.request.app.lazyHeaders = h.request.app.lazyHeaders || [];
-                h.request.app.lazyHeaders.push({ key, value, allowDuplicateKey });
+                const anyApp = h.request.app;
+                anyApp.lazyHeaders = anyApp.lazyHeaders || [];
+                if (value === undefined) {
+                    anyApp.lazyHeaders = anyApp.lazyHeaders.filter(
+                        (header) => header.key.toLowerCase() !== key.toLowerCase()
+                    );
+                } else {
+                    anyApp.lazyHeaders.push({ key, value, allowDuplicateKey });
+                }
             });
             let supportedRoutes = [];
             let routeMethodSet = new Set();

--- a/lib/build/framework/koa/framework.d.ts
+++ b/lib/build/framework/koa/framework.d.ts
@@ -25,6 +25,7 @@ export declare class KoaResponse extends BaseResponse {
     constructor(ctx: Context);
     sendHTMLResponse: (html: string) => void;
     setHeader: (key: string, value: string, allowDuplicateKey: boolean) => void;
+    removeHeader: (key: string) => void;
     setCookie: (
         key: string,
         value: string,
@@ -35,6 +36,7 @@ export declare class KoaResponse extends BaseResponse {
         path: string,
         sameSite: "strict" | "lax" | "none"
     ) => void;
+    clearCookie: (key: string) => void;
     /**
      * @param {number} statusCode
      */

--- a/lib/build/framework/koa/framework.d.ts
+++ b/lib/build/framework/koa/framework.d.ts
@@ -36,7 +36,6 @@ export declare class KoaResponse extends BaseResponse {
         path: string,
         sameSite: "strict" | "lax" | "none"
     ) => void;
-    clearCookie: (key: string) => void;
     /**
      * @param {number} statusCode
      */

--- a/lib/build/framework/koa/framework.js
+++ b/lib/build/framework/koa/framework.js
@@ -51,6 +51,7 @@ const response_1 = require("../response");
 const utils_2 = require("../utils");
 const co_body_1 = require("co-body");
 const supertokens_1 = require("../../supertokens");
+const constants_1 = require("../constants");
 class KoaRequest extends request_1.BaseRequest {
     constructor(ctx) {
         super();
@@ -141,6 +142,9 @@ class KoaResponse extends response_1.BaseResponse {
                 throw new Error("Error while setting header with key: " + key + " and value: " + value);
             }
         };
+        this.removeHeader = (key) => {
+            this.ctx.remove(key);
+        };
         this.setCookie = (key, value, domain, secure, httpOnly, expires, path, sameSite) => {
             this.ctx.cookies.set(key, value, {
                 secure,
@@ -150,6 +154,23 @@ class KoaResponse extends response_1.BaseResponse {
                 domain,
                 path,
             });
+        };
+        this.clearCookie = (key) => {
+            let setCookies = this.ctx.response.get(constants_1.COOKIE_HEADER);
+            if (setCookies === undefined || setCookies === "") {
+                return;
+            }
+            this.ctx.remove(constants_1.COOKIE_HEADER);
+            const prefix = key + "=";
+            // Typescript is weird about instanceof
+            if (!(setCookies instanceof Array)) {
+                setCookies = [setCookies];
+            }
+            for (const cookie of setCookies) {
+                if (!cookie.startsWith(prefix)) {
+                    this.ctx.set(constants_1.COOKIE_HEADER, cookie);
+                }
+            }
         };
         /**
          * @param {number} statusCode

--- a/lib/build/framework/koa/framework.js
+++ b/lib/build/framework/koa/framework.js
@@ -51,7 +51,6 @@ const response_1 = require("../response");
 const utils_2 = require("../utils");
 const co_body_1 = require("co-body");
 const supertokens_1 = require("../../supertokens");
-const constants_1 = require("../constants");
 class KoaRequest extends request_1.BaseRequest {
     constructor(ctx) {
         super();
@@ -154,23 +153,6 @@ class KoaResponse extends response_1.BaseResponse {
                 domain,
                 path,
             });
-        };
-        this.clearCookie = (key) => {
-            let setCookies = this.ctx.response.get(constants_1.COOKIE_HEADER);
-            if (setCookies === undefined || setCookies === "") {
-                return;
-            }
-            this.ctx.remove(constants_1.COOKIE_HEADER);
-            const prefix = key + "=";
-            // Typescript is weird about instanceof
-            if (!(setCookies instanceof Array)) {
-                setCookies = [setCookies];
-            }
-            for (const cookie of setCookies) {
-                if (!cookie.startsWith(prefix)) {
-                    this.ctx.set(constants_1.COOKIE_HEADER, cookie);
-                }
-            }
         };
         /**
          * @param {number} statusCode

--- a/lib/build/framework/loopback/framework.d.ts
+++ b/lib/build/framework/loopback/framework.d.ts
@@ -35,7 +35,6 @@ export declare class LoopbackResponse extends BaseResponse {
         path: string,
         sameSite: "strict" | "lax" | "none"
     ) => void;
-    clearCookie: (key: string) => void;
     setStatusCode: (statusCode: number) => void;
     sendJSONResponse: (content: any) => void;
 }

--- a/lib/build/framework/loopback/framework.d.ts
+++ b/lib/build/framework/loopback/framework.d.ts
@@ -24,6 +24,7 @@ export declare class LoopbackResponse extends BaseResponse {
     constructor(ctx: MiddlewareContext);
     sendHTMLResponse: (html: string) => void;
     setHeader: (key: string, value: string, allowDuplicateKey: boolean) => void;
+    removeHeader: (key: string) => void;
     setCookie: (
         key: string,
         value: string,
@@ -34,6 +35,7 @@ export declare class LoopbackResponse extends BaseResponse {
         path: string,
         sameSite: "strict" | "lax" | "none"
     ) => void;
+    clearCookie: (key: string) => void;
     setStatusCode: (statusCode: number) => void;
     sendJSONResponse: (content: any) => void;
 }

--- a/lib/build/framework/loopback/framework.js
+++ b/lib/build/framework/loopback/framework.js
@@ -50,7 +50,6 @@ const request_1 = require("../request");
 const response_1 = require("../response");
 const utils_2 = require("../utils");
 const supertokens_1 = require("../../supertokens");
-const constants_1 = require("../constants");
 class LoopbackRequest extends request_1.BaseRequest {
     constructor(ctx) {
         super();
@@ -126,23 +125,6 @@ class LoopbackResponse extends response_1.BaseResponse {
                 path,
                 sameSite
             );
-        };
-        this.clearCookie = (key) => {
-            let setCookies = this.response.get(constants_1.COOKIE_HEADER);
-            if (setCookies === undefined || setCookies === "") {
-                return;
-            }
-            this.response.removeHeader(constants_1.COOKIE_HEADER);
-            const prefix = key + "=";
-            // Typescript is weird about instanceof
-            if (!(setCookies instanceof Array)) {
-                setCookies = [setCookies];
-            }
-            for (const cookie of setCookies) {
-                if (!cookie.startsWith(prefix)) {
-                    this.response.header(constants_1.COOKIE_HEADER, cookie);
-                }
-            }
         };
         this.setStatusCode = (statusCode) => {
             if (!this.response.writableEnded) {

--- a/lib/build/framework/loopback/framework.js
+++ b/lib/build/framework/loopback/framework.js
@@ -50,6 +50,7 @@ const request_1 = require("../request");
 const response_1 = require("../response");
 const utils_2 = require("../utils");
 const supertokens_1 = require("../../supertokens");
+const constants_1 = require("../constants");
 class LoopbackRequest extends request_1.BaseRequest {
     constructor(ctx) {
         super();
@@ -110,6 +111,9 @@ class LoopbackResponse extends response_1.BaseResponse {
         this.setHeader = (key, value, allowDuplicateKey) => {
             utils_2.setHeaderForExpressLikeResponse(this.response, key, value, allowDuplicateKey);
         };
+        this.removeHeader = (key) => {
+            this.response.removeHeader(key);
+        };
         this.setCookie = (key, value, domain, secure, httpOnly, expires, path, sameSite) => {
             utils_2.setCookieForServerResponse(
                 this.response,
@@ -122,6 +126,23 @@ class LoopbackResponse extends response_1.BaseResponse {
                 path,
                 sameSite
             );
+        };
+        this.clearCookie = (key) => {
+            let setCookies = this.response.get(constants_1.COOKIE_HEADER);
+            if (setCookies === undefined || setCookies === "") {
+                return;
+            }
+            this.response.removeHeader(constants_1.COOKIE_HEADER);
+            const prefix = key + "=";
+            // Typescript is weird about instanceof
+            if (!(setCookies instanceof Array)) {
+                setCookies = [setCookies];
+            }
+            for (const cookie of setCookies) {
+                if (!cookie.startsWith(prefix)) {
+                    this.response.header(constants_1.COOKIE_HEADER, cookie);
+                }
+            }
         };
         this.setStatusCode = (statusCode) => {
             if (!this.response.writableEnded) {

--- a/lib/build/framework/response.d.ts
+++ b/lib/build/framework/response.d.ts
@@ -15,7 +15,6 @@ export declare abstract class BaseResponse {
         path: string,
         sameSite: "strict" | "lax" | "none"
     ) => void;
-    abstract clearCookie: (key: string) => void;
     abstract setStatusCode: (statusCode: number) => void;
     abstract sendJSONResponse: (content: any) => void;
     abstract sendHTMLResponse: (html: string) => void;

--- a/lib/build/framework/response.d.ts
+++ b/lib/build/framework/response.d.ts
@@ -4,6 +4,7 @@ export declare abstract class BaseResponse {
     original: any;
     constructor();
     abstract setHeader: (key: string, value: string, allowDuplicateKey: boolean) => void;
+    abstract removeHeader: (key: string) => void;
     abstract setCookie: (
         key: string,
         value: string,
@@ -14,6 +15,7 @@ export declare abstract class BaseResponse {
         path: string,
         sameSite: "strict" | "lax" | "none"
     ) => void;
+    abstract clearCookie: (key: string) => void;
     abstract setStatusCode: (statusCode: number) => void;
     abstract sendJSONResponse: (content: any) => void;
     abstract sendHTMLResponse: (html: string) => void;

--- a/lib/build/recipe/session/cookieAndHeaders.d.ts
+++ b/lib/build/recipe/session/cookieAndHeaders.d.ts
@@ -1,11 +1,7 @@
 // @ts-nocheck
 import { BaseRequest, BaseResponse } from "../../framework";
 import { TokenTransferMethod, TokenType, TypeNormalisedInput } from "./types";
-export declare function clearSessionFromAllTokenTransferMethods(
-    config: TypeNormalisedInput,
-    req: BaseRequest,
-    res: BaseResponse
-): void;
+export declare function clearSessionFromAllTokenTransferMethods(config: TypeNormalisedInput, res: BaseResponse): void;
 export declare function clearSession(
     config: TypeNormalisedInput,
     res: BaseResponse,

--- a/lib/build/recipe/session/cookieAndHeaders.js
+++ b/lib/build/recipe/session/cookieAndHeaders.js
@@ -24,22 +24,26 @@ const refreshTokenHeaderKey = "st-refresh-token";
 const antiCsrfHeaderKey = "anti-csrf";
 const frontTokenHeaderKey = "front-token";
 const authModeHeaderKey = "st-auth-mode";
-function clearSessionFromAllTokenTransferMethods(config, req, res) {
-    const tokenTypes = ["access", "refresh"];
-    removeTokenUpdatesFromResponse(res);
+function clearSessionFromAllTokenTransferMethods(config, res) {
+    // We are clearing the session in all transfermethods to be sure to override cookies in case they have been already added to the response.
+    // This is done to handle the following use-case:
+    // If the app overrides signInPOST to check the ban status of the user after the original implementation and throwing an UNAUTHORISED error
+    // In this case: the SDK has attached cookies to the response, but none was sent with the request
+    // We can't know which to clear since we can't reliably query or remove the set-cookie header added to the response (causes issues in some frameworks, i.e.: hapi)
+    // The safe solution in this case is to overwrite all the response cookies/headers with an empty value, which is what we are doing here
     for (const transferMethod of constants_2.availableTokenTransferMethods) {
-        if (tokenTypes.some((type) => getToken(req, type, transferMethod) !== undefined)) {
-            clearSession(config, res, transferMethod);
-        }
+        clearSession(config, res, transferMethod);
     }
 }
 exports.clearSessionFromAllTokenTransferMethods = clearSessionFromAllTokenTransferMethods;
 function clearSession(config, res, transferMethod) {
+    // If we can be specific about which transferMethod we want to clear, there is no reason to clear the other ones
     const tokenTypes = ["access", "refresh"];
     for (const token of tokenTypes) {
         setToken(config, res, token, "", 0, transferMethod);
     }
     res.removeHeader(antiCsrfHeaderKey);
+    // This can be added multiple times in some cases, but that should be OK
     res.setHeader(frontTokenHeaderKey, "remove", false);
     res.setHeader("Access-Control-Expose-Headers", frontTokenHeaderKey, true);
 }
@@ -116,14 +120,6 @@ function setToken(config, res, tokenType, value, expires, transferMethod) {
     }
 }
 exports.setToken = setToken;
-function removeTokenUpdatesFromResponse(res) {
-    res.removeHeader(antiCsrfHeaderKey);
-    res.removeHeader(frontTokenHeaderKey);
-    res.removeHeader(getResponseHeaderNameForTokenType("access"));
-    res.removeHeader(getResponseHeaderNameForTokenType("refresh"));
-    res.clearCookie(getCookieNameFromTokenType("access"));
-    res.clearCookie(getCookieNameFromTokenType("refresh"));
-}
 function setHeader(res, name, value) {
     res.setHeader(name, value, false);
     res.setHeader("Access-Control-Expose-Headers", name, true);

--- a/lib/build/recipe/session/cookieAndHeaders.js
+++ b/lib/build/recipe/session/cookieAndHeaders.js
@@ -25,19 +25,21 @@ const antiCsrfHeaderKey = "anti-csrf";
 const frontTokenHeaderKey = "front-token";
 const authModeHeaderKey = "st-auth-mode";
 function clearSessionFromAllTokenTransferMethods(config, req, res) {
+    const tokenTypes = ["access", "refresh"];
+    removeTokenUpdatesFromResponse(res);
     for (const transferMethod of constants_2.availableTokenTransferMethods) {
-        if (getToken(req, "access", transferMethod) !== undefined) {
+        if (tokenTypes.some((type) => getToken(req, type, transferMethod) !== undefined)) {
             clearSession(config, res, transferMethod);
         }
     }
 }
 exports.clearSessionFromAllTokenTransferMethods = clearSessionFromAllTokenTransferMethods;
 function clearSession(config, res, transferMethod) {
-    // If we can tell it's a cookie based session we are not clearing using headers
     const tokenTypes = ["access", "refresh"];
     for (const token of tokenTypes) {
         setToken(config, res, token, "", 0, transferMethod);
     }
+    res.removeHeader(antiCsrfHeaderKey);
     res.setHeader(frontTokenHeaderKey, "remove", false);
     res.setHeader("Access-Control-Expose-Headers", frontTokenHeaderKey, true);
 }
@@ -114,6 +116,14 @@ function setToken(config, res, tokenType, value, expires, transferMethod) {
     }
 }
 exports.setToken = setToken;
+function removeTokenUpdatesFromResponse(res) {
+    res.removeHeader(antiCsrfHeaderKey);
+    res.removeHeader(frontTokenHeaderKey);
+    res.removeHeader(getResponseHeaderNameForTokenType("access"));
+    res.removeHeader(getResponseHeaderNameForTokenType("refresh"));
+    res.clearCookie(getCookieNameFromTokenType("access"));
+    res.clearCookie(getCookieNameFromTokenType("refresh"));
+}
 function setHeader(res, name, value) {
     res.setHeader(name, value, false);
     res.setHeader("Access-Control-Expose-Headers", name, true);

--- a/lib/build/recipe/session/recipe.js
+++ b/lib/build/recipe/session/recipe.js
@@ -137,7 +137,7 @@ class SessionRecipe extends recipeModule_1.default {
                             err.payload.clearTokens === true
                         ) {
                             logger_1.logDebugMessage("errorHandler: Clearing tokens because of UNAUTHORISED response");
-                            cookieAndHeaders_1.clearSessionFromAllTokenTransferMethods(this.config, request, response);
+                            cookieAndHeaders_1.clearSessionFromAllTokenTransferMethods(this.config, response);
                         }
                         return yield this.config.errorHandlers.onUnauthorised(err.message, request, response);
                     } else if (err.type === error_1.default.TRY_REFRESH_TOKEN) {
@@ -148,7 +148,7 @@ class SessionRecipe extends recipeModule_1.default {
                         logger_1.logDebugMessage(
                             "errorHandler: Clearing tokens because of TOKEN_THEFT_DETECTED response"
                         );
-                        cookieAndHeaders_1.clearSessionFromAllTokenTransferMethods(this.config, request, response);
+                        cookieAndHeaders_1.clearSessionFromAllTokenTransferMethods(this.config, response);
                         return yield this.config.errorHandlers.onTokenTheftDetected(
                             err.payload.sessionHandle,
                             err.payload.userId,

--- a/lib/ts/framework/awsLambda/framework.ts
+++ b/lib/ts/framework/awsLambda/framework.ts
@@ -209,13 +209,6 @@ export class AWSResponse extends BaseResponse {
         this.event.supertokens.response.cookies.push(serialisedCookie);
     };
 
-    clearCookie = (key: string) => {
-        const prefix = key + "=";
-        this.event.supertokens.response.cookies = this.event.supertokens.response.cookies.filter(
-            (v) => !v.startsWith(prefix)
-        );
-    };
-
     /**
      * @param {number} statusCode
      */

--- a/lib/ts/framework/awsLambda/framework.ts
+++ b/lib/ts/framework/awsLambda/framework.ts
@@ -189,6 +189,12 @@ export class AWSResponse extends BaseResponse {
         });
     };
 
+    removeHeader = (key: string) => {
+        this.event.supertokens.response.headers = this.event.supertokens.response.headers.filter(
+            (header) => header.key.toLowerCase() !== key.toLowerCase()
+        );
+    };
+
     setCookie = (
         key: string,
         value: string,
@@ -201,6 +207,13 @@ export class AWSResponse extends BaseResponse {
     ) => {
         let serialisedCookie = serializeCookieValue(key, value, domain, secure, httpOnly, expires, path, sameSite);
         this.event.supertokens.response.cookies.push(serialisedCookie);
+    };
+
+    clearCookie = (key: string) => {
+        const prefix = key + "=";
+        this.event.supertokens.response.cookies = this.event.supertokens.response.cookies.filter(
+            (v) => !v.startsWith(prefix)
+        );
     };
 
     /**

--- a/lib/ts/framework/express/framework.ts
+++ b/lib/ts/framework/express/framework.ts
@@ -29,7 +29,6 @@ import {
 import type { Framework } from "../types";
 import SuperTokens from "../../supertokens";
 import type { SessionContainerInterface } from "../../recipe/session/types";
-import { COOKIE_HEADER } from "../constants";
 
 export class ExpressRequest extends BaseRequest {
     private request: Request;
@@ -132,24 +131,6 @@ export class ExpressResponse extends BaseResponse {
         sameSite: "strict" | "lax" | "none"
     ) => {
         setCookieForServerResponse(this.response, key, value, domain, secure, httpOnly, expires, path, sameSite);
-    };
-
-    clearCookie = (key: string) => {
-        let setCookies: string | string[] = this.response.get(COOKIE_HEADER);
-        if (setCookies === undefined || setCookies === "") {
-            return;
-        }
-        this.response.removeHeader(COOKIE_HEADER);
-        const prefix = key + "=";
-        // Typescript is weird about instanceof
-        if (!((setCookies as any) instanceof Array)) {
-            setCookies = [setCookies];
-        }
-        for (const cookie of setCookies) {
-            if (!cookie.startsWith(prefix)) {
-                this.response.header(COOKIE_HEADER, cookie);
-            }
-        }
     };
 
     /**

--- a/lib/ts/framework/express/framework.ts
+++ b/lib/ts/framework/express/framework.ts
@@ -29,6 +29,7 @@ import {
 import type { Framework } from "../types";
 import SuperTokens from "../../supertokens";
 import type { SessionContainerInterface } from "../../recipe/session/types";
+import { COOKIE_HEADER } from "../constants";
 
 export class ExpressRequest extends BaseRequest {
     private request: Request;
@@ -116,6 +117,10 @@ export class ExpressResponse extends BaseResponse {
         setHeaderForExpressLikeResponse(this.response, key, value, allowDuplicateKey);
     };
 
+    removeHeader = (key: string) => {
+        this.response.removeHeader(key);
+    };
+
     setCookie = (
         key: string,
         value: string,
@@ -127,6 +132,24 @@ export class ExpressResponse extends BaseResponse {
         sameSite: "strict" | "lax" | "none"
     ) => {
         setCookieForServerResponse(this.response, key, value, domain, secure, httpOnly, expires, path, sameSite);
+    };
+
+    clearCookie = (key: string) => {
+        let setCookies: string | string[] = this.response.get(COOKIE_HEADER);
+        if (setCookies === undefined || setCookies === "") {
+            return;
+        }
+        this.response.removeHeader(COOKIE_HEADER);
+        const prefix = key + "=";
+        // Typescript is weird about instanceof
+        if (!((setCookies as any) instanceof Array)) {
+            setCookies = [setCookies];
+        }
+        for (const cookie of setCookies) {
+            if (!cookie.startsWith(prefix)) {
+                this.response.header(COOKIE_HEADER, cookie);
+            }
+        }
     };
 
     /**

--- a/lib/ts/framework/fastify/framework.ts
+++ b/lib/ts/framework/fastify/framework.ts
@@ -110,6 +110,10 @@ export class FastifyResponse extends BaseResponse {
         }
     };
 
+    removeHeader = (key: string) => {
+        this.response.removeHeader(key);
+    };
+
     setCookie = (
         key: string,
         value: string,
@@ -158,6 +162,24 @@ export class FastifyResponse extends BaseResponse {
          * this.response.header(COOKIE_HEADER, cookieValueToSetInHeader);
          */
         this.response.header(COOKIE_HEADER, serialisedCookie);
+    };
+
+    clearCookie = (key: string) => {
+        let setCookies: string | string[] | undefined = this.response.getHeader(COOKIE_HEADER);
+        if (setCookies === undefined || setCookies === "") {
+            return;
+        }
+        this.response.removeHeader(COOKIE_HEADER);
+        const prefix = key + "=";
+        // Typescript is weird about instanceof
+        if (!((setCookies as any) instanceof Array)) {
+            setCookies = [setCookies];
+        }
+        for (const cookie of setCookies) {
+            if (!cookie.startsWith(prefix)) {
+                this.response.header(COOKIE_HEADER, cookie);
+            }
+        }
     };
 
     /**

--- a/lib/ts/framework/fastify/framework.ts
+++ b/lib/ts/framework/fastify/framework.ts
@@ -164,24 +164,6 @@ export class FastifyResponse extends BaseResponse {
         this.response.header(COOKIE_HEADER, serialisedCookie);
     };
 
-    clearCookie = (key: string) => {
-        let setCookies: string | string[] | undefined = this.response.getHeader(COOKIE_HEADER);
-        if (setCookies === undefined || setCookies === "") {
-            return;
-        }
-        this.response.removeHeader(COOKIE_HEADER);
-        const prefix = key + "=";
-        // Typescript is weird about instanceof
-        if (!((setCookies as any) instanceof Array)) {
-            setCookies = [setCookies];
-        }
-        for (const cookie of setCookies) {
-            if (!cookie.startsWith(prefix)) {
-                this.response.header(COOKIE_HEADER, cookie);
-            }
-        }
-    };
-
     /**
      * @param {number} statusCode
      */

--- a/lib/ts/framework/hapi/framework.ts
+++ b/lib/ts/framework/hapi/framework.ts
@@ -140,10 +140,6 @@ export class HapiResponse extends BaseResponse {
         }
     };
 
-    clearCookie = (key: string) => {
-        this.response.unstate(key);
-    };
-
     /**
      * @param {number} statusCode
      */

--- a/lib/ts/framework/hapi/framework.ts
+++ b/lib/ts/framework/hapi/framework.ts
@@ -70,7 +70,12 @@ export class HapiRequest extends BaseRequest {
 }
 
 export interface ExtendedResponseToolkit extends ResponseToolkit {
-    lazyHeaderBindings: (h: ResponseToolkit, key: string, value: string, allowDuplicateKey: boolean) => void;
+    lazyHeaderBindings: (
+        h: ResponseToolkit,
+        key: string,
+        value: string | undefined,
+        allowDuplicateKey: boolean
+    ) => void;
 }
 
 export class HapiResponse extends BaseResponse {
@@ -105,6 +110,10 @@ export class HapiResponse extends BaseResponse {
         }
     };
 
+    removeHeader = (key: string) => {
+        this.response.lazyHeaderBindings(this.response, key, undefined, false);
+    };
+
     setCookie = (
         key: string,
         value: string,
@@ -116,6 +125,7 @@ export class HapiResponse extends BaseResponse {
         sameSite: "strict" | "lax" | "none"
     ) => {
         let now = Date.now();
+
         if (expires > now) {
             this.response.state(key, value, {
                 isHttpOnly: httpOnly,
@@ -128,6 +138,10 @@ export class HapiResponse extends BaseResponse {
         } else {
             this.response.unstate(key);
         }
+    };
+
+    clearCookie = (key: string) => {
+        this.response.unstate(key);
     };
 
     /**
@@ -213,11 +227,18 @@ const plugin: Plugin<{}> = {
         server.decorate("toolkit", "lazyHeaderBindings", function (
             h: ResponseToolkit,
             key: string,
-            value: string,
+            value: string | undefined,
             allowDuplicateKey: boolean
         ) {
-            (h.request.app as any).lazyHeaders = (h.request.app as any).lazyHeaders || [];
-            (h.request.app as any).lazyHeaders.push({ key, value, allowDuplicateKey });
+            const anyApp = h.request.app as any;
+            anyApp.lazyHeaders = anyApp.lazyHeaders || [];
+            if (value === undefined) {
+                anyApp.lazyHeaders = anyApp.lazyHeaders.filter(
+                    (header: { key: string }) => header.key.toLowerCase() !== key.toLowerCase()
+                );
+            } else {
+                anyApp.lazyHeaders.push({ key, value, allowDuplicateKey });
+            }
         });
         let supportedRoutes: ServerRoute[] = [];
         let routeMethodSet = new Set<string>();

--- a/lib/ts/framework/koa/framework.ts
+++ b/lib/ts/framework/koa/framework.ts
@@ -23,7 +23,6 @@ import { json, form } from "co-body";
 import { SessionContainerInterface } from "../../recipe/session/types";
 import SuperTokens from "../../supertokens";
 import { Framework } from "../types";
-import { COOKIE_HEADER } from "../constants";
 
 export class KoaRequest extends BaseRequest {
     private ctx: Context;
@@ -153,24 +152,6 @@ export class KoaResponse extends BaseResponse {
             domain,
             path,
         });
-    };
-
-    clearCookie = (key: string) => {
-        let setCookies: string | string[] = this.ctx.response.get(COOKIE_HEADER);
-        if (setCookies === undefined || setCookies === "") {
-            return;
-        }
-        this.ctx.remove(COOKIE_HEADER);
-        const prefix = key + "=";
-        // Typescript is weird about instanceof
-        if (!((setCookies as any) instanceof Array)) {
-            setCookies = [setCookies];
-        }
-        for (const cookie of setCookies) {
-            if (!cookie.startsWith(prefix)) {
-                this.ctx.set(COOKIE_HEADER, cookie);
-            }
-        }
     };
 
     /**

--- a/lib/ts/framework/koa/framework.ts
+++ b/lib/ts/framework/koa/framework.ts
@@ -23,6 +23,7 @@ import { json, form } from "co-body";
 import { SessionContainerInterface } from "../../recipe/session/types";
 import SuperTokens from "../../supertokens";
 import { Framework } from "../types";
+import { COOKIE_HEADER } from "../constants";
 
 export class KoaRequest extends BaseRequest {
     private ctx: Context;
@@ -130,6 +131,10 @@ export class KoaResponse extends BaseResponse {
         }
     };
 
+    removeHeader = (key: string) => {
+        this.ctx.remove(key);
+    };
+
     setCookie = (
         key: string,
         value: string,
@@ -148,6 +153,24 @@ export class KoaResponse extends BaseResponse {
             domain,
             path,
         });
+    };
+
+    clearCookie = (key: string) => {
+        let setCookies: string | string[] = this.ctx.response.get(COOKIE_HEADER);
+        if (setCookies === undefined || setCookies === "") {
+            return;
+        }
+        this.ctx.remove(COOKIE_HEADER);
+        const prefix = key + "=";
+        // Typescript is weird about instanceof
+        if (!((setCookies as any) instanceof Array)) {
+            setCookies = [setCookies];
+        }
+        for (const cookie of setCookies) {
+            if (!cookie.startsWith(prefix)) {
+                this.ctx.set(COOKIE_HEADER, cookie);
+            }
+        }
     };
 
     /**

--- a/lib/ts/framework/loopback/framework.ts
+++ b/lib/ts/framework/loopback/framework.ts
@@ -30,6 +30,7 @@ import {
 } from "../utils";
 import SuperTokens from "../../supertokens";
 import type { Framework } from "../types";
+import { COOKIE_HEADER } from "../constants";
 
 export class LoopbackRequest extends BaseRequest {
     private request: Request;
@@ -110,6 +111,10 @@ export class LoopbackResponse extends BaseResponse {
         setHeaderForExpressLikeResponse(this.response, key, value, allowDuplicateKey);
     };
 
+    removeHeader = (key: string) => {
+        this.response.removeHeader(key);
+    };
+
     setCookie = (
         key: string,
         value: string,
@@ -121,6 +126,24 @@ export class LoopbackResponse extends BaseResponse {
         sameSite: "strict" | "lax" | "none"
     ) => {
         setCookieForServerResponse(this.response, key, value, domain, secure, httpOnly, expires, path, sameSite);
+    };
+
+    clearCookie = (key: string) => {
+        let setCookies: string | string[] = this.response.get(COOKIE_HEADER);
+        if (setCookies === undefined || setCookies === "") {
+            return;
+        }
+        this.response.removeHeader(COOKIE_HEADER);
+        const prefix = key + "=";
+        // Typescript is weird about instanceof
+        if (!((setCookies as any) instanceof Array)) {
+            setCookies = [setCookies];
+        }
+        for (const cookie of setCookies) {
+            if (!cookie.startsWith(prefix)) {
+                this.response.header(COOKIE_HEADER, cookie);
+            }
+        }
     };
 
     setStatusCode = (statusCode: number) => {

--- a/lib/ts/framework/loopback/framework.ts
+++ b/lib/ts/framework/loopback/framework.ts
@@ -30,7 +30,6 @@ import {
 } from "../utils";
 import SuperTokens from "../../supertokens";
 import type { Framework } from "../types";
-import { COOKIE_HEADER } from "../constants";
 
 export class LoopbackRequest extends BaseRequest {
     private request: Request;
@@ -126,24 +125,6 @@ export class LoopbackResponse extends BaseResponse {
         sameSite: "strict" | "lax" | "none"
     ) => {
         setCookieForServerResponse(this.response, key, value, domain, secure, httpOnly, expires, path, sameSite);
-    };
-
-    clearCookie = (key: string) => {
-        let setCookies: string | string[] = this.response.get(COOKIE_HEADER);
-        if (setCookies === undefined || setCookies === "") {
-            return;
-        }
-        this.response.removeHeader(COOKIE_HEADER);
-        const prefix = key + "=";
-        // Typescript is weird about instanceof
-        if (!((setCookies as any) instanceof Array)) {
-            setCookies = [setCookies];
-        }
-        for (const cookie of setCookies) {
-            if (!cookie.startsWith(prefix)) {
-                this.response.header(COOKIE_HEADER, cookie);
-            }
-        }
     };
 
     setStatusCode = (statusCode: number) => {

--- a/lib/ts/framework/response.ts
+++ b/lib/ts/framework/response.ts
@@ -31,7 +31,6 @@ export abstract class BaseResponse {
         path: string,
         sameSite: "strict" | "lax" | "none"
     ) => void;
-    abstract clearCookie: (key: string) => void;
     abstract setStatusCode: (statusCode: number) => void;
     abstract sendJSONResponse: (content: any) => void;
     abstract sendHTMLResponse: (html: string) => void;

--- a/lib/ts/framework/response.ts
+++ b/lib/ts/framework/response.ts
@@ -20,6 +20,7 @@ export abstract class BaseResponse {
         this.wrapperUsed = true;
     }
     abstract setHeader: (key: string, value: string, allowDuplicateKey: boolean) => void;
+    abstract removeHeader: (key: string) => void;
     abstract setCookie: (
         key: string,
         value: string,
@@ -30,6 +31,7 @@ export abstract class BaseResponse {
         path: string,
         sameSite: "strict" | "lax" | "none"
     ) => void;
+    abstract clearCookie: (key: string) => void;
     abstract setStatusCode: (statusCode: number) => void;
     abstract sendJSONResponse: (content: any) => void;
     abstract sendHTMLResponse: (html: string) => void;

--- a/lib/ts/recipe/session/cookieAndHeaders.ts
+++ b/lib/ts/recipe/session/cookieAndHeaders.ts
@@ -29,28 +29,27 @@ const frontTokenHeaderKey = "front-token";
 
 const authModeHeaderKey = "st-auth-mode";
 
-export function clearSessionFromAllTokenTransferMethods(
-    config: TypeNormalisedInput,
-    req: BaseRequest,
-    res: BaseResponse
-) {
-    const tokenTypes: TokenType[] = ["access", "refresh"];
-
-    removeTokenUpdatesFromResponse(res);
+export function clearSessionFromAllTokenTransferMethods(config: TypeNormalisedInput, res: BaseResponse) {
+    // We are clearing the session in all transfermethods to be sure to override cookies in case they have been already added to the response.
+    // This is done to handle the following use-case:
+    // If the app overrides signInPOST to check the ban status of the user after the original implementation and throwing an UNAUTHORISED error
+    // In this case: the SDK has attached cookies to the response, but none was sent with the request
+    // We can't know which to clear since we can't reliably query or remove the set-cookie header added to the response (causes issues in some frameworks, i.e.: hapi)
+    // The safe solution in this case is to overwrite all the response cookies/headers with an empty value, which is what we are doing here
     for (const transferMethod of availableTokenTransferMethods) {
-        if (tokenTypes.some((type) => getToken(req, type, transferMethod) !== undefined)) {
-            clearSession(config, res, transferMethod);
-        }
+        clearSession(config, res, transferMethod);
     }
 }
 
 export function clearSession(config: TypeNormalisedInput, res: BaseResponse, transferMethod: TokenTransferMethod) {
+    // If we can be specific about which transferMethod we want to clear, there is no reason to clear the other ones
     const tokenTypes: TokenType[] = ["access", "refresh"];
     for (const token of tokenTypes) {
         setToken(config, res, token, "", 0, transferMethod);
     }
 
     res.removeHeader(antiCsrfHeaderKey);
+    // This can be added multiple times in some cases, but that should be OK
     res.setHeader(frontTokenHeaderKey, "remove", false);
     res.setHeader("Access-Control-Expose-Headers", frontTokenHeaderKey, true);
 }
@@ -135,17 +134,6 @@ export function setToken(
     } else if (transferMethod === "header") {
         setHeader(res, getResponseHeaderNameForTokenType(tokenType), value);
     }
-}
-
-function removeTokenUpdatesFromResponse(res: BaseResponse) {
-    res.removeHeader(antiCsrfHeaderKey);
-    res.removeHeader(frontTokenHeaderKey);
-
-    res.removeHeader(getResponseHeaderNameForTokenType("access"));
-    res.removeHeader(getResponseHeaderNameForTokenType("refresh"));
-
-    res.clearCookie(getCookieNameFromTokenType("access"));
-    res.clearCookie(getCookieNameFromTokenType("refresh"));
 }
 
 export function setHeader(res: BaseResponse, name: string, value: string) {

--- a/lib/ts/recipe/session/recipe.ts
+++ b/lib/ts/recipe/session/recipe.ts
@@ -226,7 +226,7 @@ export default class SessionRecipe extends RecipeModule {
                     err.payload.clearTokens === true
                 ) {
                     logDebugMessage("errorHandler: Clearing tokens because of UNAUTHORISED response");
-                    clearSessionFromAllTokenTransferMethods(this.config, request, response);
+                    clearSessionFromAllTokenTransferMethods(this.config, response);
                 }
                 return await this.config.errorHandlers.onUnauthorised(err.message, request, response);
             } else if (err.type === STError.TRY_REFRESH_TOKEN) {
@@ -235,7 +235,7 @@ export default class SessionRecipe extends RecipeModule {
             } else if (err.type === STError.TOKEN_THEFT_DETECTED) {
                 logDebugMessage("errorHandler: returning TOKEN_THEFT_DETECTED");
                 logDebugMessage("errorHandler: Clearing tokens because of TOKEN_THEFT_DETECTED response");
-                clearSessionFromAllTokenTransferMethods(this.config, request, response);
+                clearSessionFromAllTokenTransferMethods(this.config, response);
                 return await this.config.errorHandlers.onTokenTheftDetected(
                     err.payload.sessionHandle,
                     err.payload.userId,

--- a/test/framework/awsLambda.test.js
+++ b/test/framework/awsLambda.test.js
@@ -562,9 +562,18 @@ describe(`AWS Lambda: ${printPath("[test/framework/awsLambda.test.js]")}`, funct
                 let res = extractInfoFromResponse(result);
 
                 assert.strictEqual(res.status, 401);
-                assert.strictEqual(res.accessTokenFromAny, undefined);
-                assert.strictEqual(res.refreshTokenFromAny, undefined);
-                assert.strictEqual(res.frontToken, undefined);
+                if (tokenTransferMethod === "cookie") {
+                    assert.strictEqual(res.accessToken, "");
+                    assert.strictEqual(res.refreshToken, "");
+                    assert.strictEqual(res.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+                    assert.strictEqual(res.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+                    assert.strictEqual(res.accessTokenDomain, undefined);
+                    assert.strictEqual(res.refreshTokenDomain, undefined);
+                } else {
+                    assert.strictEqual(res.accessTokenFromHeader, "");
+                    assert.strictEqual(res.refreshTokenFromHeader, "");
+                }
+                assert.strictEqual(res.frontToken, "remove");
                 assert.strictEqual(res.antiCsrf, undefined);
             });
         });

--- a/test/framework/crossFramework.testgen.js
+++ b/test/framework/crossFramework.testgen.js
@@ -1,0 +1,406 @@
+const SuperTokens = require("../../");
+const { ProcessState } = require("../../lib/build/processState");
+const { setupST, startST, killAllST, cleanST } = require("../utils");
+
+const express = require("express");
+const request = require("supertest");
+const { verifySession: expressVerifySession } = require("../../recipe/session/framework/express");
+const ExpressFramework = require("../../framework/express");
+
+const Fastify = require("fastify");
+const FastifyFramework = require("../../framework/fastify");
+const { verifySession: fastifyVerifySession } = require("../../recipe/session/framework/fastify");
+
+const HapiFramework = require("../../framework/hapi");
+const Hapi = require("@hapi/hapi");
+const { verifySession: hapiVerifySession } = require("../../recipe/session/framework/hapi");
+
+const Koa = require("koa");
+const KoaFramework = require("../../framework/koa");
+const Router = require("@koa/router");
+const { verifySession: koaVerifySession } = require("../../recipe/session/framework/koa");
+
+const loopbackRoutes = [
+    {
+        path: "/create",
+        method: "post",
+        verifySession: false,
+    },
+    {
+        path: "/create-throw",
+        method: "post",
+        verifySession: false,
+    },
+    {
+        path: "/session/verify",
+        method: "post",
+        verifySession: true,
+    },
+    {
+        path: "/session/verify/optionalCSRF",
+        method: "post",
+        verifySession: true,
+        verifySessionOpts: { antiCsrfCheck: false },
+    },
+    {
+        path: "/session/revoke",
+        method: "post",
+        verifySession: true,
+    },
+];
+
+module.exports.addCrossFrameworkTests = (getTestCases, { allTokenTransferMethods } = {}) => {
+    if (allTokenTransferMethods) {
+        addTestCases("header");
+        addTestCases("cookie");
+    } else {
+        addTestCases("cookie");
+    }
+
+    function addTestCases(tokenTransferMethod) {
+        describe(`express w/ auth-mode=${tokenTransferMethod}`, () => {
+            let app;
+            beforeEach(async () => {
+                await killAllST();
+                await setupST();
+                ProcessState.getInstance().reset();
+                app = undefined;
+            });
+
+            after(async function () {
+                await killAllST();
+                await cleanST();
+            });
+
+            getTestCases(
+                async ({ stConfig, routes }) => {
+                    await startST();
+
+                    SuperTokens.init(stConfig);
+
+                    app = express();
+
+                    app.use(ExpressFramework.middleware());
+
+                    for (const route of routes) {
+                        const handlers = [
+                            (req, res, next) =>
+                                route.handler(
+                                    ExpressFramework.wrapRequest(req),
+                                    ExpressFramework.wrapResponse(res),
+                                    next
+                                ),
+                        ];
+                        if (route.verifySession) {
+                            handlers.unshift(expressVerifySession(route.verifySessionOpts));
+                        }
+                        if (route.method === "get") {
+                            app.get(route.path, ...handlers);
+                        } else if (route.method === "post") {
+                            app.post(route.path, ...handlers);
+                        } else {
+                            throw new Error("UNKNOWN METHOD");
+                        }
+                    }
+
+                    app.use(ExpressFramework.errorHandler());
+                },
+                ({ method, path, headers }) => {
+                    const req = method === "post" ? request(app).post(path) : request(app).get(path);
+                    for (const key of Object.keys(headers)) {
+                        req.set(key, headers[key]);
+                    }
+                    return new Promise((resolve) =>
+                        req.end((err, res) => {
+                            if (err) {
+                                resolve(undefined);
+                            } else {
+                                resolve(res);
+                            }
+                        })
+                    );
+                },
+                tokenTransferMethod
+            );
+        });
+
+        describe(`fastify w/ auth-mode=${tokenTransferMethod}`, () => {
+            let server;
+            beforeEach(async () => {
+                await killAllST();
+                await setupST();
+                ProcessState.getInstance().reset();
+                server = undefined;
+            });
+
+            afterEach(async function () {
+                try {
+                    await server.close();
+                } catch (err) {}
+            });
+
+            after(async function () {
+                await killAllST();
+                await cleanST();
+            });
+
+            getTestCases(
+                async ({ stConfig, routes }) => {
+                    await startST();
+
+                    SuperTokens.init({
+                        framework: "fastify",
+                        ...stConfig,
+                    });
+
+                    server = Fastify();
+
+                    await server.register(FastifyFramework.plugin);
+                    server.setErrorHandler(FastifyFramework.errorHandler());
+                    for (const route of routes) {
+                        const handlers = [
+                            (req, res) =>
+                                route.handler(
+                                    FastifyFramework.wrapRequest(req),
+                                    FastifyFramework.wrapResponse(res),
+                                    (err) => {
+                                        throw err;
+                                    }
+                                ),
+                        ];
+                        if (route.verifySession) {
+                            handlers.unshift(fastifyVerifySession(route.verifySessionOpts));
+                        }
+                        if (route.method === "get") {
+                            server.get(route.path, ...handlers);
+                        } else if (route.method === "post") {
+                            server.post(route.path, ...handlers);
+                        } else {
+                            throw new Error("UNKNOWN METHOD");
+                        }
+                    }
+                },
+                ({ method, path, headers }) => {
+                    return server.inject({
+                        method,
+                        url: path,
+                        headers,
+                    });
+                },
+                tokenTransferMethod
+            );
+        });
+
+        describe(`hapi w/ auth-mode=${tokenTransferMethod}`, () => {
+            let server;
+            beforeEach(async () => {
+                await killAllST();
+                await setupST();
+                ProcessState.getInstance().reset();
+                server = undefined;
+            });
+
+            afterEach(async function () {
+                try {
+                    await server.close();
+                } catch (err) {}
+            });
+
+            after(async function () {
+                await killAllST();
+                await cleanST();
+            });
+
+            getTestCases(
+                async ({ stConfig, routes }) => {
+                    await startST();
+
+                    SuperTokens.init({
+                        framework: "hapi",
+                        ...stConfig,
+                    });
+
+                    server = Hapi.server({
+                        port: 3000,
+                        host: "localhost",
+                    });
+
+                    for (const route of routes) {
+                        server.route({
+                            method: route.method,
+                            path: route.path,
+                            handler: async (req, res) => {
+                                await route.handler(
+                                    HapiFramework.wrapRequest(req),
+                                    HapiFramework.wrapResponse(res),
+                                    (err) => {
+                                        throw err;
+                                    }
+                                );
+                                return "";
+                            },
+
+                            options: {
+                                pre: route.verifySession ? [{ method: hapiVerifySession() }] : [],
+                            },
+                        });
+                    }
+                    await server.register(HapiFramework.plugin);
+
+                    await server.initialize();
+                },
+                ({ method, path, headers }) => {
+                    return server.inject({
+                        method,
+                        url: path,
+                        headers,
+                    });
+                },
+                tokenTransferMethod
+            );
+        });
+
+        describe(`koa w/ auth-mode=${tokenTransferMethod}`, () => {
+            let app, server;
+            beforeEach(async () => {
+                await killAllST();
+                await setupST();
+                ProcessState.getInstance().reset();
+                app = undefined;
+                server = undefined;
+            });
+
+            afterEach(async function () {
+                try {
+                    await server.close();
+                } catch (err) {}
+            });
+
+            after(async function () {
+                await killAllST();
+                await cleanST();
+            });
+
+            getTestCases(
+                async ({ stConfig, routes }) => {
+                    await startST();
+
+                    SuperTokens.init({
+                        framework: "koa",
+                        ...stConfig,
+                    });
+
+                    app = new Koa();
+                    const router = new Router();
+                    app.use(KoaFramework.middleware());
+
+                    for (const route of routes) {
+                        const handlers = [
+                            (ctx) =>
+                                route.handler(KoaFramework.wrapRequest(ctx), KoaFramework.wrapResponse(ctx), (err) => {
+                                    throw err;
+                                }),
+                        ];
+                        if (route.verifySession) {
+                            handlers.unshift(koaVerifySession(route.verifySessionOpts));
+                        }
+                        if (route.method === "get") {
+                            router.get(route.path, ...handlers);
+                        } else if (route.method === "post") {
+                            router.post(route.path, ...handlers);
+                        } else {
+                            throw new Error("UNKNOWN METHOD");
+                        }
+                    }
+
+                    app.use(router.routes());
+                    server = app.listen(9999);
+                },
+                ({ method, path, headers }) => {
+                    const req = method === "post" ? request(server).post(path) : request(server).get(path);
+                    for (const key of Object.keys(headers)) {
+                        req.set(key, headers[key]);
+                    }
+                    return new Promise((resolve) =>
+                        req.end((err, res) => {
+                            if (err) {
+                                resolve(undefined);
+                            } else {
+                                resolve(res);
+                            }
+                        })
+                    );
+                },
+                tokenTransferMethod
+            );
+        });
+
+        describe(`loopback w/ auth-mode=${tokenTransferMethod}`, () => {
+            let app;
+            beforeEach(async () => {
+                await killAllST();
+                await setupST();
+                ProcessState.getInstance().reset();
+                app = require("./loopback-server/index.js");
+            });
+
+            afterEach(async function () {
+                try {
+                    await app.stop();
+                } catch (err) {}
+            });
+
+            after(async function () {
+                await killAllST();
+                await cleanST();
+            });
+
+            getTestCases(
+                async ({ stConfig, routes }) => {
+                    await startST();
+
+                    SuperTokens.init({
+                        framework: "loopback",
+                        ...stConfig,
+                    });
+
+                    for (const route of routes) {
+                        const matchingRoute = loopbackRoutes.find((r) => r.path === route.path);
+                        if (
+                            matchingRoute === undefined ||
+                            matchingRoute.method !== route.method ||
+                            !!matchingRoute.verifySession !== !!route.verifySession ||
+                            JSON.stringify(matchingRoute.verifySessionOpts) !==
+                                JSON.stringify(matchingRoute.verifySessionOpts)
+                        ) {
+                            throw new Error(
+                                "No matching route in loopback-server. Please implement it or skip this test"
+                            );
+                        }
+                    }
+
+                    await app.start();
+                },
+                ({ method, path, headers }) => {
+                    const req =
+                        method === "post"
+                            ? request("http://localhost:9876").post(path)
+                            : request("http://localhost:9876").get(path);
+                    for (const key of Object.keys(headers)) {
+                        req.set(key, headers[key]);
+                    }
+                    return new Promise((resolve) =>
+                        req.end((err, res) => {
+                            if (err) {
+                                resolve(undefined);
+                            } else {
+                                resolve(res);
+                            }
+                        })
+                    );
+                },
+                tokenTransferMethod
+            );
+        });
+    }
+};

--- a/test/framework/crossframework/unauthorised.test.js
+++ b/test/framework/crossframework/unauthorised.test.js
@@ -148,9 +148,18 @@ addCrossFrameworkTests(
                 );
 
                 assert.strictEqual(res.status, 401);
-                assert.strictEqual(res.accessTokenFromAny, undefined);
-                assert.strictEqual(res.refreshTokenFromAny, undefined);
-                assert.strictEqual(res.frontToken, undefined);
+                if (tokenTransferMethod === "cookie") {
+                    assert.strictEqual(res.accessToken, "");
+                    assert.strictEqual(res.refreshToken, "");
+                    assert.strictEqual(res.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+                    assert.strictEqual(res.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+                    assert.strictEqual(res.accessTokenDomain, undefined);
+                    assert.strictEqual(res.refreshTokenDomain, undefined);
+                } else {
+                    assert.strictEqual(res.accessTokenFromHeader, "");
+                    assert.strictEqual(res.refreshTokenFromHeader, "");
+                }
+                assert.strictEqual(res.frontToken, "remove");
                 assert.strictEqual(res.antiCsrf, undefined);
             });
         });

--- a/test/framework/crossframework/unauthorised.test.js
+++ b/test/framework/crossframework/unauthorised.test.js
@@ -1,0 +1,159 @@
+const { addCrossFrameworkTests } = require("../crossFramework.testgen");
+let Session = require("../../../recipe/session");
+const { extractInfoFromResponse } = require("../../utils");
+let assert = require("assert");
+
+addCrossFrameworkTests(
+    (setup, callServer, tokenTransferMethod) => {
+        describe("Throwing UNATHORISED", () => {
+            it("should clear all response cookies during refresh", async () => {
+                await setup({
+                    stConfig: {
+                        supertokens: {
+                            connectionURI: "http://localhost:8080",
+                        },
+                        appInfo: {
+                            apiDomain: "http://api.supertokens.io",
+                            appName: "SuperTokens",
+                            websiteDomain: "http://supertokens.io",
+                            apiBasePath: "/",
+                        },
+                        recipeList: [
+                            Session.init({
+                                antiCsrf: "VIA_TOKEN",
+                                override: {
+                                    apis: (oI) => {
+                                        return {
+                                            ...oI,
+                                            refreshPOST: async function (input) {
+                                                await oI.refreshPOST(input);
+                                                throw new Session.Error({
+                                                    message: "unauthorised",
+                                                    type: Session.Error.UNAUTHORISED,
+                                                    clearTokens: true,
+                                                });
+                                            },
+                                        };
+                                    },
+                                },
+                            }),
+                        ],
+                    },
+                    routes: [
+                        {
+                            path: "/create",
+                            method: "post",
+                            handler: async (req, res, next) => {
+                                await Session.createNewSession(req, res, "id1", {}, {});
+                                res.setStatusCode(200);
+                                res.sendJSONResponse("");
+                                return res.response;
+                            },
+                        },
+                    ],
+                });
+
+                let res = extractInfoFromResponse(
+                    await callServer({
+                        method: "post",
+                        path: "/create",
+                        headers: {
+                            "st-auth-mode": tokenTransferMethod,
+                        },
+                    })
+                );
+
+                assert.notStrictEqual(res.accessTokenFromAny, undefined);
+                assert.notStrictEqual(res.refreshTokenFromAny, undefined);
+
+                const refreshHeaders =
+                    tokenTransferMethod === "header"
+                        ? { authorization: `Bearer ${res.refreshTokenFromAny}` }
+                        : {
+                              cookie: `sRefreshToken=${encodeURIComponent(
+                                  res.refreshTokenFromAny
+                              )}; sIdRefreshToken=asdf`,
+                          };
+                if (res.antiCsrf) {
+                    refreshHeaders.antiCsrf = res.antiCsrf;
+                }
+
+                let resp = await callServer({
+                    method: "post",
+                    path: "/session/refresh",
+                    headers: refreshHeaders,
+                });
+
+                let res2 = extractInfoFromResponse(resp);
+
+                assert.strictEqual(res2.status, 401);
+                if (tokenTransferMethod === "cookie") {
+                    assert.strictEqual(res2.accessToken, "");
+                    assert.strictEqual(res2.refreshToken, "");
+                    assert.strictEqual(res2.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+                    assert.strictEqual(res2.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+                    assert.strictEqual(res2.accessTokenDomain, undefined);
+                    assert.strictEqual(res2.refreshTokenDomain, undefined);
+                } else {
+                    assert.strictEqual(res2.accessTokenFromHeader, "");
+                    assert.strictEqual(res2.refreshTokenFromHeader, "");
+                }
+                assert.strictEqual(res2.frontToken, "remove");
+                assert.strictEqual(res2.antiCsrf, undefined);
+            });
+
+            it("test revoking a session after createNewSession with throwing unauthorised error", async function () {
+                await setup({
+                    stConfig: {
+                        supertokens: {
+                            connectionURI: "http://localhost:8080",
+                        },
+                        appInfo: {
+                            apiDomain: "http://api.supertokens.io",
+                            appName: "SuperTokens",
+                            websiteDomain: "http://supertokens.io",
+                            apiBasePath: "/",
+                        },
+                        recipeList: [
+                            Session.init({
+                                antiCsrf: "VIA_TOKEN",
+                            }),
+                        ],
+                    },
+                    routes: [
+                        {
+                            path: "/create-throw",
+                            method: "post",
+                            handler: async (req, res, next) => {
+                                await Session.createNewSession(req, res, "id1", {}, {});
+                                next(
+                                    new Session.Error({
+                                        message: "unauthorised",
+                                        type: Session.Error.UNAUTHORISED,
+                                    })
+                                );
+                            },
+                        },
+                    ],
+                });
+
+                let res = extractInfoFromResponse(
+                    await callServer({
+                        method: "post",
+                        path: "/create-throw",
+                        headers: {
+                            "st-auth-mode": tokenTransferMethod,
+                        },
+                    })
+                );
+
+                assert.strictEqual(res.status, 401);
+                assert.strictEqual(res.accessTokenFromAny, undefined);
+                assert.strictEqual(res.refreshTokenFromAny, undefined);
+                assert.strictEqual(res.frontToken, undefined);
+                assert.strictEqual(res.antiCsrf, undefined);
+            });
+        });
+    },
+    { allTokenTransferMethods: true }
+);

--- a/test/framework/fastify.test.js
+++ b/test/framework/fastify.test.js
@@ -41,7 +41,7 @@ describe(`Fastify: ${printPath("[test/framework/fastify.test.js]")}`, function (
 
     afterEach(async function () {
         try {
-            await this.sever.close();
+            await this.server.close();
         } catch (err) {}
     });
     after(async function () {

--- a/test/framework/loopback-server/index.js
+++ b/test/framework/loopback-server/index.js
@@ -41,6 +41,20 @@ let Create = class Create {
 };
 __decorate([rest_1.post("/create"), rest_1.response(200)], Create.prototype, "handler", null);
 Create = __decorate([__param(0, core_1.inject(rest_1.RestBindings.Http.CONTEXT))], Create);
+let CreateThrowing = class CreateThrowing {
+    constructor(ctx) {
+        this.ctx = ctx;
+    }
+    async handler() {
+        await session_1.default.createNewSession(this.ctx, this.ctx, "userId", {}, {});
+        throw new session_1.default.Error({
+            message: "unauthorised",
+            type: session_1.default.Error.UNAUTHORISED,
+        });
+    }
+};
+__decorate([rest_1.post("/create-throw"), rest_1.response(200)], CreateThrowing.prototype, "handler", null);
+CreateThrowing = __decorate([__param(0, core_1.inject(rest_1.RestBindings.Http.CONTEXT))], CreateThrowing);
 let Verify = class Verify {
     constructor(ctx) {
         this.ctx = ctx;
@@ -102,6 +116,7 @@ let app = new rest_1.RestApplication({
 });
 app.middleware(loopback_1.middleware);
 app.controller(Create);
+app.controller(CreateThrowing);
 app.controller(Verify);
 app.controller(Revoke);
 app.controller(VerifyOptionalCSRF);

--- a/test/framework/loopback-server/index.ts
+++ b/test/framework/loopback-server/index.ts
@@ -9,11 +9,23 @@ class Create {
     @post("/create")
     @response(200)
     async handler() {
-        await Session.createNewSession(this.ctx, "userId", {}, {});
+        await Session.createNewSession(this.ctx, this.ctx, "userId", {}, {});
         return {};
     }
 }
 
+class CreateThrowing {
+    constructor(@inject(RestBindings.Http.CONTEXT) private ctx: MiddlewareContext) {}
+    @post("/create-throw")
+    @response(200)
+    async handler() {
+        await Session.createNewSession(this.ctx, this.ctx, "userId", {}, {});
+        throw new Session.Error({
+            message: "unauthorised",
+            type: Session.Error.UNAUTHORISED,
+        });
+    }
+}
 class Verify {
     constructor(@inject(RestBindings.Http.CONTEXT) private ctx: MiddlewareContext) {}
     @post("/session/verify")
@@ -57,6 +69,7 @@ let app = new RestApplication({
 
 app.middleware(middleware);
 app.controller(Create);
+app.controller(CreateThrowing);
 app.controller(Verify);
 app.controller(Revoke);
 app.controller(VerifyOptionalCSRF);

--- a/test/sessionExpress.test.js
+++ b/test/sessionExpress.test.js
@@ -2800,14 +2800,14 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
 
         let res2 = extractInfoFromResponse(resp);
 
-        assert(res2.antiCsrf.length > 1);
         assert.deepEqual(res2.accessToken, "");
         assert.deepEqual(res2.refreshToken, "");
         assert.deepEqual(res2.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
         assert.deepEqual(res2.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
         assert(res2.accessTokenDomain === undefined);
         assert(res2.refreshTokenDomain === undefined);
-        assert(res2.frontToken.length > 1);
+        assert.strictEqual(res2.frontToken, "remove");
+        assert.strictEqual(res2.antiCsrf, undefined);
     });
 
     it("test revoking a session during refresh with revokeSession function and sending 401", async function () {
@@ -2892,14 +2892,14 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
 
         let res2 = extractInfoFromResponse(resp);
 
-        assert(res2.antiCsrf.length > 1);
         assert.deepEqual(res2.accessToken, "");
         assert.deepEqual(res2.refreshToken, "");
         assert.deepEqual(res2.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
         assert.deepEqual(res2.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
         assert(res2.accessTokenDomain === undefined);
         assert(res2.refreshTokenDomain === undefined);
-        assert(res2.frontToken.length > 1);
+        assert.strictEqual(res2.frontToken, "remove");
+        assert.strictEqual(res2.antiCsrf, undefined);
     });
 
     it("test revoking a session during refresh with throwing unauthorised error", async function () {
@@ -2986,14 +2986,14 @@ describe(`sessionExpress: ${printPath("[test/sessionExpress.test.js]")}`, functi
 
         let res2 = extractInfoFromResponse(resp);
 
-        assert(res2.antiCsrf.length > 1);
         assert.strictEqual(res2.accessToken, "");
         assert.strictEqual(res2.refreshToken, "");
         assert.strictEqual(res2.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
         assert.strictEqual(res2.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
         assert.strictEqual(res2.accessTokenDomain, undefined);
         assert.strictEqual(res2.refreshTokenDomain, undefined);
-        assert(res2.frontToken.length > 1);
+        assert.strictEqual(res2.frontToken, "remove");
+        assert.strictEqual(res2.antiCsrf, undefined);
     });
 
     it("test revoking a session during refresh fails if just sending 401", async function () {

--- a/test/utils.js
+++ b/test/utils.js
@@ -76,10 +76,8 @@ module.exports.setKeyValueInConfig = async function (key, value) {
 
 module.exports.extractInfoFromResponse = function (res) {
     let antiCsrf = res.headers["anti-csrf"];
-    let idRefreshTokenFromHeader = res.headers["st-id-refresh-token"];
     let accessToken = undefined;
     let refreshToken = undefined;
-    let idRefreshTokenFromCookie = undefined;
     let accessTokenExpiry = undefined;
     let refreshTokenExpiry = undefined;
     let idRefreshTokenExpiry = undefined;
@@ -132,16 +130,19 @@ module.exports.extractInfoFromResponse = function (res) {
     const refreshTokenFromHeader = res.headers["st-refresh-token"];
     const accessTokenFromHeader = res.headers["st-access-token"];
 
+    const accessTokenFromAny = accessToken || accessTokenFromHeader;
+    const refreshTokenFromAny = refreshToken || refreshTokenFromHeader;
+
     return {
-        status: res.status,
+        status: res.status || res.statusCode,
         body: res.body,
         antiCsrf,
         accessToken,
         refreshToken,
         accessTokenFromHeader,
         refreshTokenFromHeader,
-        idRefreshTokenFromHeader,
-        idRefreshTokenFromCookie,
+        accessTokenFromAny,
+        refreshTokenFromAny,
         accessTokenExpiry,
         refreshTokenExpiry,
         idRefreshTokenExpiry,

--- a/test/utils.js
+++ b/test/utils.js
@@ -130,8 +130,8 @@ module.exports.extractInfoFromResponse = function (res) {
     const refreshTokenFromHeader = res.headers["st-refresh-token"];
     const accessTokenFromHeader = res.headers["st-access-token"];
 
-    const accessTokenFromAny = accessToken || accessTokenFromHeader;
-    const refreshTokenFromAny = refreshToken || refreshTokenFromHeader;
+    const accessTokenFromAny = accessToken === undefined ? accessTokenFromHeader : accessToken;
+    const refreshTokenFromAny = refreshToken === undefined ? refreshTokenFromHeader : refreshToken;
 
     return {
         status: res.status || res.statusCode,


### PR DESCRIPTION
## Summary of change

- Updates changelog
- Updates session clearing to remove any session added to current request
- Updates session clearing to remove tokens even if only refresh-token is present

## Related issues

-   https://github.com/supertokens/supertokens-node/issues/476

## Test Plan

Added testcases:
- Throwing UNAUTHORISED during refresh with only refresh token present
- Throwing UNAUTHORISED after createNewSession

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
