### PR TITLE
Fix awsLambda header typo

### DIFF
--- a/lib/ts/framework/awsLambda/framework.ts
+++ b/lib/ts/framework/awsLambda/framework.ts
@@ -216,7 +216,7 @@ export class AWSResponse extends BaseResponse {
     sendJSONResponse = (content: any) => {
         if (!this.responseSet) {
             this.content = JSON.stringify(content);
-            this.setHeader("Context-Type", "application/json", false);
+            this.setHeader("Content-Type", "application/json", false);
             this.responseSet = true;
         }
     };


### PR DESCRIPTION
## Summary of change

Fixed typo. This would cause Content-Type to be plain on Lambda with Middy.

![CleanShot 2023-01-10 at 02 08 33@2x](https://user-images.githubusercontent.com/4787898/211439097-00f54ffd-4f29-4b40-8ba6-19299f2fb49f.png)
