### PR TITLE
feat: Add logic to initalise the dashboard recipe by default

### DIFF
--- a/lib/build/recipe/dashboard/recipe.d.ts
+++ b/lib/build/recipe/dashboard/recipe.d.ts
@@ -12,9 +12,9 @@ export default class Recipe extends RecipeModule {
     recipeInterfaceImpl: RecipeInterface;
     apiImpl: APIInterface;
     isInServerlessEnv: boolean;
-    constructor(recipeId: string, appInfo: NormalisedAppinfo, isInServerlessEnv: boolean, config: TypeInput);
+    constructor(recipeId: string, appInfo: NormalisedAppinfo, isInServerlessEnv: boolean, config?: TypeInput);
     static getInstanceOrThrowError(): Recipe;
-    static init(config: TypeInput): RecipeListFunction;
+    static init(config?: TypeInput): RecipeListFunction;
     static reset(): void;
     getAPIsHandled: () => APIHandled[];
     handleAPIRequest: (

--- a/lib/build/recipe/dashboard/utils.d.ts
+++ b/lib/build/recipe/dashboard/utils.d.ts
@@ -10,7 +10,7 @@ import {
     TypeInput,
     TypeNormalisedInput,
 } from "./types";
-export declare function validateAndNormaliseUserInput(config: TypeInput): TypeNormalisedInput;
+export declare function validateAndNormaliseUserInput(config?: TypeInput): TypeNormalisedInput;
 export declare function isApiPath(path: NormalisedURLPath, appInfo: NormalisedAppinfo): boolean;
 export declare function getApiIdIfMatched(path: NormalisedURLPath, method: HTTPMethod): string | undefined;
 export declare function sendUnauthorisedAccess(res: BaseResponse): void;

--- a/lib/build/recipe/dashboard/utils.js
+++ b/lib/build/recipe/dashboard/utils.js
@@ -70,12 +70,12 @@ function validateAndNormaliseUserInput(config) {
             functions: (originalImplementation) => originalImplementation,
             apis: (originalImplementation) => originalImplementation,
         },
-        config.override
+        config === undefined ? {} : config.override
     );
     return {
-        apiKey: config.apiKey,
+        apiKey: config === undefined ? undefined : config.apiKey,
         override,
-        authMode: config.apiKey ? "api-key" : "email-password",
+        authMode: config !== undefined && config.apiKey ? "api-key" : "email-password",
     };
 }
 exports.validateAndNormaliseUserInput = validateAndNormaliseUserInput;

--- a/lib/build/supertokens.js
+++ b/lib/build/supertokens.js
@@ -59,6 +59,8 @@ const normalisedURLPath_1 = __importDefault(require("./normalisedURLPath"));
 const error_1 = __importDefault(require("./error"));
 const logger_1 = require("./logger");
 const postSuperTokensInitCallbacks_1 = require("./postSuperTokensInitCallbacks");
+const dashboard_1 = __importDefault(require("./recipe/dashboard"));
+const recipe_1 = __importDefault(require("./recipe/dashboard/recipe"));
 class SuperTokens {
     constructor(config) {
         var _a, _b;
@@ -371,6 +373,10 @@ class SuperTokens {
         this.recipeModules = config.recipeList.map((func) => {
             return func(this.appInfo, this.isInServerlessEnv);
         });
+        if (this.recipeModules.filter((i) => i.getRecipeId() === recipe_1.default.RECIPE_ID).length === 0) {
+            // This means that the user has not initialised the dashboard recipe
+            this.recipeModules.push(dashboard_1.default.init()(this.appInfo, this.isInServerlessEnv));
+        }
         let telemetry = config.telemetry === undefined ? process.env.TEST_MODE !== "testing" : config.telemetry;
         if (telemetry) {
             if (this.isInServerlessEnv) {

--- a/lib/ts/recipe/dashboard/recipe.ts
+++ b/lib/ts/recipe/dashboard/recipe.ts
@@ -68,7 +68,7 @@ export default class Recipe extends RecipeModule {
 
     isInServerlessEnv: boolean;
 
-    constructor(recipeId: string, appInfo: NormalisedAppinfo, isInServerlessEnv: boolean, config: TypeInput) {
+    constructor(recipeId: string, appInfo: NormalisedAppinfo, isInServerlessEnv: boolean, config?: TypeInput) {
         super(recipeId, appInfo);
 
         this.config = validateAndNormaliseUserInput(config);
@@ -91,7 +91,7 @@ export default class Recipe extends RecipeModule {
         throw new Error("Initialisation not done. Did you forget to call the SuperTokens.init function?");
     }
 
-    static init(config: TypeInput): RecipeListFunction {
+    static init(config?: TypeInput): RecipeListFunction {
         return (appInfo, isInServerlessEnv) => {
             if (Recipe.instance === undefined) {
                 Recipe.instance = new Recipe(Recipe.RECIPE_ID, appInfo, isInServerlessEnv, config);

--- a/lib/ts/recipe/dashboard/utils.ts
+++ b/lib/ts/recipe/dashboard/utils.ts
@@ -52,17 +52,17 @@ import ThirdPartyEmailPasswordRecipe from "../thirdpartyemailpassword/recipe";
 import ThirdPartyPasswordless from "../thirdpartypasswordless";
 import ThirdPartyPasswordlessRecipe from "../thirdpartypasswordless/recipe";
 
-export function validateAndNormaliseUserInput(config: TypeInput): TypeNormalisedInput {
+export function validateAndNormaliseUserInput(config?: TypeInput): TypeNormalisedInput {
     let override = {
         functions: (originalImplementation: RecipeInterface) => originalImplementation,
         apis: (originalImplementation: APIInterface) => originalImplementation,
-        ...config.override,
+        ...(config === undefined ? {} : config.override),
     };
 
     return {
-        apiKey: config.apiKey,
+        apiKey: config === undefined ? undefined : config.apiKey,
         override,
-        authMode: config.apiKey ? "api-key" : "email-password",
+        authMode: config !== undefined && config.apiKey ? "api-key" : "email-password",
     };
 }
 

--- a/lib/ts/supertokens.ts
+++ b/lib/ts/supertokens.ts
@@ -32,6 +32,8 @@ import { TypeFramework } from "./framework/types";
 import STError from "./error";
 import { logDebugMessage } from "./logger";
 import { PostSuperTokensInitCallbacks } from "./postSuperTokensInitCallbacks";
+import DashboardIndex from "./recipe/dashboard";
+import DashboardRecipe from "./recipe/dashboard/recipe";
 
 export default class SuperTokens {
     private static instance: SuperTokens | undefined;
@@ -82,6 +84,11 @@ export default class SuperTokens {
         this.recipeModules = config.recipeList.map((func) => {
             return func(this.appInfo, this.isInServerlessEnv);
         });
+
+        if (this.recipeModules.filter((i) => i.getRecipeId() === DashboardRecipe.RECIPE_ID).length === 0) {
+            // This means that the user has not initialised the dashboard recipe
+            this.recipeModules.push(DashboardIndex.init()(this.appInfo, this.isInServerlessEnv));
+        }
 
         let telemetry = config.telemetry === undefined ? process.env.TEST_MODE !== "testing" : config.telemetry;
 


### PR DESCRIPTION
## Summary of change

This PR adds logic to the SDK that automatically initialises the dashboard recipe if the user has not already initialised it when calling SuperTokens.init

## Related issues

-  

## Test Plan

## Documentation changes

WIP

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] ...
