### PR TITLE
feat: Add email password login to the dashboard recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [13.1.0] - 2023-02-22
+
+-   Adds APIs and logic to the dashboard recipe to enable email password based login
+
 ## [13.0.2] - 2023-02-10
 
 -   Package version update for twilio to ^4.7.2 and verify-apple-id-token to ^3.0.1

--- a/coreDriverInterfaceSupported.json
+++ b/coreDriverInterfaceSupported.json
@@ -1,4 +1,4 @@
 {
     "_comment": "contains a list of core-driver interfaces branch names that this core supports",
-    "versions": ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15"]
+    "versions": ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15", "2.16", "2.17", "2.18"]
 }

--- a/lib/build/querier.d.ts
+++ b/lib/build/querier.d.ts
@@ -22,8 +22,8 @@ export declare class Querier {
         }[],
         apiKey?: string
     ): void;
-    sendPostRequest: (path: NormalisedURLPath, body: any) => Promise<any>;
-    sendDeleteRequest: (path: NormalisedURLPath, body: any) => Promise<any>;
+    sendPostRequest: <T = any>(path: NormalisedURLPath, body: any) => Promise<T>;
+    sendDeleteRequest: (path: NormalisedURLPath, body: any, params?: any) => Promise<any>;
     sendGetRequest: (path: NormalisedURLPath, params: any) => Promise<any>;
     sendPutRequest: (path: NormalisedURLPath, body: any) => Promise<any>;
     private sendRequestHelper;

--- a/lib/build/querier.js
+++ b/lib/build/querier.js
@@ -135,7 +135,7 @@ class Querier {
                 );
             });
         // path should start with "/"
-        this.sendDeleteRequest = (path, body) =>
+        this.sendDeleteRequest = (path, body, params) =>
             __awaiter(this, void 0, void 0, function* () {
                 var _c;
                 return this.sendRequestHelper(
@@ -159,6 +159,7 @@ class Querier {
                                 url,
                                 data: body,
                                 headers,
+                                params,
                             });
                         }),
                     ((_c = this.__hosts) === null || _c === void 0 ? void 0 : _c.length) || 0

--- a/lib/build/recipe/dashboard/api/implementation.js
+++ b/lib/build/recipe/dashboard/api/implementation.js
@@ -66,6 +66,7 @@ function getAPIImplementation() {
                     new normalisedURLPath_1.default(bundleBasePathString).getAsStringDangerous();
                 let connectionURI = "";
                 const superTokensInstance = supertokens_1.default.getInstanceOrThrowError();
+                const authMode = input.options.config.authMode;
                 if (superTokensInstance.supertokens !== undefined) {
                     connectionURI = superTokensInstance.supertokens.connectionURI;
                 }
@@ -79,6 +80,7 @@ function getAPIImplementation() {
                             .appendPath(new normalisedURLPath_1.default(constants_1.DASHBOARD_API))
                             .getAsStringDangerous()}"
                         window.connectionURI = "${connectionURI}"
+                        window.authMode = "${authMode}"
                     </script>
                     <script defer src="${bundleDomain}/static/js/bundle.js"></script></head>
                     <link href="${bundleDomain}/static/css/main.css" rel="stylesheet" type="text/css">

--- a/lib/build/recipe/dashboard/api/signIn.d.ts
+++ b/lib/build/recipe/dashboard/api/signIn.d.ts
@@ -1,0 +1,3 @@
+// @ts-nocheck
+import { APIInterface, APIOptions } from "../types";
+export default function signIn(_: APIInterface, options: APIOptions): Promise<boolean>;

--- a/lib/build/recipe/dashboard/api/signIn.js
+++ b/lib/build/recipe/dashboard/api/signIn.js
@@ -44,24 +44,41 @@ var __awaiter =
             step((generator = generator.apply(thisArg, _arguments || [])).next());
         });
     };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = require("../../../utils");
-const utils_2 = require("../utils");
-function validateKey(_, options) {
+const error_1 = __importDefault(require("../../../error"));
+const querier_1 = require("../../../querier");
+const normalisedURLPath_1 = __importDefault(require("../../../normalisedURLPath"));
+function signIn(_, options) {
     return __awaiter(this, void 0, void 0, function* () {
-        const input = {
-            req: options.req,
-            config: options.config,
-            userContext: utils_1.makeDefaultUserContextFromAPI(options.req),
-        };
-        if (yield utils_2.validateApiKey(input)) {
-            options.res.sendJSONResponse({
-                status: "OK",
+        const { email, password } = yield options.req.getJSONBody();
+        if (email === undefined) {
+            throw new error_1.default({
+                message: "Missing required parameter 'email'",
+                type: error_1.default.BAD_INPUT_ERROR,
             });
-        } else {
-            utils_2.sendUnauthorisedAccess(options.res);
         }
+        if (password === undefined) {
+            throw new error_1.default({
+                message: "Missing required parameter 'password'",
+                type: error_1.default.BAD_INPUT_ERROR,
+            });
+        }
+        let querier = querier_1.Querier.getNewInstanceOrThrowError(undefined);
+        const signInResponse = yield querier.sendPostRequest(
+            new normalisedURLPath_1.default("/recipe/dashboard/signin"),
+            {
+                email,
+                password,
+            }
+        );
+        utils_1.send200Response(options.res, signInResponse);
         return true;
     });
 }
-exports.default = validateKey;
+exports.default = signIn;

--- a/lib/build/recipe/dashboard/api/signOut.d.ts
+++ b/lib/build/recipe/dashboard/api/signOut.d.ts
@@ -1,0 +1,3 @@
+// @ts-nocheck
+import { APIInterface, APIOptions } from "../types";
+export default function signOut(_: APIInterface, options: APIOptions): Promise<boolean>;

--- a/lib/build/recipe/dashboard/api/signOut.js
+++ b/lib/build/recipe/dashboard/api/signOut.js
@@ -44,24 +44,34 @@ var __awaiter =
             step((generator = generator.apply(thisArg, _arguments || [])).next());
         });
     };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = require("../../../utils");
-const utils_2 = require("../utils");
-function validateKey(_, options) {
+const querier_1 = require("../../../querier");
+const normalisedURLPath_1 = __importDefault(require("../../../normalisedURLPath"));
+function signOut(_, options) {
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
-        const input = {
-            req: options.req,
-            config: options.config,
-            userContext: utils_1.makeDefaultUserContextFromAPI(options.req),
-        };
-        if (yield utils_2.validateApiKey(input)) {
-            options.res.sendJSONResponse({
-                status: "OK",
-            });
+        if (options.config.apiKey) {
+            utils_1.send200Response(options.res, { status: "OK" });
         } else {
-            utils_2.sendUnauthorisedAccess(options.res);
+            const sessionIdFormAuthHeader =
+                (_a = options.req.getHeaderValue("authorization")) === null || _a === void 0
+                    ? void 0
+                    : _a.split(" ")[1];
+            let querier = querier_1.Querier.getNewInstanceOrThrowError(undefined);
+            const sessionDeleteResponse = yield querier.sendDeleteRequest(
+                new normalisedURLPath_1.default("/recipe/dashboard/session"),
+                {},
+                { sessionId: sessionIdFormAuthHeader }
+            );
+            utils_1.send200Response(options.res, sessionDeleteResponse);
         }
         return true;
     });
 }
-exports.default = validateKey;
+exports.default = signOut;

--- a/lib/build/recipe/dashboard/constants.d.ts
+++ b/lib/build/recipe/dashboard/constants.d.ts
@@ -1,5 +1,7 @@
 // @ts-nocheck
 export declare const DASHBOARD_API = "/dashboard";
+export declare const SIGN_IN_API = "/api/signin";
+export declare const SIGN_OUT_API = "/api/signout";
 export declare const VALIDATE_KEY_API = "/api/key/validate";
 export declare const USERS_LIST_GET_API = "/api/users";
 export declare const USERS_COUNT_API = "/api/users/count";

--- a/lib/build/recipe/dashboard/constants.js
+++ b/lib/build/recipe/dashboard/constants.js
@@ -14,8 +14,10 @@
  * under the License.
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.USER_EMAIL_VERIFY_TOKEN_API = exports.USER_PASSWORD_API = exports.USER_SESSIONS_API = exports.USER_METADATA_API = exports.USER_EMAIL_VERIFY_API = exports.USER_API = exports.USERS_COUNT_API = exports.USERS_LIST_GET_API = exports.VALIDATE_KEY_API = exports.DASHBOARD_API = void 0;
+exports.USER_EMAIL_VERIFY_TOKEN_API = exports.USER_PASSWORD_API = exports.USER_SESSIONS_API = exports.USER_METADATA_API = exports.USER_EMAIL_VERIFY_API = exports.USER_API = exports.USERS_COUNT_API = exports.USERS_LIST_GET_API = exports.VALIDATE_KEY_API = exports.SIGN_OUT_API = exports.SIGN_IN_API = exports.DASHBOARD_API = void 0;
 exports.DASHBOARD_API = "/dashboard";
+exports.SIGN_IN_API = "/api/signin";
+exports.SIGN_OUT_API = "/api/signout";
 exports.VALIDATE_KEY_API = "/api/key/validate";
 exports.USERS_LIST_GET_API = "/api/users";
 exports.USERS_COUNT_API = "/api/users/count";

--- a/lib/build/recipe/dashboard/recipe.d.ts
+++ b/lib/build/recipe/dashboard/recipe.d.ts
@@ -12,9 +12,9 @@ export default class Recipe extends RecipeModule {
     recipeInterfaceImpl: RecipeInterface;
     apiImpl: APIInterface;
     isInServerlessEnv: boolean;
-    constructor(recipeId: string, appInfo: NormalisedAppinfo, isInServerlessEnv: boolean, config: TypeInput);
+    constructor(recipeId: string, appInfo: NormalisedAppinfo, isInServerlessEnv: boolean, config?: TypeInput);
     static getInstanceOrThrowError(): Recipe;
-    static init(config: TypeInput): RecipeListFunction;
+    static init(config?: TypeInput): RecipeListFunction;
     static reset(): void;
     getAPIsHandled: () => APIHandled[];
     handleAPIRequest: (

--- a/lib/build/recipe/dashboard/recipe.js
+++ b/lib/build/recipe/dashboard/recipe.js
@@ -74,6 +74,8 @@ const userPasswordPut_1 = require("./api/userdetails/userPasswordPut");
 const userPut_1 = require("./api/userdetails/userPut");
 const userEmailVerifyTokenPost_1 = require("./api/userdetails/userEmailVerifyTokenPost");
 const userSessionsPost_1 = require("./api/userdetails/userSessionsPost");
+const signIn_1 = __importDefault(require("./api/signIn"));
+const signOut_1 = __importDefault(require("./api/signOut"));
 class Recipe extends recipeModule_1.default {
     constructor(recipeId, appInfo, isInServerlessEnv, config) {
         super(recipeId, appInfo);
@@ -103,6 +105,9 @@ class Recipe extends recipeModule_1.default {
                 // For these APIs we dont need API key validation
                 if (id === constants_1.DASHBOARD_API) {
                     return yield dashboard_1.default(this.apiImpl, options);
+                }
+                if (id === constants_1.SIGN_IN_API) {
+                    return yield signIn_1.default(this.apiImpl, options);
                 }
                 if (id === constants_1.VALIDATE_KEY_API) {
                     return yield validateKey_1.default(this.apiImpl, options);
@@ -148,6 +153,8 @@ class Recipe extends recipeModule_1.default {
                     apiFunction = userPasswordPut_1.userPasswordPut;
                 } else if (id === constants_1.USER_EMAIL_VERIFY_TOKEN_API) {
                     apiFunction = userEmailVerifyTokenPost_1.userEmailVerifyTokenPost;
+                } else if (id === constants_1.SIGN_OUT_API) {
+                    apiFunction = signOut_1.default;
                 }
                 // If the id doesnt match any APIs return false
                 if (apiFunction === undefined) {

--- a/lib/build/recipe/dashboard/recipeImplementation.js
+++ b/lib/build/recipe/dashboard/recipeImplementation.js
@@ -44,8 +44,16 @@ var __awaiter =
             step((generator = generator.apply(thisArg, _arguments || [])).next());
         });
     };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
+const normalisedURLPath_1 = __importDefault(require("../../normalisedURLPath"));
+const querier_1 = require("../../querier");
 const version_1 = require("../../version");
+const utils_1 = require("./utils");
 function getRecipeImplementation() {
     return {
         getDashboardBundleLocation: function () {
@@ -54,17 +62,25 @@ function getRecipeImplementation() {
             });
         },
         shouldAllowAccess: function (input) {
+            var _a;
             return __awaiter(this, void 0, void 0, function* () {
-                let apiKeyHeaderValue = input.req.getHeaderValue("authorization");
-                // We receieve the api key as `Bearer API_KEY`, this retrieves just the key
-                apiKeyHeaderValue =
-                    apiKeyHeaderValue === null || apiKeyHeaderValue === void 0
-                        ? void 0
-                        : apiKeyHeaderValue.split(" ")[1];
-                if (apiKeyHeaderValue === undefined) {
-                    return false;
+                // For cases where we're not using the API key, the JWT is being used; we allow their access by default
+                if (!input.config.apiKey) {
+                    // make the check for the API endpoint here with querier
+                    let querier = querier_1.Querier.getNewInstanceOrThrowError(undefined);
+                    const authHeaderValue =
+                        (_a = input.req.getHeaderValue("authorization")) === null || _a === void 0
+                            ? void 0
+                            : _a.split(" ")[1];
+                    const sessionVerificationResponse = yield querier.sendPostRequest(
+                        new normalisedURLPath_1.default("/recipe/dashboard/session/verify"),
+                        {
+                            sessionId: authHeaderValue,
+                        }
+                    );
+                    return sessionVerificationResponse.status === "OK";
                 }
-                return apiKeyHeaderValue === input.config.apiKey;
+                return yield utils_1.validateApiKey(input);
             });
         },
     };

--- a/lib/build/recipe/dashboard/types.d.ts
+++ b/lib/build/recipe/dashboard/types.d.ts
@@ -3,7 +3,7 @@ import OverrideableBuilder from "supertokens-js-override";
 import { BaseRequest, BaseResponse } from "../../framework";
 import { NormalisedAppinfo } from "../../types";
 export declare type TypeInput = {
-    apiKey: string;
+    apiKey?: string;
     override?: {
         functions?: (
             originalImplementation: RecipeInterface,
@@ -13,7 +13,8 @@ export declare type TypeInput = {
     };
 };
 export declare type TypeNormalisedInput = {
-    apiKey: string;
+    apiKey?: string;
+    authMode: AuthMode;
     override: {
         functions: (
             originalImplementation: RecipeInterface,
@@ -40,6 +41,7 @@ export declare type APIInterface = {
 };
 export declare type APIFunction = (apiImplementation: APIInterface, options: APIOptions) => Promise<any>;
 export declare type RecipeIdForUser = "emailpassword" | "thirdparty" | "passwordless";
+export declare type AuthMode = "api-key" | "email-password";
 declare type CommonUserInformation = {
     id: string;
     timeJoined: number;

--- a/lib/build/recipe/dashboard/utils.d.ts
+++ b/lib/build/recipe/dashboard/utils.d.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { BaseResponse } from "../../framework";
+import { BaseRequest, BaseResponse } from "../../framework";
 import NormalisedURLPath from "../../normalisedURLPath";
 import { HTTPMethod, NormalisedAppinfo } from "../../types";
 import {
@@ -29,3 +29,8 @@ export declare function getUserForRecipeId(
         | undefined;
 }>;
 export declare function isRecipeInitialised(recipeId: RecipeIdForUser): boolean;
+export declare function validateApiKey(input: {
+    req: BaseRequest;
+    config: TypeNormalisedInput;
+    userContext: any;
+}): Promise<boolean>;

--- a/lib/build/recipe/dashboard/utils.d.ts
+++ b/lib/build/recipe/dashboard/utils.d.ts
@@ -10,7 +10,7 @@ import {
     TypeInput,
     TypeNormalisedInput,
 } from "./types";
-export declare function validateAndNormaliseUserInput(config: TypeInput): TypeNormalisedInput;
+export declare function validateAndNormaliseUserInput(config?: TypeInput): TypeNormalisedInput;
 export declare function isApiPath(path: NormalisedURLPath, appInfo: NormalisedAppinfo): boolean;
 export declare function getApiIdIfMatched(path: NormalisedURLPath, method: HTTPMethod): string | undefined;
 export declare function sendUnauthorisedAccess(res: BaseResponse): void;

--- a/lib/build/recipe/dashboard/utils.js
+++ b/lib/build/recipe/dashboard/utils.js
@@ -50,7 +50,7 @@ var __importDefault =
         return mod && mod.__esModule ? mod : { default: mod };
     };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.isRecipeInitialised = exports.getUserForRecipeId = exports.isValidRecipeId = exports.sendUnauthorisedAccess = exports.getApiIdIfMatched = exports.isApiPath = exports.validateAndNormaliseUserInput = void 0;
+exports.validateApiKey = exports.isRecipeInitialised = exports.getUserForRecipeId = exports.isValidRecipeId = exports.sendUnauthorisedAccess = exports.getApiIdIfMatched = exports.isApiPath = exports.validateAndNormaliseUserInput = void 0;
 const normalisedURLPath_1 = __importDefault(require("../../normalisedURLPath"));
 const utils_1 = require("../../utils");
 const constants_1 = require("./constants");
@@ -65,9 +65,6 @@ const recipe_4 = __importDefault(require("../thirdpartyemailpassword/recipe"));
 const thirdpartypasswordless_1 = __importDefault(require("../thirdpartypasswordless"));
 const recipe_5 = __importDefault(require("../thirdpartypasswordless/recipe"));
 function validateAndNormaliseUserInput(config) {
-    if (config.apiKey.trim().length === 0) {
-        throw new Error("apiKey provided to Dashboard recipe cannot be empty");
-    }
     let override = Object.assign(
         {
             functions: (originalImplementation) => originalImplementation,
@@ -78,6 +75,7 @@ function validateAndNormaliseUserInput(config) {
     return {
         apiKey: config.apiKey,
         override,
+        authMode: config.apiKey ? "api-key" : "email-password",
     };
 }
 exports.validateAndNormaliseUserInput = validateAndNormaliseUserInput;
@@ -101,6 +99,12 @@ exports.isApiPath = isApiPath;
 function getApiIdIfMatched(path, method) {
     if (path.getAsStringDangerous().endsWith(constants_1.VALIDATE_KEY_API) && method === "post") {
         return constants_1.VALIDATE_KEY_API;
+    }
+    if (path.getAsStringDangerous().endsWith(constants_1.SIGN_IN_API) && method === "post") {
+        return constants_1.SIGN_IN_API;
+    }
+    if (path.getAsStringDangerous().endsWith(constants_1.SIGN_OUT_API) && method === "post") {
+        return constants_1.SIGN_OUT_API;
     }
     if (path.getAsStringDangerous().endsWith(constants_1.USERS_LIST_GET_API) && method === "get") {
         return constants_1.USERS_LIST_GET_API;
@@ -281,3 +285,16 @@ function isRecipeInitialised(recipeId) {
     return isRecipeInitialised;
 }
 exports.isRecipeInitialised = isRecipeInitialised;
+function validateApiKey(input) {
+    return __awaiter(this, void 0, void 0, function* () {
+        let apiKeyHeaderValue = input.req.getHeaderValue("authorization");
+        // We receieve the api key as `Bearer API_KEY`, this retrieves just the key
+        apiKeyHeaderValue =
+            apiKeyHeaderValue === null || apiKeyHeaderValue === void 0 ? void 0 : apiKeyHeaderValue.split(" ")[1];
+        if (apiKeyHeaderValue === undefined) {
+            return false;
+        }
+        return apiKeyHeaderValue === input.config.apiKey;
+    });
+}
+exports.validateApiKey = validateApiKey;

--- a/lib/build/recipe/dashboard/utils.js
+++ b/lib/build/recipe/dashboard/utils.js
@@ -70,12 +70,12 @@ function validateAndNormaliseUserInput(config) {
             functions: (originalImplementation) => originalImplementation,
             apis: (originalImplementation) => originalImplementation,
         },
-        config.override
+        config === undefined ? {} : config.override
     );
     return {
-        apiKey: config.apiKey,
+        apiKey: config === undefined ? undefined : config.apiKey,
         override,
-        authMode: config.apiKey ? "api-key" : "email-password",
+        authMode: config !== undefined && config.apiKey ? "api-key" : "email-password",
     };
 }
 exports.validateAndNormaliseUserInput = validateAndNormaliseUserInput;

--- a/lib/build/supertokens.js
+++ b/lib/build/supertokens.js
@@ -59,6 +59,8 @@ const normalisedURLPath_1 = __importDefault(require("./normalisedURLPath"));
 const error_1 = __importDefault(require("./error"));
 const logger_1 = require("./logger");
 const postSuperTokensInitCallbacks_1 = require("./postSuperTokensInitCallbacks");
+const dashboard_1 = __importDefault(require("./recipe/dashboard"));
+const recipe_1 = __importDefault(require("./recipe/dashboard/recipe"));
 class SuperTokens {
     constructor(config) {
         var _a, _b;
@@ -371,6 +373,10 @@ class SuperTokens {
         this.recipeModules = config.recipeList.map((func) => {
             return func(this.appInfo, this.isInServerlessEnv);
         });
+        if (this.recipeModules.filter((i) => i.getRecipeId() === recipe_1.default.RECIPE_ID).length === 0) {
+            // This means that the user has not initialised the dashboard recipe
+            this.recipeModules.push(dashboard_1.default.init()(this.appInfo, this.isInServerlessEnv));
+        }
         let telemetry = config.telemetry === undefined ? process.env.TEST_MODE !== "testing" : config.telemetry;
         if (telemetry) {
             if (this.isInServerlessEnv) {

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "13.0.2";
+export declare const version = "13.1.0";
 export declare const cdiSupported: string[];
-export declare const dashboardVersion = "0.3";
+export declare const dashboardVersion = "0.4";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "13.0.2";
-exports.cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15"];
+exports.version = "13.1.0";
+exports.cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15", "2.16", "2.17", "2.18"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
-exports.dashboardVersion = "0.3";
+exports.dashboardVersion = "0.4";

--- a/lib/ts/querier.ts
+++ b/lib/ts/querier.ts
@@ -107,7 +107,7 @@ export class Querier {
     }
 
     // path should start with "/"
-    sendPostRequest = async (path: NormalisedURLPath, body: any): Promise<any> => {
+    sendPostRequest = async <T = any>(path: NormalisedURLPath, body: any): Promise<T> => {
         return this.sendRequestHelper(
             path,
             "POST",
@@ -141,7 +141,7 @@ export class Querier {
     };
 
     // path should start with "/"
-    sendDeleteRequest = async (path: NormalisedURLPath, body: any): Promise<any> => {
+    sendDeleteRequest = async (path: NormalisedURLPath, body: any, params?: any): Promise<any> => {
         return this.sendRequestHelper(
             path,
             "DELETE",
@@ -166,6 +166,7 @@ export class Querier {
                     url,
                     data: body,
                     headers,
+                    params,
                 });
             },
             this.__hosts?.length || 0

--- a/lib/ts/recipe/dashboard/api/implementation.ts
+++ b/lib/ts/recipe/dashboard/api/implementation.ts
@@ -17,7 +17,7 @@ import NormalisedURLDomain from "../../../normalisedURLDomain";
 import NormalisedURLPath from "../../../normalisedURLPath";
 import SuperTokens from "../../../supertokens";
 import { DASHBOARD_API } from "../constants";
-import { APIInterface } from "../types";
+import { APIInterface, AuthMode } from "../types";
 
 export default function getAPIImplementation(): APIInterface {
     return {
@@ -33,6 +33,8 @@ export default function getAPIImplementation(): APIInterface {
             let connectionURI: string = "";
             const superTokensInstance = SuperTokens.getInstanceOrThrowError();
 
+            const authMode: AuthMode = input.options.config.authMode;
+
             if (superTokensInstance.supertokens !== undefined) {
                 connectionURI = superTokensInstance.supertokens.connectionURI;
             }
@@ -47,6 +49,7 @@ export default function getAPIImplementation(): APIInterface {
                             .appendPath(new NormalisedURLPath(DASHBOARD_API))
                             .getAsStringDangerous()}"
                         window.connectionURI = "${connectionURI}"
+                        window.authMode = "${authMode}"
                     </script>
                     <script defer src="${bundleDomain}/static/js/bundle.js"></script></head>
                     <link href="${bundleDomain}/static/css/main.css" rel="stylesheet" type="text/css">

--- a/lib/ts/recipe/dashboard/api/signIn.ts
+++ b/lib/ts/recipe/dashboard/api/signIn.ts
@@ -1,0 +1,56 @@
+/* Copyright (c) 2022, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { APIInterface, APIOptions } from "../types";
+import { send200Response } from "../../../utils";
+import STError from "../../../error";
+import { Querier } from "../../../querier";
+import NormalisedURLPath from "../../../normalisedURLPath";
+
+type SignInResponse =
+    | { status: "OK"; sessionId: string }
+    | { status: "INVALID_CREDENTIALS_ERROR" }
+    | { status: "USER_SUSPENDED_ERROR" };
+
+export default async function signIn(_: APIInterface, options: APIOptions): Promise<boolean> {
+    const { email, password } = await options.req.getJSONBody();
+
+    if (email === undefined) {
+        throw new STError({
+            message: "Missing required parameter 'email'",
+            type: STError.BAD_INPUT_ERROR,
+        });
+    }
+
+    if (password === undefined) {
+        throw new STError({
+            message: "Missing required parameter 'password'",
+            type: STError.BAD_INPUT_ERROR,
+        });
+    }
+
+    let querier = Querier.getNewInstanceOrThrowError(undefined);
+    const signInResponse = await querier.sendPostRequest<SignInResponse>(
+        new NormalisedURLPath("/recipe/dashboard/signin"),
+        {
+            email,
+            password,
+        }
+    );
+
+    send200Response(options.res, signInResponse);
+
+    return true;
+}

--- a/lib/ts/recipe/dashboard/api/signOut.ts
+++ b/lib/ts/recipe/dashboard/api/signOut.ts
@@ -13,20 +13,23 @@
  * under the License.
  */
 
-import { makeDefaultUserContextFromAPI } from "../../../utils";
 import { APIInterface, APIOptions } from "../types";
-import { sendUnauthorisedAccess, validateApiKey } from "../utils";
+import { send200Response } from "../../../utils";
+import { Querier } from "../../../querier";
+import NormalisedURLPath from "../../../normalisedURLPath";
 
-export default async function validateKey(_: APIInterface, options: APIOptions): Promise<boolean> {
-    const input = { req: options.req, config: options.config, userContext: makeDefaultUserContextFromAPI(options.req) };
-
-    if (await validateApiKey(input)) {
-        options.res.sendJSONResponse({
-            status: "OK",
-        });
+export default async function signOut(_: APIInterface, options: APIOptions): Promise<boolean> {
+    if (options.config.apiKey) {
+        send200Response(options.res, { status: "OK" });
     } else {
-        sendUnauthorisedAccess(options.res);
+        const sessionIdFormAuthHeader = options.req.getHeaderValue("authorization")?.split(" ")[1];
+        let querier = Querier.getNewInstanceOrThrowError(undefined);
+        const sessionDeleteResponse = await querier.sendDeleteRequest(
+            new NormalisedURLPath("/recipe/dashboard/session"),
+            {},
+            { sessionId: sessionIdFormAuthHeader }
+        );
+        send200Response(options.res, sessionDeleteResponse);
     }
-
     return true;
 }

--- a/lib/ts/recipe/dashboard/constants.ts
+++ b/lib/ts/recipe/dashboard/constants.ts
@@ -14,6 +14,8 @@
  */
 
 export const DASHBOARD_API = "/dashboard";
+export const SIGN_IN_API = "/api/signin";
+export const SIGN_OUT_API = "/api/signout";
 export const VALIDATE_KEY_API = "/api/key/validate";
 export const USERS_LIST_GET_API = "/api/users";
 export const USERS_COUNT_API = "/api/users/count";

--- a/lib/ts/recipe/dashboard/recipe.ts
+++ b/lib/ts/recipe/dashboard/recipe.ts
@@ -68,7 +68,7 @@ export default class Recipe extends RecipeModule {
 
     isInServerlessEnv: boolean;
 
-    constructor(recipeId: string, appInfo: NormalisedAppinfo, isInServerlessEnv: boolean, config: TypeInput) {
+    constructor(recipeId: string, appInfo: NormalisedAppinfo, isInServerlessEnv: boolean, config?: TypeInput) {
         super(recipeId, appInfo);
 
         this.config = validateAndNormaliseUserInput(config);
@@ -91,7 +91,7 @@ export default class Recipe extends RecipeModule {
         throw new Error("Initialisation not done. Did you forget to call the SuperTokens.init function?");
     }
 
-    static init(config: TypeInput): RecipeListFunction {
+    static init(config?: TypeInput): RecipeListFunction {
         return (appInfo, isInServerlessEnv) => {
             if (Recipe.instance === undefined) {
                 Recipe.instance = new Recipe(Recipe.RECIPE_ID, appInfo, isInServerlessEnv, config);

--- a/lib/ts/recipe/dashboard/recipe.ts
+++ b/lib/ts/recipe/dashboard/recipe.ts
@@ -22,6 +22,8 @@ import APIImplementation from "./api/implementation";
 import { getApiIdIfMatched, isApiPath, validateAndNormaliseUserInput } from "./utils";
 import {
     DASHBOARD_API,
+    SIGN_IN_API,
+    SIGN_OUT_API,
     USERS_COUNT_API,
     USERS_LIST_GET_API,
     USER_API,
@@ -51,6 +53,8 @@ import { userPasswordPut } from "./api/userdetails/userPasswordPut";
 import { userPut } from "./api/userdetails/userPut";
 import { userEmailVerifyTokenPost } from "./api/userdetails/userEmailVerifyTokenPost";
 import { userSessionsPost } from "./api/userdetails/userSessionsPost";
+import signIn from "./api/signIn";
+import signOut from "./api/signOut";
 
 export default class Recipe extends RecipeModule {
     private static instance: Recipe | undefined = undefined;
@@ -143,6 +147,10 @@ export default class Recipe extends RecipeModule {
             return await dashboard(this.apiImpl, options);
         }
 
+        if (id === SIGN_IN_API) {
+            return await signIn(this.apiImpl, options);
+        }
+
         if (id === VALIDATE_KEY_API) {
             return await validateKey(this.apiImpl, options);
         }
@@ -194,6 +202,8 @@ export default class Recipe extends RecipeModule {
             apiFunction = userPasswordPut;
         } else if (id === USER_EMAIL_VERIFY_TOKEN_API) {
             apiFunction = userEmailVerifyTokenPost;
+        } else if (id === SIGN_OUT_API) {
+            apiFunction = signOut;
         }
 
         // If the id doesnt match any APIs return false

--- a/lib/ts/recipe/dashboard/recipeImplementation.ts
+++ b/lib/ts/recipe/dashboard/recipeImplementation.ts
@@ -13,8 +13,11 @@
  * under the License.
  */
 
+import NormalisedURLPath from "../../normalisedURLPath";
+import { Querier } from "../../querier";
 import { dashboardVersion } from "../../version";
 import { RecipeInterface } from "./types";
+import { validateApiKey } from "./utils";
 
 export default function getRecipeImplementation(): RecipeInterface {
     return {
@@ -22,16 +25,20 @@ export default function getRecipeImplementation(): RecipeInterface {
             return `https://cdn.jsdelivr.net/gh/supertokens/dashboard@v${dashboardVersion}/build/`;
         },
         shouldAllowAccess: async function (input) {
-            let apiKeyHeaderValue: string | undefined = input.req.getHeaderValue("authorization");
-
-            // We receieve the api key as `Bearer API_KEY`, this retrieves just the key
-            apiKeyHeaderValue = apiKeyHeaderValue?.split(" ")[1];
-
-            if (apiKeyHeaderValue === undefined) {
-                return false;
+            // For cases where we're not using the API key, the JWT is being used; we allow their access by default
+            if (!input.config.apiKey) {
+                // make the check for the API endpoint here with querier
+                let querier = Querier.getNewInstanceOrThrowError(undefined);
+                const authHeaderValue = input.req.getHeaderValue("authorization")?.split(" ")[1];
+                const sessionVerificationResponse = await querier.sendPostRequest(
+                    new NormalisedURLPath("/recipe/dashboard/session/verify"),
+                    {
+                        sessionId: authHeaderValue,
+                    }
+                );
+                return sessionVerificationResponse.status === "OK";
             }
-
-            return apiKeyHeaderValue === input.config.apiKey;
+            return await validateApiKey(input);
         },
     };
 }

--- a/lib/ts/recipe/dashboard/types.ts
+++ b/lib/ts/recipe/dashboard/types.ts
@@ -18,7 +18,7 @@ import { BaseRequest, BaseResponse } from "../../framework";
 import { NormalisedAppinfo } from "../../types";
 
 export type TypeInput = {
-    apiKey: string;
+    apiKey?: string;
     override?: {
         functions?: (
             originalImplementation: RecipeInterface,
@@ -29,7 +29,8 @@ export type TypeInput = {
 };
 
 export type TypeNormalisedInput = {
-    apiKey: string;
+    apiKey?: string;
+    authMode: AuthMode;
     override: {
         functions: (
             originalImplementation: RecipeInterface,
@@ -61,6 +62,8 @@ export type APIInterface = {
 export type APIFunction = (apiImplementation: APIInterface, options: APIOptions) => Promise<any>;
 
 export type RecipeIdForUser = "emailpassword" | "thirdparty" | "passwordless";
+
+export type AuthMode = "api-key" | "email-password";
 
 type CommonUserInformation = {
     id: string;

--- a/lib/ts/recipe/dashboard/utils.ts
+++ b/lib/ts/recipe/dashboard/utils.ts
@@ -52,17 +52,17 @@ import ThirdPartyEmailPasswordRecipe from "../thirdpartyemailpassword/recipe";
 import ThirdPartyPasswordless from "../thirdpartypasswordless";
 import ThirdPartyPasswordlessRecipe from "../thirdpartypasswordless/recipe";
 
-export function validateAndNormaliseUserInput(config: TypeInput): TypeNormalisedInput {
+export function validateAndNormaliseUserInput(config?: TypeInput): TypeNormalisedInput {
     let override = {
         functions: (originalImplementation: RecipeInterface) => originalImplementation,
         apis: (originalImplementation: APIInterface) => originalImplementation,
-        ...config.override,
+        ...(config === undefined ? {} : config.override),
     };
 
     return {
-        apiKey: config.apiKey,
+        apiKey: config === undefined ? undefined : config.apiKey,
         override,
-        authMode: config.apiKey ? "api-key" : "email-password",
+        authMode: config !== undefined && config.apiKey ? "api-key" : "email-password",
     };
 }
 

--- a/lib/ts/supertokens.ts
+++ b/lib/ts/supertokens.ts
@@ -32,6 +32,8 @@ import { TypeFramework } from "./framework/types";
 import STError from "./error";
 import { logDebugMessage } from "./logger";
 import { PostSuperTokensInitCallbacks } from "./postSuperTokensInitCallbacks";
+import DashboardIndex from "./recipe/dashboard";
+import DashboardRecipe from "./recipe/dashboard/recipe";
 
 export default class SuperTokens {
     private static instance: SuperTokens | undefined;
@@ -82,6 +84,11 @@ export default class SuperTokens {
         this.recipeModules = config.recipeList.map((func) => {
             return func(this.appInfo, this.isInServerlessEnv);
         });
+
+        if (this.recipeModules.filter((i) => i.getRecipeId() === DashboardRecipe.RECIPE_ID).length === 0) {
+            // This means that the user has not initialised the dashboard recipe
+            this.recipeModules.push(DashboardIndex.init()(this.appInfo, this.isInServerlessEnv));
+        }
 
         let telemetry = config.telemetry === undefined ? process.env.TEST_MODE !== "testing" : config.telemetry;
 

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,9 +12,9 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "13.0.2";
+export const version = "13.1.0";
 
-export const cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15"];
+export const cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15", "2.16", "2.17", "2.18"];
 
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
-export const dashboardVersion = "0.3";
+export const dashboardVersion = "0.4";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "13.0.2",
+    "version": "13.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "13.0.2",
+            "version": "13.1.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "axios": "0.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "13.0.2",
+    "version": "13.1.0",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

Adds APIs and logic to enable email password based login to the dashboard

## Related issues

-  https://github.com/supertokens/dashboard/issues/55

## Test Plan


## Documentation changes

WIP

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] ...
