### PR TITLE
refactor: Use auth mode instead of manually checking for api key in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [13.1.1] - 2023-02-24
+
+-   Refactor dashboard recipe to use auth mode instead of manually checking for api key
+
 ## [13.1.0] - 2023-02-22
 
 -   Adds APIs and logic to the dashboard recipe to enable email password based login

--- a/lib/build/recipe/dashboard/api/signOut.js
+++ b/lib/build/recipe/dashboard/api/signOut.js
@@ -56,7 +56,7 @@ const normalisedURLPath_1 = __importDefault(require("../../../normalisedURLPath"
 function signOut(_, options) {
     var _a;
     return __awaiter(this, void 0, void 0, function* () {
-        if (options.config.apiKey) {
+        if (options.config.authMode === "api-key") {
             utils_1.send200Response(options.res, { status: "OK" });
         } else {
             const sessionIdFormAuthHeader =

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "13.1.0";
+export declare const version = "13.1.1";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.4";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "13.1.0";
+exports.version = "13.1.1";
 exports.cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15", "2.16", "2.17", "2.18"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.4";

--- a/lib/ts/recipe/dashboard/api/signOut.ts
+++ b/lib/ts/recipe/dashboard/api/signOut.ts
@@ -19,7 +19,7 @@ import { Querier } from "../../../querier";
 import NormalisedURLPath from "../../../normalisedURLPath";
 
 export default async function signOut(_: APIInterface, options: APIOptions): Promise<boolean> {
-    if (options.config.apiKey) {
+    if (options.config.authMode === "api-key") {
         send200Response(options.res, { status: "OK" });
     } else {
         const sessionIdFormAuthHeader = options.req.getHeaderValue("authorization")?.split(" ")[1];

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "13.1.0";
+export const version = "13.1.1";
 
 export const cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15", "2.16", "2.17", "2.18"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "13.1.0",
+    "version": "13.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "13.1.0",
+            "version": "13.1.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "axios": "0.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "13.1.0",
+    "version": "13.1.1",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

Refactors dashboard sign out logic to check for the auth mode in the normalised config instead of manually checking for the api key 

## Related issues

-   

## Test Plan

## Documentation changes


## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] ...
