### PR TITLE
fix: Fix issue of BaseRequest getHeaderValue not handling case insensitivity

### DIFF
--- a/lib/build/framework/awsLambda/framework.js
+++ b/lib/build/framework/awsLambda/framework.js
@@ -115,7 +115,7 @@ class AWSRequest extends request_1.BaseRequest {
             if (this.event.headers === undefined || this.event.headers === null) {
                 return undefined;
             }
-            return utils_2.normalizeHeaderValue(this.event.headers[key]);
+            return utils_2.normalizeHeaderValue(utils_1.getFromObjectCaseInsensitive(key, this.event.headers));
         };
         this.getOriginalURL = () => {
             let path = this.event.path;

--- a/lib/build/framework/fastify/framework.js
+++ b/lib/build/framework/fastify/framework.js
@@ -85,7 +85,7 @@ class FastifyRequest extends request_1.BaseRequest {
             return utils_2.getCookieValueFromHeaders(this.request.headers, key);
         };
         this.getHeaderValue = (key) => {
-            return utils_2.normalizeHeaderValue(this.request.headers[key]);
+            return utils_2.normalizeHeaderValue(utils_1.getFromObjectCaseInsensitive(key, this.request.headers));
         };
         this.getOriginalURL = () => {
             return this.request.url;

--- a/lib/build/framework/utils.js
+++ b/lib/build/framework/utils.js
@@ -56,6 +56,7 @@ const body_parser_1 = require("body-parser");
 const http_1 = require("http");
 const error_1 = __importDefault(require("../error"));
 const constants_1 = require("./constants");
+const utils_1 = require("../utils");
 function getCookieValueFromHeaders(headers, key) {
     if (headers === undefined || headers === null) {
         return undefined;
@@ -78,7 +79,7 @@ function getCookieValueFromIncomingMessage(request, key) {
 }
 exports.getCookieValueFromIncomingMessage = getCookieValueFromIncomingMessage;
 function getHeaderValueFromIncomingMessage(request, key) {
-    return normalizeHeaderValue(request.headers[key]);
+    return normalizeHeaderValue(utils_1.getFromObjectCaseInsensitive(key, request.headers));
 }
 exports.getHeaderValueFromIncomingMessage = getHeaderValueFromIncomingMessage;
 function normalizeHeaderValue(value) {

--- a/lib/build/utils.d.ts
+++ b/lib/build/utils.d.ts
@@ -14,3 +14,4 @@ export declare function frontendHasInterceptor(req: BaseRequest): boolean;
 export declare function humaniseMilliseconds(ms: number): string;
 export declare function makeDefaultUserContextFromAPI(request: BaseRequest): any;
 export declare function getTopLevelDomainForSameSiteResolution(url: string): string;
+export declare function getFromObjectCaseInsensitive<T>(key: string, object: Record<string, T>): T | undefined;

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -41,7 +41,7 @@ var __importDefault =
         return mod && mod.__esModule ? mod : { default: mod };
     };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getTopLevelDomainForSameSiteResolution = exports.makeDefaultUserContextFromAPI = exports.humaniseMilliseconds = exports.frontendHasInterceptor = exports.getRidFromHeader = exports.isAnIpAddress = exports.send200Response = exports.sendNon200Response = exports.sendNon200ResponseWithMessage = exports.normaliseHttpMethod = exports.normaliseInputAppInfoOrThrowError = exports.maxVersion = exports.getLargestVersionFromIntersection = void 0;
+exports.getFromObjectCaseInsensitive = exports.getTopLevelDomainForSameSiteResolution = exports.makeDefaultUserContextFromAPI = exports.humaniseMilliseconds = exports.frontendHasInterceptor = exports.getRidFromHeader = exports.isAnIpAddress = exports.send200Response = exports.sendNon200Response = exports.sendNon200ResponseWithMessage = exports.normaliseHttpMethod = exports.normaliseInputAppInfoOrThrowError = exports.maxVersion = exports.getLargestVersionFromIntersection = void 0;
 const psl = __importStar(require("psl"));
 const normalisedURLDomain_1 = __importDefault(require("./normalisedURLDomain"));
 const normalisedURLPath_1 = __importDefault(require("./normalisedURLPath"));
@@ -194,3 +194,11 @@ function getTopLevelDomainForSameSiteResolution(url) {
     return parsedURL.domain;
 }
 exports.getTopLevelDomainForSameSiteResolution = getTopLevelDomainForSameSiteResolution;
+function getFromObjectCaseInsensitive(key, object) {
+    const matchedKeys = Object.keys(object).filter((i) => i.toLocaleLowerCase() === key.toLocaleLowerCase());
+    if (matchedKeys.length === 0) {
+        return undefined;
+    }
+    return object[matchedKeys[0]];
+}
+exports.getFromObjectCaseInsensitive = getFromObjectCaseInsensitive;

--- a/lib/ts/framework/awsLambda/framework.ts
+++ b/lib/ts/framework/awsLambda/framework.ts
@@ -22,7 +22,7 @@ import type {
     Callback,
 } from "aws-lambda";
 import { HTTPMethod } from "../../types";
-import { normaliseHttpMethod } from "../../utils";
+import { getFromObjectCaseInsensitive, normaliseHttpMethod } from "../../utils";
 import { BaseRequest } from "../request";
 import { BaseResponse } from "../response";
 import { normalizeHeaderValue, getCookieValueFromHeaders, serializeCookieValue } from "../utils";
@@ -116,7 +116,7 @@ export class AWSRequest extends BaseRequest {
         if (this.event.headers === undefined || this.event.headers === null) {
             return undefined;
         }
-        return normalizeHeaderValue(this.event.headers[key]);
+        return normalizeHeaderValue(getFromObjectCaseInsensitive(key, this.event.headers));
     };
 
     getOriginalURL = (): string => {

--- a/lib/ts/framework/fastify/framework.ts
+++ b/lib/ts/framework/fastify/framework.ts
@@ -20,7 +20,7 @@ import type {
     FastifyPluginCallback,
 } from "fastify";
 import type { HTTPMethod } from "../../types";
-import { normaliseHttpMethod } from "../../utils";
+import { getFromObjectCaseInsensitive, normaliseHttpMethod } from "../../utils";
 import { BaseRequest } from "../request";
 import { BaseResponse } from "../response";
 import { serializeCookieValue, normalizeHeaderValue, getCookieValueFromHeaders } from "../utils";
@@ -66,7 +66,7 @@ export class FastifyRequest extends BaseRequest {
     };
 
     getHeaderValue = (key: string): string | undefined => {
-        return normalizeHeaderValue(this.request.headers[key]);
+        return normalizeHeaderValue(getFromObjectCaseInsensitive(key, this.request.headers));
     };
 
     getOriginalURL = (): string => {

--- a/lib/ts/framework/utils.ts
+++ b/lib/ts/framework/utils.ts
@@ -22,6 +22,7 @@ import STError from "../error";
 import type { HTTPMethod } from "../types";
 import { NextApiRequest } from "next";
 import { COOKIE_HEADER } from "./constants";
+import { getFromObjectCaseInsensitive } from "../utils";
 
 export function getCookieValueFromHeaders(headers: any, key: string): string | undefined {
     if (headers === undefined || headers === null) {
@@ -50,7 +51,7 @@ export function getCookieValueFromIncomingMessage(request: IncomingMessage, key:
 }
 
 export function getHeaderValueFromIncomingMessage(request: IncomingMessage, key: string): string | undefined {
-    return normalizeHeaderValue(request.headers[key]);
+    return normalizeHeaderValue(getFromObjectCaseInsensitive(key, request.headers));
 }
 
 export function normalizeHeaderValue(value: string | string[] | undefined): string | undefined {

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -156,3 +156,13 @@ export function getTopLevelDomainForSameSiteResolution(url: string): string {
     }
     return parsedURL.domain;
 }
+
+export function getFromObjectCaseInsensitive<T>(key: string, object: Record<string, T>): T | undefined {
+    const matchedKeys = Object.keys(object).filter((i) => i.toLocaleLowerCase() === key.toLocaleLowerCase());
+
+    if (matchedKeys.length === 0) {
+        return undefined;
+    }
+
+    return object[matchedKeys[0]];
+}

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,20 @@
+const assert = require("assert");
+const { getFromObjectCaseInsensitive } = require("../lib/build/utils");
+
+describe("SuperTokens utils test", () => {
+    it("Test getFromObjectCaseInsensitive", () => {
+        const testObj = {
+            AuthOriZation: "test",
+        };
+
+        assert.equal(getFromObjectCaseInsensitive("test", testObj), undefined);
+        // Exact
+        assert.equal(getFromObjectCaseInsensitive("AuthOriZation", testObj), "test");
+        // All lower case
+        assert.equal(getFromObjectCaseInsensitive("authorization", testObj), "test");
+        // Traditional case
+        assert.equal(getFromObjectCaseInsensitive("Authorization", testObj), "test");
+        // Weird casing
+        assert.equal(getFromObjectCaseInsensitive("authoriZation", testObj), "test");
+    });
+});


### PR DESCRIPTION
## Summary of change
- Adds a utility function that fetches a value from any object in a case insensitive way
- Adds a utils test file to test the functionality of the new function

## Related issues

-  #508 

## Test Plan

Adds tests

## Documentation changes

None needed

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] Update version and CHANGELOG
