### PR TITLE
refactor: Do not automatically initialise the dashboard recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [13.1.3] - 2023-03-08
+
+### Changed
+
+-   The dashboard recipe is no longer intialised automatically
+
 ## [13.1.2] - 2023-02-27
 
 ### Fixes

--- a/lib/build/supertokens.js
+++ b/lib/build/supertokens.js
@@ -59,7 +59,6 @@ const normalisedURLPath_1 = __importDefault(require("./normalisedURLPath"));
 const error_1 = __importDefault(require("./error"));
 const logger_1 = require("./logger");
 const postSuperTokensInitCallbacks_1 = require("./postSuperTokensInitCallbacks");
-const dashboard_1 = __importDefault(require("./recipe/dashboard"));
 const recipe_1 = __importDefault(require("./recipe/dashboard/recipe"));
 class SuperTokens {
     constructor(config) {
@@ -373,10 +372,6 @@ class SuperTokens {
         this.recipeModules = config.recipeList.map((func) => {
             return func(this.appInfo, this.isInServerlessEnv);
         });
-        if (this.recipeModules.filter((i) => i.getRecipeId() === recipe_1.default.RECIPE_ID).length === 0) {
-            // This means that the user has not initialised the dashboard recipe
-            this.recipeModules.push(dashboard_1.default.init()(this.appInfo, this.isInServerlessEnv));
-        }
         let telemetry = config.telemetry === undefined ? process.env.TEST_MODE !== "testing" : config.telemetry;
         if (telemetry) {
             if (this.isInServerlessEnv) {

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "13.1.2";
+export declare const version = "13.1.3";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.4";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "13.1.2";
+exports.version = "13.1.3";
 exports.cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15", "2.16", "2.17", "2.18"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.4";

--- a/lib/ts/supertokens.ts
+++ b/lib/ts/supertokens.ts
@@ -32,7 +32,6 @@ import { TypeFramework } from "./framework/types";
 import STError from "./error";
 import { logDebugMessage } from "./logger";
 import { PostSuperTokensInitCallbacks } from "./postSuperTokensInitCallbacks";
-import DashboardIndex from "./recipe/dashboard";
 import DashboardRecipe from "./recipe/dashboard/recipe";
 
 export default class SuperTokens {
@@ -84,11 +83,6 @@ export default class SuperTokens {
         this.recipeModules = config.recipeList.map((func) => {
             return func(this.appInfo, this.isInServerlessEnv);
         });
-
-        if (this.recipeModules.filter((i) => i.getRecipeId() === DashboardRecipe.RECIPE_ID).length === 0) {
-            // This means that the user has not initialised the dashboard recipe
-            this.recipeModules.push(DashboardIndex.init()(this.appInfo, this.isInServerlessEnv));
-        }
 
         let telemetry = config.telemetry === undefined ? process.env.TEST_MODE !== "testing" : config.telemetry;
 

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "13.1.2";
+export const version = "13.1.3";
 
 export const cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15", "2.16", "2.17", "2.18"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "13.1.2",
+    "version": "13.1.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "13.1.2",
+            "version": "13.1.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "axios": "0.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "13.1.2",
+    "version": "13.1.3",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -219,8 +219,7 @@ describe(`configTest: ${printPath("[test/config.test.js]")}`, function () {
                 recipeList: [Session.init({ getTokenTransferMethod: () => "cookie" })],
             });
             SessionRecipe.getInstanceOrThrowError();
-            // The number of recipes should be 2 because we initialise the dashboard recipe by default
-            assert(SuperTokens.getInstanceOrThrowError().recipeModules.length === 2);
+            assert(SuperTokens.getInstanceOrThrowError().recipeModules.length === 1);
             resetAll();
         }
 
@@ -238,8 +237,7 @@ describe(`configTest: ${printPath("[test/config.test.js]")}`, function () {
             });
             SessionRecipe.getInstanceOrThrowError();
             EmailPasswordRecipe.getInstanceOrThrowError();
-            // The number of recipes should be 3 because we initialise the dashboard recipe by default
-            assert(SuperTokens.getInstanceOrThrowError().recipeModules.length === 3);
+            assert(SuperTokens.getInstanceOrThrowError().recipeModules.length === 2);
             resetAll();
         }
     });


### PR DESCRIPTION
## Summary of change

- Removes logic from supertokens init to initialise the dashboard recipe if the user has not already done it

## Related issues

-  

## Test Plan

All existing tests should pass, config tests have been modified to reflect this change

## Documentation changes

WIP

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] 
