### PR TITLE
fix: Removes dashboard import from supertokens class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [13.1.4] - 2023-03-16
+
+### Fixes
+
+-   Fixes an issue where importing recipes without importing the package index file would cause crashes
+
 ## [13.1.3] - 2023-03-08
 
 ### Changed

--- a/lib/build/supertokens.js
+++ b/lib/build/supertokens.js
@@ -59,7 +59,6 @@ const normalisedURLPath_1 = __importDefault(require("./normalisedURLPath"));
 const error_1 = __importDefault(require("./error"));
 const logger_1 = require("./logger");
 const postSuperTokensInitCallbacks_1 = require("./postSuperTokensInitCallbacks");
-const recipe_1 = __importDefault(require("./recipe/dashboard/recipe"));
 class SuperTokens {
     constructor(config) {
         var _a, _b;
@@ -396,7 +395,6 @@ class SuperTokens {
             throw new Error("calling testing function in non testing env");
         }
         querier_1.Querier.reset();
-        recipe_1.default.reset();
         SuperTokens.instance = undefined;
     }
     static getInstanceOrThrowError() {

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "13.1.3";
+export declare const version = "13.1.4";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.4";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "13.1.3";
+exports.version = "13.1.4";
 exports.cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15", "2.16", "2.17", "2.18"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.4";

--- a/lib/ts/supertokens.ts
+++ b/lib/ts/supertokens.ts
@@ -32,7 +32,6 @@ import { TypeFramework } from "./framework/types";
 import STError from "./error";
 import { logDebugMessage } from "./logger";
 import { PostSuperTokensInitCallbacks } from "./postSuperTokensInitCallbacks";
-import DashboardRecipe from "./recipe/dashboard/recipe";
 
 export default class SuperTokens {
     private static instance: SuperTokens | undefined;
@@ -134,7 +133,6 @@ export default class SuperTokens {
             throw new Error("calling testing function in non testing env");
         }
         Querier.reset();
-        DashboardRecipe.reset();
         SuperTokens.instance = undefined;
     }
 

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "13.1.3";
+export const version = "13.1.4";
 
 export const cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15", "2.16", "2.17", "2.18"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "13.1.3",
+    "version": "13.1.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "13.1.3",
+            "version": "13.1.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "axios": "0.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "13.1.3",
+    "version": "13.1.4",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {

--- a/test/frontendIntegration/index.js
+++ b/test/frontendIntegration/index.js
@@ -16,6 +16,7 @@ let SuperTokens = require("../../");
 let Session = require("../../recipe/session");
 let SuperTokensRaw = require("../../lib/build/supertokens").default;
 let SessionRecipeRaw = require("../../lib/build/recipe/session/recipe").default;
+let DashboardRecipeRaw = require("../../lib/build/recipe/dashboard/recipe").default;
 let express = require("express");
 let cookieParser = require("cookie-parser");
 let bodyParser = require("body-parser");
@@ -175,6 +176,7 @@ app.post("/setAntiCsrf", async (req, res) => {
     if (enableAntiCsrf !== undefined) {
         SuperTokensRaw.reset();
         SessionRecipeRaw.reset();
+        DashboardRecipeRaw.reset();
         SuperTokens.init(getConfig(enableAntiCsrf));
     }
     res.send("success");
@@ -187,6 +189,7 @@ app.post("/setEnableJWT", async (req, res) => {
     if (enableJWT !== undefined) {
         SuperTokensRaw.reset();
         SessionRecipeRaw.reset();
+        DashboardRecipeRaw.reset();
         SuperTokens.init(getConfig(lastSetEnableAntiCSRF, enableJWT));
     }
     res.send("success");
@@ -208,6 +211,7 @@ app.post("/reinitialiseBackendConfig", async (req, res) => {
 
     SuperTokensRaw.reset();
     SessionRecipeRaw.reset();
+    DashboardRecipeRaw.reset();
     SuperTokens.init(getConfig(lastSetEnableAntiCSRF, currentEnableJWT, jwtPropertyName));
 
     res.send("");


### PR DESCRIPTION
## Summary of change

- Removes the dashboard import from the supertokens class to fix an issue where importing a recipe without importing the package index would cause the server to crash

## Related issues

-   #513 

## Test Plan

All existing tests pass

## Documentation changes

NA

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] ...
