### PR TITLE
chore: Add tests for circular imports

### DIFF
--- a/test/import.test.js
+++ b/test/import.test.js
@@ -1,0 +1,43 @@
+const { printPath, getAllFilesInDirectory } = require("./utils");
+const { resolve } = require("path");
+const { writeFileSync, rmSync } = require("fs");
+const { existsSync } = require("fs");
+const { execSync } = require("child_process");
+
+const testFileName = "importtest.js";
+const testFilePath = resolve(process.cwd(), `./${testFileName}`);
+
+describe(`importTests: ${printPath("[test/import.test.js]")}`, function () {
+    after(function () {
+        // The exists check is just a precaution
+        if (existsSync(testFilePath)) {
+            rmSync(testFilePath);
+        }
+    });
+
+    /**
+     * This test does the following:
+     * 1. Gets a list of all files in the build folder recursively
+     * 2. For each build file, creates a simple js file that imports the build file
+     * 3. Runs the generated js file
+     *
+     * The test fails if there is any error thrown when trying to run any of the generated files.
+     *
+     * This is to prevent issues arising from circular imports where certain variables from the
+     * default exports for recipes are not intialised correctly.
+     * (Refer to: https://github.com/supertokens/supertokens-node/issues/513)
+     */
+    it("Test that importing all build files independently does not cause errors", function () {
+        const fileNames = getAllFilesInDirectory(resolve(process.cwd(), "./lib/build")).filter(
+            (i) => !i.endsWith(".d.ts")
+        );
+
+        fileNames.forEach((fileName) => {
+            const relativeFilePath = fileName.replace(process.cwd(), "");
+            writeFileSync(testFilePath, `require(".${relativeFilePath}")`);
+
+            // This will throw an error if the command fails
+            execSync(`node ${resolve(process.cwd(), `./${testFileName}`)}`);
+        });
+    });
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -34,6 +34,7 @@ let { Querier } = require("../lib/build/querier");
 let { maxVersion } = require("../lib/build/utils");
 const { default: OpenIDRecipe } = require("../lib/build/recipe/openid/recipe");
 const { wrapRequest } = require("../framework/express");
+const { join } = require("path");
 
 module.exports.printPath = function (path) {
     return `${createFormat([consoleOptions.yellow, consoleOptions.italic, consoleOptions.dim])}${path}${createFormat([
@@ -560,4 +561,18 @@ module.exports.mockRequest = () => {
         header: (key) => headers[key],
     };
     return req;
+};
+
+module.exports.getAllFilesInDirectory = (path) => {
+    return fs
+        .readdirSync(path, {
+            withFileTypes: true,
+        })
+        .flatMap((file) => {
+            if (file.isDirectory()) {
+                return this.getAllFilesInDirectory(join(path, file.name));
+            } else {
+                return join(path, file.name);
+            }
+        });
 };


### PR DESCRIPTION
## Summary of change

- Adds tests to make sure circular imports dont cause issues by importing every build file individually

## Related issues

- 

## Test Plan

All existing tests pass and added new tests

## Documentation changes

NA

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] ...
