### PR TITLE
fix: Fix getHeaderValue case sensitivity, Hapi dashboard APIs 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixes
+
+-   Fixed an issue where BaseRequest implmentations for frameworks such as AWS Lambda would not consider case sensitivity when fetching request headers
+
 ## [13.1.4] - 2023-03-16
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [13.1.5] - 2023-03-17
+
 ### Fixes
 
 -   Fixed an issue where BaseRequest implmentations for frameworks such as AWS Lambda would not consider case sensitivity when fetching request headers
+-   Fixes an issue where dashboard recipe APIs would return 404 for Hapi
 
 ## [13.1.4] - 2023-03-16
 

--- a/lib/build/framework/awsLambda/framework.js
+++ b/lib/build/framework/awsLambda/framework.js
@@ -115,7 +115,7 @@ class AWSRequest extends request_1.BaseRequest {
             if (this.event.headers === undefined || this.event.headers === null) {
                 return undefined;
             }
-            return utils_2.normalizeHeaderValue(this.event.headers[key]);
+            return utils_2.normalizeHeaderValue(utils_1.getFromObjectCaseInsensitive(key, this.event.headers));
         };
         this.getOriginalURL = () => {
             let path = this.event.path;

--- a/lib/build/framework/fastify/framework.js
+++ b/lib/build/framework/fastify/framework.js
@@ -85,7 +85,7 @@ class FastifyRequest extends request_1.BaseRequest {
             return utils_2.getCookieValueFromHeaders(this.request.headers, key);
         };
         this.getHeaderValue = (key) => {
-            return utils_2.normalizeHeaderValue(this.request.headers[key]);
+            return utils_2.normalizeHeaderValue(utils_1.getFromObjectCaseInsensitive(key, this.request.headers));
         };
         this.getOriginalURL = () => {
             return this.request.url;

--- a/lib/build/framework/utils.js
+++ b/lib/build/framework/utils.js
@@ -56,6 +56,7 @@ const body_parser_1 = require("body-parser");
 const http_1 = require("http");
 const error_1 = __importDefault(require("../error"));
 const constants_1 = require("./constants");
+const utils_1 = require("../utils");
 function getCookieValueFromHeaders(headers, key) {
     if (headers === undefined || headers === null) {
         return undefined;
@@ -78,7 +79,7 @@ function getCookieValueFromIncomingMessage(request, key) {
 }
 exports.getCookieValueFromIncomingMessage = getCookieValueFromIncomingMessage;
 function getHeaderValueFromIncomingMessage(request, key) {
-    return normalizeHeaderValue(request.headers[key]);
+    return normalizeHeaderValue(utils_1.getFromObjectCaseInsensitive(key, request.headers));
 }
 exports.getHeaderValueFromIncomingMessage = getHeaderValueFromIncomingMessage;
 function normalizeHeaderValue(value) {

--- a/lib/build/recipe/dashboard/recipe.js
+++ b/lib/build/recipe/dashboard/recipe.js
@@ -86,10 +86,150 @@ class Recipe extends recipeModule_1.default {
              * handles a specific API path and method and then returns the ID.
              *
              * For the dashboard recipe this logic is fully custom and handled inside the
-             * `returnAPIIdIfCanHandleRequest` method of this class. Since this array is never
-             * used for this recipe, we simply return an empty array.
+             * `returnAPIIdIfCanHandleRequest` method of this class.
+             *
+             * For most frameworks this array is redundant because the `returnAPIIdIfCanHandleRequest` is used.
+             * But for frameworks such as Hapi that require all APIs to be declared up front, this array is used
+             * to make sure that the framework does not return a 404
              */
-            return [];
+            return [
+                {
+                    id: constants_1.DASHBOARD_API,
+                    pathWithoutApiBasePath: new normalisedURLPath_1.default(
+                        utils_1.getApiPathWithDashboardBase(constants_1.DASHBOARD_API)
+                    ),
+                    disabled: false,
+                    method: "get",
+                },
+                {
+                    id: constants_1.SIGN_IN_API,
+                    pathWithoutApiBasePath: new normalisedURLPath_1.default(
+                        utils_1.getApiPathWithDashboardBase(constants_1.SIGN_IN_API)
+                    ),
+                    disabled: false,
+                    method: "post",
+                },
+                {
+                    id: constants_1.VALIDATE_KEY_API,
+                    pathWithoutApiBasePath: new normalisedURLPath_1.default(
+                        utils_1.getApiPathWithDashboardBase(constants_1.VALIDATE_KEY_API)
+                    ),
+                    disabled: false,
+                    method: "post",
+                },
+                {
+                    id: constants_1.SIGN_OUT_API,
+                    pathWithoutApiBasePath: new normalisedURLPath_1.default(
+                        utils_1.getApiPathWithDashboardBase(constants_1.SIGN_OUT_API)
+                    ),
+                    disabled: false,
+                    method: "post",
+                },
+                {
+                    id: constants_1.USERS_LIST_GET_API,
+                    pathWithoutApiBasePath: new normalisedURLPath_1.default(
+                        utils_1.getApiPathWithDashboardBase(constants_1.USERS_LIST_GET_API)
+                    ),
+                    disabled: false,
+                    method: "get",
+                },
+                {
+                    id: constants_1.USERS_COUNT_API,
+                    pathWithoutApiBasePath: new normalisedURLPath_1.default(
+                        utils_1.getApiPathWithDashboardBase(constants_1.USERS_COUNT_API)
+                    ),
+                    disabled: false,
+                    method: "get",
+                },
+                {
+                    id: constants_1.USER_API,
+                    pathWithoutApiBasePath: new normalisedURLPath_1.default(
+                        utils_1.getApiPathWithDashboardBase(constants_1.USER_API)
+                    ),
+                    disabled: false,
+                    method: "get",
+                },
+                {
+                    id: constants_1.USER_API,
+                    pathWithoutApiBasePath: new normalisedURLPath_1.default(
+                        utils_1.getApiPathWithDashboardBase(constants_1.USER_API)
+                    ),
+                    disabled: false,
+                    method: "post",
+                },
+                {
+                    id: constants_1.USER_API,
+                    pathWithoutApiBasePath: new normalisedURLPath_1.default(
+                        utils_1.getApiPathWithDashboardBase(constants_1.USER_API)
+                    ),
+                    disabled: false,
+                    method: "delete",
+                },
+                {
+                    id: constants_1.USER_EMAIL_VERIFY_API,
+                    pathWithoutApiBasePath: new normalisedURLPath_1.default(
+                        utils_1.getApiPathWithDashboardBase(constants_1.USER_EMAIL_VERIFY_API)
+                    ),
+                    disabled: false,
+                    method: "get",
+                },
+                {
+                    id: constants_1.USER_EMAIL_VERIFY_API,
+                    pathWithoutApiBasePath: new normalisedURLPath_1.default(
+                        utils_1.getApiPathWithDashboardBase(constants_1.USER_EMAIL_VERIFY_API)
+                    ),
+                    disabled: false,
+                    method: "put",
+                },
+                {
+                    id: constants_1.USER_METADATA_API,
+                    pathWithoutApiBasePath: new normalisedURLPath_1.default(
+                        utils_1.getApiPathWithDashboardBase(constants_1.USER_METADATA_API)
+                    ),
+                    disabled: false,
+                    method: "get",
+                },
+                {
+                    id: constants_1.USER_METADATA_API,
+                    pathWithoutApiBasePath: new normalisedURLPath_1.default(
+                        utils_1.getApiPathWithDashboardBase(constants_1.USER_METADATA_API)
+                    ),
+                    disabled: false,
+                    method: "put",
+                },
+                {
+                    id: constants_1.USER_SESSIONS_API,
+                    pathWithoutApiBasePath: new normalisedURLPath_1.default(
+                        utils_1.getApiPathWithDashboardBase(constants_1.USER_SESSIONS_API)
+                    ),
+                    disabled: false,
+                    method: "get",
+                },
+                {
+                    id: constants_1.USER_SESSIONS_API,
+                    pathWithoutApiBasePath: new normalisedURLPath_1.default(
+                        utils_1.getApiPathWithDashboardBase(constants_1.USER_SESSIONS_API)
+                    ),
+                    disabled: false,
+                    method: "post",
+                },
+                {
+                    id: constants_1.USER_PASSWORD_API,
+                    pathWithoutApiBasePath: new normalisedURLPath_1.default(
+                        utils_1.getApiPathWithDashboardBase(constants_1.USER_PASSWORD_API)
+                    ),
+                    disabled: false,
+                    method: "put",
+                },
+                {
+                    id: constants_1.USER_EMAIL_VERIFY_TOKEN_API,
+                    pathWithoutApiBasePath: new normalisedURLPath_1.default(
+                        utils_1.getApiPathWithDashboardBase(constants_1.USER_EMAIL_VERIFY_TOKEN_API)
+                    ),
+                    disabled: false,
+                    method: "post",
+                },
+            ];
         };
         this.handleAPIRequest = (id, req, res, __, ___) =>
             __awaiter(this, void 0, void 0, function* () {

--- a/lib/build/recipe/dashboard/utils.d.ts
+++ b/lib/build/recipe/dashboard/utils.d.ts
@@ -34,3 +34,4 @@ export declare function validateApiKey(input: {
     config: TypeNormalisedInput;
     userContext: any;
 }): Promise<boolean>;
+export declare function getApiPathWithDashboardBase(path: string): string;

--- a/lib/build/recipe/dashboard/utils.js
+++ b/lib/build/recipe/dashboard/utils.js
@@ -50,7 +50,7 @@ var __importDefault =
         return mod && mod.__esModule ? mod : { default: mod };
     };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.validateApiKey = exports.isRecipeInitialised = exports.getUserForRecipeId = exports.isValidRecipeId = exports.sendUnauthorisedAccess = exports.getApiIdIfMatched = exports.isApiPath = exports.validateAndNormaliseUserInput = void 0;
+exports.getApiPathWithDashboardBase = exports.validateApiKey = exports.isRecipeInitialised = exports.getUserForRecipeId = exports.isValidRecipeId = exports.sendUnauthorisedAccess = exports.getApiIdIfMatched = exports.isApiPath = exports.validateAndNormaliseUserInput = void 0;
 const normalisedURLPath_1 = __importDefault(require("../../normalisedURLPath"));
 const utils_1 = require("../../utils");
 const constants_1 = require("./constants");
@@ -298,3 +298,7 @@ function validateApiKey(input) {
     });
 }
 exports.validateApiKey = validateApiKey;
+function getApiPathWithDashboardBase(path) {
+    return constants_1.DASHBOARD_API + path;
+}
+exports.getApiPathWithDashboardBase = getApiPathWithDashboardBase;

--- a/lib/build/utils.d.ts
+++ b/lib/build/utils.d.ts
@@ -14,3 +14,4 @@ export declare function frontendHasInterceptor(req: BaseRequest): boolean;
 export declare function humaniseMilliseconds(ms: number): string;
 export declare function makeDefaultUserContextFromAPI(request: BaseRequest): any;
 export declare function getTopLevelDomainForSameSiteResolution(url: string): string;
+export declare function getFromObjectCaseInsensitive<T>(key: string, object: Record<string, T>): T | undefined;

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -41,7 +41,7 @@ var __importDefault =
         return mod && mod.__esModule ? mod : { default: mod };
     };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getTopLevelDomainForSameSiteResolution = exports.makeDefaultUserContextFromAPI = exports.humaniseMilliseconds = exports.frontendHasInterceptor = exports.getRidFromHeader = exports.isAnIpAddress = exports.send200Response = exports.sendNon200Response = exports.sendNon200ResponseWithMessage = exports.normaliseHttpMethod = exports.normaliseInputAppInfoOrThrowError = exports.maxVersion = exports.getLargestVersionFromIntersection = void 0;
+exports.getFromObjectCaseInsensitive = exports.getTopLevelDomainForSameSiteResolution = exports.makeDefaultUserContextFromAPI = exports.humaniseMilliseconds = exports.frontendHasInterceptor = exports.getRidFromHeader = exports.isAnIpAddress = exports.send200Response = exports.sendNon200Response = exports.sendNon200ResponseWithMessage = exports.normaliseHttpMethod = exports.normaliseInputAppInfoOrThrowError = exports.maxVersion = exports.getLargestVersionFromIntersection = void 0;
 const psl = __importStar(require("psl"));
 const normalisedURLDomain_1 = __importDefault(require("./normalisedURLDomain"));
 const normalisedURLPath_1 = __importDefault(require("./normalisedURLPath"));
@@ -194,3 +194,11 @@ function getTopLevelDomainForSameSiteResolution(url) {
     return parsedURL.domain;
 }
 exports.getTopLevelDomainForSameSiteResolution = getTopLevelDomainForSameSiteResolution;
+function getFromObjectCaseInsensitive(key, object) {
+    const matchedKeys = Object.keys(object).filter((i) => i.toLocaleLowerCase() === key.toLocaleLowerCase());
+    if (matchedKeys.length === 0) {
+        return undefined;
+    }
+    return object[matchedKeys[0]];
+}
+exports.getFromObjectCaseInsensitive = getFromObjectCaseInsensitive;

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "13.1.4";
+export declare const version = "13.1.5";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.4";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "13.1.4";
+exports.version = "13.1.5";
 exports.cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15", "2.16", "2.17", "2.18"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.4";

--- a/lib/ts/framework/awsLambda/framework.ts
+++ b/lib/ts/framework/awsLambda/framework.ts
@@ -22,7 +22,7 @@ import type {
     Callback,
 } from "aws-lambda";
 import { HTTPMethod } from "../../types";
-import { normaliseHttpMethod } from "../../utils";
+import { getFromObjectCaseInsensitive, normaliseHttpMethod } from "../../utils";
 import { BaseRequest } from "../request";
 import { BaseResponse } from "../response";
 import { normalizeHeaderValue, getCookieValueFromHeaders, serializeCookieValue } from "../utils";
@@ -116,7 +116,7 @@ export class AWSRequest extends BaseRequest {
         if (this.event.headers === undefined || this.event.headers === null) {
             return undefined;
         }
-        return normalizeHeaderValue(this.event.headers[key]);
+        return normalizeHeaderValue(getFromObjectCaseInsensitive(key, this.event.headers));
     };
 
     getOriginalURL = (): string => {

--- a/lib/ts/framework/fastify/framework.ts
+++ b/lib/ts/framework/fastify/framework.ts
@@ -20,7 +20,7 @@ import type {
     FastifyPluginCallback,
 } from "fastify";
 import type { HTTPMethod } from "../../types";
-import { normaliseHttpMethod } from "../../utils";
+import { getFromObjectCaseInsensitive, normaliseHttpMethod } from "../../utils";
 import { BaseRequest } from "../request";
 import { BaseResponse } from "../response";
 import { serializeCookieValue, normalizeHeaderValue, getCookieValueFromHeaders } from "../utils";
@@ -66,7 +66,7 @@ export class FastifyRequest extends BaseRequest {
     };
 
     getHeaderValue = (key: string): string | undefined => {
-        return normalizeHeaderValue(this.request.headers[key]);
+        return normalizeHeaderValue(getFromObjectCaseInsensitive(key, this.request.headers));
     };
 
     getOriginalURL = (): string => {

--- a/lib/ts/framework/utils.ts
+++ b/lib/ts/framework/utils.ts
@@ -22,6 +22,7 @@ import STError from "../error";
 import type { HTTPMethod } from "../types";
 import { NextApiRequest } from "next";
 import { COOKIE_HEADER } from "./constants";
+import { getFromObjectCaseInsensitive } from "../utils";
 
 export function getCookieValueFromHeaders(headers: any, key: string): string | undefined {
     if (headers === undefined || headers === null) {
@@ -50,7 +51,7 @@ export function getCookieValueFromIncomingMessage(request: IncomingMessage, key:
 }
 
 export function getHeaderValueFromIncomingMessage(request: IncomingMessage, key: string): string | undefined {
-    return normalizeHeaderValue(request.headers[key]);
+    return normalizeHeaderValue(getFromObjectCaseInsensitive(key, request.headers));
 }
 
 export function normalizeHeaderValue(value: string | string[] | undefined): string | undefined {

--- a/lib/ts/recipe/dashboard/recipe.ts
+++ b/lib/ts/recipe/dashboard/recipe.ts
@@ -19,7 +19,7 @@ import { APIHandled, HTTPMethod, NormalisedAppinfo, RecipeListFunction } from ".
 import { APIFunction, APIInterface, APIOptions, RecipeInterface, TypeInput, TypeNormalisedInput } from "./types";
 import RecipeImplementation from "./recipeImplementation";
 import APIImplementation from "./api/implementation";
-import { getApiIdIfMatched, isApiPath, validateAndNormaliseUserInput } from "./utils";
+import { getApiIdIfMatched, getApiPathWithDashboardBase, isApiPath, validateAndNormaliseUserInput } from "./utils";
 import {
     DASHBOARD_API,
     SIGN_IN_API,
@@ -117,10 +117,116 @@ export default class Recipe extends RecipeModule {
          * handles a specific API path and method and then returns the ID.
          *
          * For the dashboard recipe this logic is fully custom and handled inside the
-         * `returnAPIIdIfCanHandleRequest` method of this class. Since this array is never
-         * used for this recipe, we simply return an empty array.
+         * `returnAPIIdIfCanHandleRequest` method of this class.
+         *
+         * For most frameworks this array is redundant because the `returnAPIIdIfCanHandleRequest` is used.
+         * But for frameworks such as Hapi that require all APIs to be declared up front, this array is used
+         * to make sure that the framework does not return a 404
          */
-        return [];
+        return [
+            {
+                id: DASHBOARD_API,
+                pathWithoutApiBasePath: new NormalisedURLPath(getApiPathWithDashboardBase(DASHBOARD_API)),
+                disabled: false,
+                method: "get",
+            },
+            {
+                id: SIGN_IN_API,
+                pathWithoutApiBasePath: new NormalisedURLPath(getApiPathWithDashboardBase(SIGN_IN_API)),
+                disabled: false,
+                method: "post",
+            },
+            {
+                id: VALIDATE_KEY_API,
+                pathWithoutApiBasePath: new NormalisedURLPath(getApiPathWithDashboardBase(VALIDATE_KEY_API)),
+                disabled: false,
+                method: "post",
+            },
+            {
+                id: SIGN_OUT_API,
+                pathWithoutApiBasePath: new NormalisedURLPath(getApiPathWithDashboardBase(SIGN_OUT_API)),
+                disabled: false,
+                method: "post",
+            },
+            {
+                id: USERS_LIST_GET_API,
+                pathWithoutApiBasePath: new NormalisedURLPath(getApiPathWithDashboardBase(USERS_LIST_GET_API)),
+                disabled: false,
+                method: "get",
+            },
+            {
+                id: USERS_COUNT_API,
+                pathWithoutApiBasePath: new NormalisedURLPath(getApiPathWithDashboardBase(USERS_COUNT_API)),
+                disabled: false,
+                method: "get",
+            },
+            {
+                id: USER_API,
+                pathWithoutApiBasePath: new NormalisedURLPath(getApiPathWithDashboardBase(USER_API)),
+                disabled: false,
+                method: "get",
+            },
+            {
+                id: USER_API,
+                pathWithoutApiBasePath: new NormalisedURLPath(getApiPathWithDashboardBase(USER_API)),
+                disabled: false,
+                method: "post",
+            },
+            {
+                id: USER_API,
+                pathWithoutApiBasePath: new NormalisedURLPath(getApiPathWithDashboardBase(USER_API)),
+                disabled: false,
+                method: "delete",
+            },
+            {
+                id: USER_EMAIL_VERIFY_API,
+                pathWithoutApiBasePath: new NormalisedURLPath(getApiPathWithDashboardBase(USER_EMAIL_VERIFY_API)),
+                disabled: false,
+                method: "get",
+            },
+            {
+                id: USER_EMAIL_VERIFY_API,
+                pathWithoutApiBasePath: new NormalisedURLPath(getApiPathWithDashboardBase(USER_EMAIL_VERIFY_API)),
+                disabled: false,
+                method: "put",
+            },
+            {
+                id: USER_METADATA_API,
+                pathWithoutApiBasePath: new NormalisedURLPath(getApiPathWithDashboardBase(USER_METADATA_API)),
+                disabled: false,
+                method: "get",
+            },
+            {
+                id: USER_METADATA_API,
+                pathWithoutApiBasePath: new NormalisedURLPath(getApiPathWithDashboardBase(USER_METADATA_API)),
+                disabled: false,
+                method: "put",
+            },
+            {
+                id: USER_SESSIONS_API,
+                pathWithoutApiBasePath: new NormalisedURLPath(getApiPathWithDashboardBase(USER_SESSIONS_API)),
+                disabled: false,
+                method: "get",
+            },
+            {
+                id: USER_SESSIONS_API,
+                pathWithoutApiBasePath: new NormalisedURLPath(getApiPathWithDashboardBase(USER_SESSIONS_API)),
+                disabled: false,
+                method: "post",
+            },
+            {
+                id: USER_PASSWORD_API,
+                pathWithoutApiBasePath: new NormalisedURLPath(getApiPathWithDashboardBase(USER_PASSWORD_API)),
+                disabled: false,
+                method: "put",
+            },
+            {
+                id: USER_EMAIL_VERIFY_TOKEN_API,
+                pathWithoutApiBasePath: new NormalisedURLPath(getApiPathWithDashboardBase(USER_EMAIL_VERIFY_TOKEN_API)),
+                disabled: false,
+                method: "post",
+            },
+        ];
     };
 
     handleAPIRequest = async (

--- a/lib/ts/recipe/dashboard/utils.ts
+++ b/lib/ts/recipe/dashboard/utils.ts
@@ -361,3 +361,7 @@ export async function validateApiKey(input: { req: BaseRequest; config: TypeNorm
 
     return apiKeyHeaderValue === input.config.apiKey;
 }
+
+export function getApiPathWithDashboardBase(path: string): string {
+    return DASHBOARD_API + path;
+}

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -156,3 +156,13 @@ export function getTopLevelDomainForSameSiteResolution(url: string): string {
     }
     return parsedURL.domain;
 }
+
+export function getFromObjectCaseInsensitive<T>(key: string, object: Record<string, T>): T | undefined {
+    const matchedKeys = Object.keys(object).filter((i) => i.toLocaleLowerCase() === key.toLocaleLowerCase());
+
+    if (matchedKeys.length === 0) {
+        return undefined;
+    }
+
+    return object[matchedKeys[0]];
+}

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "13.1.4";
+export const version = "13.1.5";
 
 export const cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15", "2.16", "2.17", "2.18"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "13.1.4",
+    "version": "13.1.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "13.1.4",
+            "version": "13.1.5",
             "license": "Apache-2.0",
             "dependencies": {
                 "axios": "0.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "13.1.4",
+    "version": "13.1.5",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {

--- a/test/import.test.js
+++ b/test/import.test.js
@@ -1,0 +1,43 @@
+const { printPath, getAllFilesInDirectory } = require("./utils");
+const { resolve } = require("path");
+const { writeFileSync, rmSync } = require("fs");
+const { existsSync } = require("fs");
+const { execSync } = require("child_process");
+
+const testFileName = "importtest.js";
+const testFilePath = resolve(process.cwd(), `./${testFileName}`);
+
+describe(`importTests: ${printPath("[test/import.test.js]")}`, function () {
+    after(function () {
+        // The exists check is just a precaution
+        if (existsSync(testFilePath)) {
+            rmSync(testFilePath);
+        }
+    });
+
+    /**
+     * This test does the following:
+     * 1. Gets a list of all files in the build folder recursively
+     * 2. For each build file, creates a simple js file that imports the build file
+     * 3. Runs the generated js file
+     *
+     * The test fails if there is any error thrown when trying to run any of the generated files.
+     *
+     * This is to prevent issues arising from circular imports where certain variables from the
+     * default exports for recipes are not intialised correctly.
+     * (Refer to: https://github.com/supertokens/supertokens-node/issues/513)
+     */
+    it("Test that importing all build files independently does not cause errors", function () {
+        const fileNames = getAllFilesInDirectory(resolve(process.cwd(), "./lib/build")).filter(
+            (i) => !i.endsWith(".d.ts")
+        );
+
+        fileNames.forEach((fileName) => {
+            const relativeFilePath = fileName.replace(process.cwd(), "");
+            writeFileSync(testFilePath, `require(".${relativeFilePath}")`);
+
+            // This will throw an error if the command fails
+            execSync(`node ${resolve(process.cwd(), `./${testFileName}`)}`);
+        });
+    });
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -34,6 +34,7 @@ let { Querier } = require("../lib/build/querier");
 let { maxVersion } = require("../lib/build/utils");
 const { default: OpenIDRecipe } = require("../lib/build/recipe/openid/recipe");
 const { wrapRequest } = require("../framework/express");
+const { join } = require("path");
 
 module.exports.printPath = function (path) {
     return `${createFormat([consoleOptions.yellow, consoleOptions.italic, consoleOptions.dim])}${path}${createFormat([
@@ -560,4 +561,18 @@ module.exports.mockRequest = () => {
         header: (key) => headers[key],
     };
     return req;
+};
+
+module.exports.getAllFilesInDirectory = (path) => {
+    return fs
+        .readdirSync(path, {
+            withFileTypes: true,
+        })
+        .flatMap((file) => {
+            if (file.isDirectory()) {
+                return this.getAllFilesInDirectory(join(path, file.name));
+            } else {
+                return join(path, file.name);
+            }
+        });
 };

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,20 @@
+const assert = require("assert");
+const { getFromObjectCaseInsensitive } = require("../lib/build/utils");
+
+describe("SuperTokens utils test", () => {
+    it("Test getFromObjectCaseInsensitive", () => {
+        const testObj = {
+            AuthOriZation: "test",
+        };
+
+        assert.equal(getFromObjectCaseInsensitive("test", testObj), undefined);
+        // Exact
+        assert.equal(getFromObjectCaseInsensitive("AuthOriZation", testObj), "test");
+        // All lower case
+        assert.equal(getFromObjectCaseInsensitive("authorization", testObj), "test");
+        // Traditional case
+        assert.equal(getFromObjectCaseInsensitive("Authorization", testObj), "test");
+        // Weird casing
+        assert.equal(getFromObjectCaseInsensitive("authoriZation", testObj), "test");
+    });
+});


### PR DESCRIPTION
## Summary of change

- Fixes getHeaderValue's logic to add case insensitivity
- Fixes an issue where Hapi returns 404 for all Dashboard recipe APIs
- Adds tests to check if circular imports causes issues
- Adds tests for reading headers in frameworks

## Related issues

-   #508 
-   #513 

## Test Plan

Existing and new tests should pass

## Documentation changes

NA

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] ...
