### PR TITLE
Enable search only for CDI version above 2.20

### DIFF
--- a/lib/build/recipe/dashboard/api/implementation.js
+++ b/lib/build/recipe/dashboard/api/implementation.js
@@ -52,7 +52,9 @@ var __importDefault =
 Object.defineProperty(exports, "__esModule", { value: true });
 const normalisedURLDomain_1 = __importDefault(require("../../../normalisedURLDomain"));
 const normalisedURLPath_1 = __importDefault(require("../../../normalisedURLPath"));
+const querier_1 = require("../../../querier");
 const supertokens_1 = __importDefault(require("../../../supertokens"));
+const utils_1 = require("../../../utils");
 const constants_1 = require("../constants");
 function getAPIImplementation() {
     return {
@@ -70,6 +72,14 @@ function getAPIImplementation() {
                 if (superTokensInstance.supertokens !== undefined) {
                     connectionURI = superTokensInstance.supertokens.connectionURI;
                 }
+                let isSearchEnabled = false;
+                const cdiVersion = yield querier_1.Querier.getNewInstanceOrThrowError(
+                    input.options.recipeId
+                ).getAPIVersion();
+                if (utils_1.maxVersion("2.20", cdiVersion) === "2.20") {
+                    // Only enable search if CDI version is 2.20 or above
+                    isSearchEnabled = true;
+                }
                 return `
             <html>
                 <head>
@@ -81,6 +91,7 @@ function getAPIImplementation() {
                             .getAsStringDangerous()}"
                         window.connectionURI = "${connectionURI}"
                         window.authMode = "${authMode}"
+                        window.isSearchEnabled = "${isSearchEnabled}"
                     </script>
                     <script defer src="${bundleDomain}/static/js/bundle.js"></script></head>
                     <link href="${bundleDomain}/static/css/main.css" rel="stylesheet" type="text/css">

--- a/lib/ts/recipe/dashboard/api/implementation.ts
+++ b/lib/ts/recipe/dashboard/api/implementation.ts
@@ -15,7 +15,9 @@
 
 import NormalisedURLDomain from "../../../normalisedURLDomain";
 import NormalisedURLPath from "../../../normalisedURLPath";
+import { Querier } from "../../../querier";
 import SuperTokens from "../../../supertokens";
+import { maxVersion } from "../../../utils";
 import { DASHBOARD_API } from "../constants";
 import { APIInterface, AuthMode } from "../types";
 
@@ -39,6 +41,13 @@ export default function getAPIImplementation(): APIInterface {
                 connectionURI = superTokensInstance.supertokens.connectionURI;
             }
 
+            let isSearchEnabled = false;
+            const cdiVersion = await Querier.getNewInstanceOrThrowError(input.options.recipeId).getAPIVersion();
+            if (maxVersion("2.20", cdiVersion) === "2.20") {
+                // Only enable search if CDI version is 2.20 or above
+                isSearchEnabled = true;
+            }
+
             return `
             <html>
                 <head>
@@ -50,6 +59,7 @@ export default function getAPIImplementation(): APIInterface {
                             .getAsStringDangerous()}"
                         window.connectionURI = "${connectionURI}"
                         window.authMode = "${authMode}"
+                        window.isSearchEnabled = "${isSearchEnabled}"
                     </script>
                     <script defer src="${bundleDomain}/static/js/bundle.js"></script></head>
                     <link href="${bundleDomain}/static/css/main.css" rel="stylesheet" type="text/css">


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
