### PR TITLE
fix: update createJWT in openId and session recipes + CDI version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
--   Added support for CDI version `2.19`
+-   Added support for CDI version `2.21`
 -   Dropped support for CDI version `2.8`-`2.18`
 -   Changed the interface and configuration of the Session recipe, see below for details. If you do not use the Session recipe directly and do not provide custom configuration, then no migration is necessary.
 -   `getAccessTokenPayload` will now return standard (`sub`, `iat`, `exp`) claims and some SuperTokens specific claims along the user defined ones in `getAccessTokenPayload`.

--- a/coreDriverInterfaceSupported.json
+++ b/coreDriverInterfaceSupported.json
@@ -1,4 +1,4 @@
 {
     "_comment": "contains a list of core-driver interfaces branch names that this core supports",
-    "versions": ["2.19"]
+    "versions": ["2.21"]
 }

--- a/lib/build/recipe/openid/index.d.ts
+++ b/lib/build/recipe/openid/index.d.ts
@@ -12,6 +12,7 @@ export default class OpenIdRecipeWrapper {
     static createJWT(
         payload?: any,
         validitySeconds?: number,
+        useStaticSigningKey?: boolean,
         userContext?: any
     ): Promise<
         | {

--- a/lib/build/recipe/openid/index.js
+++ b/lib/build/recipe/openid/index.js
@@ -13,10 +13,11 @@ class OpenIdRecipeWrapper {
             userContext: userContext === undefined ? {} : userContext,
         });
     }
-    static createJWT(payload, validitySeconds, userContext) {
+    static createJWT(payload, validitySeconds, useStaticSigningKey, userContext) {
         return recipe_1.default.getInstanceOrThrowError().jwtRecipe.recipeInterfaceImpl.createJWT({
             payload,
             validitySeconds,
+            useStaticSigningKey,
             userContext: userContext === undefined ? {} : userContext,
         });
     }

--- a/lib/build/recipe/openid/recipeImplementation.js
+++ b/lib/build/recipe/openid/recipeImplementation.js
@@ -55,12 +55,13 @@ function getRecipeInterface(config, jwtRecipeImplementation) {
                 };
             });
         },
-        createJWT: function ({ payload, validitySeconds, userContext }) {
+        createJWT: function ({ payload, validitySeconds, useStaticSigningKey, userContext }) {
             return __awaiter(this, void 0, void 0, function* () {
                 payload = payload === undefined || payload === null ? {} : payload;
                 let issuer = config.issuerDomain.getAsStringDangerous() + config.issuerPath.getAsStringDangerous();
                 return yield jwtRecipeImplementation.createJWT({
                     payload: Object.assign({ iss: issuer }, payload),
+                    useStaticSigningKey,
                     validitySeconds,
                     userContext,
                 });

--- a/lib/build/recipe/openid/types.d.ts
+++ b/lib/build/recipe/openid/types.d.ts
@@ -81,6 +81,7 @@ export declare type RecipeInterface = {
     createJWT(input: {
         payload?: any;
         validitySeconds?: number;
+        useStaticSigningKey?: boolean;
         userContext: any;
     }): Promise<
         | {

--- a/lib/build/recipe/session/index.d.ts
+++ b/lib/build/recipe/session/index.d.ts
@@ -162,6 +162,7 @@ export default class SessionWrapper {
     static createJWT(
         payload?: any,
         validitySeconds?: number,
+        useStaticSigningKey?: boolean,
         userContext?: any
     ): Promise<
         | {

--- a/lib/build/recipe/session/index.js
+++ b/lib/build/recipe/session/index.js
@@ -308,10 +308,11 @@ class SessionWrapper {
             userContext,
         });
     }
-    static createJWT(payload, validitySeconds, userContext = {}) {
+    static createJWT(payload, validitySeconds, useStaticSigningKey, userContext = {}) {
         return recipe_1.default.getInstanceOrThrowError().openIdRecipe.recipeImplementation.createJWT({
             payload,
             validitySeconds,
+            useStaticSigningKey,
             userContext,
         });
     }

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -16,6 +16,6 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * under the License.
  */
 exports.version = "13.1.3";
-exports.cdiSupported = ["2.19"];
+exports.cdiSupported = ["2.21"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.4";

--- a/lib/ts/recipe/openid/index.ts
+++ b/lib/ts/recipe/openid/index.ts
@@ -9,10 +9,11 @@ export default class OpenIdRecipeWrapper {
         });
     }
 
-    static createJWT(payload?: any, validitySeconds?: number, userContext?: any) {
+    static createJWT(payload?: any, validitySeconds?: number, useStaticSigningKey?: boolean, userContext?: any) {
         return OpenIdRecipe.getInstanceOrThrowError().jwtRecipe.recipeInterfaceImpl.createJWT({
             payload,
             validitySeconds,
+            useStaticSigningKey,
             userContext: userContext === undefined ? {} : userContext,
         });
     }

--- a/lib/ts/recipe/openid/recipeImplementation.ts
+++ b/lib/ts/recipe/openid/recipeImplementation.ts
@@ -40,10 +40,12 @@ export default function getRecipeInterface(
         createJWT: async function ({
             payload,
             validitySeconds,
+            useStaticSigningKey,
             userContext,
         }: {
             payload?: any;
             validitySeconds?: number;
+            useStaticSigningKey?: boolean;
             userContext: any;
         }): Promise<
             | {
@@ -62,6 +64,7 @@ export default function getRecipeInterface(
                     iss: issuer,
                     ...payload,
                 },
+                useStaticSigningKey,
                 validitySeconds,
                 userContext,
             });

--- a/lib/ts/recipe/openid/types.ts
+++ b/lib/ts/recipe/openid/types.ts
@@ -99,6 +99,7 @@ export type RecipeInterface = {
     createJWT(input: {
         payload?: any;
         validitySeconds?: number;
+        useStaticSigningKey?: boolean;
         userContext: any;
     }): Promise<
         | {

--- a/lib/ts/recipe/session/index.ts
+++ b/lib/ts/recipe/session/index.ts
@@ -355,10 +355,11 @@ export default class SessionWrapper {
         });
     }
 
-    static createJWT(payload?: any, validitySeconds?: number, userContext: any = {}) {
+    static createJWT(payload?: any, validitySeconds?: number, useStaticSigningKey?: boolean, userContext: any = {}) {
         return Recipe.getInstanceOrThrowError().openIdRecipe.recipeImplementation.createJWT({
             payload,
             validitySeconds,
+            useStaticSigningKey,
             userContext,
         });
     }

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -14,7 +14,7 @@
  */
 export const version = "13.1.3";
 
-export const cdiSupported = ["2.19"];
+export const cdiSupported = ["2.21"];
 
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 export const dashboardVersion = "0.4";


### PR DESCRIPTION
## Summary of change

- update createJWT in openId and session recipes 
- Update CDI version after merge

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
