### PR TITLE
chore: Account linking general refactor

### DIFF
--- a/lib/build/recipe/accountlinking/index.d.ts
+++ b/lib/build/recipe/accountlinking/index.d.ts
@@ -104,7 +104,13 @@ export default class Wrapper {
               wasRecipeUserDeleted: boolean;
           }
         | {
-              status: "NO_PRIMARY_USER_FOUND";
+              status: "PRIMARY_USER_NOT_FOUND";
+          }
+        | {
+              status: "RESTART_FLOW_ERROR";
+          }
+        | {
+              status: "RECIPE_USER_NOT_FOUND";
           }
     >;
     static fetchFromAccountToLinkTable(

--- a/lib/build/recipe/accountlinking/index.d.ts
+++ b/lib/build/recipe/accountlinking/index.d.ts
@@ -62,15 +62,12 @@ export default class Wrapper {
     ): Promise<
         | {
               status: "OK";
+              accountsAlreadyLinked: boolean;
           }
         | {
               status: "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
               description: string;
               primaryUserId: string;
-          }
-        | {
-              status: "ACCOUNTS_ALREADY_LINKED_ERROR";
-              description: string;
           }
         | {
               status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
@@ -85,14 +82,11 @@ export default class Wrapper {
     ): Promise<
         | {
               status: "OK";
+              accountsAlreadyLinked: boolean;
           }
         | {
               status: "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
               primaryUserId: string;
-              description: string;
-          }
-        | {
-              status: "ACCOUNTS_ALREADY_LINKED_ERROR";
               description: string;
           }
         | {

--- a/lib/build/recipe/accountlinking/index.d.ts
+++ b/lib/build/recipe/accountlinking/index.d.ts
@@ -30,6 +30,7 @@ export default class Wrapper {
     ): Promise<
         | {
               status: "OK";
+              wasAlreadyAPrimaryUser: boolean;
           }
         | {
               status:
@@ -46,6 +47,7 @@ export default class Wrapper {
         | {
               status: "OK";
               user: import("../../types").User;
+              wasAlreadyAPrimaryUser: boolean;
           }
         | {
               status:
@@ -104,13 +106,8 @@ export default class Wrapper {
               wasRecipeUserDeleted: boolean;
           }
         | {
-              status: "PRIMARY_USER_NOT_FOUND";
-          }
-        | {
-              status: "RESTART_FLOW_ERROR";
-          }
-        | {
-              status: "RECIPE_USER_NOT_FOUND";
+              status: "PRIMARY_USER_NOT_FOUND_ERROR" | "RECIPE_USER_NOT_FOUND_ERROR";
+              description: string;
           }
     >;
     static fetchFromAccountToLinkTable(

--- a/lib/build/recipe/accountlinking/index.d.ts
+++ b/lib/build/recipe/accountlinking/index.d.ts
@@ -34,7 +34,7 @@ export default class Wrapper {
         | {
               status:
                   | "RECIPE_USER_ID_ALREADY_LINKED_WITH_PRIMARY_USER_ID_ERROR"
-                  | "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                  | "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
               primaryUserId: string;
               description: string;
           }
@@ -50,7 +50,7 @@ export default class Wrapper {
         | {
               status:
                   | "RECIPE_USER_ID_ALREADY_LINKED_WITH_PRIMARY_USER_ID_ERROR"
-                  | "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                  | "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
               primaryUserId: string;
               description: string;
           }
@@ -70,7 +70,7 @@ export default class Wrapper {
               primaryUserId: string;
           }
         | {
-              status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+              status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
               primaryUserId: string;
               description: string;
           }
@@ -90,7 +90,7 @@ export default class Wrapper {
               description: string;
           }
         | {
-              status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+              status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
               primaryUserId: string;
               description: string;
           }

--- a/lib/build/recipe/accountlinking/recipe.d.ts
+++ b/lib/build/recipe/accountlinking/recipe.d.ts
@@ -108,7 +108,7 @@ export default class Recipe extends RecipeModule {
               | {
                     accountsLinked: false;
                     reason:
-                        | "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
+                        | "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
                         | "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
                     primaryUserId: string;
                 }

--- a/lib/build/recipe/accountlinking/recipe.js
+++ b/lib/build/recipe/accountlinking/recipe.js
@@ -253,25 +253,6 @@ class Recipe extends recipeModule_1.default {
                     userContext,
                 });
                 if (result.status === "OK") {
-                    /**
-                     * We now mark the same email of other linked recipes as verified if the new user's email
-                     * is verified.
-                     */
-                    if (newUser.email !== undefined && newUserVerified) {
-                        let recipeUserIdsForEmailVerificationUpdate = primaryUser.loginMethods
-                            .filter((u) => u.email === newUser.email && !u.verified)
-                            .map((l) => l.recipeUserId);
-                        recipeUserIdsForEmailVerificationUpdate = Array.from(
-                            new Set(recipeUserIdsForEmailVerificationUpdate)
-                        );
-                        for (let i = 0; i < recipeUserIdsForEmailVerificationUpdate.length; i++) {
-                            yield this.markEmailAsVerified({
-                                email: newUser.email,
-                                recipeUserId: recipeUserIdsForEmailVerificationUpdate[i],
-                                userContext,
-                            });
-                        }
-                    }
                     return primaryUser.id;
                 } else if (result.status === "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR") {
                     return result.primaryUserId;

--- a/lib/build/recipe/accountlinking/recipe.js
+++ b/lib/build/recipe/accountlinking/recipe.js
@@ -185,31 +185,14 @@ class Recipe extends recipeModule_1.default {
         // this function returns the user ID for which the session will be created.
         this.doPostSignUpAccountLinkingOperations = ({ newUser, newUserVerified, recipeUserId, userContext }) =>
             __awaiter(this, void 0, void 0, function* () {
-                let accountInfo;
-                if (newUser.email !== undefined) {
-                    accountInfo = {
-                        email: newUser.email,
-                    };
-                } else if (newUser.phoneNumber !== undefined) {
-                    accountInfo = {
-                        phoneNumber: newUser.phoneNumber,
-                    };
-                } else if (newUser.thirdParty !== undefined) {
-                    accountInfo = {
-                        thirdPartyId: newUser.thirdParty.id,
-                        thirdPartyUserId: newUser.thirdParty.userId,
-                    };
-                } else {
-                    throw Error("this error should never be thrown");
-                }
-                let users = yield this.recipeInterfaceImpl.listUsersByAccountInfo({
-                    accountInfo,
+                let user = yield this.getPrimaryUserIdThatCanBeLinkedToRecipeUserId({
+                    recipeUserId,
                     userContext,
                 });
-                if (users.length === 0) {
+                if (user === undefined) {
                     return recipeUserId;
                 }
-                let primaryUser = users.find((u) => u.isPrimaryUser);
+                let primaryUser = user;
                 let shouldDoAccountLinking = yield this.config.shouldDoAutomaticAccountLinking(
                     newUser,
                     primaryUser,
@@ -756,8 +739,9 @@ class Recipe extends recipeModule_1.default {
                             ) {
                                 primaryUserId = linkAccountsResult.primaryUserId;
                             }
-                            console.log(primaryUserId); // TODO: remove this
-                            // TODO: remove session claim if session claim exists
+                            console.log(primaryUserId); // TODO NEMI: remove this
+                            // TODO NEMI: The caller of this function should
+                            // remove session claim if session claim exists
                             // else create a new session
                         }
                     }

--- a/lib/build/recipe/accountlinking/recipe.js
+++ b/lib/build/recipe/accountlinking/recipe.js
@@ -239,7 +239,7 @@ class Recipe extends recipeModule_1.default {
                     return primaryUser.id;
                 } else if (result.status === "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR") {
                     return result.primaryUserId;
-                } else if (result.status === "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR") {
+                } else if (result.status === "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR") {
                     return result.primaryUserId;
                 } else {
                     return primaryUser.id;
@@ -330,7 +330,7 @@ class Recipe extends recipeModule_1.default {
                         });
                     } else if (
                         createPrimaryUserResult.status ===
-                        "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
+                        "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
                     ) {
                         /* this can come here if in the following example:
                     - User creates a primary account (P1) using email R
@@ -466,7 +466,7 @@ class Recipe extends recipeModule_1.default {
                         return {
                             createRecipeUser: false,
                             accountsLinked: false,
-                            reason: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR",
+                            reason: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR",
                             primaryUserId: primaryUserIfExists.id,
                         };
                     }
@@ -512,10 +512,10 @@ class Recipe extends recipeModule_1.default {
                     };
                 }
                 if (
-                    canLinkAccounts.status === "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR" ||
+                    canLinkAccounts.status === "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR" ||
                     canLinkAccounts.status === "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
                 ) {
-                    /* ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR can be possible if
+                    /* ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR can be possible if
                 - existingUser has email E1
                 - you try and link an account with email E2
                 - there already exists another primary account with email E2
@@ -733,7 +733,7 @@ class Recipe extends recipeModule_1.default {
                             let primaryUserId = primaryUser.id;
                             if (
                                 linkAccountsResult.status ===
-                                    "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR" ||
+                                    "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR" ||
                                 linkAccountsResult.status ===
                                     "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
                             ) {

--- a/lib/build/recipe/accountlinking/recipe.js
+++ b/lib/build/recipe/accountlinking/recipe.js
@@ -57,21 +57,166 @@ const supertokens_js_override_1 = __importDefault(require("supertokens-js-overri
 const recipeImplementation_1 = __importDefault(require("./recipeImplementation"));
 const querier_1 = require("../../querier");
 const error_1 = __importDefault(require("../../error"));
-const recipe_1 = __importDefault(require("../emailverification/recipe"));
+const emailVerificationClaim_1 = require("../emailverification/emailVerificationClaim");
 class Recipe extends recipeModule_1.default {
     constructor(recipeId, appInfo, config, _recipes, _ingredients) {
         super(recipeId, appInfo);
+        // this function returns the user ID for which the session will be created.
+        this.createPrimaryUserIdOrLinkAccounts = ({
+            recipeUserId,
+            isVerified,
+            checkAccountsToLinkTableAsWell,
+            userContext,
+        }) =>
+            __awaiter(this, void 0, void 0, function* () {
+                let recipeUser = yield __1.getUser(recipeUserId, userContext);
+                if (recipeUser === undefined) {
+                    throw Error("Race condition error. It means that the input recipeUserId was deleted");
+                }
+                if (recipeUser.isPrimaryUser) {
+                    return recipeUser.id;
+                }
+                // now we try and find a linking candidate.
+                let primaryUser = yield this.getPrimaryUserIdThatCanBeLinkedToRecipeUserId({
+                    recipeUserId,
+                    checkAccountsToLinkTableAsWell,
+                    userContext,
+                });
+                if (primaryUser === undefined) {
+                    // this means that this can become a primary user.
+                    // we can use the 0 index cause this user is
+                    // not a primary user.
+                    let shouldDoAccountLinking = yield this.config.shouldDoAutomaticAccountLinking(
+                        recipeUser.loginMethods[0],
+                        undefined,
+                        undefined,
+                        userContext
+                    );
+                    if (!shouldDoAccountLinking.shouldAutomaticallyLink) {
+                        return recipeUserId;
+                    }
+                    if (shouldDoAccountLinking.shouldRequireVerification && !isVerified) {
+                        return recipeUserId;
+                    }
+                    let createPrimaryUserResult = yield this.recipeInterfaceImpl.createPrimaryUser({
+                        recipeUserId: recipeUserId,
+                        userContext,
+                    });
+                    if (createPrimaryUserResult.status === "OK") {
+                        return createPrimaryUserResult.user.id;
+                    }
+                    // status is "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR" or "RECIPE_USER_ID_ALREADY_LINKED_WITH_PRIMARY_USER_ID_ERROR"
+                    // if it comes here, it means that the recipe
+                    // user ID is already linked to another primary
+                    // user id (race condition), or that some other
+                    // primary user ID exists with the same email / phone number (again, race condition).
+                    // So we do recursion here to try again.
+                    return yield this.createPrimaryUserIdOrLinkAccounts({
+                        recipeUserId,
+                        isVerified,
+                        checkAccountsToLinkTableAsWell,
+                        userContext,
+                    });
+                } else {
+                    // this means that we found a primary user ID which can be linked to this recipe user ID. So we try and link them.
+                    // we can use the 0 index cause this user is
+                    // not a primary user.
+                    let shouldDoAccountLinking = yield this.config.shouldDoAutomaticAccountLinking(
+                        recipeUser.loginMethods[0],
+                        primaryUser,
+                        undefined,
+                        userContext
+                    );
+                    if (!shouldDoAccountLinking.shouldAutomaticallyLink) {
+                        return recipeUserId;
+                    }
+                    if (shouldDoAccountLinking.shouldRequireVerification && !isVerified) {
+                        return recipeUserId;
+                    }
+                    let linkAccountsResult = yield this.recipeInterfaceImpl.linkAccounts({
+                        recipeUserId: recipeUserId,
+                        primaryUserId: primaryUser.id,
+                        userContext,
+                    });
+                    if (linkAccountsResult.status === "OK") {
+                        return primaryUser.id;
+                    } else if (
+                        linkAccountsResult.status === "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
+                    ) {
+                        // this can happen cause of a race condition
+                        // wherein the recipe user ID get's linked to
+                        // some other primary user whilst this function is running.
+                        // But this is OK cause we just care about
+                        // returning the user ID of the linked user
+                        // which the result has.
+                        return linkAccountsResult.primaryUserId;
+                    } else {
+                        // status is "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
+                        // it can come here if the recipe user ID
+                        // can't be linked to the primary user ID cause
+                        // the email / phone number is associated with some other primary user ID.
+                        // This can happen due to a race condition in which
+                        // the email has changed from one primary user to another during this function call,
+                        // or it can happen if the accounts to link table
+                        // contains a user which this is supposed to
+                        // be linked to, but we can't link it cause during the time the user was added to that table and now, some other primary user has
+                        // got this email.
+                        // So we try again, but without caring about
+                        // the accounts to link table (cause they we will end up in an infinite recursion).
+                        return yield this.createPrimaryUserIdOrLinkAccounts({
+                            recipeUserId,
+                            isVerified,
+                            checkAccountsToLinkTableAsWell: false,
+                            userContext,
+                        });
+                    }
+                }
+            });
+        this.getPrimaryUserIdThatCanBeLinkedToRecipeUserId = ({
+            recipeUserId,
+            checkAccountsToLinkTableAsWell,
+            userContext,
+        }) =>
+            __awaiter(this, void 0, void 0, function* () {
+                // first we check if this user itself is a
+                // primary user or not. If it is, we return that.
+                let user = yield __1.getUser(recipeUserId, userContext);
+                if (user === undefined) {
+                    return undefined;
+                }
+                if (user.isPrimaryUser) {
+                    return user;
+                }
+                // then we check the accounts to link table. This
+                // table can have an entry if this user was trying
+                // to be linked to another user post sign in but required
+                // email verification.
+                if (checkAccountsToLinkTableAsWell) {
+                    let pUser = yield this.recipeInterfaceImpl.fetchFromAccountToLinkTable({
+                        recipeUserId,
+                        userContext,
+                    });
+                    if (pUser !== undefined && pUser.isPrimaryUser) {
+                        return pUser;
+                    }
+                }
+                // finally, we try and find a primary user based on
+                // the email / phone number / third party ID.
+                let users = yield this.recipeInterfaceImpl.listUsersByAccountInfo({
+                    accountInfo: user.loginMethods[0],
+                    userContext,
+                });
+                return users.find((u) => u.isPrimaryUser);
+            });
         this.transformUserInfoIntoVerifiedAndUnverifiedBucket = (user) => {
             let identities = {
                 verified: {
                     emails: [],
                     phoneNumbers: [],
-                    thirdParty: [],
                 },
                 unverified: {
                     emails: [],
                     phoneNumbers: [],
-                    thirdParty: [],
                 },
             };
             for (let i = 0; i < user.loginMethods.length; i++) {
@@ -90,13 +235,6 @@ class Recipe extends recipeModule_1.default {
                         identities.unverified.phoneNumbers.push(loginMethod.phoneNumber);
                     }
                 }
-                if (loginMethod.thirdParty !== undefined) {
-                    if (loginMethod.verified) {
-                        identities.verified.thirdParty.push(loginMethod.thirdParty);
-                    } else {
-                        identities.unverified.thirdParty.push(loginMethod.thirdParty);
-                    }
-                }
             }
             // we remove duplicate emails / phone numbers from the above arrays.
             identities.verified.emails = Array.from(new Set(identities.verified.emails));
@@ -109,37 +247,24 @@ class Recipe extends recipeModule_1.default {
         };
         this.isSignUpAllowed = ({ newUser, userContext }) =>
             __awaiter(this, void 0, void 0, function* () {
-                let accountInfo;
-                if (newUser.email !== undefined) {
-                    accountInfo = {
-                        email: newUser.email,
-                    };
-                } else if (newUser.phoneNumber !== undefined) {
-                    accountInfo = {
-                        phoneNumber: newUser.phoneNumber,
-                    };
-                } else if (newUser.thirdParty !== undefined) {
-                    accountInfo = {
-                        thirdPartyId: newUser.thirdParty.id,
-                        thirdPartyUserId: newUser.thirdParty.userId,
-                    };
-                } else {
-                    // It's not possible to come here because all the login methods are covered above.
-                    throw new Error("Should never come here");
-                }
+                // we find other accounts based on the email / phone number.
                 let users = yield this.recipeInterfaceImpl.listUsersByAccountInfo({
-                    accountInfo,
+                    accountInfo: newUser,
                     userContext,
                 });
                 if (users.length === 0) {
+                    // this is a brand new email / phone number, so we allow sign up.
                     return true;
                 }
-                /**
-                 * For a given email/phoneNumber, there can only exists
-                 * one primary user at max
-                 */
+                // now we check if there exists some primary user with the same email / phone number
+                // such that that info is not verified for that account. In this case, we do not allow
+                // sign up cause we cannot link this new account to that primary account yet (since
+                // the email / phone is unverified), and we can't make this a primary user either (since
+                // then there would be two primary users with the same email / phone number - which is
+                // not allowed..)
                 let primaryUser = users.find((u) => u.isPrimaryUser);
                 if (primaryUser === undefined) {
+                    // since there is no primary user, we allow the sign up..
                     return true;
                 }
                 let shouldDoAccountLinking = yield this.config.shouldDoAutomaticAccountLinking(
@@ -152,9 +277,16 @@ class Recipe extends recipeModule_1.default {
                     return true;
                 }
                 if (!shouldDoAccountLinking.shouldRequireVerification) {
+                    // the dev says they do not care about verification before account linking
+                    // so we can link this new user to the primary user post recipe user creation
+                    // even if that user's email / phone number is not verified.
                     return true;
                 }
                 let identitiesForPrimaryUser = this.transformUserInfoIntoVerifiedAndUnverifiedBucket(primaryUser);
+                // we check the verified array and not the
+                // unverfied array cause we allow signing up
+                // even if one of the recipe accounts has the
+                // email / phone numbers as verified for the primary account.
                 if (newUser.email !== undefined) {
                     return identitiesForPrimaryUser.verified.emails.includes(newUser.email);
                 }
@@ -163,111 +295,29 @@ class Recipe extends recipeModule_1.default {
                 }
                 return false;
             });
-        this.markEmailAsVerified = ({ email, recipeUserId, userContext }) =>
+        this.linkAccountsWithUserFromSession = ({ session, newUser, createRecipeUserFunc, userContext }) =>
             __awaiter(this, void 0, void 0, function* () {
-                const emailVerificationInstance = recipe_1.default.getInstance();
-                if (emailVerificationInstance !== undefined) {
-                    const tokenResponse = yield emailVerificationInstance.recipeInterfaceImpl.createEmailVerificationToken(
-                        {
-                            userId: recipeUserId,
-                            email,
-                            userContext,
-                        }
-                    );
-                    if (tokenResponse.status === "OK") {
-                        yield emailVerificationInstance.recipeInterfaceImpl.verifyEmailUsingToken({
-                            token: tokenResponse.token,
-                            userContext,
-                        });
-                    }
-                }
-            });
-        // this function returns the user ID for which the session will be created.
-        this.doPostSignUpAccountLinkingOperations = ({ newUser, newUserVerified, recipeUserId, userContext }) =>
-            __awaiter(this, void 0, void 0, function* () {
-                let user = yield this.getPrimaryUserIdThatCanBeLinkedToRecipeUserId({
-                    recipeUserId,
-                    userContext,
-                });
-                if (user === undefined) {
-                    return recipeUserId;
-                }
-                let primaryUser = user;
-                let shouldDoAccountLinking = yield this.config.shouldDoAutomaticAccountLinking(
-                    newUser,
-                    primaryUser,
-                    undefined,
-                    userContext
-                );
-                if (!shouldDoAccountLinking.shouldAutomaticallyLink) {
-                    return recipeUserId;
-                }
-                if (shouldDoAccountLinking.shouldRequireVerification && !newUserVerified) {
-                    return recipeUserId;
-                }
-                let createPrimaryUserResult = yield this.recipeInterfaceImpl.createPrimaryUser({
-                    recipeUserId,
-                    userContext,
-                });
-                if (createPrimaryUserResult.status === "OK") {
-                    return createPrimaryUserResult.user.id;
-                }
-                if (
-                    createPrimaryUserResult.status === "RECIPE_USER_ID_ALREADY_LINKED_WITH_PRIMARY_USER_ID_ERROR" &&
-                    createPrimaryUserResult.primaryUserId === recipeUserId
-                ) {
-                    return createPrimaryUserResult.primaryUserId;
-                }
-                // if it comes here, it means that that there is already a primary user for the
-                // account info, or that this recipeUserId is already linked. Either way, we proceed
-                // to the next step, cause that takes care of both these cases.
-                if (primaryUser === undefined) {
-                    // it can come here if there is a race condition. So we just try again
-                    return yield this.doPostSignUpAccountLinkingOperations({
-                        newUser: newUser,
-                        newUserVerified: newUserVerified,
-                        recipeUserId,
-                        userContext,
-                    });
-                }
-                let result = yield this.recipeInterfaceImpl.linkAccounts({
-                    recipeUserId,
-                    primaryUserId: primaryUser.id,
-                    userContext,
-                });
-                if (result.status === "OK") {
-                    return primaryUser.id;
-                } else if (result.status === "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR") {
-                    return result.primaryUserId;
-                } else if (result.status === "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR") {
-                    return result.primaryUserId;
-                } else {
-                    return primaryUser.id;
-                }
-            });
-        this.accountLinkPostSignInViaSession = ({ session, newUser, newUserVerified, userContext }) =>
-            __awaiter(this, void 0, void 0, function* () {
-                let userId = session.getUserId();
+                // In order to link the newUser to the session user,
+                // we need to first make sure that the session user
+                // is a primary user (or make them one if they are not).
                 let existingUser = yield this.recipeInterfaceImpl.getUser({
-                    userId,
+                    userId: session.getUserId(),
                     userContext,
                 });
                 if (existingUser === undefined) {
                     // this can come here if the user ID in the session belongs to a user
                     // that is not recognized by SuperTokens. In this case, we
-                    // disallow this kind of operation.
+                    // simply return the session user ID
                     return {
-                        createRecipeUser: false,
-                        accountsLinked: false,
-                        reason: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                        status: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                        description:
+                            "We cannot link accounts since the session belongs to a user ID that does not exist in SuperTokens.",
                     };
                 }
-                /**
-                 * checking if the user with existing session
-                 * is a primary user or not
-                 */
                 if (!existingUser.isPrimaryUser) {
-                    // first we check if the newUser should be a candidate for account linking
+                    // we will try and make the existing user a primary user. But before that, we must ask the
+                    // dev if they want to allow for that.
+                    // we ask the dev if the new user should be a candidate for account linking.
                     const shouldDoAccountLinkingOfNewUser = yield this.config.shouldDoAutomaticAccountLinking(
                         newUser,
                         undefined,
@@ -276,44 +326,52 @@ class Recipe extends recipeModule_1.default {
                     );
                     if (!shouldDoAccountLinkingOfNewUser.shouldAutomaticallyLink) {
                         return {
-                            createRecipeUser: false,
-                            accountsLinked: false,
-                            reason: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                            status: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                            description: "Account linking not allowed by the developer for new user.",
                         };
                     }
+                    // we do not care about the new user's verification status here cause we are in the process of making the session user a primary user first.
                     // Now we ask the user if the existing login method can be linked to anything
                     // (since it's not a primary user)
                     // here we can use the index of 0 cause the existingUser is not a primary user,
                     // therefore it will only have one login method in the loginMethods' array.
-                    let existingUserAccountInfoAndEmailWithRecipeId = {
-                        recipeId: existingUser.loginMethods[0].recipeId,
-                        email: existingUser.loginMethods[0].email,
-                        phoneNumber: existingUser.loginMethods[0].phoneNumber,
-                        thirdParty: existingUser.loginMethods[0].thirdParty,
-                    };
                     const shouldDoAccountLinkingOfExistingUser = yield this.config.shouldDoAutomaticAccountLinking(
-                        existingUserAccountInfoAndEmailWithRecipeId,
+                        existingUser.loginMethods[0],
                         undefined,
                         session,
                         userContext
                     );
                     if (!shouldDoAccountLinkingOfExistingUser.shouldAutomaticallyLink) {
                         return {
-                            createRecipeUser: false,
-                            accountsLinked: false,
-                            reason: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                            status: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                            description: "Account linking not allowed by the developer for existing user.",
                         };
                     }
                     if (
                         shouldDoAccountLinkingOfExistingUser.shouldRequireVerification &&
                         !existingUser.loginMethods[0].verified
                     ) {
-                        return {
-                            createRecipeUser: false,
-                            accountsLinked: false,
-                            reason: "EXISTING_ACCOUNT_NEEDS_TO_BE_VERIFIED_ERROR",
-                        };
+                        // We do not allow creation of primary user
+                        // if the existing user is not verified
+                        // cause if we do, then it blocks sign up
+                        // with other methods for the same email / phone number
+                        // until this account is verified. This can be
+                        // used by an attacker to prevent sign up from
+                        // their victim by setting the account
+                        // in this state and not verifying the account.
+                        // The downside to this is that cause of this,
+                        // in situations like MFA, we are forcing
+                        // email verification to happen right after the user
+                        // has finished setting up the second factor.
+                        // This may not be something that the developer
+                        // wants. But they can always switch this off
+                        // by providing the right impl for shouldDoAutomaticAccountLinking
+                        // this function will throw an email verification validation error.
+                        yield session.assertClaims([
+                            emailVerificationClaim_1.EmailVerificationClaim.validators.isVerified(undefined, 0),
+                        ]);
                     }
+                    // now we can try and create a primary user for the existing user
                     let createPrimaryUserResult = yield this.recipeInterfaceImpl.createPrimaryUser({
                         recipeUserId: existingUser.loginMethods[0].recipeUserId,
                         userContext,
@@ -322,10 +380,10 @@ class Recipe extends recipeModule_1.default {
                         // this can happen if there is a race condition in which the
                         // existing user becomes a primary user ID by the time the code
                         // execution comes into this block. So we call the function once again.
-                        return yield this.accountLinkPostSignInViaSession({
+                        return yield this.linkAccountsWithUserFromSession({
                             session,
                             newUser,
-                            newUserVerified,
+                            createRecipeUserFunc,
                             userContext,
                         });
                     } else if (
@@ -339,10 +397,9 @@ class Recipe extends recipeModule_1.default {
                     - In this case, existingUser (A2 account), cannot become a primary user
                     - So we are in a stuck state, and must ask the end user to contact support*/
                         return {
-                            createRecipeUser: false,
-                            accountsLinked: false,
-                            reason: createPrimaryUserResult.status,
-                            primaryUserId: createPrimaryUserResult.primaryUserId,
+                            status: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                            description:
+                                "No account can be linked to the session account cause the session account is not a primary account and the account info is already associated with another primary account, so we cannot make this a primary account either. Please contact support.",
                         };
                     } else if (createPrimaryUserResult.status === "OK") {
                         // this if condition is not needed, but for some reason TS complains if it's not there.
@@ -351,10 +408,7 @@ class Recipe extends recipeModule_1.default {
                     // at this point, the existingUser is a primary user. So we can
                     // go ahead and attempt account linking for the new user and existingUser.
                 }
-                /**
-                 * checking if account linking is allowed for given primary user
-                 * and new login info
-                 */
+                // before proceeding to link the two accounts, we must ask the dev if it's allowed to link them
                 const shouldDoAccountLinking = yield this.config.shouldDoAutomaticAccountLinking(
                     newUser,
                     existingUser,
@@ -363,43 +417,20 @@ class Recipe extends recipeModule_1.default {
                 );
                 if (!shouldDoAccountLinking.shouldAutomaticallyLink) {
                     return {
-                        createRecipeUser: false,
-                        accountsLinked: false,
-                        reason: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                        status: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                        description: "Account linking not allowed by the developer for new user.",
                     };
                 }
-                /**
-                 * checking if a recipe user already exists for the given
-                 * login info
-                 */
-                let accountInfo;
-                if (newUser.email !== undefined) {
-                    accountInfo = {
-                        email: newUser.email,
-                    };
-                } else if (newUser.phoneNumber !== undefined) {
-                    accountInfo = {
-                        phoneNumber: newUser.phoneNumber,
-                    };
-                } else if (newUser.thirdParty !== undefined) {
-                    accountInfo = {
-                        thirdPartyId: newUser.thirdParty.id,
-                        thirdPartyUserId: newUser.thirdParty.userId,
-                    };
-                } else {
-                    throw Error("this error should never be thrown");
-                }
-                /**
-                 * We try and find if there is an existing recipe user for the same login method
-                 * and same identifying info as the newUser object.
-                 */
+                // in order to link accounts, we need to have the recipe user ID of the new account.
                 let usersArrayThatHaveSameAccountInfoAsNewUser = yield this.recipeInterfaceImpl.listUsersByAccountInfo({
-                    accountInfo,
+                    accountInfo: newUser,
                     userContext,
                 });
+                let newUserIsVerified = false;
                 const userObjThatHasSameAccountInfoAndRecipeIdAsNewUser = usersArrayThatHaveSameAccountInfoAsNewUser.find(
                     (u) =>
                         u.loginMethods.find((lU) => {
+                            let found = false;
                             if (lU.recipeId !== newUser.recipeId) {
                                 return false;
                             }
@@ -407,186 +438,55 @@ class Recipe extends recipeModule_1.default {
                                 if (lU.thirdParty === undefined) {
                                     return false;
                                 }
-                                return (
+                                found =
                                     lU.thirdParty.id === newUser.thirdParty.id &&
-                                    lU.thirdParty.userId === newUser.thirdParty.userId
-                                );
+                                    lU.thirdParty.userId === newUser.thirdParty.userId;
+                            } else {
+                                found = lU.email === newUser.email || newUser.phoneNumber === newUser.phoneNumber;
                             }
-                            return lU.email === newUser.email || newUser.phoneNumber === newUser.phoneNumber;
+                            if (!found) {
+                                return false;
+                            }
+                            newUserIsVerified = lU.verified;
+                            return true;
                         })
                 );
                 if (userObjThatHasSameAccountInfoAndRecipeIdAsNewUser === undefined) {
                     /*
                 Before proceeding to linking accounts, we need to create the recipe user ID associated
-                with newUser. In order to do that in a secure way, we need to check if the accountInfo
-                of the newUser is the same as of the existingUser - if it is, then we can go ahead, else
-                we will have to check about the verification status of the newUser's accountInfo
+                with newUser. In order to do that we should check if there is some other primary user
+                has the same account info - cause if there is, then linking to this existingUser will not
+                be possible anyway, so we don't create a new recipe user cause if we did, then this
+                recipe user will not be a candidate for automatic account linking in the future
                 */
-                    /**
-                     * if recipe user doesn't exists, we check if
-                     * any of the identifying info associated with
-                     * the primary user equals to the identifying info
-                     * of the given input. If so, return createRecipeUser
-                     * as true to let the recipe know that a recipe user needs
-                     * to be created and set updateVerificationClaim to false
-                     * so the recipe will call back this function when the
-                     * recipe user is created
-                     */
-                    let identitiesForExistingUser = this.transformUserInfoIntoVerifiedAndUnverifiedBucket(existingUser);
-                    if (newUser.email !== undefined) {
-                        let result =
-                            identitiesForExistingUser.verified.emails.includes(newUser.email) ||
-                            identitiesForExistingUser.unverified.emails.includes(newUser.email);
-                        if (result) {
-                            return {
-                                createRecipeUser: true,
-                                updateAccountLinkingClaim: "NO_CHANGE",
-                            };
-                        }
-                    }
-                    if (newUser.phoneNumber !== undefined) {
-                        let result =
-                            identitiesForExistingUser.verified.phoneNumbers.includes(newUser.phoneNumber) ||
-                            identitiesForExistingUser.unverified.phoneNumbers.includes(newUser.phoneNumber);
-                        if (result) {
-                            return {
-                                createRecipeUser: true,
-                                updateAccountLinkingClaim: "NO_CHANGE",
-                            };
-                        }
-                    }
-                    /**
-                     * checking if there already exists any other primary
-                     * user which is associated with the account info
-                     * for the newUser
-                     */
-                    const primaryUserIfExists = usersArrayThatHaveSameAccountInfoAsNewUser.find((u) => u.isPrimaryUser);
-                    if (primaryUserIfExists !== undefined) {
-                        // TODO: as per the lucid chart diagram, there should be an assert here?
+                    let otherPrimaryUser = usersArrayThatHaveSameAccountInfoAsNewUser.find((u) => u.isPrimaryUser);
+                    if (otherPrimaryUser !== undefined && otherPrimaryUser.id !== existingUser.id) {
                         return {
-                            createRecipeUser: false,
-                            accountsLinked: false,
-                            reason: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR",
-                            primaryUserId: primaryUserIfExists.id,
+                            status: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                            description:
+                                "Not allowed because it will lead to two primary user id having same account info",
                         };
                     }
-                    /**
-                     * if the existing info is not verified, we do want
-                     * to create a recipe user but don't want recipe
-                     * to again callback this function for any further
-                     * linking part. Instead, we want the recipe to
-                     * update the session claim so it can be known that
-                     * the new account needs to be verified. So, return
-                     * createRecipeUser as true to let the recipe know
-                     * that a recipe user needs to be created and set
-                     * updateVerificationClaim to true so the recipe will
-                     * not call back this function and update the session
-                     * claim instead
-                     */
-                    if (!newUserVerified && shouldDoAccountLinking.shouldRequireVerification) {
+                    // we create the new recipe user
+                    yield createRecipeUserFunc(newUser);
+                    // now when we recurse, the new recipe user will be found and we can try linking again.
+                    return yield this.linkAccountsWithUserFromSession({
+                        session,
+                        newUser,
+                        createRecipeUserFunc,
+                        userContext,
+                    });
+                }
+                // now we check about the email verification of the new user. If it's verified, we proceed
+                // to try and link the accounts, and if not, we send email verification error ONLY if the email
+                // or phone number of the new account is different compared to the existing account.
+                if (usersArrayThatHaveSameAccountInfoAsNewUser.find((u) => u.id === existingUser.id) === undefined) {
+                    // this means that the existing user does not share anything in common with the new user
+                    // in terms of account info. So we check for email verification status..
+                    if (!newUserIsVerified && shouldDoAccountLinking.shouldRequireVerification) {
+                        // we stop the flow and ask the user to verify this email first.
                         return {
-                            createRecipeUser: true,
-                            updateAccountLinkingClaim: "ADD_CLAIM",
-                        };
-                    }
-                    return {
-                        createRecipeUser: true,
-                        updateAccountLinkingClaim: "NO_CHANGE",
-                    };
-                }
-                /**
-                 * checking if the primary user (associated with session)
-                 * and recipe user (associated with login info) can be
-                 * linked
-                 */
-                let canLinkAccounts = yield this.recipeInterfaceImpl.canLinkAccounts({
-                    recipeUserId: userObjThatHasSameAccountInfoAndRecipeIdAsNewUser.id,
-                    primaryUserId: existingUser.id,
-                    userContext,
-                });
-                if (canLinkAccounts.status === "OK" && canLinkAccounts.accountsAlreadyLinked) {
-                    return {
-                        createRecipeUser: false,
-                        accountsLinked: true,
-                        updateAccountLinkingClaim: "REMOVE_CLAIM",
-                    };
-                }
-                if (
-                    canLinkAccounts.status === "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR" ||
-                    canLinkAccounts.status === "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
-                ) {
-                    /* ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR can be possible if
-                - existingUser has email E1
-                - you try and link an account with email E2
-                - there already exists another primary account with email E2
-                - so linking of existingUser and new account would fail
-                - this is a stuck state cause the user will have to contact support or login to their other account.*/
-                    /**
-                 * RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR can be possible if:
-                    - existingUser has email E1
-                    - you try and link an account with email E2
-                    - there already exists another primary account with email E2 that is linked to new account (input to this function)
-                    - so linking of existingUser and new account would fail
-                    - this is a stuck state cause the user will have to contact support or login to their other account.
-                 */
-                    return {
-                        createRecipeUser: false,
-                        accountsLinked: false,
-                        reason: canLinkAccounts.status,
-                        primaryUserId: canLinkAccounts.primaryUserId,
-                    };
-                }
-                let accountInfoForExistingUser = this.transformUserInfoIntoVerifiedAndUnverifiedBucket(existingUser);
-                let newUserAccountInfoIsAssociatedWithExistingUser = false;
-                let newUsersEmailAlreadyVerifiedInExistingUser = false;
-                if (newUser.email !== undefined) {
-                    newUserAccountInfoIsAssociatedWithExistingUser =
-                        accountInfoForExistingUser.verified.emails.includes(newUser.email) ||
-                        accountInfoForExistingUser.unverified.emails.includes(newUser.email);
-                    newUsersEmailAlreadyVerifiedInExistingUser = accountInfoForExistingUser.verified.emails.includes(
-                        newUser.email
-                    );
-                } else if (newUser.phoneNumber !== undefined) {
-                    newUserAccountInfoIsAssociatedWithExistingUser =
-                        accountInfoForExistingUser.verified.phoneNumbers.includes(newUser.phoneNumber) ||
-                        accountInfoForExistingUser.unverified.phoneNumbers.includes(newUser.phoneNumber);
-                }
-                if (newUserAccountInfoIsAssociatedWithExistingUser) {
-                    /**
-                     * let Ly belong to P1 such that Ly equal to Lx.
-                     * if LY verified or if Lx is verfied,
-                     * then mark all Ly and Lx as verified
-                     */
-                    if (
-                        newUser.email !== undefined &&
-                        (newUsersEmailAlreadyVerifiedInExistingUser || newUserVerified)
-                    ) {
-                        let recipeUserIdsForEmailVerificationUpdate = existingUser.loginMethods
-                            .filter((u) => u.email === newUser.email && !u.verified)
-                            .map((l) => l.recipeUserId);
-                        if (!newUserVerified) {
-                            recipeUserIdsForEmailVerificationUpdate.push(
-                                userObjThatHasSameAccountInfoAndRecipeIdAsNewUser.id
-                            );
-                        }
-                        recipeUserIdsForEmailVerificationUpdate = Array.from(
-                            new Set(recipeUserIdsForEmailVerificationUpdate)
-                        );
-                        for (let i = 0; i < recipeUserIdsForEmailVerificationUpdate.length; i++) {
-                            const recipeUserId = recipeUserIdsForEmailVerificationUpdate[i];
-                            yield this.markEmailAsVerified({
-                                email: newUser.email,
-                                recipeUserId,
-                                userContext,
-                            });
-                        }
-                    }
-                } else {
-                    if (shouldDoAccountLinking.shouldRequireVerification && !newUserVerified) {
-                        return {
-                            createRecipeUser: false,
-                            accountsLinked: false,
-                            updateAccountLinkingClaim: "ADD_CLAIM",
+                            status: "NEW_ACCOUNT_NEEDS_TO_BE_VERIFIED_ERROR",
                         };
                     }
                 }
@@ -597,154 +497,25 @@ class Recipe extends recipeModule_1.default {
                 });
                 if (linkAccountResponse.status === "OK") {
                     return {
-                        createRecipeUser: false,
-                        accountsLinked: true,
-                        updateAccountLinkingClaim: "REMOVE_CLAIM",
+                        status: "OK",
                     };
-                } else {
+                } else if (
+                    linkAccountResponse.status === "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
+                ) {
+                    // this means that the the new user is already linked to some other primary user ID,
+                    // so we can't link it to the existing user.
                     return {
-                        createRecipeUser: false,
-                        accountsLinked: false,
-                        primaryUserId: linkAccountResponse.primaryUserId,
-                        reason: linkAccountResponse.status,
-                    };
-                }
-            });
-        this.getPrimaryUserIdThatCanBeLinkedToRecipeUserId = ({ recipeUserId, userContext }) =>
-            __awaiter(this, void 0, void 0, function* () {
-                let user = yield __1.getUser(recipeUserId, userContext);
-                if (user === undefined) {
-                    return undefined;
-                }
-                if (user.isPrimaryUser) {
-                    return user;
-                }
-                let pUser = yield this.recipeInterfaceImpl.fetchFromAccountToLinkTable({ recipeUserId, userContext });
-                if (pUser !== undefined && pUser.isPrimaryUser) {
-                    return pUser;
-                }
-                let accountInfo;
-                let loginMethodInfo = user.loginMethods[0]; // this is a recipe user so there will be only one item in the array
-                if (loginMethodInfo.email !== undefined) {
-                    accountInfo = {
-                        email: loginMethodInfo.email,
-                    };
-                } else if (loginMethodInfo.phoneNumber !== undefined) {
-                    accountInfo = {
-                        phoneNumber: loginMethodInfo.phoneNumber,
-                    };
-                } else if (loginMethodInfo.thirdParty !== undefined) {
-                    accountInfo = {
-                        thirdPartyId: loginMethodInfo.thirdParty.id,
-                        thirdPartyUserId: loginMethodInfo.thirdParty.userId,
+                        status: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                        description: "New user is already linked to another account",
                     };
                 } else {
-                    throw Error("this error should never be thrown");
-                }
-                let users = yield this.recipeInterfaceImpl.listUsersByAccountInfo({
-                    accountInfo,
-                    userContext,
-                });
-                return users.find((u) => u.isPrimaryUser);
-            });
-        this.createPrimaryUserIdOrLinkAccountsAfterEmailVerification = ({ recipeUserId, session, userContext }) =>
-            __awaiter(this, void 0, void 0, function* () {
-                let primaryUser = yield this.getPrimaryUserIdThatCanBeLinkedToRecipeUserId({
-                    recipeUserId,
-                    userContext,
-                });
-                if (primaryUser === undefined) {
-                    let user = yield __1.getUser(recipeUserId, userContext);
-                    if (user === undefined) {
-                        throw Error("this error should never be thrown");
-                    }
-                    if (user.isPrimaryUser) {
-                        // this can come here cause of a race condition.
-                        yield this.createPrimaryUserIdOrLinkAccountsAfterEmailVerification({
-                            recipeUserId,
-                            session,
-                            userContext,
-                        });
-                        return;
-                    }
-                    let shouldDoAccountLinking = yield this.config.shouldDoAutomaticAccountLinking(
-                        {
-                            recipeId: user.loginMethods[0].recipeId,
-                            email: user.loginMethods[0].email,
-                            phoneNumber: user.loginMethods[0].phoneNumber,
-                            thirdParty: user.loginMethods[0].thirdParty,
-                        },
-                        undefined,
-                        session,
-                        userContext
-                    );
-                    if (shouldDoAccountLinking.shouldAutomaticallyLink) {
-                        let response = yield this.recipeInterfaceImpl.createPrimaryUser({
-                            recipeUserId: recipeUserId,
-                            userContext,
-                        });
-                        if (response.status === "OK") {
-                            // TODO: remove session claim
-                        } else {
-                            // it can come here cause of a race condition..
-                            yield this.createPrimaryUserIdOrLinkAccountsAfterEmailVerification({
-                                recipeUserId,
-                                session,
-                                userContext,
-                            });
-                        }
-                    }
-                } else {
-                    /**
-                     * recipeUser already linked with primaryUser
-                     */
-                    let recipeUser = primaryUser.loginMethods.find((u) => u.recipeUserId === recipeUserId);
-                    if (recipeUser === undefined) {
-                        let user = yield __1.getUser(recipeUserId, userContext);
-                        if (user === undefined) {
-                            throw Error("this error should never be thrown");
-                        }
-                        if (user.isPrimaryUser) {
-                            // this can come here cause of a race condition.
-                            yield this.createPrimaryUserIdOrLinkAccountsAfterEmailVerification({
-                                recipeUserId,
-                                session,
-                                userContext,
-                            });
-                            return;
-                        }
-                        let shouldDoAccountLinking = yield this.config.shouldDoAutomaticAccountLinking(
-                            {
-                                recipeId: user.loginMethods[0].recipeId,
-                                email: user.loginMethods[0].email,
-                                phoneNumber: user.loginMethods[0].phoneNumber,
-                                thirdParty: user.loginMethods[0].thirdParty,
-                            },
-                            primaryUser,
-                            session,
-                            userContext
-                        );
-                        if (shouldDoAccountLinking.shouldAutomaticallyLink) {
-                            let linkAccountsResult = yield this.recipeInterfaceImpl.linkAccounts({
-                                recipeUserId: recipeUserId,
-                                primaryUserId: primaryUser.id,
-                                userContext,
-                            });
-                            let primaryUserId = primaryUser.id;
-                            if (
-                                linkAccountsResult.status ===
-                                    "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR" ||
-                                linkAccountsResult.status ===
-                                    "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
-                            ) {
-                                primaryUserId = linkAccountsResult.primaryUserId;
-                            }
-                            console.log(primaryUserId); // TODO NEMI: remove this
-                            // TODO NEMI: The caller of this function should
-                            // remove session claim if session claim exists
-                            // else create a new session
-                        }
-                    }
+                    // status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
+                    // this means that the account info of the newUser already belongs to some other primary user ID.
+                    // So we cannot link it to existing user.
+                    return {
+                        status: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                        description: "Not allowed because it will lead to two primary user id having same account info",
+                    };
                 }
             });
         this.config = utils_1.validateAndNormaliseUserInput(appInfo, config);

--- a/lib/build/recipe/accountlinking/recipe.js
+++ b/lib/build/recipe/accountlinking/recipe.js
@@ -540,7 +540,7 @@ class Recipe extends recipeModule_1.default {
                     primaryUserId: existingUser.id,
                     userContext,
                 });
-                if (canLinkAccounts.status === "ACCOUNTS_ALREADY_LINKED_ERROR") {
+                if (canLinkAccounts.status === "OK" && canLinkAccounts.accountsAlreadyLinked) {
                     return {
                         createRecipeUser: false,
                         accountsLinked: true,
@@ -631,10 +631,7 @@ class Recipe extends recipeModule_1.default {
                     primaryUserId: existingUser.id,
                     userContext,
                 });
-                if (
-                    linkAccountResponse.status === "OK" ||
-                    linkAccountResponse.status === "ACCOUNTS_ALREADY_LINKED_ERROR"
-                ) {
+                if (linkAccountResponse.status === "OK") {
                     return {
                         createRecipeUser: false,
                         accountsLinked: true,

--- a/lib/build/recipe/accountlinking/recipeImplementation.js
+++ b/lib/build/recipe/accountlinking/recipeImplementation.js
@@ -52,6 +52,7 @@ var __importDefault =
 Object.defineProperty(exports, "__esModule", { value: true });
 const normalisedURLPath_1 = __importDefault(require("../../normalisedURLPath"));
 const session_1 = __importDefault(require("../session"));
+const recipe_1 = __importDefault(require("./recipe"));
 function getRecipeImplementation(querier, config) {
     return {
         getRecipeUserIdsForPrimaryUserIds: function ({ primaryUserIds }) {
@@ -170,6 +171,25 @@ function getRecipeImplementation(querier, config) {
                     let loginMethodInfo = user.loginMethods.find((u) => u.recipeUserId === recipeUserId);
                     if (loginMethodInfo === undefined) {
                         throw Error("this error should never be thrown");
+                    }
+                    /**
+                     * We now mark the same email of other linked recipes as verified if the new user's email is verified.
+                     */
+                    if (loginMethodInfo.email !== undefined && loginMethodInfo.verified) {
+                        // it is safe to force unwrap loginMethodInfo here because we have already checked that it is not undefined.
+                        let recipeUserIdsForEmailVerificationUpdate = user.loginMethods
+                            .filter((u) => u.email === loginMethodInfo.email && !u.verified)
+                            .map((l) => l.recipeUserId);
+                        recipeUserIdsForEmailVerificationUpdate = Array.from(
+                            new Set(recipeUserIdsForEmailVerificationUpdate)
+                        );
+                        for (let i = 0; i < recipeUserIdsForEmailVerificationUpdate.length; i++) {
+                            yield recipe_1.default.getInstanceOrThrowError().markEmailAsVerified({
+                                email: loginMethodInfo.email,
+                                recipeUserId: recipeUserIdsForEmailVerificationUpdate[i],
+                                userContext,
+                            });
+                        }
                     }
                     yield config.onAccountLinked(
                         user,

--- a/lib/build/recipe/accountlinking/recipeImplementation.js
+++ b/lib/build/recipe/accountlinking/recipeImplementation.js
@@ -134,6 +134,18 @@ function getRecipeImplementation(querier, config) {
                         primaryUserId,
                     }
                 );
+                if (result.status === "OK") {
+                    return {
+                        status: "OK",
+                        accountsAlreadyLinked: false,
+                    };
+                }
+                if (result.status === "ACCOUNTS_ALREADY_LINKED_ERROR") {
+                    return {
+                        status: "OK",
+                        accountsAlreadyLinked: true,
+                    };
+                }
                 return result;
             });
         },
@@ -171,6 +183,22 @@ function getRecipeImplementation(querier, config) {
                         },
                         userContext
                     );
+                    return {
+                        status: "OK",
+                        accountsAlreadyLinked: false,
+                    };
+                } else if (accountsLinkingResult.status === "ACCOUNTS_ALREADY_LINKED_ERROR") {
+                    let user = yield this.getUser({
+                        userId: primaryUserId,
+                        userContext,
+                    });
+                    if (user === undefined) {
+                        throw Error("this error should never be thrown");
+                    }
+                    return {
+                        status: "OK",
+                        accountsAlreadyLinked: true,
+                    };
                 }
                 return accountsLinkingResult;
             });

--- a/lib/build/recipe/accountlinking/recipeImplementation.js
+++ b/lib/build/recipe/accountlinking/recipeImplementation.js
@@ -52,7 +52,6 @@ var __importDefault =
 Object.defineProperty(exports, "__esModule", { value: true });
 const normalisedURLPath_1 = __importDefault(require("../../normalisedURLPath"));
 const session_1 = __importDefault(require("../session"));
-const recipe_1 = __importDefault(require("./recipe"));
 function getRecipeImplementation(querier, config) {
     return {
         getRecipeUserIdsForPrimaryUserIds: function ({ primaryUserIds }) {
@@ -135,18 +134,6 @@ function getRecipeImplementation(querier, config) {
                         primaryUserId,
                     }
                 );
-                if (result.status === "OK") {
-                    return {
-                        status: "OK",
-                        accountsAlreadyLinked: false,
-                    };
-                }
-                if (result.status === "ACCOUNTS_ALREADY_LINKED_ERROR") {
-                    return {
-                        status: "OK",
-                        accountsAlreadyLinked: true,
-                    };
-                }
                 return result;
             });
         },
@@ -159,7 +146,7 @@ function getRecipeImplementation(querier, config) {
                         primaryUserId,
                     }
                 );
-                if (accountsLinkingResult.status === "OK") {
+                if (accountsLinkingResult.status === "OK" && !accountsLinkingResult.accountsAlreadyLinked) {
                     yield session_1.default.revokeAllSessionsForUser(recipeUserId, userContext);
                     let user = yield this.getUser({
                         userId: primaryUserId,
@@ -172,53 +159,7 @@ function getRecipeImplementation(querier, config) {
                     if (loginMethodInfo === undefined) {
                         throw Error("this error should never be thrown");
                     }
-                    /**
-                     * We now mark the same email of other linked recipes as verified if the new user's email is verified.
-                     */
-                    if (loginMethodInfo.email !== undefined && loginMethodInfo.verified) {
-                        // it is safe to force unwrap loginMethodInfo here because we have already checked that it is not undefined.
-                        let recipeUserIdsForEmailVerificationUpdate = user.loginMethods
-                            .filter((u) => u.email === loginMethodInfo.email && !u.verified)
-                            .map((l) => l.recipeUserId);
-                        recipeUserIdsForEmailVerificationUpdate = Array.from(
-                            new Set(recipeUserIdsForEmailVerificationUpdate)
-                        );
-                        for (let i = 0; i < recipeUserIdsForEmailVerificationUpdate.length; i++) {
-                            yield recipe_1.default.getInstanceOrThrowError().markEmailAsVerified({
-                                email: loginMethodInfo.email,
-                                recipeUserId: recipeUserIdsForEmailVerificationUpdate[i],
-                                userContext,
-                            });
-                        }
-                    }
-                    yield config.onAccountLinked(
-                        user,
-                        {
-                            recipeId: loginMethodInfo.recipeId,
-                            recipeUserId: loginMethodInfo.recipeUserId,
-                            timeJoined: loginMethodInfo.timeJoined,
-                            email: loginMethodInfo.email,
-                            phoneNumber: loginMethodInfo.phoneNumber,
-                            thirdParty: loginMethodInfo.thirdParty,
-                        },
-                        userContext
-                    );
-                    return {
-                        status: "OK",
-                        accountsAlreadyLinked: false,
-                    };
-                } else if (accountsLinkingResult.status === "ACCOUNTS_ALREADY_LINKED_ERROR") {
-                    let user = yield this.getUser({
-                        userId: primaryUserId,
-                        userContext,
-                    });
-                    if (user === undefined) {
-                        throw Error("this error should never be thrown");
-                    }
-                    return {
-                        status: "OK",
-                        accountsAlreadyLinked: true,
-                    };
+                    yield config.onAccountLinked(user, loginMethodInfo, userContext);
                 }
                 return accountsLinkingResult;
             });
@@ -232,28 +173,33 @@ function getRecipeImplementation(querier, config) {
                 let primaryUserId = recipeUserIdToPrimaryUserIdMapping[recipeUserId];
                 if (primaryUserId === undefined) {
                     return {
-                        status: "RECIPE_USER_NOT_FOUND",
+                        status: "RECIPE_USER_NOT_FOUND_ERROR",
+                        description: "No user exists with the provided recipeUserId",
                     };
                 }
                 if (primaryUserId === null) {
                     return {
-                        status: "PRIMARY_USER_NOT_FOUND",
+                        status: "PRIMARY_USER_NOT_FOUND_ERROR",
+                        description:
+                            "The input recipeUserId is not linked to any primary user, or is not a primary user itself",
                     };
                 }
-                /**
-                 * primaryUserId === recipeUserId
-                 */
                 if (primaryUserId === recipeUserId) {
                     let user = yield this.getUser({
                         userId: primaryUserId,
                         userContext,
                     });
                     if (user === undefined) {
-                        return {
-                            status: "RESTART_FLOW_ERROR",
-                        };
+                        // this can happen cause of some race condition..
+                        return this.unlinkAccounts({
+                            recipeUserId,
+                            userContext,
+                        });
                     }
                     if (user.loginMethods.length > 1) {
+                        // we delete the user here cause if we didn't
+                        // do that, then it would result in the primary user ID having the same
+                        // user ID as the recipe user ID, but they are not linked. So this is not allowed.
                         yield this.deleteUser({
                             userId: recipeUserId,
                             removeAllLinkedAccounts: false,
@@ -274,13 +220,8 @@ function getRecipeImplementation(querier, config) {
                 );
                 if (accountsUnlinkingResult.status === "OK") {
                     yield session_1.default.revokeAllSessionsForUser(recipeUserId, userContext);
-                } else {
-                    throw Error(`error thrown from core while unlinking accounts: ${accountsUnlinkingResult.status}`);
                 }
-                return {
-                    status: "OK",
-                    wasRecipeUserDeleted: false,
-                };
+                return accountsUnlinkingResult;
             });
         },
         getUser: function ({ userId }) {

--- a/lib/build/recipe/accountlinking/recipeImplementation.js
+++ b/lib/build/recipe/accountlinking/recipeImplementation.js
@@ -211,10 +211,14 @@ function getRecipeImplementation(querier, config) {
                 });
                 let primaryUserId = recipeUserIdToPrimaryUserIdMapping[recipeUserId];
                 if (primaryUserId === undefined) {
-                    throw new Error("input recipeUserId does not exist");
+                    return {
+                        status: "RECIPE_USER_NOT_FOUND",
+                    };
                 }
                 if (primaryUserId === null) {
-                    throw Error("recipeUserId is not associated with any primaryUserId");
+                    return {
+                        status: "PRIMARY_USER_NOT_FOUND",
+                    };
                 }
                 /**
                  * primaryUserId === recipeUserId
@@ -225,7 +229,9 @@ function getRecipeImplementation(querier, config) {
                         userContext,
                     });
                     if (user === undefined) {
-                        throw new Error("Seems like a race condition issue occurred. Please try again");
+                        return {
+                            status: "RESTART_FLOW_ERROR",
+                        };
                     }
                     if (user.loginMethods.length > 1) {
                         yield this.deleteUser({

--- a/lib/build/recipe/accountlinking/types.d.ts
+++ b/lib/build/recipe/accountlinking/types.d.ts
@@ -5,7 +5,7 @@ import { SessionContainer } from "../session";
 export declare type TypeInput = {
     onAccountLinked?: (user: User, newAccountInfo: RecipeLevelUser, userContext: any) => Promise<void>;
     shouldDoAutomaticAccountLinking?: (
-        newAccountInfo: AccountInfoAndEmailWithRecipeId,
+        newAccountInfo: AccountInfoWithRecipeId,
         user: User | undefined,
         session: SessionContainer | undefined,
         userContext: any
@@ -28,7 +28,7 @@ export declare type TypeInput = {
 export declare type TypeNormalisedInput = {
     onAccountLinked: (user: User, newAccountInfo: RecipeLevelUser, userContext: any) => Promise<void>;
     shouldDoAutomaticAccountLinking: (
-        newAccountInfo: AccountInfoAndEmailWithRecipeId,
+        newAccountInfo: AccountInfoWithRecipeId,
         user: User | undefined,
         session: SessionContainer | undefined,
         userContext: any
@@ -86,6 +86,7 @@ export declare type RecipeInterface = {
     }) => Promise<
         | {
               status: "OK";
+              wasAlreadyAPrimaryUser: boolean;
           }
         | {
               status:
@@ -102,6 +103,7 @@ export declare type RecipeInterface = {
         | {
               status: "OK";
               user: User;
+              wasAlreadyAPrimaryUser: boolean;
           }
         | {
               status:
@@ -160,13 +162,8 @@ export declare type RecipeInterface = {
               wasRecipeUserDeleted: boolean;
           }
         | {
-              status: "PRIMARY_USER_NOT_FOUND";
-          }
-        | {
-              status: "RESTART_FLOW_ERROR";
-          }
-        | {
-              status: "RECIPE_USER_NOT_FOUND";
+              status: "PRIMARY_USER_NOT_FOUND_ERROR" | "RECIPE_USER_NOT_FOUND_ERROR";
+              description: string;
           }
     >;
     getUser: (input: { userId: string; userContext: any }) => Promise<User | undefined>;
@@ -205,8 +202,7 @@ export declare type RecipeLevelUser = {
         userId: string;
     };
 };
-export declare type AccountInfoAndEmailWithRecipeId = {
-    recipeId: "emailpassword" | "thirdparty" | "passwordless";
+export declare type AccountInfo = {
     email?: string;
     phoneNumber?: string;
     thirdParty?: {
@@ -214,14 +210,6 @@ export declare type AccountInfoAndEmailWithRecipeId = {
         userId: string;
     };
 };
-export declare type AccountInfo =
-    | {
-          email: string;
-      }
-    | {
-          phoneNumber: string;
-      }
-    | {
-          thirdPartyId: string;
-          thirdPartyUserId: string;
-      };
+export declare type AccountInfoWithRecipeId = {
+    recipeId: "emailpassword" | "thirdparty" | "passwordless";
+} & AccountInfo;

--- a/lib/build/recipe/accountlinking/types.d.ts
+++ b/lib/build/recipe/accountlinking/types.d.ts
@@ -160,7 +160,13 @@ export declare type RecipeInterface = {
               wasRecipeUserDeleted: boolean;
           }
         | {
-              status: "NO_PRIMARY_USER_FOUND";
+              status: "PRIMARY_USER_NOT_FOUND";
+          }
+        | {
+              status: "RESTART_FLOW_ERROR";
+          }
+        | {
+              status: "RECIPE_USER_NOT_FOUND";
           }
     >;
     getUser: (input: { userId: string; userContext: any }) => Promise<User | undefined>;

--- a/lib/build/recipe/accountlinking/types.d.ts
+++ b/lib/build/recipe/accountlinking/types.d.ts
@@ -118,15 +118,12 @@ export declare type RecipeInterface = {
     }) => Promise<
         | {
               status: "OK";
+              accountsAlreadyLinked: boolean;
           }
         | {
               status: "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
               description: string;
               primaryUserId: string;
-          }
-        | {
-              status: "ACCOUNTS_ALREADY_LINKED_ERROR";
-              description: string;
           }
         | {
               status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
@@ -141,14 +138,11 @@ export declare type RecipeInterface = {
     }) => Promise<
         | {
               status: "OK";
+              accountsAlreadyLinked: boolean;
           }
         | {
               status: "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
               primaryUserId: string;
-              description: string;
-          }
-        | {
-              status: "ACCOUNTS_ALREADY_LINKED_ERROR";
               description: string;
           }
         | {

--- a/lib/build/recipe/accountlinking/types.d.ts
+++ b/lib/build/recipe/accountlinking/types.d.ts
@@ -90,7 +90,7 @@ export declare type RecipeInterface = {
         | {
               status:
                   | "RECIPE_USER_ID_ALREADY_LINKED_WITH_PRIMARY_USER_ID_ERROR"
-                  | "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                  | "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
               primaryUserId: string;
               description: string;
           }
@@ -106,7 +106,7 @@ export declare type RecipeInterface = {
         | {
               status:
                   | "RECIPE_USER_ID_ALREADY_LINKED_WITH_PRIMARY_USER_ID_ERROR"
-                  | "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                  | "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
               primaryUserId: string;
               description: string;
           }
@@ -126,7 +126,7 @@ export declare type RecipeInterface = {
               primaryUserId: string;
           }
         | {
-              status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+              status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
               primaryUserId: string;
               description: string;
           }
@@ -146,7 +146,7 @@ export declare type RecipeInterface = {
               description: string;
           }
         | {
-              status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+              status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
               primaryUserId: string;
               description: string;
           }

--- a/lib/build/recipe/emailpassword/types.d.ts
+++ b/lib/build/recipe/emailpassword/types.d.ts
@@ -284,7 +284,7 @@ export declare type APIInterface = {
                     description: string;
                 }
               | {
-                    status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                    status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
                     primaryUserId: string;
                     description: string;
                 }

--- a/lib/build/recipe/passwordless/types.d.ts
+++ b/lib/build/recipe/passwordless/types.d.ts
@@ -361,7 +361,7 @@ export declare type APIInterface = {
                     description: string;
                 }
               | {
-                    status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                    status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
                     primaryUserId: string;
                     description: string;
                 }

--- a/lib/build/recipe/thirdparty/types.d.ts
+++ b/lib/build/recipe/thirdparty/types.d.ts
@@ -175,7 +175,7 @@ export declare type APIInterface = {
                     description: string;
                 }
               | {
-                    status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                    status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
                     primaryUserId: string;
                     description: string;
                 }

--- a/lib/build/recipe/thirdpartyemailpassword/types.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/types.d.ts
@@ -181,7 +181,7 @@ export declare type APIInterface = {
                     description: string;
                 }
               | {
-                    status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                    status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
                     primaryUserId: string;
                     description: string;
                 }
@@ -319,7 +319,7 @@ export declare type APIInterface = {
                     description: string;
                 }
               | {
-                    status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                    status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
                     primaryUserId: string;
                     description: string;
                 }

--- a/lib/build/recipe/thirdpartypasswordless/types.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/types.d.ts
@@ -315,7 +315,7 @@ export declare type APIInterface = {
                     description: string;
                 }
               | {
-                    status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                    status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
                     primaryUserId: string;
                     description: string;
                 }
@@ -502,7 +502,7 @@ export declare type APIInterface = {
                     description: string;
                 }
               | {
-                    status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                    status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
                     primaryUserId: string;
                     description: string;
                 }

--- a/lib/ts/recipe/accountlinking/recipe.ts
+++ b/lib/ts/recipe/accountlinking/recipe.ts
@@ -333,7 +333,7 @@ export default class Recipe extends RecipeModule {
             return primaryUser.id;
         } else if (result.status === "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR") {
             return result.primaryUserId;
-        } else if (result.status === "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR") {
+        } else if (result.status === "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR") {
             return result.primaryUserId;
         } else {
             return primaryUser.id;
@@ -379,7 +379,7 @@ export default class Recipe extends RecipeModule {
               | {
                     accountsLinked: false;
                     reason:
-                        | "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
+                        | "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
                         | "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
                     primaryUserId: string;
                 }
@@ -472,7 +472,7 @@ export default class Recipe extends RecipeModule {
                     userContext,
                 });
             } else if (
-                createPrimaryUserResult.status === "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
+                createPrimaryUserResult.status === "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
             ) {
                 /* this can come here if in the following example: 
                 - User creates a primary account (P1) using email R
@@ -614,7 +614,7 @@ export default class Recipe extends RecipeModule {
                 return {
                     createRecipeUser: false,
                     accountsLinked: false,
-                    reason: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR",
+                    reason: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR",
                     primaryUserId: primaryUserIfExists.id,
                 };
             }
@@ -661,10 +661,10 @@ export default class Recipe extends RecipeModule {
             };
         }
         if (
-            canLinkAccounts.status === "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR" ||
+            canLinkAccounts.status === "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR" ||
             canLinkAccounts.status === "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
         ) {
-            /* ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR can be possible if 
+            /* ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR can be possible if 
             - existingUser has email E1
             - you try and link an account with email E2
             - there already exists another primary account with email E2
@@ -896,7 +896,7 @@ export default class Recipe extends RecipeModule {
                     let primaryUserId = primaryUser.id;
                     if (
                         linkAccountsResult.status ===
-                            "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR" ||
+                            "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR" ||
                         linkAccountsResult.status === "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
                     ) {
                         primaryUserId = linkAccountsResult.primaryUserId;

--- a/lib/ts/recipe/accountlinking/recipe.ts
+++ b/lib/ts/recipe/accountlinking/recipe.ts
@@ -346,25 +346,6 @@ export default class Recipe extends RecipeModule {
             userContext,
         });
         if (result.status === "OK") {
-            /**
-             * We now mark the same email of other linked recipes as verified if the new user's email
-             * is verified.
-             */
-
-            if (newUser.email !== undefined && newUserVerified) {
-                let recipeUserIdsForEmailVerificationUpdate = primaryUser.loginMethods
-                    .filter((u) => u.email === newUser.email && !u.verified)
-                    .map((l) => l.recipeUserId);
-                recipeUserIdsForEmailVerificationUpdate = Array.from(new Set(recipeUserIdsForEmailVerificationUpdate));
-
-                for (let i = 0; i < recipeUserIdsForEmailVerificationUpdate.length; i++) {
-                    await this.markEmailAsVerified({
-                        email: newUser.email,
-                        recipeUserId: recipeUserIdsForEmailVerificationUpdate[i],
-                        userContext,
-                    });
-                }
-            }
             return primaryUser.id;
         } else if (result.status === "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR") {
             return result.primaryUserId;

--- a/lib/ts/recipe/accountlinking/recipe.ts
+++ b/lib/ts/recipe/accountlinking/recipe.ts
@@ -19,20 +19,14 @@ import normalisedURLPath from "../../normalisedURLPath";
 import RecipeModule from "../../recipeModule";
 import type { APIHandled, HTTPMethod, NormalisedAppinfo, RecipeListFunction, User } from "../../types";
 import { SessionContainer } from "../session";
-import type {
-    TypeNormalisedInput,
-    RecipeInterface,
-    TypeInput,
-    AccountInfoAndEmailWithRecipeId,
-    AccountInfo,
-} from "./types";
+import type { TypeNormalisedInput, RecipeInterface, TypeInput, AccountInfoWithRecipeId } from "./types";
 import { validateAndNormaliseUserInput } from "./utils";
 import { getUser } from "../..";
 import OverrideableBuilder from "supertokens-js-override";
 import RecipeImplementation from "./recipeImplementation";
 import { Querier } from "../../querier";
 import SuperTokensError from "../../error";
-import EmailVerification from "../emailverification/recipe";
+import { EmailVerificationClaim } from "../emailverification/emailVerificationClaim";
 
 export default class Recipe extends RecipeModule {
     private static instance: Recipe | undefined = undefined;
@@ -107,34 +101,195 @@ export default class Recipe extends RecipeModule {
         return SuperTokensError.isErrorFromSuperTokens(err) && err.fromRecipe === Recipe.RECIPE_ID;
     }
 
+    // this function returns the user ID for which the session will be created.
+    createPrimaryUserIdOrLinkAccounts = async ({
+        recipeUserId,
+        isVerified,
+        checkAccountsToLinkTableAsWell,
+        userContext,
+    }: {
+        recipeUserId: string;
+        isVerified: boolean;
+        checkAccountsToLinkTableAsWell: boolean;
+        userContext: any;
+    }): Promise<string> => {
+        let recipeUser = await getUser(recipeUserId, userContext);
+        if (recipeUser === undefined) {
+            throw Error("Race condition error. It means that the input recipeUserId was deleted");
+        }
+
+        if (recipeUser.isPrimaryUser) {
+            return recipeUser.id;
+        }
+
+        // now we try and find a linking candidate.
+        let primaryUser = await this.getPrimaryUserIdThatCanBeLinkedToRecipeUserId({
+            recipeUserId,
+            checkAccountsToLinkTableAsWell,
+            userContext,
+        });
+
+        if (primaryUser === undefined) {
+            // this means that this can become a primary user.
+
+            // we can use the 0 index cause this user is
+            // not a primary user.
+            let shouldDoAccountLinking = await this.config.shouldDoAutomaticAccountLinking(
+                recipeUser.loginMethods[0],
+                undefined,
+                undefined,
+                userContext
+            );
+
+            if (!shouldDoAccountLinking.shouldAutomaticallyLink) {
+                return recipeUserId;
+            }
+
+            if (shouldDoAccountLinking.shouldRequireVerification && !isVerified) {
+                return recipeUserId;
+            }
+
+            let createPrimaryUserResult = await this.recipeInterfaceImpl.createPrimaryUser({
+                recipeUserId: recipeUserId,
+                userContext,
+            });
+
+            if (createPrimaryUserResult.status === "OK") {
+                return createPrimaryUserResult.user.id;
+            }
+
+            // status is "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR" or "RECIPE_USER_ID_ALREADY_LINKED_WITH_PRIMARY_USER_ID_ERROR"
+
+            // if it comes here, it means that the recipe
+            // user ID is already linked to another primary
+            // user id (race condition), or that some other
+            // primary user ID exists with the same email / phone number (again, race condition).
+            // So we do recursion here to try again.
+            return await this.createPrimaryUserIdOrLinkAccounts({
+                recipeUserId,
+                isVerified,
+                checkAccountsToLinkTableAsWell,
+                userContext,
+            });
+        } else {
+            // this means that we found a primary user ID which can be linked to this recipe user ID. So we try and link them.
+
+            // we can use the 0 index cause this user is
+            // not a primary user.
+            let shouldDoAccountLinking = await this.config.shouldDoAutomaticAccountLinking(
+                recipeUser.loginMethods[0],
+                primaryUser,
+                undefined,
+                userContext
+            );
+
+            if (!shouldDoAccountLinking.shouldAutomaticallyLink) {
+                return recipeUserId;
+            }
+
+            if (shouldDoAccountLinking.shouldRequireVerification && !isVerified) {
+                return recipeUserId;
+            }
+
+            let linkAccountsResult = await this.recipeInterfaceImpl.linkAccounts({
+                recipeUserId: recipeUserId,
+                primaryUserId: primaryUser.id,
+                userContext,
+            });
+
+            if (linkAccountsResult.status === "OK") {
+                return primaryUser.id;
+            } else if (
+                linkAccountsResult.status === "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
+            ) {
+                // this can happen cause of a race condition
+                // wherein the recipe user ID get's linked to
+                // some other primary user whilst this function is running.
+                // But this is OK cause we just care about
+                // returning the user ID of the linked user
+                // which the result has.
+                return linkAccountsResult.primaryUserId;
+            } else {
+                // status is "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
+                // it can come here if the recipe user ID
+                // can't be linked to the primary user ID cause
+                // the email / phone number is associated with some other primary user ID.
+                // This can happen due to a race condition in which
+                // the email has changed from one primary user to another during this function call,
+                // or it can happen if the accounts to link table
+                // contains a user which this is supposed to
+                // be linked to, but we can't link it cause during the time the user was added to that table and now, some other primary user has
+                // got this email.
+
+                // So we try again, but without caring about
+                // the accounts to link table (cause they we will end up in an infinite recursion).
+                return await this.createPrimaryUserIdOrLinkAccounts({
+                    recipeUserId,
+                    isVerified,
+                    checkAccountsToLinkTableAsWell: false,
+                    userContext,
+                });
+            }
+        }
+    };
+
+    getPrimaryUserIdThatCanBeLinkedToRecipeUserId = async ({
+        recipeUserId,
+        checkAccountsToLinkTableAsWell,
+        userContext,
+    }: {
+        recipeUserId: string;
+        checkAccountsToLinkTableAsWell: boolean;
+        userContext: any;
+    }): Promise<User | undefined> => {
+        // first we check if this user itself is a
+        // primary user or not. If it is, we return that.
+        let user = await getUser(recipeUserId, userContext);
+        if (user === undefined) {
+            return undefined;
+        }
+        if (user.isPrimaryUser) {
+            return user;
+        }
+
+        // then we check the accounts to link table. This
+        // table can have an entry if this user was trying
+        // to be linked to another user post sign in but required
+        // email verification.
+        if (checkAccountsToLinkTableAsWell) {
+            let pUser = await this.recipeInterfaceImpl.fetchFromAccountToLinkTable({ recipeUserId, userContext });
+            if (pUser !== undefined && pUser.isPrimaryUser) {
+                return pUser;
+            }
+        }
+
+        // finally, we try and find a primary user based on
+        // the email / phone number / third party ID.
+        let users = await this.recipeInterfaceImpl.listUsersByAccountInfo({
+            accountInfo: user.loginMethods[0],
+            userContext,
+        });
+        return users.find((u) => u.isPrimaryUser);
+    };
+
     transformUserInfoIntoVerifiedAndUnverifiedBucket = (user: User) => {
         let identities: {
             verified: {
                 emails: string[];
                 phoneNumbers: string[];
-                thirdParty: {
-                    id: string;
-                    userId: string;
-                }[];
             };
             unverified: {
                 emails: string[];
                 phoneNumbers: string[];
-                thirdParty: {
-                    id: string;
-                    userId: string;
-                }[];
             };
         } = {
             verified: {
                 emails: [],
                 phoneNumbers: [],
-                thirdParty: [],
             },
             unverified: {
                 emails: [],
                 phoneNumbers: [],
-                thirdParty: [],
             },
         };
         for (let i = 0; i < user.loginMethods.length; i++) {
@@ -153,13 +308,6 @@ export default class Recipe extends RecipeModule {
                     identities.unverified.phoneNumbers.push(loginMethod.phoneNumber);
                 }
             }
-            if (loginMethod.thirdParty !== undefined) {
-                if (loginMethod.verified) {
-                    identities.verified.thirdParty.push(loginMethod.thirdParty);
-                } else {
-                    identities.unverified.thirdParty.push(loginMethod.thirdParty);
-                }
-            }
         }
 
         // we remove duplicate emails / phone numbers from the above arrays.
@@ -176,43 +324,31 @@ export default class Recipe extends RecipeModule {
         newUser,
         userContext,
     }: {
-        newUser: AccountInfoAndEmailWithRecipeId;
+        newUser: AccountInfoWithRecipeId;
         userContext: any;
     }): Promise<boolean> => {
-        let accountInfo: AccountInfo;
-        if (newUser.email !== undefined) {
-            accountInfo = {
-                email: newUser.email,
-            };
-        } else if (newUser.phoneNumber !== undefined) {
-            accountInfo = {
-                phoneNumber: newUser.phoneNumber,
-            };
-        } else if (newUser.thirdParty !== undefined) {
-            accountInfo = {
-                thirdPartyId: newUser.thirdParty.id,
-                thirdPartyUserId: newUser.thirdParty.userId,
-            };
-        } else {
-            // It's not possible to come here because all the login methods are covered above.
-            throw new Error("Should never come here");
-        }
-
+        // we find other accounts based on the email / phone number.
         let users = await this.recipeInterfaceImpl.listUsersByAccountInfo({
-            accountInfo,
+            accountInfo: newUser,
             userContext,
         });
         if (users.length === 0) {
+            // this is a brand new email / phone number, so we allow sign up.
             return true;
         }
-        /**
-         * For a given email/phoneNumber, there can only exists
-         * one primary user at max
-         */
+
+        // now we check if there exists some primary user with the same email / phone number
+        // such that that info is not verified for that account. In this case, we do not allow
+        // sign up cause we cannot link this new account to that primary account yet (since
+        // the email / phone is unverified), and we can't make this a primary user either (since
+        // then there would be two primary users with the same email / phone number - which is
+        // not allowed..)
         let primaryUser = users.find((u) => u.isPrimaryUser);
         if (primaryUser === undefined) {
+            // since there is no primary user, we allow the sign up..
             return true;
         }
+
         let shouldDoAccountLinking = await this.config.shouldDoAutomaticAccountLinking(
             newUser,
             primaryUser,
@@ -223,11 +359,18 @@ export default class Recipe extends RecipeModule {
             return true;
         }
         if (!shouldDoAccountLinking.shouldRequireVerification) {
+            // the dev says they do not care about verification before account linking
+            // so we can link this new user to the primary user post recipe user creation
+            // even if that user's email / phone number is not verified.
             return true;
         }
 
         let identitiesForPrimaryUser = this.transformUserInfoIntoVerifiedAndUnverifiedBucket(primaryUser);
 
+        // we check the verified array and not the
+        // unverfied array cause we allow signing up
+        // even if one of the recipe accounts has the
+        // email / phone numbers as verified for the primary account.
         if (newUser.email !== undefined) {
             return identitiesForPrimaryUser.verified.emails.includes(newUser.email);
         }
@@ -237,225 +380,110 @@ export default class Recipe extends RecipeModule {
         return false;
     };
 
-    markEmailAsVerified = async ({
-        email,
-        recipeUserId,
-        userContext,
-    }: {
-        email: string;
-        recipeUserId: string;
-        userContext: any;
-    }): Promise<void> => {
-        const emailVerificationInstance = EmailVerification.getInstance();
-        if (emailVerificationInstance !== undefined) {
-            const tokenResponse = await emailVerificationInstance.recipeInterfaceImpl.createEmailVerificationToken({
-                userId: recipeUserId,
-                email,
-                userContext,
-            });
-
-            if (tokenResponse.status === "OK") {
-                await emailVerificationInstance.recipeInterfaceImpl.verifyEmailUsingToken({
-                    token: tokenResponse.token,
-                    userContext,
-                });
-            }
-        }
-    };
-
-    // this function returns the user ID for which the session will be created.
-    doPostSignUpAccountLinkingOperations = async ({
-        newUser,
-        newUserVerified,
-        recipeUserId,
-        userContext,
-    }: {
-        newUser: AccountInfoAndEmailWithRecipeId;
-        newUserVerified: boolean;
-        recipeUserId: string;
-        userContext: any;
-    }): Promise<string> => {
-        let user = await this.getPrimaryUserIdThatCanBeLinkedToRecipeUserId({
-            recipeUserId,
-            userContext,
-        });
-
-        if (user === undefined) {
-            return recipeUserId;
-        }
-        let primaryUser = user;
-        let shouldDoAccountLinking = await this.config.shouldDoAutomaticAccountLinking(
-            newUser,
-            primaryUser,
-            undefined,
-            userContext
-        );
-        if (!shouldDoAccountLinking.shouldAutomaticallyLink) {
-            return recipeUserId;
-        }
-        if (shouldDoAccountLinking.shouldRequireVerification && !newUserVerified) {
-            return recipeUserId;
-        }
-
-        let createPrimaryUserResult = await this.recipeInterfaceImpl.createPrimaryUser({
-            recipeUserId,
-            userContext,
-        });
-        if (createPrimaryUserResult.status === "OK") {
-            return createPrimaryUserResult.user.id;
-        }
-        if (
-            createPrimaryUserResult.status === "RECIPE_USER_ID_ALREADY_LINKED_WITH_PRIMARY_USER_ID_ERROR" &&
-            createPrimaryUserResult.primaryUserId === recipeUserId
-        ) {
-            return createPrimaryUserResult.primaryUserId;
-        }
-        // if it comes here, it means that that there is already a primary user for the
-        // account info, or that this recipeUserId is already linked. Either way, we proceed
-        // to the next step, cause that takes care of both these cases.
-
-        if (primaryUser === undefined) {
-            // it can come here if there is a race condition. So we just try again
-            return await this.doPostSignUpAccountLinkingOperations({
-                newUser: newUser,
-                newUserVerified: newUserVerified,
-                recipeUserId,
-                userContext,
-            });
-        }
-
-        let result = await this.recipeInterfaceImpl.linkAccounts({
-            recipeUserId,
-            primaryUserId: primaryUser.id,
-            userContext,
-        });
-        if (result.status === "OK") {
-            return primaryUser.id;
-        } else if (result.status === "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR") {
-            return result.primaryUserId;
-        } else if (result.status === "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR") {
-            return result.primaryUserId;
-        } else {
-            return primaryUser.id;
-        }
-    };
-
-    accountLinkPostSignInViaSession = async ({
+    linkAccountsWithUserFromSession = async ({
         session,
         newUser,
-        newUserVerified,
+        createRecipeUserFunc,
         userContext,
     }: {
         session: SessionContainer;
-        newUser: AccountInfoAndEmailWithRecipeId;
-        newUserVerified: boolean;
+        newUser: AccountInfoWithRecipeId;
+        createRecipeUserFunc: (newUser: AccountInfoWithRecipeId) => Promise<void>;
         userContext: any;
     }): Promise<
         | {
-              createRecipeUser: true;
-
-              // if the value of updateAccountLinkingClaim is NO_CHANGE, it also means that the
-              // consumer of this function should call this function again.
-              updateAccountLinkingClaim: "ADD_CLAIM" | "NO_CHANGE";
+              status: "OK" | "NEW_ACCOUNT_NEEDS_TO_BE_VERIFIED_ERROR";
           }
-        | ({
-              createRecipeUser: false;
-          } & (
-              | {
-                    accountsLinked: true;
-                    updateAccountLinkingClaim: "REMOVE_CLAIM";
-                }
-              | {
-                    accountsLinked: false;
-                    updateAccountLinkingClaim: "ADD_CLAIM";
-                }
-              | {
-                    accountsLinked: false;
-                    reason:
-                        | "ACCOUNT_LINKING_NOT_ALLOWED_ERROR"
-                        | "EXISTING_ACCOUNT_NEEDS_TO_BE_VERIFIED_ERROR"
-                        | "NEW_ACCOUNT_NEEDS_TO_BE_VERIFIED_ERROR";
-                }
-              | {
-                    accountsLinked: false;
-                    reason:
-                        | "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
-                        | "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
-                    primaryUserId: string;
-                }
-          ))
+        | {
+              status: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR";
+              description: string;
+          }
     > => {
-        let userId = session.getUserId();
+        // In order to link the newUser to the session user,
+        // we need to first make sure that the session user
+        // is a primary user (or make them one if they are not).
+
         let existingUser = await this.recipeInterfaceImpl.getUser({
-            userId,
+            userId: session.getUserId(),
             userContext,
         });
+
         if (existingUser === undefined) {
             // this can come here if the user ID in the session belongs to a user
             // that is not recognized by SuperTokens. In this case, we
-            // disallow this kind of operation.
+            // simply return the session user ID
             return {
-                createRecipeUser: false,
-                accountsLinked: false,
-                reason: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                status: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                description:
+                    "We cannot link accounts since the session belongs to a user ID that does not exist in SuperTokens.",
             };
         }
-        /**
-         * checking if the user with existing session
-         * is a primary user or not
-         */
+
         if (!existingUser.isPrimaryUser) {
-            // first we check if the newUser should be a candidate for account linking
+            // we will try and make the existing user a primary user. But before that, we must ask the
+            // dev if they want to allow for that.
+
+            // we ask the dev if the new user should be a candidate for account linking.
             const shouldDoAccountLinkingOfNewUser = await this.config.shouldDoAutomaticAccountLinking(
                 newUser,
                 undefined,
                 session,
                 userContext
             );
+
             if (!shouldDoAccountLinkingOfNewUser.shouldAutomaticallyLink) {
                 return {
-                    createRecipeUser: false,
-                    accountsLinked: false,
-                    reason: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                    status: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                    description: "Account linking not allowed by the developer for new user.",
                 };
             }
+            // we do not care about the new user's verification status here cause we are in the process of making the session user a primary user first.
 
             // Now we ask the user if the existing login method can be linked to anything
             // (since it's not a primary user)
 
             // here we can use the index of 0 cause the existingUser is not a primary user,
             // therefore it will only have one login method in the loginMethods' array.
-            let existingUserAccountInfoAndEmailWithRecipeId: AccountInfoAndEmailWithRecipeId = {
-                recipeId: existingUser.loginMethods[0].recipeId,
-                email: existingUser.loginMethods[0].email,
-                phoneNumber: existingUser.loginMethods[0].phoneNumber,
-                thirdParty: existingUser.loginMethods[0].thirdParty,
-            };
 
             const shouldDoAccountLinkingOfExistingUser = await this.config.shouldDoAutomaticAccountLinking(
-                existingUserAccountInfoAndEmailWithRecipeId,
+                existingUser.loginMethods[0],
                 undefined,
                 session,
                 userContext
             );
+
             if (!shouldDoAccountLinkingOfExistingUser.shouldAutomaticallyLink) {
                 return {
-                    createRecipeUser: false,
-                    accountsLinked: false,
-                    reason: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                    status: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                    description: "Account linking not allowed by the developer for existing user.",
                 };
             }
+
             if (
                 shouldDoAccountLinkingOfExistingUser.shouldRequireVerification &&
                 !existingUser.loginMethods[0].verified
             ) {
-                return {
-                    createRecipeUser: false,
-                    accountsLinked: false,
-                    reason: "EXISTING_ACCOUNT_NEEDS_TO_BE_VERIFIED_ERROR",
-                };
+                // We do not allow creation of primary user
+                // if the existing user is not verified
+                // cause if we do, then it blocks sign up
+                // with other methods for the same email / phone number
+                // until this account is verified. This can be
+                // used by an attacker to prevent sign up from
+                // their victim by setting the account
+                // in this state and not verifying the account.
+                // The downside to this is that cause of this,
+                // in situations like MFA, we are forcing
+                // email verification to happen right after the user
+                // has finished setting up the second factor.
+                // This may not be something that the developer
+                // wants. But they can always switch this off
+                // by providing the right impl for shouldDoAutomaticAccountLinking
+
+                // this function will throw an email verification validation error.
+                await session.assertClaims([EmailVerificationClaim.validators.isVerified(undefined, 0)]);
             }
 
+            // now we can try and create a primary user for the existing user
             let createPrimaryUserResult = await this.recipeInterfaceImpl.createPrimaryUser({
                 recipeUserId: existingUser.loginMethods[0].recipeUserId,
                 userContext,
@@ -465,10 +493,10 @@ export default class Recipe extends RecipeModule {
                 // this can happen if there is a race condition in which the
                 // existing user becomes a primary user ID by the time the code
                 // execution comes into this block. So we call the function once again.
-                return await this.accountLinkPostSignInViaSession({
+                return await this.linkAccountsWithUserFromSession({
                     session,
                     newUser,
-                    newUserVerified,
+                    createRecipeUserFunc,
                     userContext,
                 });
             } else if (
@@ -481,10 +509,9 @@ export default class Recipe extends RecipeModule {
                 - In this case, existingUser (A2 account), cannot become a primary user
                 - So we are in a stuck state, and must ask the end user to contact support*/
                 return {
-                    createRecipeUser: false,
-                    accountsLinked: false,
-                    reason: createPrimaryUserResult.status,
-                    primaryUserId: createPrimaryUserResult.primaryUserId,
+                    status: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                    description:
+                        "No account can be linked to the session account cause the session account is not a primary account and the account info is already associated with another primary account, so we cannot make this a primary account either. Please contact support.",
                 };
             } else if (createPrimaryUserResult.status === "OK") {
                 // this if condition is not needed, but for some reason TS complains if it's not there.
@@ -495,10 +522,8 @@ export default class Recipe extends RecipeModule {
             // go ahead and attempt account linking for the new user and existingUser.
         }
 
-        /**
-         * checking if account linking is allowed for given primary user
-         * and new login info
-         */
+        // before proceeding to link the two accounts, we must ask the dev if it's allowed to link them
+
         const shouldDoAccountLinking = await this.config.shouldDoAutomaticAccountLinking(
             newUser,
             existingUser,
@@ -507,45 +532,21 @@ export default class Recipe extends RecipeModule {
         );
         if (!shouldDoAccountLinking.shouldAutomaticallyLink) {
             return {
-                createRecipeUser: false,
-                accountsLinked: false,
-                reason: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                status: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                description: "Account linking not allowed by the developer for new user.",
             };
         }
 
-        /**
-         * checking if a recipe user already exists for the given
-         * login info
-         */
-        let accountInfo: AccountInfo;
-        if (newUser.email !== undefined) {
-            accountInfo = {
-                email: newUser.email,
-            };
-        } else if (newUser.phoneNumber !== undefined) {
-            accountInfo = {
-                phoneNumber: newUser.phoneNumber,
-            };
-        } else if (newUser.thirdParty !== undefined) {
-            accountInfo = {
-                thirdPartyId: newUser.thirdParty.id,
-                thirdPartyUserId: newUser.thirdParty.userId,
-            };
-        } else {
-            throw Error("this error should never be thrown");
-        }
-
-        /**
-         * We try and find if there is an existing recipe user for the same login method
-         * and same identifying info as the newUser object.
-         */
+        // in order to link accounts, we need to have the recipe user ID of the new account.
         let usersArrayThatHaveSameAccountInfoAsNewUser = await this.recipeInterfaceImpl.listUsersByAccountInfo({
-            accountInfo,
+            accountInfo: newUser,
             userContext,
         });
 
+        let newUserIsVerified = false;
         const userObjThatHasSameAccountInfoAndRecipeIdAsNewUser = usersArrayThatHaveSameAccountInfoAsNewUser.find((u) =>
             u.loginMethods.find((lU) => {
+                let found = false;
                 if (lU.recipeId !== newUser.recipeId) {
                     return false;
                 }
@@ -553,185 +554,60 @@ export default class Recipe extends RecipeModule {
                     if (lU.thirdParty === undefined) {
                         return false;
                     }
-                    return (
+                    found =
                         lU.thirdParty.id === newUser.thirdParty!.id &&
-                        lU.thirdParty.userId === newUser.thirdParty!.userId
-                    );
+                        lU.thirdParty.userId === newUser.thirdParty!.userId;
+                } else {
+                    found = lU.email === newUser.email || newUser.phoneNumber === newUser.phoneNumber;
                 }
-                return lU.email === newUser.email || newUser.phoneNumber === newUser.phoneNumber;
+                if (!found) {
+                    return false;
+                }
+                newUserIsVerified = lU.verified;
+                return true;
             })
         );
 
         if (userObjThatHasSameAccountInfoAndRecipeIdAsNewUser === undefined) {
             /*
             Before proceeding to linking accounts, we need to create the recipe user ID associated
-            with newUser. In order to do that in a secure way, we need to check if the accountInfo
-            of the newUser is the same as of the existingUser - if it is, then we can go ahead, else
-            we will have to check about the verification status of the newUser's accountInfo
+            with newUser. In order to do that we should check if there is some other primary user
+            has the same account info - cause if there is, then linking to this existingUser will not
+            be possible anyway, so we don't create a new recipe user cause if we did, then this
+            recipe user will not be a candidate for automatic account linking in the future
             */
 
-            /**
-             * if recipe user doesn't exists, we check if
-             * any of the identifying info associated with
-             * the primary user equals to the identifying info
-             * of the given input. If so, return createRecipeUser
-             * as true to let the recipe know that a recipe user needs
-             * to be created and set updateVerificationClaim to false
-             * so the recipe will call back this function when the
-             * recipe user is created
-             */
-            let identitiesForExistingUser = this.transformUserInfoIntoVerifiedAndUnverifiedBucket(existingUser);
-            if (newUser.email !== undefined) {
-                let result =
-                    identitiesForExistingUser.verified.emails.includes(newUser.email) ||
-                    identitiesForExistingUser.unverified.emails.includes(newUser.email);
-                if (result) {
-                    return {
-                        createRecipeUser: true,
-                        updateAccountLinkingClaim: "NO_CHANGE",
-                    };
-                }
-            }
-            if (newUser.phoneNumber !== undefined) {
-                let result =
-                    identitiesForExistingUser.verified.phoneNumbers.includes(newUser.phoneNumber) ||
-                    identitiesForExistingUser.unverified.phoneNumbers.includes(newUser.phoneNumber);
-                if (result) {
-                    return {
-                        createRecipeUser: true,
-                        updateAccountLinkingClaim: "NO_CHANGE",
-                    };
-                }
-            }
-            /**
-             * checking if there already exists any other primary
-             * user which is associated with the account info
-             * for the newUser
-             */
-            const primaryUserIfExists = usersArrayThatHaveSameAccountInfoAsNewUser.find((u) => u.isPrimaryUser);
-            if (primaryUserIfExists !== undefined) {
-                // TODO: as per the lucid chart diagram, there should be an assert here?
+            let otherPrimaryUser = usersArrayThatHaveSameAccountInfoAsNewUser.find((u) => u.isPrimaryUser);
+            if (otherPrimaryUser !== undefined && otherPrimaryUser.id !== existingUser.id) {
                 return {
-                    createRecipeUser: false,
-                    accountsLinked: false,
-                    reason: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR",
-                    primaryUserId: primaryUserIfExists.id,
+                    status: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                    description: "Not allowed because it will lead to two primary user id having same account info",
                 };
             }
-            /**
-             * if the existing info is not verified, we do want
-             * to create a recipe user but don't want recipe
-             * to again callback this function for any further
-             * linking part. Instead, we want the recipe to
-             * update the session claim so it can be known that
-             * the new account needs to be verified. So, return
-             * createRecipeUser as true to let the recipe know
-             * that a recipe user needs to be created and set
-             * updateVerificationClaim to true so the recipe will
-             * not call back this function and update the session
-             * claim instead
-             */
-            if (!newUserVerified && shouldDoAccountLinking.shouldRequireVerification) {
+
+            // we create the new recipe user
+            await createRecipeUserFunc(newUser);
+
+            // now when we recurse, the new recipe user will be found and we can try linking again.
+            return await this.linkAccountsWithUserFromSession({
+                session,
+                newUser,
+                createRecipeUserFunc,
+                userContext,
+            });
+        }
+
+        // now we check about the email verification of the new user. If it's verified, we proceed
+        // to try and link the accounts, and if not, we send email verification error ONLY if the email
+        // or phone number of the new account is different compared to the existing account.
+        if (usersArrayThatHaveSameAccountInfoAsNewUser.find((u) => u.id === existingUser!.id) === undefined) {
+            // this means that the existing user does not share anything in common with the new user
+            // in terms of account info. So we check for email verification status..
+
+            if (!newUserIsVerified && shouldDoAccountLinking.shouldRequireVerification) {
+                // we stop the flow and ask the user to verify this email first.
                 return {
-                    createRecipeUser: true,
-                    updateAccountLinkingClaim: "ADD_CLAIM",
-                };
-            }
-            return {
-                createRecipeUser: true,
-                updateAccountLinkingClaim: "NO_CHANGE",
-            };
-        }
-
-        /**
-         * checking if the primary user (associated with session)
-         * and recipe user (associated with login info) can be
-         * linked
-         */
-        let canLinkAccounts = await this.recipeInterfaceImpl.canLinkAccounts({
-            recipeUserId: userObjThatHasSameAccountInfoAndRecipeIdAsNewUser.id,
-            primaryUserId: existingUser.id,
-            userContext,
-        });
-        if (canLinkAccounts.status === "OK" && canLinkAccounts.accountsAlreadyLinked) {
-            return {
-                createRecipeUser: false,
-                accountsLinked: true,
-                updateAccountLinkingClaim: "REMOVE_CLAIM",
-            };
-        }
-        if (
-            canLinkAccounts.status === "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR" ||
-            canLinkAccounts.status === "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
-        ) {
-            /* ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR can be possible if 
-            - existingUser has email E1
-            - you try and link an account with email E2
-            - there already exists another primary account with email E2
-            - so linking of existingUser and new account would fail
-            - this is a stuck state cause the user will have to contact support or login to their other account.*/
-
-            /**
-             * RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR can be possible if:
-                - existingUser has email E1
-                - you try and link an account with email E2
-                - there already exists another primary account with email E2 that is linked to new account (input to this function)
-                - so linking of existingUser and new account would fail
-                - this is a stuck state cause the user will have to contact support or login to their other account.
-             */
-            return {
-                createRecipeUser: false,
-                accountsLinked: false,
-                reason: canLinkAccounts.status,
-                primaryUserId: canLinkAccounts.primaryUserId,
-            };
-        }
-
-        let accountInfoForExistingUser = this.transformUserInfoIntoVerifiedAndUnverifiedBucket(existingUser);
-
-        let newUserAccountInfoIsAssociatedWithExistingUser = false;
-        let newUsersEmailAlreadyVerifiedInExistingUser = false;
-        if (newUser.email !== undefined) {
-            newUserAccountInfoIsAssociatedWithExistingUser =
-                accountInfoForExistingUser.verified.emails.includes(newUser.email) ||
-                accountInfoForExistingUser.unverified.emails.includes(newUser.email);
-            newUsersEmailAlreadyVerifiedInExistingUser = accountInfoForExistingUser.verified.emails.includes(
-                newUser.email
-            );
-        } else if (newUser.phoneNumber !== undefined) {
-            newUserAccountInfoIsAssociatedWithExistingUser =
-                accountInfoForExistingUser.verified.phoneNumbers.includes(newUser.phoneNumber) ||
-                accountInfoForExistingUser.unverified.phoneNumbers.includes(newUser.phoneNumber);
-        }
-        if (newUserAccountInfoIsAssociatedWithExistingUser) {
-            /**
-             * let Ly belong to P1 such that Ly equal to Lx.
-             * if LY verified or if Lx is verfied,
-             * then mark all Ly and Lx as verified
-             */
-            if (newUser.email !== undefined && (newUsersEmailAlreadyVerifiedInExistingUser || newUserVerified)) {
-                let recipeUserIdsForEmailVerificationUpdate = existingUser.loginMethods
-                    .filter((u) => u.email === newUser.email && !u.verified)
-                    .map((l) => l.recipeUserId);
-                if (!newUserVerified) {
-                    recipeUserIdsForEmailVerificationUpdate.push(userObjThatHasSameAccountInfoAndRecipeIdAsNewUser.id);
-                }
-                recipeUserIdsForEmailVerificationUpdate = Array.from(new Set(recipeUserIdsForEmailVerificationUpdate));
-                for (let i = 0; i < recipeUserIdsForEmailVerificationUpdate.length; i++) {
-                    const recipeUserId = recipeUserIdsForEmailVerificationUpdate[i];
-                    await this.markEmailAsVerified({
-                        email: newUser.email,
-                        recipeUserId,
-                        userContext,
-                    });
-                }
-            }
-        } else {
-            if (shouldDoAccountLinking.shouldRequireVerification && !newUserVerified) {
-                return {
-                    createRecipeUser: false,
-                    accountsLinked: false,
-                    updateAccountLinkingClaim: "ADD_CLAIM",
+                    status: "NEW_ACCOUNT_NEEDS_TO_BE_VERIFIED_ERROR",
                 };
             }
         }
@@ -741,173 +617,26 @@ export default class Recipe extends RecipeModule {
             primaryUserId: existingUser.id,
             userContext,
         });
+
         if (linkAccountResponse.status === "OK") {
             return {
-                createRecipeUser: false,
-                accountsLinked: true,
-                updateAccountLinkingClaim: "REMOVE_CLAIM",
+                status: "OK",
             };
-        } else {
+        } else if (linkAccountResponse.status === "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR") {
+            // this means that the the new user is already linked to some other primary user ID,
+            // so we can't link it to the existing user.
             return {
-                createRecipeUser: false,
-                accountsLinked: false,
-                primaryUserId: linkAccountResponse.primaryUserId,
-                reason: linkAccountResponse.status,
-            };
-        }
-    };
-
-    getPrimaryUserIdThatCanBeLinkedToRecipeUserId = async ({
-        recipeUserId,
-        userContext,
-    }: {
-        recipeUserId: string;
-        userContext: any;
-    }): Promise<User | undefined> => {
-        let user = await getUser(recipeUserId, userContext);
-        if (user === undefined) {
-            return undefined;
-        }
-        if (user.isPrimaryUser) {
-            return user;
-        }
-        let pUser = await this.recipeInterfaceImpl.fetchFromAccountToLinkTable({ recipeUserId, userContext });
-        if (pUser !== undefined && pUser.isPrimaryUser) {
-            return pUser;
-        }
-
-        let accountInfo: AccountInfo;
-        let loginMethodInfo = user.loginMethods[0]; // this is a recipe user so there will be only one item in the array
-        if (loginMethodInfo.email !== undefined) {
-            accountInfo = {
-                email: loginMethodInfo.email,
-            };
-        } else if (loginMethodInfo.phoneNumber !== undefined) {
-            accountInfo = {
-                phoneNumber: loginMethodInfo.phoneNumber,
-            };
-        } else if (loginMethodInfo.thirdParty !== undefined) {
-            accountInfo = {
-                thirdPartyId: loginMethodInfo.thirdParty.id,
-                thirdPartyUserId: loginMethodInfo.thirdParty.userId,
+                status: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                description: "New user is already linked to another account",
             };
         } else {
-            throw Error("this error should never be thrown");
-        }
-        let users = await this.recipeInterfaceImpl.listUsersByAccountInfo({
-            accountInfo,
-            userContext,
-        });
-        return users.find((u) => u.isPrimaryUser);
-    };
-
-    createPrimaryUserIdOrLinkAccountsAfterEmailVerification = async ({
-        recipeUserId,
-        session,
-        userContext,
-    }: {
-        recipeUserId: string;
-        session: SessionContainer | undefined;
-        userContext: any;
-    }) => {
-        let primaryUser = await this.getPrimaryUserIdThatCanBeLinkedToRecipeUserId({
-            recipeUserId,
-            userContext,
-        });
-        if (primaryUser === undefined) {
-            let user = await getUser(recipeUserId, userContext);
-            if (user === undefined) {
-                throw Error("this error should never be thrown");
-            }
-            if (user.isPrimaryUser) {
-                // this can come here cause of a race condition.
-                await this.createPrimaryUserIdOrLinkAccountsAfterEmailVerification({
-                    recipeUserId,
-                    session,
-                    userContext,
-                });
-                return;
-            }
-            let shouldDoAccountLinking = await this.config.shouldDoAutomaticAccountLinking(
-                {
-                    recipeId: user.loginMethods[0].recipeId,
-                    email: user.loginMethods[0].email,
-                    phoneNumber: user.loginMethods[0].phoneNumber,
-                    thirdParty: user.loginMethods[0].thirdParty,
-                },
-                undefined,
-                session,
-                userContext
-            );
-
-            if (shouldDoAccountLinking.shouldAutomaticallyLink) {
-                let response = await this.recipeInterfaceImpl.createPrimaryUser({
-                    recipeUserId: recipeUserId,
-                    userContext,
-                });
-                if (response.status === "OK") {
-                    // TODO: remove session claim
-                } else {
-                    // it can come here cause of a race condition..
-                    await this.createPrimaryUserIdOrLinkAccountsAfterEmailVerification({
-                        recipeUserId,
-                        session,
-                        userContext,
-                    });
-                }
-            }
-        } else {
-            /**
-             * recipeUser already linked with primaryUser
-             */
-            let recipeUser = primaryUser.loginMethods.find((u) => u.recipeUserId === recipeUserId);
-            if (recipeUser === undefined) {
-                let user = await getUser(recipeUserId, userContext);
-                if (user === undefined) {
-                    throw Error("this error should never be thrown");
-                }
-                if (user.isPrimaryUser) {
-                    // this can come here cause of a race condition.
-                    await this.createPrimaryUserIdOrLinkAccountsAfterEmailVerification({
-                        recipeUserId,
-                        session,
-                        userContext,
-                    });
-                    return;
-                }
-                let shouldDoAccountLinking = await this.config.shouldDoAutomaticAccountLinking(
-                    {
-                        recipeId: user.loginMethods[0].recipeId,
-                        email: user.loginMethods[0].email,
-                        phoneNumber: user.loginMethods[0].phoneNumber,
-                        thirdParty: user.loginMethods[0].thirdParty,
-                    },
-                    primaryUser,
-                    session,
-                    userContext
-                );
-
-                if (shouldDoAccountLinking.shouldAutomaticallyLink) {
-                    let linkAccountsResult = await this.recipeInterfaceImpl.linkAccounts({
-                        recipeUserId: recipeUserId,
-                        primaryUserId: primaryUser.id,
-                        userContext,
-                    });
-                    let primaryUserId = primaryUser.id;
-                    if (
-                        linkAccountsResult.status ===
-                            "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR" ||
-                        linkAccountsResult.status === "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
-                    ) {
-                        primaryUserId = linkAccountsResult.primaryUserId;
-                    }
-                    console.log(primaryUserId); // TODO NEMI: remove this
-
-                    // TODO NEMI: The caller of this function should
-                    // remove session claim if session claim exists
-                    // else create a new session
-                }
-            }
+            // status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
+            // this means that the account info of the newUser already belongs to some other primary user ID.
+            // So we cannot link it to existing user.
+            return {
+                status: "ACCOUNT_LINKING_NOT_ALLOWED_ERROR",
+                description: "Not allowed because it will lead to two primary user id having same account info",
+            };
         }
     };
 }

--- a/lib/ts/recipe/accountlinking/recipe.ts
+++ b/lib/ts/recipe/accountlinking/recipe.ts
@@ -275,31 +275,15 @@ export default class Recipe extends RecipeModule {
         recipeUserId: string;
         userContext: any;
     }): Promise<string> => {
-        let accountInfo: AccountInfo;
-        if (newUser.email !== undefined) {
-            accountInfo = {
-                email: newUser.email,
-            };
-        } else if (newUser.phoneNumber !== undefined) {
-            accountInfo = {
-                phoneNumber: newUser.phoneNumber,
-            };
-        } else if (newUser.thirdParty !== undefined) {
-            accountInfo = {
-                thirdPartyId: newUser.thirdParty.id,
-                thirdPartyUserId: newUser.thirdParty.userId,
-            };
-        } else {
-            throw Error("this error should never be thrown");
-        }
-        let users = await this.recipeInterfaceImpl.listUsersByAccountInfo({
-            accountInfo,
+        let user = await this.getPrimaryUserIdThatCanBeLinkedToRecipeUserId({
+            recipeUserId,
             userContext,
         });
-        if (users.length === 0) {
+
+        if (user === undefined) {
             return recipeUserId;
         }
-        let primaryUser = users.find((u) => u.isPrimaryUser);
+        let primaryUser = user;
         let shouldDoAccountLinking = await this.config.shouldDoAutomaticAccountLinking(
             newUser,
             primaryUser,
@@ -917,9 +901,10 @@ export default class Recipe extends RecipeModule {
                     ) {
                         primaryUserId = linkAccountsResult.primaryUserId;
                     }
-                    console.log(primaryUserId); // TODO: remove this
+                    console.log(primaryUserId); // TODO NEMI: remove this
 
-                    // TODO: remove session claim if session claim exists
+                    // TODO NEMI: The caller of this function should
+                    // remove session claim if session claim exists
                     // else create a new session
                 }
             }

--- a/lib/ts/recipe/accountlinking/recipe.ts
+++ b/lib/ts/recipe/accountlinking/recipe.ts
@@ -688,7 +688,7 @@ export default class Recipe extends RecipeModule {
             primaryUserId: existingUser.id,
             userContext,
         });
-        if (canLinkAccounts.status === "ACCOUNTS_ALREADY_LINKED_ERROR") {
+        if (canLinkAccounts.status === "OK" && canLinkAccounts.accountsAlreadyLinked) {
             return {
                 createRecipeUser: false,
                 accountsLinked: true,
@@ -776,7 +776,7 @@ export default class Recipe extends RecipeModule {
             primaryUserId: existingUser.id,
             userContext,
         });
-        if (linkAccountResponse.status === "OK" || linkAccountResponse.status === "ACCOUNTS_ALREADY_LINKED_ERROR") {
+        if (linkAccountResponse.status === "OK") {
             return {
                 createRecipeUser: false,
                 accountsLinked: true,

--- a/lib/ts/recipe/accountlinking/recipeImplementation.ts
+++ b/lib/ts/recipe/accountlinking/recipeImplementation.ts
@@ -119,7 +119,7 @@ export default function getRecipeImplementation(querier: Querier, config: TypeNo
             | {
                   status:
                       | "RECIPE_USER_ID_ALREADY_LINKED_WITH_PRIMARY_USER_ID_ERROR"
-                      | "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                      | "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
                   primaryUserId: string;
                   description: string;
               }
@@ -147,7 +147,7 @@ export default function getRecipeImplementation(querier: Querier, config: TypeNo
             | {
                   status:
                       | "RECIPE_USER_ID_ALREADY_LINKED_WITH_PRIMARY_USER_ID_ERROR"
-                      | "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                      | "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
                   primaryUserId: string;
                   description: string;
               }
@@ -178,7 +178,7 @@ export default function getRecipeImplementation(querier: Querier, config: TypeNo
                   primaryUserId: string;
               }
             | {
-                  status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                  status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
                   primaryUserId: string;
                   description: string;
               }
@@ -226,7 +226,7 @@ export default function getRecipeImplementation(querier: Querier, config: TypeNo
                   description: string;
               }
             | {
-                  status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                  status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
                   primaryUserId: string;
                   description: string;
               }

--- a/lib/ts/recipe/accountlinking/types.ts
+++ b/lib/ts/recipe/accountlinking/types.ts
@@ -107,7 +107,7 @@ export type RecipeInterface = {
         | {
               status:
                   | "RECIPE_USER_ID_ALREADY_LINKED_WITH_PRIMARY_USER_ID_ERROR"
-                  | "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                  | "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
               primaryUserId: string;
               description: string;
           }
@@ -123,7 +123,7 @@ export type RecipeInterface = {
         | {
               status:
                   | "RECIPE_USER_ID_ALREADY_LINKED_WITH_PRIMARY_USER_ID_ERROR"
-                  | "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                  | "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
               primaryUserId: string;
               description: string;
           }
@@ -143,7 +143,7 @@ export type RecipeInterface = {
               primaryUserId: string;
           }
         | {
-              status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+              status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
               primaryUserId: string;
               description: string;
           }
@@ -163,7 +163,7 @@ export type RecipeInterface = {
               description: string;
           }
         | {
-              status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+              status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
               primaryUserId: string;
               description: string;
           }

--- a/lib/ts/recipe/accountlinking/types.ts
+++ b/lib/ts/recipe/accountlinking/types.ts
@@ -135,15 +135,12 @@ export type RecipeInterface = {
     }) => Promise<
         | {
               status: "OK";
+              accountsAlreadyLinked: boolean;
           }
         | {
               status: "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
               description: string;
               primaryUserId: string;
-          }
-        | {
-              status: "ACCOUNTS_ALREADY_LINKED_ERROR";
-              description: string;
           }
         | {
               status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
@@ -158,14 +155,11 @@ export type RecipeInterface = {
     }) => Promise<
         | {
               status: "OK";
+              accountsAlreadyLinked: boolean;
           }
         | {
               status: "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
               primaryUserId: string;
-              description: string;
-          }
-        | {
-              status: "ACCOUNTS_ALREADY_LINKED_ERROR";
               description: string;
           }
         | {

--- a/lib/ts/recipe/accountlinking/types.ts
+++ b/lib/ts/recipe/accountlinking/types.ts
@@ -20,7 +20,7 @@ import { SessionContainer } from "../session";
 export type TypeInput = {
     onAccountLinked?: (user: User, newAccountInfo: RecipeLevelUser, userContext: any) => Promise<void>;
     shouldDoAutomaticAccountLinking?: (
-        newAccountInfo: AccountInfoAndEmailWithRecipeId,
+        newAccountInfo: AccountInfoWithRecipeId,
         user: User | undefined,
         session: SessionContainer | undefined,
         userContext: any
@@ -44,7 +44,7 @@ export type TypeInput = {
 export type TypeNormalisedInput = {
     onAccountLinked: (user: User, newAccountInfo: RecipeLevelUser, userContext: any) => Promise<void>;
     shouldDoAutomaticAccountLinking: (
-        newAccountInfo: AccountInfoAndEmailWithRecipeId,
+        newAccountInfo: AccountInfoWithRecipeId,
         user: User | undefined,
         session: SessionContainer | undefined,
         userContext: any
@@ -103,6 +103,7 @@ export type RecipeInterface = {
     }) => Promise<
         | {
               status: "OK";
+              wasAlreadyAPrimaryUser: boolean;
           }
         | {
               status:
@@ -119,6 +120,7 @@ export type RecipeInterface = {
         | {
               status: "OK";
               user: User;
+              wasAlreadyAPrimaryUser: boolean;
           }
         | {
               status:
@@ -177,13 +179,8 @@ export type RecipeInterface = {
               wasRecipeUserDeleted: boolean;
           }
         | {
-              status: "PRIMARY_USER_NOT_FOUND";
-          }
-        | {
-              status: "RESTART_FLOW_ERROR";
-          }
-        | {
-              status: "RECIPE_USER_NOT_FOUND";
+              status: "PRIMARY_USER_NOT_FOUND_ERROR" | "RECIPE_USER_NOT_FOUND_ERROR";
+              description: string;
           }
     >;
     getUser: (input: { userId: string; userContext: any }) => Promise<User | undefined>;
@@ -216,8 +213,7 @@ export type RecipeLevelUser = {
     };
 };
 
-export type AccountInfoAndEmailWithRecipeId = {
-    recipeId: "emailpassword" | "thirdparty" | "passwordless";
+export type AccountInfo = {
     email?: string;
     phoneNumber?: string;
     thirdParty?: {
@@ -226,14 +222,6 @@ export type AccountInfoAndEmailWithRecipeId = {
     };
 };
 
-export type AccountInfo =
-    | {
-          email: string;
-      }
-    | {
-          phoneNumber: string;
-      }
-    | {
-          thirdPartyId: string;
-          thirdPartyUserId: string;
-      };
+export type AccountInfoWithRecipeId = {
+    recipeId: "emailpassword" | "thirdparty" | "passwordless";
+} & AccountInfo;

--- a/lib/ts/recipe/accountlinking/types.ts
+++ b/lib/ts/recipe/accountlinking/types.ts
@@ -177,7 +177,13 @@ export type RecipeInterface = {
               wasRecipeUserDeleted: boolean;
           }
         | {
-              status: "NO_PRIMARY_USER_FOUND";
+              status: "PRIMARY_USER_NOT_FOUND";
+          }
+        | {
+              status: "RESTART_FLOW_ERROR";
+          }
+        | {
+              status: "RECIPE_USER_NOT_FOUND";
           }
     >;
     getUser: (input: { userId: string; userContext: any }) => Promise<User | undefined>;

--- a/lib/ts/recipe/accountlinking/utils.ts
+++ b/lib/ts/recipe/accountlinking/utils.ts
@@ -20,13 +20,13 @@ import type {
     RecipeLevelUser,
     RecipeInterface,
     TypeNormalisedInput,
-    AccountInfoAndEmailWithRecipeId,
+    AccountInfoWithRecipeId,
 } from "./types";
 
 async function defaultOnAccountLinked(_user: User, _newAccountInfo: RecipeLevelUser, _userContext: any) {}
 
 async function defaultShouldDoAutomaticAccountLinking(
-    _newAccountInfo: AccountInfoAndEmailWithRecipeId,
+    _newAccountInfo: AccountInfoWithRecipeId,
     _user: User | undefined,
     _session: SessionContainer | undefined,
     _userContext: any

--- a/lib/ts/recipe/emailpassword/api/implementation.ts
+++ b/lib/ts/recipe/emailpassword/api/implementation.ts
@@ -28,7 +28,7 @@ export default function getAPIImplementation(): APIInterface {
                   description: string;
               }
             | {
-                  status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                  status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
                   primaryUserId: string;
                   description: string;
               }

--- a/lib/ts/recipe/emailpassword/types.ts
+++ b/lib/ts/recipe/emailpassword/types.ts
@@ -294,7 +294,7 @@ export type APIInterface = {
                     description: string;
                 }
               | {
-                    status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                    status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
                     primaryUserId: string;
                     description: string;
                 }

--- a/lib/ts/recipe/passwordless/types.ts
+++ b/lib/ts/recipe/passwordless/types.ts
@@ -408,7 +408,7 @@ export type APIInterface = {
                     description: string;
                 }
               | {
-                    status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                    status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
                     primaryUserId: string;
                     description: string;
                 }

--- a/lib/ts/recipe/thirdparty/api/implementation.ts
+++ b/lib/ts/recipe/thirdparty/api/implementation.ts
@@ -33,7 +33,7 @@ export default function getAPIInterface(): APIInterface {
                   description: string;
               }
             | {
-                  status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                  status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
                   primaryUserId: string;
                   description: string;
               }

--- a/lib/ts/recipe/thirdparty/types.ts
+++ b/lib/ts/recipe/thirdparty/types.ts
@@ -190,7 +190,7 @@ export type APIInterface = {
                     description: string;
                 }
               | {
-                    status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                    status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
                     primaryUserId: string;
                     description: string;
                 }

--- a/lib/ts/recipe/thirdpartyemailpassword/types.ts
+++ b/lib/ts/recipe/thirdpartyemailpassword/types.ts
@@ -183,7 +183,7 @@ export type APIInterface = {
                     description: string;
                 }
               | {
-                    status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                    status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
                     primaryUserId: string;
                     description: string;
                 }
@@ -327,7 +327,7 @@ export type APIInterface = {
                     description: string;
                 }
               | {
-                    status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                    status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
                     primaryUserId: string;
                     description: string;
                 }

--- a/lib/ts/recipe/thirdpartypasswordless/types.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/types.ts
@@ -371,7 +371,7 @@ export type APIInterface = {
                     description: string;
                 }
               | {
-                    status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                    status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
                     primaryUserId: string;
                     description: string;
                 }
@@ -549,7 +549,7 @@ export type APIInterface = {
                     description: string;
                 }
               | {
-                    status: "ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+                    status: "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
                     primaryUserId: string;
                     description: string;
                 }


### PR DESCRIPTION
## Summary of change

- Added `accountsAlreadyLinked` to canLink and link accounts functions
- Renamed `ACCOUNT_INFO_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR` to `ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR`
- Replaced error throwing in unlink accounts with

```ts
{
    status: "PRIMARY_USER_NOT_FOUND";
}
| {
    status: "RESTART_FLOW_ERROR";
}
| {
    status: "RECIPE_USER_NOT_FOUND";
}
```

- Calls `getPrimaryUserIdThatCanBeLinkedToRecipeUserId` inside `doPostSignUpAccountLinkingOperations` instead of `listUsersByAccountInfo`
- Moves logic of marking emails as verified after linking to linkAccounts

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
