### PR TITLE
test: fix test failures in CI

### DIFF
--- a/lib/build/recipe/session/sessionFunctions.js
+++ b/lib/build/recipe/session/sessionFunctions.js
@@ -86,6 +86,7 @@ exports.createNewSession = createNewSession;
  * @description authenticates a session. To be used in APIs that require authentication
  */
 function getSession(helpers, parsedAccessToken, antiCsrfToken, doAntiCsrfCheck, alwaysCheckCore) {
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         let accessTokenInfo;
         try {
@@ -219,7 +220,10 @@ function getSession(helpers, parsedAccessToken, antiCsrfToken, doAntiCsrfCheck, 
         );
         if (response.status === "OK") {
             delete response.status;
-            response.session.expiryTime = response.accessToken.expiry;
+            response.session.expiryTime =
+                ((_a = response.accessToken) === null || _a === void 0 ? void 0 : _a.expiry) || // if we got a new accesstoken we take the expiry time from there
+                (accessTokenInfo === null || accessTokenInfo === void 0 ? void 0 : accessTokenInfo.expiryTime) || // if we didn't get a new access token but could validate the token take that info (alwaysCheckCore === true, or parentRefreshTokenHash1 !== null)
+                parsedAccessToken.payload["expiryTime"]; // if the token didn't pass validation, but we got here, it means it was a v2 token that we didn't have the key cached for.
             return response;
         } else if (response.status === "UNAUTHORISED") {
             logger_1.logDebugMessage("getSession: Returning UNAUTHORISED because of core response");

--- a/lib/ts/recipe/session/sessionFunctions.ts
+++ b/lib/ts/recipe/session/sessionFunctions.ts
@@ -206,7 +206,10 @@ export async function getSession(
     let response = await helpers.querier.sendPostRequest(new NormalisedURLPath("/recipe/session/verify"), requestBody);
     if (response.status === "OK") {
         delete response.status;
-        response.session.expiryTime = response.accessToken.expiry;
+        response.session.expiryTime =
+            response.accessToken?.expiry || // if we got a new accesstoken we take the expiry time from there
+            accessTokenInfo?.expiryTime || // if we didn't get a new access token but could validate the token take that info (alwaysCheckCore === true, or parentRefreshTokenHash1 !== null)
+            parsedAccessToken.payload["expiryTime"]; // if the token didn't pass validation, but we got here, it means it was a v2 token that we didn't have the key cached for.
         return response;
     } else if (response.status === "UNAUTHORISED") {
         logDebugMessage("getSession: Returning UNAUTHORISED because of core response");

--- a/test/framework/fastify.test.js
+++ b/test/framework/fastify.test.js
@@ -1234,6 +1234,7 @@ describe(`Fastify: ${printPath("[test/framework/fastify.test.js]")}`, function (
                 "refreshTokenHash1",
                 "sessionHandle",
                 "sub",
+                "iss",
             ])
         );
         //invalid session handle when updating the jwt payload

--- a/test/framework/hapi.test.js
+++ b/test/framework/hapi.test.js
@@ -1269,6 +1269,7 @@ describe(`Hapi: ${printPath("[test/framework/hapi.test.js]")}`, function () {
                 "refreshTokenHash1",
                 "sessionHandle",
                 "sub",
+                "iss",
             ])
         );
 

--- a/test/framework/koa.test.js
+++ b/test/framework/koa.test.js
@@ -1433,6 +1433,7 @@ describe(`Koa: ${printPath("[test/framework/koa.test.js]")}`, function () {
                 "refreshTokenHash1",
                 "sessionHandle",
                 "sub",
+                "iss",
             ])
         );
         //invalid session handle when updating the jwt payload

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -1649,7 +1649,7 @@ describe(`middleware: ${printPath("[test/middleware.test.js]")}`, function () {
     });
 
     it("test session verify middleware without error handler added", async function () {
-        await setKeyValueInConfig("access_token_validity", 2);
+        await setKeyValueInConfig("access_token_validity", 5);
         await startST();
         SuperTokens.init({
             supertokens: {

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -527,7 +527,7 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
             true
         );
         assert(response2.session != undefined);
-        assert(Object.keys(response2.session).length === 3);
+        assert(Object.keys(response2.session).length === 4);
 
         let response3 = await SessionFunctions.getSession(
             s.recipeInterfaceImpl.helpers,
@@ -537,7 +537,7 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
             true
         );
         assert(response3.session != undefined);
-        assert(Object.keys(response3.session).length === 3);
+        assert(Object.keys(response3.session).length === 4);
     });
 
     //check session verify for with / without anti-csrf present**
@@ -1001,7 +1001,7 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
             true
         );
         assert(response2.session != undefined);
-        assert(Object.keys(response2.session).length === 3);
+        assert(Object.keys(response2.session).length === 4);
 
         //passing anti-csrf token as undefined and anti-csrf check as true
         let response3 = await SessionFunctions.getSession(
@@ -1012,7 +1012,7 @@ describe(`session: ${printPath("[test/session.test.js]")}`, function () {
             true
         );
         assert(response3.session != undefined);
-        assert(Object.keys(response3.session).length === 3);
+        assert(Object.keys(response3.session).length === 4);
     });
 
     it("test that anti-csrf disabled and sameSite none does not throw an error", async function () {


### PR DESCRIPTION
## Summary of change

- it fixes a bug in sessionFunctions.ts setting the expirityTime in case we called the Core during session verification
- it updates the frontend integration server to mimic old behaviour using mergeIntoAccessTokenPayload
- Update some test assertions

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
