### PR TITLE
fix: Dashboard API key based login always failing with invalid API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixes
+
+## [14.0.1] - 2023-05-11
+
+-   Fixes an issue where API key based login with dashboard would return invalid API key even if the entered API key was valid
+
 ## [14.0.0] - 2023-05-04
 
 ### Breaking Changes

--- a/lib/build/recipe/dashboard/utils.js
+++ b/lib/build/recipe/dashboard/utils.js
@@ -72,10 +72,10 @@ function validateAndNormaliseUserInput(config) {
         },
         config === undefined ? {} : config.override
     );
-    return {
+    return Object.assign(Object.assign({}, config), {
         override,
         authMode: config !== undefined && config.apiKey ? "api-key" : "email-password",
-    };
+    });
 }
 exports.validateAndNormaliseUserInput = validateAndNormaliseUserInput;
 function isApiPath(path, appInfo) {

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "14.0.0";
+export declare const version = "14.0.1";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.6";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "14.0.0";
+exports.version = "14.0.1";
 exports.cdiSupported = ["2.21"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.6";

--- a/lib/ts/recipe/dashboard/utils.ts
+++ b/lib/ts/recipe/dashboard/utils.ts
@@ -62,6 +62,7 @@ export function validateAndNormaliseUserInput(config?: TypeInput): TypeNormalise
     };
 
     return {
+        ...config,
         override,
         authMode: config !== undefined && config.apiKey ? "api-key" : "email-password",
     };

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "14.0.0";
+export const version = "14.0.1";
 
 export const cdiSupported = ["2.21"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "14.0.0",
+    "version": "14.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "14.0.0",
+            "version": "14.0.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "axios": "0.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "14.0.0",
+    "version": "14.0.1",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {

--- a/test/dashboard.test.js
+++ b/test/dashboard.test.js
@@ -1,0 +1,63 @@
+const { printPath, setupST, startST, killAllST, cleanST, resetAll } = require("./utils");
+let STExpress = require("../");
+let Dashboard = require("../recipe/dashboard");
+let DashboardRecipe = require("../lib/build/recipe/dashboard/recipe").default;
+let assert = require("assert");
+let { ProcessState } = require("../lib/build/processState");
+
+describe(`dashboard: ${printPath("[test/dashboard.test.js]")}`, function () {
+    beforeEach(async function () {
+        await killAllST();
+        await setupST();
+        ProcessState.getInstance().reset();
+    });
+
+    after(async function () {
+        await killAllST();
+        await cleanST();
+    });
+
+    it("Test that normalised config is generated correctly", async function () {
+        await startST();
+
+        {
+            STExpress.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                },
+                appInfo: {
+                    apiDomain: "api.supertokens.io",
+                    appName: "SuperTokens",
+                    websiteDomain: "supertokens.io",
+                },
+                recipeList: [Dashboard.init()],
+            });
+
+            let config = DashboardRecipe.getInstanceOrThrowError().config;
+
+            assert.equal(config.apiKey, undefined);
+            assert.equal(config.authMode, "email-password");
+
+            resetAll();
+        }
+
+        {
+            STExpress.init({
+                supertokens: {
+                    connectionURI: "http://localhost:8080",
+                },
+                appInfo: {
+                    apiDomain: "api.supertokens.io",
+                    appName: "SuperTokens",
+                    websiteDomain: "supertokens.io",
+                },
+                recipeList: [Dashboard.init({ apiKey: "test" })],
+            });
+
+            let config = DashboardRecipe.getInstanceOrThrowError().config;
+
+            assert.equal(config.authMode, "api-key");
+            assert.equal(config.apiKey, "test");
+        }
+    });
+});


### PR DESCRIPTION
## Summary of change

- Fixes an issue with Dashboard recipe initialisation which would result in API key based login always failing

## Related issues

- 

## Test Plan

Added tests to make sure config gets normalised correctly

## Documentation changes
None

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] ...
