### PR TITLE
feat!: make loading access token from the request overrideable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
-### Breaking changes
+## [14.0.2] - 2023-05-11
+
+### Changes
 
 -   Made the access token string optional in the overrideable `getSession` function
 -   Moved checking if the access token is defined into the overrideable `getSession` function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Breaking changes
+
+-   Made the access token string optional in the overrideable `getSession` function
+-   Moved checking if the access token is defined into the overrideable `getSession` function
+
 ## [14.0.1] - 2023-05-11
 
 -   Fixes an issue where API key based login with dashboard would return invalid API key even if the entered API key was valid

--- a/lib/build/recipe/session/recipeImplementation.js
+++ b/lib/build/recipe/session/recipeImplementation.js
@@ -168,6 +168,27 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                     );
                 }
                 logger_1.logDebugMessage("getSession: Started");
+                if (accessTokenString === undefined) {
+                    if ((options === null || options === void 0 ? void 0 : options.sessionRequired) === false) {
+                        logger_1.logDebugMessage(
+                            "getSession: returning undefined because accessToken is undefined and sessionRequired is false"
+                        );
+                        // there is no session that exists here, and the user wants session verification
+                        // to be optional. So we return undefined.
+                        return undefined;
+                    }
+                    logger_1.logDebugMessage("getSession: UNAUTHORISED because accessToken in request is undefined");
+                    throw new error_1.default({
+                        message:
+                            "Session does not exist. Are you sending the session tokens in the request with the appropriate token transfer method?",
+                        type: error_1.default.UNAUTHORISED,
+                        payload: {
+                            // we do not clear the session here because of a
+                            // race condition mentioned here: https://github.com/supertokens/supertokens-node/issues/17
+                            clearTokens: false,
+                        },
+                    });
+                }
                 let accessToken;
                 try {
                     accessToken = jwt_1.parseJWTWithoutSignatureVerification(accessTokenString);

--- a/lib/build/recipe/session/sessionRequestFunctions.js
+++ b/lib/build/recipe/session/sessionRequestFunctions.js
@@ -108,26 +108,6 @@ function getSessionFromRequest({ req, res, config, recipeInterfaceImpl, options,
             logger_1.logDebugMessage("getSession: using cookie transfer method");
             requestTransferMethod = "cookie";
             accessToken = accessTokens["cookie"];
-        } else {
-            if (sessionOptional) {
-                logger_1.logDebugMessage(
-                    "getSession: returning undefined because accessToken is undefined and sessionRequired is false"
-                );
-                // there is no session that exists here, and the user wants session verification
-                // to be optional. So we return undefined.
-                return undefined;
-            }
-            logger_1.logDebugMessage("getSession: UNAUTHORISED because accessToken in request is undefined");
-            throw new error_1.default({
-                message:
-                    "Session does not exist. Are you sending the session tokens in the request with the appropriate token transfer method?",
-                type: error_1.default.UNAUTHORISED,
-                payload: {
-                    // we do not clear the session here because of a
-                    // race condition mentioned here: https://github.com/supertokens/supertokens-node/issues/17
-                    clearTokens: false,
-                },
-            });
         }
         let antiCsrfToken = cookieAndHeaders_1.getAntiCsrfTokenFromHeaders(req);
         let doAntiCsrfCheck = options !== undefined ? options.antiCsrfCheck : undefined;
@@ -155,7 +135,7 @@ function getSessionFromRequest({ req, res, config, recipeInterfaceImpl, options,
         }
         logger_1.logDebugMessage("getSession: Value of doAntiCsrfCheck is: " + doAntiCsrfCheck);
         const session = yield recipeInterfaceImpl.getSession({
-            accessToken: accessToken.rawTokenString,
+            accessToken: accessToken === null || accessToken === void 0 ? void 0 : accessToken.rawTokenString,
             antiCsrfToken,
             options: Object.assign(Object.assign({}, options), { antiCsrfCheck: doAntiCsrfCheck }),
             userContext,
@@ -167,10 +147,20 @@ function getSessionFromRequest({ req, res, config, recipeInterfaceImpl, options,
                 userContext
             );
             yield session.assertClaims(claimValidators, userContext);
+            // requestTransferMethod can only be undefined here if the user overridden getSession
+            // to load the session by a custom method in that (very niche) case they also need to
+            // override how the session is attached to the response.
+            // In that scenario the transferMethod passed to attachToRequestResponse likely doesn't
+            // matter, still, we follow the general fallback logic
             yield session.attachToRequestResponse({
                 req,
                 res,
-                transferMethod: requestTransferMethod,
+                transferMethod:
+                    requestTransferMethod !== undefined
+                        ? requestTransferMethod
+                        : allowedTransferMethod !== "any"
+                        ? allowedTransferMethod
+                        : "header",
             });
         }
         return session;

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -165,7 +165,7 @@ export declare type RecipeInterface = {
         userContext: any;
     }): Promise<SessionClaimValidator[]> | SessionClaimValidator[];
     getSession(input: {
-        accessToken: string;
+        accessToken: string | undefined;
         antiCsrfToken?: string;
         options?: VerifySessionOptions;
         userContext: any;

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "14.0.1";
+export declare const version = "14.0.2";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.6";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "14.0.1";
+exports.version = "14.0.2";
 exports.cdiSupported = ["2.21"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.6";

--- a/lib/ts/recipe/session/recipeImplementation.ts
+++ b/lib/ts/recipe/session/recipeImplementation.ts
@@ -142,6 +142,28 @@ export default function getRecipeInterface(
                 );
             }
             logDebugMessage("getSession: Started");
+            if (accessTokenString === undefined) {
+                if (options?.sessionRequired === false) {
+                    logDebugMessage(
+                        "getSession: returning undefined because accessToken is undefined and sessionRequired is false"
+                    );
+                    // there is no session that exists here, and the user wants session verification
+                    // to be optional. So we return undefined.
+                    return undefined;
+                }
+
+                logDebugMessage("getSession: UNAUTHORISED because accessToken in request is undefined");
+                throw new SessionError({
+                    message:
+                        "Session does not exist. Are you sending the session tokens in the request with the appropriate token transfer method?",
+                    type: SessionError.UNAUTHORISED,
+                    payload: {
+                        // we do not clear the session here because of a
+                        // race condition mentioned here: https://github.com/supertokens/supertokens-node/issues/17
+                        clearTokens: false,
+                    },
+                });
+            }
 
             let accessToken: ParsedJWTInfo | undefined;
             try {

--- a/lib/ts/recipe/session/sessionRequestFunctions.ts
+++ b/lib/ts/recipe/session/sessionRequestFunctions.ts
@@ -84,7 +84,7 @@ export async function getSessionFromRequest({
         forCreateNewSession: false,
         userContext,
     });
-    let requestTransferMethod: TokenTransferMethod;
+    let requestTransferMethod: TokenTransferMethod | undefined;
     let accessToken: ParsedJWTInfo | undefined;
 
     if (
@@ -101,27 +101,6 @@ export async function getSessionFromRequest({
         logDebugMessage("getSession: using cookie transfer method");
         requestTransferMethod = "cookie";
         accessToken = accessTokens["cookie"];
-    } else {
-        if (sessionOptional) {
-            logDebugMessage(
-                "getSession: returning undefined because accessToken is undefined and sessionRequired is false"
-            );
-            // there is no session that exists here, and the user wants session verification
-            // to be optional. So we return undefined.
-            return undefined;
-        }
-
-        logDebugMessage("getSession: UNAUTHORISED because accessToken in request is undefined");
-        throw new SessionError({
-            message:
-                "Session does not exist. Are you sending the session tokens in the request with the appropriate token transfer method?",
-            type: SessionError.UNAUTHORISED,
-            payload: {
-                // we do not clear the session here because of a
-                // race condition mentioned here: https://github.com/supertokens/supertokens-node/issues/17
-                clearTokens: false,
-            },
-        });
     }
 
     let antiCsrfToken = getAntiCsrfTokenFromHeaders(req);
@@ -152,7 +131,7 @@ export async function getSessionFromRequest({
 
     logDebugMessage("getSession: Value of doAntiCsrfCheck is: " + doAntiCsrfCheck);
     const session = await recipeInterfaceImpl.getSession({
-        accessToken: accessToken.rawTokenString,
+        accessToken: accessToken?.rawTokenString,
         antiCsrfToken,
         options: { ...options, antiCsrfCheck: doAntiCsrfCheck },
         userContext,
@@ -166,10 +145,20 @@ export async function getSessionFromRequest({
         );
         await session.assertClaims(claimValidators, userContext);
 
+        // requestTransferMethod can only be undefined here if the user overridden getSession
+        // to load the session by a custom method in that (very niche) case they also need to
+        // override how the session is attached to the response.
+        // In that scenario the transferMethod passed to attachToRequestResponse likely doesn't
+        // matter, still, we follow the general fallback logic
         await session.attachToRequestResponse({
             req,
             res,
-            transferMethod: requestTransferMethod,
+            transferMethod:
+                requestTransferMethod !== undefined
+                    ? requestTransferMethod
+                    : allowedTransferMethod !== "any"
+                    ? allowedTransferMethod
+                    : "header",
         });
     }
     return session;

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -201,7 +201,7 @@ export type RecipeInterface = {
     }): Promise<SessionClaimValidator[]> | SessionClaimValidator[];
 
     getSession(input: {
-        accessToken: string;
+        accessToken: string | undefined;
         antiCsrfToken?: string;
         options?: VerifySessionOptions;
         userContext: any;

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "14.0.1";
+export const version = "14.0.2";
 
 export const cdiSupported = ["2.21"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "14.0.1",
+    "version": "14.0.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "14.0.1",
+            "version": "14.0.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "axios": "0.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "14.0.1",
+    "version": "14.0.2",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

- make loading access token from the request overrideable
-   Made the access token string optional in the overrideable `getSession` function
-   Moved checking if the access token is defined into the overrideable `getSession` function

## Related issues

-   

## Test Plan

Will be tested manually by an example in the auth-react repo

## Documentation changes

N/A, it's only relevant in a very niche usecase

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
