### PR TITLE
feat: Add a helper function to read the original request from the user context inside overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Changes
+
+-   Added a new `getRequestFromUserContext` function that can be used to read the original network request from the user context in overridden APIs and recipe functions
+
 ## [14.0.2] - 2023-05-11
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [14.1.0] - 2023-05-23
+
 ### Changes
 
 -   Added a new `getRequestFromUserContext` function that can be used to read the original network request from the user context in overridden APIs and recipe functions

--- a/lib/build/index.d.ts
+++ b/lib/build/index.d.ts
@@ -79,6 +79,7 @@ export default class SuperTokensWrapper {
     }): Promise<{
         status: "OK" | "UNKNOWN_MAPPING_ERROR";
     }>;
+    static getRequestFromUserContext(userContext: any | undefined): import("./framework").BaseRequest | undefined;
 }
 export declare let init: typeof SuperTokens.init;
 export declare let getAllCORSHeaders: typeof SuperTokensWrapper.getAllCORSHeaders;
@@ -90,4 +91,5 @@ export declare let createUserIdMapping: typeof SuperTokensWrapper.createUserIdMa
 export declare let getUserIdMapping: typeof SuperTokensWrapper.getUserIdMapping;
 export declare let deleteUserIdMapping: typeof SuperTokensWrapper.deleteUserIdMapping;
 export declare let updateOrDeleteUserIdMappingInfo: typeof SuperTokensWrapper.updateOrDeleteUserIdMappingInfo;
+export declare let getRequestFromUserContext: typeof SuperTokensWrapper.getRequestFromUserContext;
 export declare let Error: typeof SuperTokensError;

--- a/lib/build/index.js
+++ b/lib/build/index.js
@@ -19,7 +19,7 @@ var __importDefault =
         return mod && mod.__esModule ? mod : { default: mod };
     };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.Error = exports.updateOrDeleteUserIdMappingInfo = exports.deleteUserIdMapping = exports.getUserIdMapping = exports.createUserIdMapping = exports.deleteUser = exports.getUsersNewestFirst = exports.getUsersOldestFirst = exports.getUserCount = exports.getAllCORSHeaders = exports.init = void 0;
+exports.Error = exports.getRequestFromUserContext = exports.updateOrDeleteUserIdMappingInfo = exports.deleteUserIdMapping = exports.getUserIdMapping = exports.createUserIdMapping = exports.deleteUser = exports.getUsersNewestFirst = exports.getUsersOldestFirst = exports.getUserCount = exports.getAllCORSHeaders = exports.init = void 0;
 const supertokens_1 = __importDefault(require("./supertokens"));
 const error_1 = __importDefault(require("./error"));
 // For Express
@@ -57,6 +57,9 @@ class SuperTokensWrapper {
     static updateOrDeleteUserIdMappingInfo(input) {
         return supertokens_1.default.getInstanceOrThrowError().updateOrDeleteUserIdMappingInfo(input);
     }
+    static getRequestFromUserContext(userContext) {
+        return supertokens_1.default.getInstanceOrThrowError().getRequestFromUserContext(userContext);
+    }
 }
 exports.default = SuperTokensWrapper;
 SuperTokensWrapper.init = supertokens_1.default.init;
@@ -71,4 +74,5 @@ exports.createUserIdMapping = SuperTokensWrapper.createUserIdMapping;
 exports.getUserIdMapping = SuperTokensWrapper.getUserIdMapping;
 exports.deleteUserIdMapping = SuperTokensWrapper.deleteUserIdMapping;
 exports.updateOrDeleteUserIdMappingInfo = SuperTokensWrapper.updateOrDeleteUserIdMappingInfo;
+exports.getRequestFromUserContext = SuperTokensWrapper.getRequestFromUserContext;
 exports.Error = SuperTokensWrapper.Error;

--- a/lib/build/supertokens.d.ts
+++ b/lib/build/supertokens.d.ts
@@ -90,4 +90,5 @@ export default class SuperTokens {
     }>;
     middleware: (request: BaseRequest, response: BaseResponse) => Promise<boolean>;
     errorHandler: (err: any, request: BaseRequest, response: BaseResponse) => Promise<void>;
+    getRequestFromUserContext: (userContext: any | undefined) => BaseRequest | undefined;
 }

--- a/lib/build/supertokens.js
+++ b/lib/build/supertokens.js
@@ -318,6 +318,21 @@ class SuperTokens {
                 }
                 throw err;
             });
+        this.getRequestFromUserContext = (userContext) => {
+            if (userContext === undefined) {
+                return undefined;
+            }
+            if (typeof userContext !== "object") {
+                return undefined;
+            }
+            if (userContext._default === undefined) {
+                return undefined;
+            }
+            if (userContext._default.request === undefined) {
+                return undefined;
+            }
+            return userContext._default.request;
+        };
         logger_1.logDebugMessage("Started SuperTokens with debug logging (supertokens.init called)");
         logger_1.logDebugMessage("appInfo: " + JSON.stringify(config.appInfo));
         this.framework = config.framework !== undefined ? config.framework : "express";

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "14.0.2";
+export declare const version = "14.1.0";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.6";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "14.0.2";
+exports.version = "14.1.0";
 exports.cdiSupported = ["2.21"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.6";

--- a/lib/ts/index.ts
+++ b/lib/ts/index.ts
@@ -94,6 +94,10 @@ export default class SuperTokensWrapper {
     }) {
         return SuperTokens.getInstanceOrThrowError().updateOrDeleteUserIdMappingInfo(input);
     }
+
+    static getRequestFromUserContext(userContext: any | undefined) {
+        return SuperTokens.getInstanceOrThrowError().getRequestFromUserContext(userContext);
+    }
 }
 
 export let init = SuperTokensWrapper.init;
@@ -115,5 +119,7 @@ export let getUserIdMapping = SuperTokensWrapper.getUserIdMapping;
 export let deleteUserIdMapping = SuperTokensWrapper.deleteUserIdMapping;
 
 export let updateOrDeleteUserIdMappingInfo = SuperTokensWrapper.updateOrDeleteUserIdMappingInfo;
+
+export let getRequestFromUserContext = SuperTokensWrapper.getRequestFromUserContext;
 
 export let Error = SuperTokensWrapper.Error;

--- a/lib/ts/supertokens.ts
+++ b/lib/ts/supertokens.ts
@@ -408,4 +408,24 @@ export default class SuperTokens {
         }
         throw err;
     };
+
+    getRequestFromUserContext = (userContext: any | undefined): BaseRequest | undefined => {
+        if (userContext === undefined) {
+            return undefined;
+        }
+
+        if (typeof userContext !== "object") {
+            return undefined;
+        }
+
+        if (userContext._default === undefined) {
+            return undefined;
+        }
+
+        if (userContext._default.request === undefined) {
+            return undefined;
+        }
+
+        return userContext._default.request;
+    };
 }

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "14.0.2";
+export const version = "14.1.0";
 
 export const cdiSupported = ["2.21"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "14.0.2",
+    "version": "14.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "14.0.2",
+            "version": "14.1.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "axios": "0.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "14.0.2",
+    "version": "14.1.0",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

- Added a helper function exported by the SuperTokens class that makes it easier to get the original request from the user context
- This reduces the boilerplate of always having to use `usercontext._default.request` and also allows the request to be strongly typed

## Related issues

-  

## Test Plan

Added a test to make sure the new function works correctly

## Documentation changes

WIP

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] Upgrade version (if needed)
