### PR TITLE
feat: Allow users to set emails as admins when initialising the Dashboard recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+-   The Dashboard recipe now accepts a new `admins` property which can be used to give Dashboard Users write privileges for the user dashboard.
+
+### Changes
+
+-   Dashboard APIs now return a status code `403` for all non-GET requests if the currently logged in Dashboard User is not listed in the `admins` array
+
 ## [14.1.1] - 2023-05-24
 
 ### Added

--- a/lib/build/framework/fastify/index.d.ts
+++ b/lib/build/framework/fastify/index.d.ts
@@ -1,21 +1,18 @@
 // @ts-nocheck
 /// <reference types="node" />
 export type { SessionRequest } from "./framework";
-export declare const plugin: import("fastify").FastifyPluginCallback<
-    Record<never, never>,
-    import("fastify").RawServerDefault
->;
+export declare const plugin: import("fastify").FastifyPluginCallback<Record<never, never>, import("http").Server>;
 export declare const errorHandler: () => (
     err: any,
     req: import("fastify").FastifyRequest<
         import("fastify/types/route").RouteGenericInterface,
-        import("fastify").RawServerDefault,
+        import("http").Server,
         import("http").IncomingMessage
     >,
     res: import("fastify").FastifyReply<
-        import("fastify").RawServerDefault,
+        import("http").Server,
         import("http").IncomingMessage,
-        import("http").ServerResponse<import("http").IncomingMessage>,
+        import("http").ServerResponse,
         import("fastify/types/route").RouteGenericInterface,
         unknown
     >

--- a/lib/build/framework/utils.d.ts
+++ b/lib/build/framework/utils.d.ts
@@ -47,7 +47,7 @@ export declare function setCookieForServerResponse(
     expires: number,
     path: string,
     sameSite: "strict" | "lax" | "none"
-): ServerResponse<IncomingMessage>;
+): ServerResponse;
 export declare function getCookieValueToSetInHeader(
     prev: string | string[] | undefined,
     val: string | string[],

--- a/lib/build/recipe/dashboard/api/apiKeyProtector.js
+++ b/lib/build/recipe/dashboard/api/apiKeyProtector.js
@@ -30,6 +30,11 @@ var __awaiter =
             step((generator = generator.apply(thisArg, _arguments || [])).next());
         });
     };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 /* Copyright (c) 2022, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -45,15 +50,28 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+const error_1 = __importDefault(require("../error"));
 const utils_1 = require("../../../utils");
 const utils_2 = require("../utils");
 function apiKeyProtector(apiImplementation, options, apiFunction) {
     return __awaiter(this, void 0, void 0, function* () {
-        const shouldAllowAccess = yield options.recipeImplementation.shouldAllowAccess({
-            req: options.req,
-            config: options.config,
-            userContext: utils_1.makeDefaultUserContextFromAPI(options.req),
-        });
+        let shouldAllowAccess = false;
+        try {
+            shouldAllowAccess = yield options.recipeImplementation.shouldAllowAccess({
+                req: options.req,
+                config: options.config,
+                userContext: utils_1.makeDefaultUserContextFromAPI(options.req),
+            });
+        } catch (e) {
+            if (error_1.default.isErrorFromSuperTokens(e) && e.type === error_1.default.OPERATION_NOT_ALLOWED) {
+                options.res.setStatusCode(403);
+                options.res.sendJSONResponse({
+                    message: e.message,
+                });
+                return true;
+            }
+            throw e;
+        }
         if (!shouldAllowAccess) {
             utils_2.sendUnauthorisedAccess(options.res);
             return true;

--- a/lib/build/recipe/dashboard/error.d.ts
+++ b/lib/build/recipe/dashboard/error.d.ts
@@ -1,0 +1,6 @@
+// @ts-nocheck
+import STError from "../../error";
+export default class DashboardError extends STError {
+    static OPERATION_NOT_ALLOWED: "OPERATION_NOT_ALLOWED";
+    constructor(message?: string);
+}

--- a/lib/build/recipe/dashboard/error.js
+++ b/lib/build/recipe/dashboard/error.js
@@ -1,0 +1,32 @@
+"use strict";
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
+Object.defineProperty(exports, "__esModule", { value: true });
+/* Copyright (c) 2022, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+const error_1 = __importDefault(require("../../error"));
+class DashboardError extends error_1.default {
+    constructor(message) {
+        super({
+            message: message !== undefined ? message : "You are not permitted to perform this operation",
+            type: DashboardError.OPERATION_NOT_ALLOWED,
+        });
+    }
+}
+exports.default = DashboardError;
+DashboardError.OPERATION_NOT_ALLOWED = "OPERATION_NOT_ALLOWED";

--- a/lib/build/recipe/dashboard/recipeImplementation.js
+++ b/lib/build/recipe/dashboard/recipeImplementation.js
@@ -54,6 +54,8 @@ const normalisedURLPath_1 = __importDefault(require("../../normalisedURLPath"));
 const querier_1 = require("../../querier");
 const version_1 = require("../../version");
 const utils_1 = require("./utils");
+const error_1 = __importDefault(require("./error"));
+const logger_1 = require("../../logger");
 function getRecipeImplementation() {
     return {
         getDashboardBundleLocation: function () {
@@ -78,7 +80,31 @@ function getRecipeImplementation() {
                             sessionId: authHeaderValue,
                         }
                     );
-                    return sessionVerificationResponse.status === "OK";
+                    if (sessionVerificationResponse.status !== "OK") {
+                        return false;
+                    }
+                    // For all non GET requests we also want to check if the user is allowed to perform this operation
+                    if (input.req.getMethod() !== "get") {
+                        const admins = input.config.admins;
+                        // If the user has provided no admins, allow
+                        if (admins.length === 0) {
+                            return true;
+                        }
+                        const emailFromResponse = sessionVerificationResponse.email;
+                        // This is possible if they are using an older core, in which case we log and fail
+                        if (emailFromResponse === undefined) {
+                            // TODO NEMI: Should we provide a minimum supported version here?
+                            logger_1.logDebugMessage(
+                                "User Dashboard: You are using an older version of SuperTokens core, to use the 'admins' property when initialising the Dashboard recipe please upgrade to the latest SuperTokens core version."
+                            );
+                            throw new error_1.default();
+                        }
+                        // Allow only if the email is present in the admin list
+                        if (!admins.includes(emailFromResponse)) {
+                            throw new error_1.default();
+                        }
+                    }
+                    return true;
                 }
                 return yield utils_1.validateApiKey(input);
             });

--- a/lib/build/recipe/dashboard/recipeImplementation.js
+++ b/lib/build/recipe/dashboard/recipeImplementation.js
@@ -81,7 +81,6 @@ function getRecipeImplementation() {
                             sessionId: authHeaderValue,
                         }
                     );
-                    console.log(sessionVerificationResponse);
                     if (sessionVerificationResponse.status !== "OK") {
                         return false;
                     }

--- a/lib/build/recipe/dashboard/recipeImplementation.js
+++ b/lib/build/recipe/dashboard/recipeImplementation.js
@@ -56,6 +56,7 @@ const version_1 = require("../../version");
 const utils_1 = require("./utils");
 const error_1 = __importDefault(require("./error"));
 const logger_1 = require("../../logger");
+const constants_1 = require("./constants");
 function getRecipeImplementation() {
     return {
         getDashboardBundleLocation: function () {
@@ -80,11 +81,16 @@ function getRecipeImplementation() {
                             sessionId: authHeaderValue,
                         }
                     );
+                    console.log(sessionVerificationResponse);
                     if (sessionVerificationResponse.status !== "OK") {
                         return false;
                     }
                     // For all non GET requests we also want to check if the user is allowed to perform this operation
                     if (input.req.getMethod() !== "get") {
+                        // We dont want to block the analytics API
+                        if (input.req.getOriginalURL().endsWith(constants_1.DASHBOARD_ANALYTICS_API)) {
+                            return true;
+                        }
                         const admins = input.config.admins;
                         // If the user has provided no admins, allow
                         if (admins.length === 0) {

--- a/lib/build/recipe/dashboard/recipeImplementation.js
+++ b/lib/build/recipe/dashboard/recipeImplementation.js
@@ -57,6 +57,7 @@ const utils_1 = require("./utils");
 const error_1 = __importDefault(require("./error"));
 const logger_1 = require("../../logger");
 const constants_1 = require("./constants");
+const utils_2 = require("../../utils");
 function getRecipeImplementation() {
     return {
         getDashboardBundleLocation: function () {
@@ -85,7 +86,7 @@ function getRecipeImplementation() {
                         return false;
                     }
                     // For all non GET requests we also want to check if the user is allowed to perform this operation
-                    if (input.req.getMethod() !== "get") {
+                    if (utils_2.normaliseHttpMethod(input.req.getMethod()) !== "get") {
                         // We dont want to block the analytics API
                         if (input.req.getOriginalURL().endsWith(constants_1.DASHBOARD_ANALYTICS_API)) {
                             return true;
@@ -98,9 +99,8 @@ function getRecipeImplementation() {
                         const emailFromResponse = sessionVerificationResponse.email;
                         // This is possible if they are using an older core, in which case we log and fail
                         if (emailFromResponse === undefined) {
-                            // TODO NEMI: Should we provide a minimum supported version here?
                             logger_1.logDebugMessage(
-                                "User Dashboard: You are using an older version of SuperTokens core, to use the 'admins' property when initialising the Dashboard recipe please upgrade to the latest SuperTokens core version."
+                                "User Dashboard: You are using an older version of SuperTokens core, to use the 'admins' property when initialising the Dashboard recipe please upgrade to a core version that is >= 6.0"
                             );
                             throw new error_1.default();
                         }

--- a/lib/build/recipe/dashboard/types.d.ts
+++ b/lib/build/recipe/dashboard/types.d.ts
@@ -4,6 +4,7 @@ import { BaseRequest, BaseResponse } from "../../framework";
 import { NormalisedAppinfo } from "../../types";
 export declare type TypeInput = {
     apiKey?: string;
+    admins?: string[];
     override?: {
         functions?: (
             originalImplementation: RecipeInterface,
@@ -14,6 +15,7 @@ export declare type TypeInput = {
 };
 export declare type TypeNormalisedInput = {
     apiKey?: string;
+    admins: string[];
     authMode: AuthMode;
     override: {
         functions: (

--- a/lib/build/recipe/dashboard/utils.js
+++ b/lib/build/recipe/dashboard/utils.js
@@ -81,7 +81,7 @@ function validateAndNormaliseUserInput(config) {
     }
     let admins = [];
     if ((config === null || config === void 0 ? void 0 : config.admins) !== undefined) {
-        admins = config.admins;
+        admins = config.admins.map((email) => utils_1.normaliseEmail(email));
     }
     return Object.assign(Object.assign({}, config), {
         override,

--- a/lib/build/recipe/dashboard/utils.js
+++ b/lib/build/recipe/dashboard/utils.js
@@ -64,6 +64,7 @@ const thirdpartyemailpassword_1 = __importDefault(require("../thirdpartyemailpas
 const recipe_4 = __importDefault(require("../thirdpartyemailpassword/recipe"));
 const thirdpartypasswordless_1 = __importDefault(require("../thirdpartypasswordless"));
 const recipe_5 = __importDefault(require("../thirdpartypasswordless/recipe"));
+const logger_1 = require("../../logger");
 function validateAndNormaliseUserInput(config) {
     let override = Object.assign(
         {
@@ -72,9 +73,20 @@ function validateAndNormaliseUserInput(config) {
         },
         config === undefined ? {} : config.override
     );
+    if (
+        (config === null || config === void 0 ? void 0 : config.apiKey) !== undefined &&
+        (config === null || config === void 0 ? void 0 : config.admins) !== undefined
+    ) {
+        logger_1.logDebugMessage("User Dashboard: Providing 'admins' has no effect when using an apiKey.");
+    }
+    let admins = [];
+    if ((config === null || config === void 0 ? void 0 : config.admins) !== undefined) {
+        admins = config.admins;
+    }
     return Object.assign(Object.assign({}, config), {
         override,
         authMode: config !== undefined && config.apiKey ? "api-key" : "email-password",
+        admins,
     });
 }
 exports.validateAndNormaliseUserInput = validateAndNormaliseUserInput;

--- a/lib/build/utils.d.ts
+++ b/lib/build/utils.d.ts
@@ -16,3 +16,4 @@ export declare function makeDefaultUserContextFromAPI(request: BaseRequest): any
 export declare function setRequestInUserContextIfNotDefined(userContext: any | undefined, request: BaseRequest): any;
 export declare function getTopLevelDomainForSameSiteResolution(url: string): string;
 export declare function getFromObjectCaseInsensitive<T>(key: string, object: Record<string, T>): T | undefined;
+export declare function normaliseEmail(email: string): string;

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -41,7 +41,7 @@ var __importDefault =
         return mod && mod.__esModule ? mod : { default: mod };
     };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getFromObjectCaseInsensitive = exports.getTopLevelDomainForSameSiteResolution = exports.setRequestInUserContextIfNotDefined = exports.makeDefaultUserContextFromAPI = exports.humaniseMilliseconds = exports.frontendHasInterceptor = exports.getRidFromHeader = exports.isAnIpAddress = exports.send200Response = exports.sendNon200Response = exports.sendNon200ResponseWithMessage = exports.normaliseHttpMethod = exports.normaliseInputAppInfoOrThrowError = exports.maxVersion = exports.getLargestVersionFromIntersection = void 0;
+exports.normaliseEmail = exports.getFromObjectCaseInsensitive = exports.getTopLevelDomainForSameSiteResolution = exports.setRequestInUserContextIfNotDefined = exports.makeDefaultUserContextFromAPI = exports.humaniseMilliseconds = exports.frontendHasInterceptor = exports.getRidFromHeader = exports.isAnIpAddress = exports.send200Response = exports.sendNon200Response = exports.sendNon200ResponseWithMessage = exports.normaliseHttpMethod = exports.normaliseInputAppInfoOrThrowError = exports.maxVersion = exports.getLargestVersionFromIntersection = void 0;
 const psl = __importStar(require("psl"));
 const normalisedURLDomain_1 = __importDefault(require("./normalisedURLDomain"));
 const normalisedURLPath_1 = __importDefault(require("./normalisedURLPath"));
@@ -211,3 +211,9 @@ function getFromObjectCaseInsensitive(key, object) {
     return object[matchedKeys[0]];
 }
 exports.getFromObjectCaseInsensitive = getFromObjectCaseInsensitive;
+function normaliseEmail(email) {
+    email = email.trim();
+    email = email.toLowerCase();
+    return email;
+}
+exports.normaliseEmail = normaliseEmail;

--- a/lib/ts/recipe/dashboard/api/apiKeyProtector.ts
+++ b/lib/ts/recipe/dashboard/api/apiKeyProtector.ts
@@ -12,6 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+import RecipeError from "../error";
 import { makeDefaultUserContextFromAPI } from "../../../utils";
 import { APIFunction, APIInterface, APIOptions } from "../types";
 import { sendUnauthorisedAccess } from "../utils";
@@ -21,11 +22,25 @@ export default async function apiKeyProtector(
     options: APIOptions,
     apiFunction: APIFunction
 ): Promise<boolean> {
-    const shouldAllowAccess = await options.recipeImplementation.shouldAllowAccess({
-        req: options.req,
-        config: options.config,
-        userContext: makeDefaultUserContextFromAPI(options.req),
-    });
+    let shouldAllowAccess = false;
+
+    try {
+        shouldAllowAccess = await options.recipeImplementation.shouldAllowAccess({
+            req: options.req,
+            config: options.config,
+            userContext: makeDefaultUserContextFromAPI(options.req),
+        });
+    } catch (e) {
+        if (RecipeError.isErrorFromSuperTokens(e) && e.type === RecipeError.OPERATION_NOT_ALLOWED) {
+            options.res.setStatusCode(403);
+            options.res.sendJSONResponse({
+                message: e.message,
+            });
+            return true;
+        }
+
+        throw e;
+    }
 
     if (!shouldAllowAccess) {
         sendUnauthorisedAccess(options.res);

--- a/lib/ts/recipe/dashboard/error.ts
+++ b/lib/ts/recipe/dashboard/error.ts
@@ -1,0 +1,26 @@
+/* Copyright (c) 2022, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+import STError from "../../error";
+
+export default class DashboardError extends STError {
+    static OPERATION_NOT_ALLOWED: "OPERATION_NOT_ALLOWED" = "OPERATION_NOT_ALLOWED";
+
+    constructor(message?: string) {
+        super({
+            message: message !== undefined ? message : "You are not permitted to perform this operation",
+            type: DashboardError.OPERATION_NOT_ALLOWED,
+        });
+    }
+}

--- a/lib/ts/recipe/dashboard/recipeImplementation.ts
+++ b/lib/ts/recipe/dashboard/recipeImplementation.ts
@@ -40,7 +40,6 @@ export default function getRecipeImplementation(): RecipeInterface {
                     }
                 );
 
-                console.log(sessionVerificationResponse);
                 if (sessionVerificationResponse.status !== "OK") {
                     return false;
                 }

--- a/lib/ts/recipe/dashboard/recipeImplementation.ts
+++ b/lib/ts/recipe/dashboard/recipeImplementation.ts
@@ -20,6 +20,7 @@ import { RecipeInterface } from "./types";
 import { validateApiKey } from "./utils";
 import RecipeError from "./error";
 import { logDebugMessage } from "../../logger";
+import { DASHBOARD_ANALYTICS_API } from "./constants";
 
 export default function getRecipeImplementation(): RecipeInterface {
     return {
@@ -39,12 +40,18 @@ export default function getRecipeImplementation(): RecipeInterface {
                     }
                 );
 
+                console.log(sessionVerificationResponse);
                 if (sessionVerificationResponse.status !== "OK") {
                     return false;
                 }
 
                 // For all non GET requests we also want to check if the user is allowed to perform this operation
                 if (input.req.getMethod() !== "get") {
+                    // We dont want to block the analytics API
+                    if (input.req.getOriginalURL().endsWith(DASHBOARD_ANALYTICS_API)) {
+                        return true;
+                    }
+
                     const admins = input.config.admins;
 
                     // If the user has provided no admins, allow

--- a/lib/ts/recipe/dashboard/recipeImplementation.ts
+++ b/lib/ts/recipe/dashboard/recipeImplementation.ts
@@ -21,6 +21,7 @@ import { validateApiKey } from "./utils";
 import RecipeError from "./error";
 import { logDebugMessage } from "../../logger";
 import { DASHBOARD_ANALYTICS_API } from "./constants";
+import { normaliseHttpMethod } from "../../utils";
 
 export default function getRecipeImplementation(): RecipeInterface {
     return {
@@ -45,7 +46,7 @@ export default function getRecipeImplementation(): RecipeInterface {
                 }
 
                 // For all non GET requests we also want to check if the user is allowed to perform this operation
-                if (input.req.getMethod() !== "get") {
+                if (normaliseHttpMethod(input.req.getMethod()) !== "get") {
                     // We dont want to block the analytics API
                     if (input.req.getOriginalURL().endsWith(DASHBOARD_ANALYTICS_API)) {
                         return true;
@@ -62,9 +63,8 @@ export default function getRecipeImplementation(): RecipeInterface {
 
                     // This is possible if they are using an older core, in which case we log and fail
                     if (emailFromResponse === undefined) {
-                        // TODO NEMI: Should we provide a minimum supported version here?
                         logDebugMessage(
-                            "User Dashboard: You are using an older version of SuperTokens core, to use the 'admins' property when initialising the Dashboard recipe please upgrade to the latest SuperTokens core version."
+                            "User Dashboard: You are using an older version of SuperTokens core, to use the 'admins' property when initialising the Dashboard recipe please upgrade to a core version that is >= 6.0"
                         );
                         throw new RecipeError();
                     }

--- a/lib/ts/recipe/dashboard/recipeImplementation.ts
+++ b/lib/ts/recipe/dashboard/recipeImplementation.ts
@@ -18,6 +18,8 @@ import { Querier } from "../../querier";
 import { dashboardVersion } from "../../version";
 import { RecipeInterface } from "./types";
 import { validateApiKey } from "./utils";
+import RecipeError from "./error";
+import { logDebugMessage } from "../../logger";
 
 export default function getRecipeImplementation(): RecipeInterface {
     return {
@@ -36,7 +38,38 @@ export default function getRecipeImplementation(): RecipeInterface {
                         sessionId: authHeaderValue,
                     }
                 );
-                return sessionVerificationResponse.status === "OK";
+
+                if (sessionVerificationResponse.status !== "OK") {
+                    return false;
+                }
+
+                // For all non GET requests we also want to check if the user is allowed to perform this operation
+                if (input.req.getMethod() !== "get") {
+                    const admins = input.config.admins;
+
+                    // If the user has provided no admins, allow
+                    if (admins.length === 0) {
+                        return true;
+                    }
+
+                    const emailFromResponse = sessionVerificationResponse.email;
+
+                    // This is possible if they are using an older core, in which case we log and fail
+                    if (emailFromResponse === undefined) {
+                        // TODO NEMI: Should we provide a minimum supported version here?
+                        logDebugMessage(
+                            "User Dashboard: You are using an older version of SuperTokens core, to use the 'admins' property when initialising the Dashboard recipe please upgrade to the latest SuperTokens core version."
+                        );
+                        throw new RecipeError();
+                    }
+
+                    // Allow only if the email is present in the admin list
+                    if (!admins.includes(emailFromResponse)) {
+                        throw new RecipeError();
+                    }
+                }
+
+                return true;
             }
             return await validateApiKey(input);
         },

--- a/lib/ts/recipe/dashboard/types.ts
+++ b/lib/ts/recipe/dashboard/types.ts
@@ -19,6 +19,7 @@ import { NormalisedAppinfo } from "../../types";
 
 export type TypeInput = {
     apiKey?: string;
+    admins?: string[];
     override?: {
         functions?: (
             originalImplementation: RecipeInterface,
@@ -30,6 +31,7 @@ export type TypeInput = {
 
 export type TypeNormalisedInput = {
     apiKey?: string;
+    admins: string[];
     authMode: AuthMode;
     override: {
         functions: (

--- a/lib/ts/recipe/dashboard/utils.ts
+++ b/lib/ts/recipe/dashboard/utils.ts
@@ -53,6 +53,7 @@ import ThirdPartyEmailPassword from "../thirdpartyemailpassword";
 import ThirdPartyEmailPasswordRecipe from "../thirdpartyemailpassword/recipe";
 import ThirdPartyPasswordless from "../thirdpartypasswordless";
 import ThirdPartyPasswordlessRecipe from "../thirdpartypasswordless/recipe";
+import { logDebugMessage } from "../../logger";
 
 export function validateAndNormaliseUserInput(config?: TypeInput): TypeNormalisedInput {
     let override = {
@@ -61,10 +62,21 @@ export function validateAndNormaliseUserInput(config?: TypeInput): TypeNormalise
         ...(config === undefined ? {} : config.override),
     };
 
+    if (config?.apiKey !== undefined && config?.admins !== undefined) {
+        logDebugMessage("User Dashboard: Providing 'admins' has no effect when using an apiKey.");
+    }
+
+    let admins: string[] = [];
+
+    if (config?.admins !== undefined) {
+        admins = config.admins;
+    }
+
     return {
         ...config,
         override,
         authMode: config !== undefined && config.apiKey ? "api-key" : "email-password",
+        admins,
     };
 }
 

--- a/lib/ts/recipe/dashboard/utils.ts
+++ b/lib/ts/recipe/dashboard/utils.ts
@@ -16,7 +16,7 @@
 import { BaseRequest, BaseResponse } from "../../framework";
 import NormalisedURLPath from "../../normalisedURLPath";
 import { HTTPMethod, NormalisedAppinfo } from "../../types";
-import { sendNon200ResponseWithMessage } from "../../utils";
+import { normaliseEmail, sendNon200ResponseWithMessage } from "../../utils";
 import {
     DASHBOARD_API,
     SEARCH_TAGS_API,
@@ -69,7 +69,7 @@ export function validateAndNormaliseUserInput(config?: TypeInput): TypeNormalise
     let admins: string[] = [];
 
     if (config?.admins !== undefined) {
-        admins = config.admins;
+        admins = config.admins.map((email) => normaliseEmail(email));
     }
 
     return {

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -178,3 +178,10 @@ export function getFromObjectCaseInsensitive<T>(key: string, object: Record<stri
 
     return object[matchedKeys[0]];
 }
+
+export function normaliseEmail(email: string): string {
+    email = email.trim();
+    email = email.toLowerCase();
+
+    return email;
+}


### PR DESCRIPTION
## Summary of change

- Adds a new `admins` property to Dashboard init. This is a string array used to set the emails of the dashboard users that can perform write operations
- Changes the logic of session verification in the Dashboard APIs to return a 403 if the user's email is not present in the admins list (For non-GET APIs only). Note that we make an exception for the analytics POST API
- Changes the logic of shouldAllowAccess to throw a custom error if the user is not allowed to perform the action

## Related issues

- ...

## Test Plan

## Documentation changes

WIP

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] ...
