### PR TITLE
feat: add initial interface for oauth2 recipe

### DIFF
--- a/lib/build/recipe/oauth2/types.d.ts
+++ b/lib/build/recipe/oauth2/types.d.ts
@@ -2,6 +2,7 @@
 import { BaseRequest, BaseResponse } from "../../framework";
 import OverrideableBuilder from "supertokens-js-override";
 import { GeneralErrorResponse, JSONObject } from "../../types";
+import { SessionContainer } from "../session";
 export declare type TypeInput = {
     override?: {
         functions?: (
@@ -28,11 +29,17 @@ export declare type APIOptions = {
     req: BaseRequest;
     res: BaseResponse;
 };
-export declare type RecipeInterface = {
-    tokensPOST(input: {
-        payload?: any;
-        validitySeconds?: number;
-        useStaticSigningKey?: boolean;
+export declare type APIInterface = {
+    tokenPOST(input: {
+        clientId: string;
+        grantType: GrantType;
+        clientSecret?: string;
+        code?: string;
+        codeVerifier?: string;
+        refreshToken?: string;
+        redirectUri?: string;
+        scope: string[];
+        options: APIOptions;
         userContext: any;
     }): Promise<
         | {
@@ -46,76 +53,177 @@ export declare type RecipeInterface = {
     >;
     authorizeGET(input: {
         clientId: string;
-        responseType: string;
-        redirectUri?: string;
-        scopes: string[];
+        responseType: ResponseType[];
+        redirectUri: string;
+        scope: string[];
         state?: string;
         codeChallenge?: string;
-        codeChallengeMethod?: string;
-        prompt?: string;
+        codeChallengeMethod?: CodeChallengeMethod;
+        prompt?: OAuthPromptType;
         nonce?: string;
-        acr_values?: string;
-        maxAge?: number;
-        options: APIOptions;
-        userContext: any;
-    }): Promise<{
-        redirectUrl: string;
-    }>;
-    authorizePOST(input: {
-        clientId: string;
-        responseType: string;
-        redirectUri?: string;
-        scopes: string[];
-        state?: string;
-        codeChallenge?: string;
-        codeChallengeMethod?: string;
-        prompt?: string;
-        nonce?: string;
-        acr_values?: string;
-        maxAge?: number;
-        options: APIOptions;
-        userContext: any;
-    }): Promise<{
-        redirectUrl: string;
-    }>;
-    getRedirectUrlPOST(input: {
-        clientId: string;
-        responseType: string;
-        redirectUri?: string;
-        scopes: string[];
-        state?: string;
-        codeChallenge?: string;
-        codeChallengeMethod?: string;
-        prompt?: string;
-        nonce?: string;
-        acr_values?: string;
-        maxAge?: number;
+        session?: SessionContainer;
         options: APIOptions;
         userContext: any;
     }): Promise<
         | {
-              status: "OK";
+              redirectUrl: string;
+          }
+        | GeneralErrorResponse
+    >;
+    authorizePOST(input: {
+        clientId: string;
+        responseType: ResponseType[];
+        redirectUri: string;
+        scope: string[];
+        state?: string;
+        codeChallenge?: string;
+        codeChallengeMethod?: CodeChallengeMethod;
+        prompt?: OAuthPromptType;
+        nonce?: string;
+        session?: SessionContainer;
+        options: APIOptions;
+        userContext: any;
+    }): Promise<
+        | {
               redirectUrl: string;
           }
         | GeneralErrorResponse
     >;
     userInfoGET(input: {
+        oauth2AccessToken: string;
         options: APIOptions;
         userContext: any;
-    }): Promise<{
-        status: "OK";
-        sub: string;
-        email?: string;
-        email_verified?: boolean;
-        phoneNumber?: string;
-    }>;
+    }): Promise<
+        | JSONObject
+        | {
+              status: "UNAUTHORISED";
+              message: string;
+          }
+    >;
 };
-export declare type APIInterface = {
+export declare type RecipeInterface = {
+    getUserInfo(input: { oauth2AccessToken: string; userContext: any }): Promise<JSONObject>;
+    createAuthCode(input: {
+        clientId: string;
+        responseType: ResponseType;
+        redirectUri?: string;
+        scopes: string[];
+        codeChallenge?: string;
+        codeChallengeMethod?: CodeChallengeMethod;
+        prompt?: OAuthPromptType;
+        nonce?: string;
+        allQueryParams: string;
+        session: SessionContainer;
+        userContext: any;
+    }): Promise<
+        | {
+              status: "OK";
+              code?: string;
+              idToken?: string;
+          }
+        | {
+              status: "CLIENT_ERROR";
+              error: AuthorizationErrorCode;
+              errorDescription: string;
+              errorURI: string;
+          }
+        | {
+              status: "AUTH_ERROR";
+              error: string;
+          }
+    >;
+    createTokens(
+        input:
+            | {
+                  clientId: string;
+                  grantType: "authorization_code";
+                  clientSecret?: string;
+                  code?: string;
+                  codeVerifier?: string;
+                  redirectUri: string;
+                  scope?: string[];
+                  allQueryParams: string;
+                  userContext: any;
+              }
+            | {
+                  clientId: string;
+                  grantType: "client_credentials";
+                  clientSecret: string;
+                  scope?: string[];
+                  userContext: any;
+              }
+            | {
+                  clientId: string;
+                  grantType: "refresh_token";
+                  clientSecret?: string;
+                  refreshToken?: string;
+                  scope?: string[];
+                  userContext: any;
+              }
+    ): Promise<
+        | {
+              status: "OK";
+              tokenType: "Bearer";
+              accessToken: string;
+              refreshToken?: string;
+              idToken?: string;
+              expiresIn: number;
+          }
+        | {
+              status: "CLIENT_ERROR";
+              error: TokensErrorCode;
+          }
+    >;
+    verifyAccessToken(input: {
+        clientId: string;
+        accessToken: string;
+    }): Promise<{
+        sessionHandle?: string;
+        scopes: string[];
+        timeCreated: number;
+        lastUpdated: number;
+        timeAccessTokenExpires: number;
+        timeRefreshTokenExpires?: number;
+    }>;
+    getTokenInfo(input: {
+        clientId: string;
+        refreshToken?: string;
+        authCode?: string;
+    }): Promise<{
+        sessionHandle?: string;
+        scopes: string[];
+        timeCreated: number;
+        lastUpdated: number;
+        timeAccessTokenExpires: number;
+        timeRefreshTokenExpires?: number;
+    }>;
+    revokeToken(
+        input:
+            | {
+                  clientId: string;
+              }
+            | {
+                  sessionHandle: string;
+              }
+            | {
+                  accessToken: string;
+              }
+    ): Promise<void>;
+    revokeAuthCodes(
+        input:
+            | {
+                  clientId: string;
+              }
+            | {
+                  sessionHandle: string;
+              }
+    ): Promise<void>;
     buildAccessToken(input: {
         clientId: string;
         userId?: string;
         sessionHandle?: string;
         scopes: string[];
+        userContext: any;
     }): Promise<{
         payload?: JSONObject;
         lifetimeInSecs?: number;
@@ -125,31 +233,55 @@ export declare type APIInterface = {
         userId?: string;
         sessionHandle?: string;
         scopes: string[];
+        userContext: any;
     }): Promise<{
         payload?: JSONObject;
         lifetimeInSecs?: number;
     }>;
     getRefreshTokenLifetime(): Promise<number | undefined>;
-    buildAuthorizeRedirectUrl(input: {
-        clientId: string;
-        redirectUri: string;
-        error?: string;
-        code?: string;
-        idToken?: string;
-    }): Promise<string>;
     validateScopes(input: {
         clientId: string;
         userId?: string;
         sessionHandle?: string;
         scopes: string[];
+        userContext: any;
     }): Promise<
         | {
               status: "OK";
               grantedScopes: string[];
           }
         | {
-              status: "SCOPE_ERROR";
+              status: "INVALID_SCOPE_ERROR";
+              message: string;
+          }
+        | {
+              status: "ACCESS_DENIED_ERROR";
               message: string;
           }
     >;
+    shouldIssueRefreshToken(input: {
+        clientId: string;
+        userId?: string;
+        sessionHandle?: string;
+        scopes: string[];
+        userContext: any;
+    }): Promise<boolean>;
 };
+export declare type ResponseType = "code" | "id_token" | "token";
+export declare type CodeChallengeMethod = "S256";
+export declare type GrantType = "authorization_code" | "client_credentials" | "refresh_token" | "password";
+export declare type OAuthPromptType = "none" | "login" | "consent" | "select_account";
+export declare type AuthorizationErrorCode =
+    | "invalid_request"
+    | "unauthorized_client"
+    | "access_denied"
+    | "unsupported_response_type"
+    | "invalid_scope"
+    | "server_error"
+    | "temporarily_unavailable";
+export declare type TokensErrorCode =
+    | "invalid_request"
+    | "invalid_client"
+    | "invalid_grant"
+    | "unsupported_grant_type"
+    | "invalid_scope";

--- a/lib/build/recipe/oauth2/types.d.ts
+++ b/lib/build/recipe/oauth2/types.d.ts
@@ -1,0 +1,155 @@
+// @ts-nocheck
+import { BaseRequest, BaseResponse } from "../../framework";
+import OverrideableBuilder from "supertokens-js-override";
+import { GeneralErrorResponse, JSONObject } from "../../types";
+export declare type TypeInput = {
+    override?: {
+        functions?: (
+            originalImplementation: RecipeInterface,
+            builder?: OverrideableBuilder<RecipeInterface>
+        ) => RecipeInterface;
+        apis?: (originalImplementation: APIInterface, builder?: OverrideableBuilder<APIInterface>) => APIInterface;
+    };
+};
+export declare type TypeNormalisedInput = {
+    override: {
+        functions: (
+            originalImplementation: RecipeInterface,
+            builder?: OverrideableBuilder<RecipeInterface>
+        ) => RecipeInterface;
+        apis: (originalImplementation: APIInterface, builder?: OverrideableBuilder<APIInterface>) => APIInterface;
+    };
+};
+export declare type APIOptions = {
+    recipeImplementation: RecipeInterface;
+    config: TypeNormalisedInput;
+    recipeId: string;
+    isInServerlessEnv: boolean;
+    req: BaseRequest;
+    res: BaseResponse;
+};
+export declare type RecipeInterface = {
+    tokensPOST(input: {
+        payload?: any;
+        validitySeconds?: number;
+        useStaticSigningKey?: boolean;
+        userContext: any;
+    }): Promise<
+        | {
+              token_type: "Bearer";
+              access_token: string;
+              refresh_token?: string;
+              id_token?: string;
+              expires_in: number;
+          }
+        | GeneralErrorResponse
+    >;
+    authorizeGET(input: {
+        clientId: string;
+        responseType: string;
+        redirectUri?: string;
+        scopes: string[];
+        state?: string;
+        codeChallenge?: string;
+        codeChallengeMethod?: string;
+        prompt?: string;
+        nonce?: string;
+        acr_values?: string;
+        maxAge?: number;
+        options: APIOptions;
+        userContext: any;
+    }): Promise<{
+        redirectUrl: string;
+    }>;
+    authorizePOST(input: {
+        clientId: string;
+        responseType: string;
+        redirectUri?: string;
+        scopes: string[];
+        state?: string;
+        codeChallenge?: string;
+        codeChallengeMethod?: string;
+        prompt?: string;
+        nonce?: string;
+        acr_values?: string;
+        maxAge?: number;
+        options: APIOptions;
+        userContext: any;
+    }): Promise<{
+        redirectUrl: string;
+    }>;
+    getRedirectUrlPOST(input: {
+        clientId: string;
+        responseType: string;
+        redirectUri?: string;
+        scopes: string[];
+        state?: string;
+        codeChallenge?: string;
+        codeChallengeMethod?: string;
+        prompt?: string;
+        nonce?: string;
+        acr_values?: string;
+        maxAge?: number;
+        options: APIOptions;
+        userContext: any;
+    }): Promise<
+        | {
+              status: "OK";
+              redirectUrl: string;
+          }
+        | GeneralErrorResponse
+    >;
+    userInfoGET(input: {
+        options: APIOptions;
+        userContext: any;
+    }): Promise<{
+        status: "OK";
+        sub: string;
+        email?: string;
+        email_verified?: boolean;
+        phoneNumber?: string;
+    }>;
+};
+export declare type APIInterface = {
+    buildAccessToken(input: {
+        clientId: string;
+        userId?: string;
+        sessionHandle?: string;
+        scopes: string[];
+    }): Promise<{
+        payload?: JSONObject;
+        lifetimeInSecs?: number;
+    }>;
+    buildIdToken(input: {
+        clientId: string;
+        userId?: string;
+        sessionHandle?: string;
+        scopes: string[];
+    }): Promise<{
+        payload?: JSONObject;
+        lifetimeInSecs?: number;
+    }>;
+    getRefreshTokenLifetime(): Promise<number | undefined>;
+    buildAuthorizeRedirectUrl(input: {
+        clientId: string;
+        redirectUri: string;
+        error?: string;
+        code?: string;
+        idToken?: string;
+    }): Promise<string>;
+    validateScopes(input: {
+        clientId: string;
+        userId?: string;
+        sessionHandle?: string;
+        scopes: string[];
+    }): Promise<
+        | {
+              status: "OK";
+              grantedScopes: string[];
+          }
+        | {
+              status: "SCOPE_ERROR";
+              message: string;
+          }
+    >;
+};

--- a/lib/build/recipe/oauth2/types.js
+++ b/lib/build/recipe/oauth2/types.js
@@ -1,0 +1,16 @@
+"use strict";
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/lib/ts/recipe/oauth2/types.ts
+++ b/lib/ts/recipe/oauth2/types.ts
@@ -90,9 +90,12 @@ export type APIInterface = {
 
         options: APIOptions;
         userContext: any;
-    }): Promise<{
-        redirectUrl: string; // This will end up as a 302, encoding both error and success
-    }>;
+    }): Promise<
+        | {
+              redirectUrl: string; // This will end up as a 302, encoding both error and success
+          }
+        | GeneralErrorResponse
+    >;
     authorizePOST(input: {
         clientId: string;
         responseType: ResponseType[]; // add enum
@@ -112,11 +115,18 @@ export type APIInterface = {
 
         options: APIOptions;
         userContext: any;
-    }): Promise<{
-        redirectUrl: string; // This will end up as a 302, encoding both error and success
-    }>;
+    }): Promise<
+        | {
+              redirectUrl: string; // This will end up as a 302, encoding both error and success
+          }
+        | GeneralErrorResponse
+    >;
 
-    userInfoGET(input: { oauth2AccessToken: string; options: APIOptions; userContext: any }): Promise<JSONObject>;
+    userInfoGET(input: {
+        oauth2AccessToken: string;
+        options: APIOptions;
+        userContext: any;
+    }): Promise<JSONObject | { status: "UNAUTHORISED"; message: string }>;
 };
 
 export type RecipeInterface = {
@@ -256,6 +266,14 @@ export type RecipeInterface = {
         | { status: "INVALID_SCOPE_ERROR"; message: string } // Returning this signifies a client error and should result in a redirection back to the client with the "invalid_scope" error
         | { status: "ACCESS_DENIED_ERROR"; message: string } // This means we need to redirect to the auth frontend (i.e.: there is a claim validation issue we can resolve there)
     >;
+
+    shouldIssueRefreshToken(input: {
+        clientId: string;
+        userId?: string;
+        sessionHandle?: string;
+        scopes: string[];
+        userContext: any;
+    }): Promise<boolean>;
 };
 
 export type ResponseType = "code" | "id_token" | "token"; // We do not support "token", but it's a possible input value.

--- a/lib/ts/recipe/oauth2/types.ts
+++ b/lib/ts/recipe/oauth2/types.ts
@@ -129,7 +129,7 @@ export type RecipeInterface = {
         oauth2AccessToken: string;
 
         userContext: any;
-    }): Promise<JSONObject | { status: "UNAUTHORISED_ERROR" }>;
+    }): Promise<{ status: "OK"; info: JSONObject } | { status: "UNAUTHORISED_ERROR" }>;
 
     createAuthCode(input: {
         clientId: string;

--- a/lib/ts/recipe/oauth2/types.ts
+++ b/lib/ts/recipe/oauth2/types.ts
@@ -16,6 +16,7 @@
 import { BaseRequest, BaseResponse } from "../../framework";
 import OverrideableBuilder from "supertokens-js-override";
 import { GeneralErrorResponse, JSONObject } from "../../types";
+import { SessionContainer } from "../session";
 
 export type TypeInput = {
     override?: {
@@ -46,11 +47,18 @@ export type APIOptions = {
     res: BaseResponse;
 };
 
-export type RecipeInterface = {
-    tokensPOST(input: {
-        payload?: any;
-        validitySeconds?: number;
-        useStaticSigningKey?: boolean;
+export type APIInterface = {
+    tokenPOST(input: {
+        clientId: string;
+        grantType: GrantType;
+        clientSecret?: string;
+        code?: string;
+        codeVerifier?: string;
+        refreshToken?: string;
+        redirectUri?: string;
+        scope: string[];
+
+        options: APIOptions;
         userContext: any;
     }): Promise<
         | {
@@ -65,22 +73,20 @@ export type RecipeInterface = {
     // The OpenId spec states that we have to support both POST and GET
     authorizeGET(input: {
         clientId: string;
-        responseType: string;
-        redirectUri?: string;
-        scopes: string[];
+        responseType: ResponseType[];
+        redirectUri: string;
+        scope: string[];
         state?: string;
 
         // PKCE
         codeChallenge?: string;
-        codeChallengeMethod?: string;
+        codeChallengeMethod?: CodeChallengeMethod;
 
         // OpenIdConnect
-        prompt?: string;
+        prompt?: OAuthPromptType;
         nonce?: string;
 
-        // Not sure if we want to support these
-        acr_values?: string;
-        maxAge?: number;
+        session?: SessionContainer;
 
         options: APIOptions;
         userContext: any;
@@ -89,91 +95,186 @@ export type RecipeInterface = {
     }>;
     authorizePOST(input: {
         clientId: string;
-        responseType: string;
-        redirectUri?: string;
-        scopes: string[];
+        responseType: ResponseType[]; // add enum
+        redirectUri: string;
+        scope: string[];
         state?: string;
 
         // PKCE
         codeChallenge?: string;
-        codeChallengeMethod?: string;
+        codeChallengeMethod?: CodeChallengeMethod;
 
         // OpenIdConnect
-        prompt?: string;
+        prompt?: OAuthPromptType;
         nonce?: string;
 
-        // Not sure if we want to support these
-        acr_values?: string;
-        maxAge?: number;
+        session?: SessionContainer;
 
         options: APIOptions;
         userContext: any;
     }): Promise<{
         redirectUrl: string; // This will end up as a 302, encoding both error and success
     }>;
-    // This is intended to be used when we want to do the redirection in the FE (e.g.: header based auth)
-    getRedirectUrlPOST(input: {
+
+    userInfoGET(input: { oauth2AccessToken: string; options: APIOptions; userContext: any }): Promise<JSONObject>;
+};
+
+export type RecipeInterface = {
+    getUserInfo(input: {
+        oauth2AccessToken: string;
+
+        userContext: any;
+    }): Promise<JSONObject>;
+
+    createAuthCode(input: {
         clientId: string;
-        responseType: string;
+        responseType: ResponseType;
         redirectUri?: string;
         scopes: string[];
-        state?: string;
 
         // PKCE
         codeChallenge?: string;
-        codeChallengeMethod?: string;
+        codeChallengeMethod?: CodeChallengeMethod;
 
         // OpenIdConnect
-        prompt?: string;
+        prompt?: OAuthPromptType;
         nonce?: string;
 
-        // Not sure if we want to support these
-        acr_values?: string;
-        maxAge?: number;
+        allQueryParams: string;
 
-        options: APIOptions;
+        session: SessionContainer;
         userContext: any;
     }): Promise<
+        // State is added into the url on the endpoint level
         | {
               status: "OK";
-              redirectUrl: string;
+              code?: string;
+              idToken?: string;
           }
-        | GeneralErrorResponse
+        | { status: "CLIENT_ERROR"; error: AuthorizationErrorCode; errorDescription: string; errorURI: string } // these are redirected back to the client
+        | { status: "AUTH_ERROR"; error: string } // This gets a redirection to the auth frontend
     >;
 
-    userInfoGET(input: {
-        options: APIOptions;
-        userContext: any;
-    }): Promise<{ status: "OK"; sub: string; email?: string; email_verified?: boolean; phoneNumber?: string }>; // We should define this in a way that doesn't require adding all claims here
-};
+    createTokens(
+        input:
+            | {
+                  clientId: string;
+                  grantType: "authorization_code";
+                  clientSecret?: string;
+                  code?: string;
+                  codeVerifier?: string;
+                  redirectUri: string;
+                  scope?: string[];
 
-export type APIInterface = {
+                  allQueryParams: string;
+
+                  userContext: any;
+              }
+            | {
+                  clientId: string;
+                  grantType: "client_credentials";
+                  clientSecret: string;
+                  scope?: string[];
+
+                  userContext: any;
+              }
+            | {
+                  clientId: string;
+                  grantType: "refresh_token";
+                  clientSecret?: string;
+                  refreshToken?: string;
+                  scope?: string[];
+
+                  userContext: any;
+              }
+    ): Promise<
+        // State is added into the url on the endpoint level
+        | {
+              status: "OK";
+              tokenType: "Bearer";
+              accessToken: string;
+              refreshToken?: string;
+              idToken?: string;
+              expiresIn: number;
+          }
+        | { status: "CLIENT_ERROR"; error: TokensErrorCode } // This results in a 400 with the error code added. The status specifies that this is a client error to be consistent with the createAuthCode
+    >;
+
+    verifyAccessToken(input: {
+        clientId: string;
+        accessToken: string;
+    }): Promise<{
+        sessionHandle?: string;
+        scopes: string[];
+        timeCreated: number;
+        lastUpdated: number;
+        timeAccessTokenExpires: number;
+        timeRefreshTokenExpires?: number;
+    }>;
+
+    getTokenInfo(input: {
+        clientId: string;
+        refreshToken?: string;
+        authCode?: string;
+    }): Promise<{
+        sessionHandle?: string;
+        scopes: string[];
+        timeCreated: number;
+        lastUpdated: number;
+        timeAccessTokenExpires: number;
+        timeRefreshTokenExpires?: number;
+    }>;
+
+    revokeToken(input: { clientId: string } | { sessionHandle: string } | { accessToken: string }): Promise<void>;
+    revokeAuthCodes(input: { clientId: string } | { sessionHandle: string }): Promise<void>;
+
+    // Customization points called by createTokens&createAuthCode
     buildAccessToken(input: {
         clientId: string;
         userId?: string;
         sessionHandle?: string;
         scopes: string[];
+        userContext: any;
     }): Promise<{ payload?: JSONObject; lifetimeInSecs?: number }>; // Returning undefined for these props means we use the default from Core
     buildIdToken(input: {
         clientId: string;
         userId?: string;
         sessionHandle?: string;
         scopes: string[];
+        userContext: any;
     }): Promise<{ payload?: JSONObject; lifetimeInSecs?: number }>; // Returning undefined for these props means we use the defaults from BE SDKs
     getRefreshTokenLifetime(): Promise<number | undefined>; // Returning undefined means we use the default from Core
-
-    buildAuthorizeRedirectUrl(input: {
-        clientId: string;
-        redirectUri: string;
-        error?: string;
-        code?: string;
-        idToken?: string;
-    }): Promise<string>;
 
     validateScopes(input: {
         clientId: string;
         userId?: string;
         sessionHandle?: string;
         scopes: string[];
-    }): Promise<{ status: "OK"; grantedScopes: string[] } | { status: "SCOPE_ERROR"; message: string }>;
+        userContext: any;
+    }): Promise<
+        | { status: "OK"; grantedScopes: string[] }
+        | { status: "INVALID_SCOPE_ERROR"; message: string } // Returning this signifies a client error and should result in a redirection back to the client with the "invalid_scope" error
+        | { status: "ACCESS_DENIED_ERROR"; message: string } // This means we need to redirect to the auth frontend (i.e.: there is a claim validation issue we can resolve there)
+    >;
 };
+
+export type ResponseType = "code" | "id_token" | "token"; // We do not support "token", but it's a possible input value.
+export type CodeChallengeMethod = "S256";
+
+export type GrantType = "authorization_code" | "client_credentials" | "refresh_token" | "password"; // We do not support "password", but it's a possible input value.
+export type OAuthPromptType = "none" | "login" | "consent" | "select_account";
+export type AuthorizationErrorCode =
+    | "invalid_request"
+    | "unauthorized_client"
+    | "access_denied"
+    | "unsupported_response_type"
+    | "invalid_scope"
+    | "server_error"
+    | "temporarily_unavailable";
+
+export type TokensErrorCode =
+    | "invalid_request"
+    | "invalid_client"
+    | "invalid_grant"
+    | "unsupported_grant_type"
+    | "invalid_scope";

--- a/lib/ts/recipe/oauth2/types.ts
+++ b/lib/ts/recipe/oauth2/types.ts
@@ -1,0 +1,179 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { BaseRequest, BaseResponse } from "../../framework";
+import OverrideableBuilder from "supertokens-js-override";
+import { GeneralErrorResponse, JSONObject } from "../../types";
+
+export type TypeInput = {
+    override?: {
+        functions?: (
+            originalImplementation: RecipeInterface,
+            builder?: OverrideableBuilder<RecipeInterface>
+        ) => RecipeInterface;
+        apis?: (originalImplementation: APIInterface, builder?: OverrideableBuilder<APIInterface>) => APIInterface;
+    };
+};
+
+export type TypeNormalisedInput = {
+    override: {
+        functions: (
+            originalImplementation: RecipeInterface,
+            builder?: OverrideableBuilder<RecipeInterface>
+        ) => RecipeInterface;
+        apis: (originalImplementation: APIInterface, builder?: OverrideableBuilder<APIInterface>) => APIInterface;
+    };
+};
+
+export type APIOptions = {
+    recipeImplementation: RecipeInterface;
+    config: TypeNormalisedInput;
+    recipeId: string;
+    isInServerlessEnv: boolean;
+    req: BaseRequest;
+    res: BaseResponse;
+};
+
+export type RecipeInterface = {
+    tokensPOST(input: {
+        payload?: any;
+        validitySeconds?: number;
+        useStaticSigningKey?: boolean;
+        userContext: any;
+    }): Promise<
+        | {
+              token_type: "Bearer";
+              access_token: string;
+              refresh_token?: string;
+              id_token?: string;
+              expires_in: number;
+          }
+        | GeneralErrorResponse
+    >;
+    // The OpenId spec states that we have to support both POST and GET
+    authorizeGET(input: {
+        clientId: string;
+        responseType: string;
+        redirectUri?: string;
+        scopes: string[];
+        state?: string;
+
+        // PKCE
+        codeChallenge?: string;
+        codeChallengeMethod?: string;
+
+        // OpenIdConnect
+        prompt?: string;
+        nonce?: string;
+
+        // Not sure if we want to support these
+        acr_values?: string;
+        maxAge?: number;
+
+        options: APIOptions;
+        userContext: any;
+    }): Promise<{
+        redirectUrl: string; // This will end up as a 302, encoding both error and success
+    }>;
+    authorizePOST(input: {
+        clientId: string;
+        responseType: string;
+        redirectUri?: string;
+        scopes: string[];
+        state?: string;
+
+        // PKCE
+        codeChallenge?: string;
+        codeChallengeMethod?: string;
+
+        // OpenIdConnect
+        prompt?: string;
+        nonce?: string;
+
+        // Not sure if we want to support these
+        acr_values?: string;
+        maxAge?: number;
+
+        options: APIOptions;
+        userContext: any;
+    }): Promise<{
+        redirectUrl: string; // This will end up as a 302, encoding both error and success
+    }>;
+    // This is intended to be used when we want to do the redirection in the FE (e.g.: header based auth)
+    getRedirectUrlPOST(input: {
+        clientId: string;
+        responseType: string;
+        redirectUri?: string;
+        scopes: string[];
+        state?: string;
+
+        // PKCE
+        codeChallenge?: string;
+        codeChallengeMethod?: string;
+
+        // OpenIdConnect
+        prompt?: string;
+        nonce?: string;
+
+        // Not sure if we want to support these
+        acr_values?: string;
+        maxAge?: number;
+
+        options: APIOptions;
+        userContext: any;
+    }): Promise<
+        | {
+              status: "OK";
+              redirectUrl: string;
+          }
+        | GeneralErrorResponse
+    >;
+
+    userInfoGET(input: {
+        options: APIOptions;
+        userContext: any;
+    }): Promise<{ status: "OK"; sub: string; email?: string; email_verified?: boolean; phoneNumber?: string }>; // We should define this in a way that doesn't require adding all claims here
+};
+
+export type APIInterface = {
+    buildAccessToken(input: {
+        clientId: string;
+        userId?: string;
+        sessionHandle?: string;
+        scopes: string[];
+    }): Promise<{ payload?: JSONObject; lifetimeInSecs?: number }>; // Returning undefined for these props means we use the default from Core
+    buildIdToken(input: {
+        clientId: string;
+        userId?: string;
+        sessionHandle?: string;
+        scopes: string[];
+    }): Promise<{ payload?: JSONObject; lifetimeInSecs?: number }>; // Returning undefined for these props means we use the defaults from BE SDKs
+    getRefreshTokenLifetime(): Promise<number | undefined>; // Returning undefined means we use the default from Core
+
+    buildAuthorizeRedirectUrl(input: {
+        clientId: string;
+        redirectUri: string;
+        error?: string;
+        code?: string;
+        idToken?: string;
+    }): Promise<string>;
+
+    validateScopes(input: {
+        clientId: string;
+        userId?: string;
+        sessionHandle?: string;
+        scopes: string[];
+    }): Promise<{ status: "OK"; grantedScopes: string[] } | { status: "SCOPE_ERROR"; message: string }>;
+};

--- a/lib/ts/recipe/oauth2/types.ts
+++ b/lib/ts/recipe/oauth2/types.ts
@@ -16,7 +16,7 @@
 import { BaseRequest, BaseResponse } from "../../framework";
 import OverrideableBuilder from "supertokens-js-override";
 import { GeneralErrorResponse, JSONObject } from "../../types";
-import { SessionContainer } from "../session";
+import { SessionContainer, SessionInformation } from "../session";
 
 export type TypeInput = {
     override?: {
@@ -152,7 +152,7 @@ export type RecipeInterface = {
               code?: string;
               idToken?: string;
           }
-        | { status: "CLIENT_ERROR"; error: AuthorizationErrorCode; errorDescription: string; errorURI: string } // these are redirected back to the client
+        | { status: "CLIENT_ERROR"; error: AuthorizationErrorCode; errorDescription?: string; errorURI?: string } // these are redirected back to the client
         | { status: "AUTH_ERROR"; error: string } // This gets a redirection to the auth frontend
     >;
 
@@ -165,7 +165,7 @@ export type RecipeInterface = {
                   code?: string;
                   codeVerifier?: string;
                   redirectUri: string;
-                  scope?: string[];
+                  scopes?: string[];
 
                   queryString: string;
 
@@ -175,7 +175,7 @@ export type RecipeInterface = {
                   clientId: string;
                   grantType: "client_credentials";
                   clientSecret: string;
-                  scope?: string[];
+                  scopes?: string[];
 
                   queryString: string;
 
@@ -186,7 +186,7 @@ export type RecipeInterface = {
                   grantType: "refresh_token";
                   clientSecret?: string;
                   refreshToken?: string;
-                  scope?: string[];
+                  scopes?: string[];
 
                   queryString: string;
 
@@ -264,16 +264,23 @@ export type RecipeInterface = {
     // Customization points called by createTokens&createAuthCode
     buildAccessToken(input: {
         tokenInfo: TokenBuilderInfo;
+        sessionInformation?: SessionInformation;
         userContext: any;
     }): Promise<{ payload?: JSONObject; lifetimeInSecs?: number }>; // Returning undefined for these props means we use the default from Core
     buildIdToken(input: {
         tokenInfo: TokenBuilderInfo;
+        sessionInformation?: SessionInformation;
         userContext: any;
     }): Promise<{ payload?: JSONObject; lifetimeInSecs?: number }>; // Returning undefined for these props means we use the defaults from BE SDKs
-    getRefreshTokenLifetime(input: { tokenInfo: TokenBuilderInfo; userContext: any }): Promise<number | undefined>; // Returning undefined means we use the default from Core
+    getRefreshTokenLifetime(input: {
+        tokenInfo: TokenBuilderInfo;
+        sessionInformation?: SessionInformation;
+        userContext: any;
+    }): Promise<number | undefined>; // Returning undefined means we use the default from Core
 
     validateScopes(input: {
         tokenInfo: TokenBuilderInfo;
+        sessionInformation?: SessionInformation;
         userContext: any;
     }): Promise<
         | { status: "OK"; grantedScopes: string[] }
@@ -281,7 +288,11 @@ export type RecipeInterface = {
         | { status: "ACCESS_DENIED_ERROR"; message: string } // This means we need to redirect to the auth frontend (i.e.: there is a claim validation issue we can resolve there)
     >;
 
-    shouldIssueRefreshToken(input: { tokenInfo: TokenInfo; userContext: any }): Promise<boolean>;
+    shouldIssueRefreshToken(input: {
+        tokenInfo: TokenBuilderInfo;
+        sessionInformation?: SessionInformation;
+        userContext: any;
+    }): Promise<boolean>;
 };
 
 export type TokenBuilderInfo = {


### PR DESCRIPTION
## Summary of change

add initial interface for oauth2 recipe

## Related issues

-  

## Test Plan

N/A

## Documentation changes

N/A

## Checklist for important updates

-   [ ] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
