### PR TITLE
fix: tenantId compulsory in getAllowedDomainsForTenantId

### DIFF
--- a/lib/build/recipe/multitenancy/recipe.d.ts
+++ b/lib/build/recipe/multitenancy/recipe.d.ts
@@ -14,7 +14,7 @@ export default class Recipe extends RecipeModule {
     apiImpl: APIInterface;
     isInServerlessEnv: boolean;
     staticThirdPartyProviders: ProviderInput[];
-    getAllowedDomainsForTenantId?: (tenantId: string | undefined, userContext: any) => Promise<string[] | undefined>;
+    getAllowedDomainsForTenantId?: (tenantId: string, userContext: any) => Promise<string[] | undefined>;
     constructor(recipeId: string, appInfo: NormalisedAppinfo, isInServerlessEnv: boolean, config?: TypeInput);
     static getInstanceOrThrowError(): Recipe;
     static getInstance(): Recipe | undefined;

--- a/lib/build/recipe/multitenancy/types.d.ts
+++ b/lib/build/recipe/multitenancy/types.d.ts
@@ -18,7 +18,7 @@ export interface NormalisedErrorHandlers {
     onRecipeDisabledForTenantError: RecipeDisabledForTenantErrorHandlerMiddleware;
 }
 export declare type TypeInput = {
-    getAllowedDomainsForTenantId?: (tenantId: string | undefined, userContext: any) => Promise<string[] | undefined>;
+    getAllowedDomainsForTenantId?: (tenantId: string, userContext: any) => Promise<string[] | undefined>;
     errorHandlers?: ErrorHandlers;
     override?: {
         functions?: (
@@ -29,7 +29,7 @@ export declare type TypeInput = {
     };
 };
 export declare type TypeNormalisedInput = {
-    getAllowedDomainsForTenantId?: (tenantId: string | undefined, userContext: any) => Promise<string[] | undefined>;
+    getAllowedDomainsForTenantId?: (tenantId: string, userContext: any) => Promise<string[] | undefined>;
     errorHandlers: NormalisedErrorHandlers;
     override: {
         functions: (

--- a/lib/ts/recipe/multitenancy/recipe.ts
+++ b/lib/ts/recipe/multitenancy/recipe.ts
@@ -45,7 +45,7 @@ export default class Recipe extends RecipeModule {
 
     staticThirdPartyProviders: ProviderInput[] = [];
 
-    getAllowedDomainsForTenantId?: (tenantId: string | undefined, userContext: any) => Promise<string[] | undefined>;
+    getAllowedDomainsForTenantId?: (tenantId: string, userContext: any) => Promise<string[] | undefined>;
 
     constructor(recipeId: string, appInfo: NormalisedAppinfo, isInServerlessEnv: boolean, config?: TypeInput) {
         super(recipeId, appInfo);

--- a/lib/ts/recipe/multitenancy/types.ts
+++ b/lib/ts/recipe/multitenancy/types.ts
@@ -37,7 +37,7 @@ export interface NormalisedErrorHandlers {
 }
 
 export type TypeInput = {
-    getAllowedDomainsForTenantId?: (tenantId: string | undefined, userContext: any) => Promise<string[] | undefined>;
+    getAllowedDomainsForTenantId?: (tenantId: string, userContext: any) => Promise<string[] | undefined>;
 
     errorHandlers?: ErrorHandlers;
     override?: {
@@ -50,7 +50,7 @@ export type TypeInput = {
 };
 
 export type TypeNormalisedInput = {
-    getAllowedDomainsForTenantId?: (tenantId: string | undefined, userContext: any) => Promise<string[] | undefined>;
+    getAllowedDomainsForTenantId?: (tenantId: string, userContext: any) => Promise<string[] | undefined>;
 
     errorHandlers: NormalisedErrorHandlers;
     override: {


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
