### PR TITLE
fix: Fix issue of user dashboard showing email as unverified even if it is verified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [15.0.2] - 2023-07-31
+
+-   Fixes an issue where the user management dashboard would incorrectly show an email as unverified even if it was verified
+
 ## [15.0.1] - 2023-07-19
 
 -   Passes missing `tenantId` to claim build function

--- a/lib/build/recipe/dashboard/api/userdetails/userEmailVerifyGet.js
+++ b/lib/build/recipe/dashboard/api/userdetails/userEmailVerifyGet.js
@@ -57,7 +57,7 @@ const userEmailverifyGet = (_, ___, options, userContext) =>
                 status: "FEATURE_NOT_ENABLED_ERROR",
             };
         }
-        const response = yield emailverification_1.default.isEmailVerified(userId, userContext);
+        const response = yield emailverification_1.default.isEmailVerified(userId, undefined, userContext);
         return {
             status: "OK",
             isVerified: response,

--- a/lib/build/recipe/dashboard/api/userdetails/userEmailVerifyPut.js
+++ b/lib/build/recipe/dashboard/api/userdetails/userEmailVerifyPut.js
@@ -78,7 +78,7 @@ const userEmailVerifyPut = (_, tenantId, options, userContext) =>
                 throw new Error("Should not come here");
             }
         } else {
-            yield emailverification_1.default.unverifyEmail(userId, userContext);
+            yield emailverification_1.default.unverifyEmail(userId, undefined, userContext);
         }
         return {
             status: "OK",

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "15.0.1";
+export declare const version = "15.0.2";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.7";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "15.0.1";
+exports.version = "15.0.2";
 exports.cdiSupported = ["3.0"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.7";

--- a/lib/ts/recipe/dashboard/api/userdetails/userEmailVerifyGet.ts
+++ b/lib/ts/recipe/dashboard/api/userdetails/userEmailVerifyGet.ts
@@ -36,7 +36,7 @@ export const userEmailverifyGet: APIFunction = async (
         };
     }
 
-    const response = await EmailVerification.isEmailVerified(userId, userContext);
+    const response = await EmailVerification.isEmailVerified(userId, undefined, userContext);
     return {
         status: "OK",
         isVerified: response,

--- a/lib/ts/recipe/dashboard/api/userdetails/userEmailVerifyPut.ts
+++ b/lib/ts/recipe/dashboard/api/userdetails/userEmailVerifyPut.ts
@@ -55,7 +55,7 @@ export const userEmailVerifyPut = async (
             throw new Error("Should not come here");
         }
     } else {
-        await EmailVerification.unverifyEmail(userId, userContext);
+        await EmailVerification.unverifyEmail(userId, undefined, userContext);
     }
 
     return {

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "15.0.1";
+export const version = "15.0.2";
 
 export const cdiSupported = ["3.0"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "15.0.1",
+    "version": "15.0.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "15.0.1",
+            "version": "15.0.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "15.0.1",
+    "version": "15.0.2",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {

--- a/test/dashboard/userEmailVerifyGet.test.js
+++ b/test/dashboard/userEmailVerifyGet.test.js
@@ -1,0 +1,100 @@
+const { ProcessState } = require("../../lib/build/processState");
+const { printPath, killAllST, setupST, cleanST, startST } = require("../utils");
+let STExpress = require("../../");
+let Dashboard = require("../../recipe/dashboard");
+let EmailVerification = require("../../recipe/emailverification");
+let EmailPassword = require("../../recipe/emailpassword");
+const express = require("express");
+let { middleware, errorHandler } = require("../../framework/express");
+const request = require("supertest");
+let assert = require("assert");
+let Session = require("../../recipe/session");
+
+describe(`User Dashboard userEmailVerifyGet: ${printPath("[test/dashboard/userEmailVerifyGet.test.js]")}`, () => {
+    beforeEach(async () => {
+        await killAllST();
+        await setupST();
+        ProcessState.getInstance().reset();
+    });
+
+    after(async function () {
+        await killAllST();
+        await cleanST();
+    });
+
+    it("Test that api returns correct value for email verification", async () => {
+        await startST();
+        STExpress.init({
+            supertokens: {
+                connectionURI: "http://localhost:8080",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                Dashboard.init({
+                    apiKey: "testapikey",
+                }),
+                EmailPassword.init(),
+                EmailVerification.init({
+                    mode: "OPTIONAL",
+                }),
+                Session.init(),
+            ],
+        });
+
+        const app = express();
+
+        app.use(middleware());
+
+        app.use(errorHandler());
+
+        const signUpResponse = await EmailPassword.signUp("public", "test@supertokens.com", "abcd1234");
+        assert(signUpResponse.status === "OK");
+
+        const user = signUpResponse.user;
+
+        const emailVerificationUrl = "/auth/dashboard/api/user/email/verify";
+
+        let emailVerifyResponse = await new Promise((res) => {
+            request(app)
+                .get(emailVerificationUrl + "?email=test@supertokens.com&userId=" + user.id)
+                .set("Authorization", "Bearer testapikey")
+                .end((err, response) => {
+                    if (err) {
+                        res(undefined);
+                    } else {
+                        res(JSON.parse(response.text));
+                    }
+                });
+        });
+
+        assert(emailVerifyResponse.status === "OK");
+        assert(emailVerifyResponse.isVerified === false);
+
+        const tokenResponse = await EmailVerification.createEmailVerificationToken("public", user.id);
+        assert(tokenResponse.status === "OK");
+
+        const verificationResponse = await EmailVerification.verifyEmailUsingToken("public", tokenResponse.token);
+
+        assert(verificationResponse.status === "OK");
+
+        emailVerifyResponse = await new Promise((res) => {
+            request(app)
+                .get(emailVerificationUrl + "?email=test@supertokens.com&userId=" + user.id)
+                .set("Authorization", "Bearer testapikey")
+                .end((err, response) => {
+                    if (err) {
+                        res(undefined);
+                    } else {
+                        res(JSON.parse(response.text));
+                    }
+                });
+        });
+
+        assert(emailVerifyResponse.status === "OK");
+        assert(emailVerifyResponse.isVerified === true);
+    });
+});


### PR DESCRIPTION
## Summary of change

- Fixes an issue where the dashboard recipe was incorrectly passing the user context as the email when trying to check if an email is verified and when unverifying the email. This would result in the email as always being unverified on the frontend

## Related issues

-   #661 

## Test Plan

Adds additional tests

## Documentation changes

NA

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] ...
