### PR TITLE
refactor: Add handling for when Saas returns 429 because of rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [14.1.4] - 2023-08-28
+
+-   Adds logic to retry network calls if the core returns status 429
+
 ## [14.1.3] - 2023-07-03
 
 ### Changes

--- a/lib/build/constants.d.ts
+++ b/lib/build/constants.d.ts
@@ -1,3 +1,4 @@
 // @ts-nocheck
 export declare const HEADER_RID = "rid";
 export declare const HEADER_FDI = "fdi-version";
+export declare const RATE_LIMIT_STATUS_CODE = 429;

--- a/lib/build/constants.js
+++ b/lib/build/constants.js
@@ -14,6 +14,7 @@
  * under the License.
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.HEADER_FDI = exports.HEADER_RID = void 0;
+exports.RATE_LIMIT_STATUS_CODE = exports.HEADER_FDI = exports.HEADER_RID = void 0;
 exports.HEADER_RID = "rid";
 exports.HEADER_FDI = "fdi-version";
+exports.RATE_LIMIT_STATUS_CODE = 429;

--- a/lib/build/querier.js
+++ b/lib/build/querier.js
@@ -92,6 +92,7 @@ const utils_1 = require("./utils");
 const version_1 = require("./version");
 const normalisedURLPath_1 = __importDefault(require("./normalisedURLPath"));
 const processState_1 = require("./processState");
+const constants_1 = require("./constants");
 class Querier {
     // we have rIdToCore so that recipes can force change the rId sent to core. This is a hack until the core is able
     // to support multiple rIds per API
@@ -264,7 +265,7 @@ class Querier {
                 );
             });
         // path should start with "/"
-        this.sendRequestHelper = (path, method, requestFunc, numberOfTries) =>
+        this.sendRequestHelper = (path, method, requestFunc, numberOfTries, retryInfoMap) =>
             __awaiter(this, void 0, void 0, function* () {
                 var _f;
                 if (this.__hosts === undefined) {
@@ -278,6 +279,13 @@ class Querier {
                 let currentDomain = this.__hosts[Querier.lastTriedIndex].domain.getAsStringDangerous();
                 let currentBasePath = this.__hosts[Querier.lastTriedIndex].basePath.getAsStringDangerous();
                 const url = currentDomain + currentBasePath + path.getAsStringDangerous();
+                const maxRetries = 5;
+                if (retryInfoMap === undefined) {
+                    retryInfoMap = {};
+                }
+                if (retryInfoMap[url] === undefined) {
+                    retryInfoMap[url] = maxRetries;
+                }
                 Querier.lastTriedIndex++;
                 Querier.lastTriedIndex = Querier.lastTriedIndex % this.__hosts.length;
                 try {
@@ -304,9 +312,25 @@ class Querier {
                         err.message !== undefined &&
                         (err.message.includes("Failed to fetch") || err.message.includes("ECONNREFUSED"))
                     ) {
-                        return yield this.sendRequestHelper(path, method, requestFunc, numberOfTries - 1);
+                        return yield this.sendRequestHelper(path, method, requestFunc, numberOfTries - 1, retryInfoMap);
                     }
                     if (err instanceof cross_fetch_1.Response) {
+                        if (err.status === constants_1.RATE_LIMIT_STATUS_CODE) {
+                            const retriesLeft = retryInfoMap[url];
+                            if (retriesLeft > 0) {
+                                retryInfoMap[url] = retriesLeft - 1;
+                                const attemptsMade = maxRetries - retriesLeft;
+                                const delay = 10 + 250 * attemptsMade;
+                                yield new Promise((resolve) => setTimeout(resolve, delay));
+                                return yield this.sendRequestHelper(
+                                    path,
+                                    method,
+                                    requestFunc,
+                                    numberOfTries,
+                                    retryInfoMap
+                                );
+                            }
+                        }
                         throw new Error(
                             "SuperTokens core threw an error for a " +
                                 method +
@@ -317,9 +341,8 @@ class Querier {
                                 " and message: " +
                                 (yield err.text())
                         );
-                    } else {
-                        throw err;
                     }
+                    throw err;
                 }
             });
         this.__hosts = hosts;

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "14.1.3";
+export declare const version = "14.1.4";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.6";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "14.1.3";
+exports.version = "14.1.4";
 exports.cdiSupported = ["2.21"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.6";

--- a/lib/ts/constants.ts
+++ b/lib/ts/constants.ts
@@ -15,3 +15,4 @@
 
 export const HEADER_RID = "rid";
 export const HEADER_FDI = "fdi-version";
+export const RATE_LIMIT_STATUS_CODE = 429;

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "14.1.3";
+export const version = "14.1.4";
 
 export const cdiSupported = ["2.21"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "14.1.3",
+    "version": "14.1.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "14.1.3",
+            "version": "14.1.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "14.1.3",
+    "version": "14.1.4",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {

--- a/test/ratelimiting.test.js
+++ b/test/ratelimiting.test.js
@@ -1,0 +1,236 @@
+const { ProcessState } = require("../lib/build/processState");
+const { printPath, killAllST, setupST, cleanST, startST } = require("./utils");
+let STExpress = require("../");
+let Dashboard = require("../recipe/dashboard");
+let EmailVerification = require("../recipe/emailverification");
+let EmailPassword = require("../recipe/emailpassword");
+const express = require("express");
+let { middleware, errorHandler } = require("../framework/express");
+let Session = require("../recipe/session");
+let { Querier } = require("../lib/build/querier");
+const { default: NormalisedURLPath } = require("../lib/build/normalisedURLPath");
+let assert = require("assert");
+const RateLimitedStatus = 429;
+
+describe(`Querier rate limiting: ${printPath("[test/ratelimiting.test.js]")}`, () => {
+    beforeEach(async () => {
+        await killAllST();
+        await setupST();
+        ProcessState.getInstance().reset();
+    });
+
+    after(async function () {
+        await killAllST();
+        await cleanST();
+        Querier.apiVersion = undefined;
+    });
+
+    it("Test that network call is retried properly", async () => {
+        await startST();
+        STExpress.init({
+            supertokens: {
+                // Using 8083 because we need querier to call the test express server instead of the core
+                connectionURI: "http://localhost:8083",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                Dashboard.init({
+                    apiKey: "testapikey",
+                }),
+                EmailPassword.init(),
+                EmailVerification.init({
+                    mode: "OPTIONAL",
+                }),
+                Session.init(),
+            ],
+        });
+        Querier.apiVersion = "3.0";
+
+        let numbersOfTimesRetried = 0;
+        let numberOfTimesSecondCalled = 0;
+        let numberOfTimesThirdCalled = 0;
+
+        const app = express();
+
+        app.use(middleware());
+
+        app.get("/testing", async (_, res, __) => {
+            numbersOfTimesRetried++;
+            return res.status(RateLimitedStatus).json({});
+        });
+
+        app.get("/testing2", async (_, res, __) => {
+            numberOfTimesSecondCalled++;
+
+            if (numberOfTimesSecondCalled === 3) {
+                return res.status(200).json({});
+            }
+
+            return res.status(RateLimitedStatus).json({});
+        });
+
+        app.get("/testing3", async (_, res, __) => {
+            numberOfTimesThirdCalled++;
+            return res.status(200).json({});
+        });
+
+        app.use(errorHandler());
+
+        const server = app.listen(8083, () => {});
+
+        let q = Querier.getNewInstanceOrThrowError(undefined);
+
+        try {
+            await q.sendGetRequest(new NormalisedURLPath("/testing"), {});
+        } catch (e) {
+            if (!e.message.includes("with status code: 429")) {
+                throw e;
+            }
+        }
+
+        // 1 initial request + 5 retries
+        assert.equal(numbersOfTimesRetried, 6);
+
+        await q.sendGetRequest(new NormalisedURLPath("/testing2"), {});
+        assert.equal(numberOfTimesSecondCalled, 3);
+
+        await q.sendGetRequest(new NormalisedURLPath("/testing3"), {});
+        assert.equal(numberOfTimesThirdCalled, 1);
+
+        server.close();
+    });
+
+    it("Test that rate limiting errors are thrown back to the user", async () => {
+        await startST();
+        STExpress.init({
+            supertokens: {
+                // Using 8083 because we need querier to call the test express server instead of the core
+                connectionURI: "http://localhost:8083",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                Dashboard.init({
+                    apiKey: "testapikey",
+                }),
+                EmailPassword.init(),
+                EmailVerification.init({
+                    mode: "OPTIONAL",
+                }),
+                Session.init(),
+            ],
+        });
+        Querier.apiVersion = "3.0";
+
+        const app = express();
+
+        app.use(middleware());
+
+        app.get("/testing", async (_, res, __) => {
+            return res.status(RateLimitedStatus).json({
+                status: "RATE_ERROR",
+            });
+        });
+
+        app.use(errorHandler());
+
+        const server = app.listen(8083, () => {});
+
+        let q = Querier.getNewInstanceOrThrowError(undefined);
+
+        try {
+            await q.sendGetRequest(new NormalisedURLPath("/testing"), {});
+        } catch (e) {
+            if (!e.message.includes("with status code: 429")) {
+                throw e;
+            }
+
+            assert.equal(e.message.includes('message: {"status":"RATE_ERROR"}'), true);
+        }
+
+        server.close();
+    });
+
+    it("Test that parallel calls have independent retry counters", async () => {
+        await startST();
+        STExpress.init({
+            supertokens: {
+                // Using 8083 because we need querier to call the test express server instead of the core
+                connectionURI: "http://localhost:8083",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                Dashboard.init({
+                    apiKey: "testapikey",
+                }),
+                EmailPassword.init(),
+                EmailVerification.init({
+                    mode: "OPTIONAL",
+                }),
+                Session.init(),
+            ],
+        });
+        Querier.apiVersion = "3.0";
+
+        const app = express();
+
+        app.use(middleware());
+
+        let numberOfTimesFirstCalled = 0;
+        let numberOfTimesSecondCalled = 0;
+
+        app.get("/testing", async (req, res, __) => {
+            if (req.query.id === "1") {
+                numberOfTimesFirstCalled++;
+            } else {
+                numberOfTimesSecondCalled++;
+            }
+            return res.status(RateLimitedStatus).json({});
+        });
+
+        app.use(errorHandler());
+
+        const server = app.listen(8083, () => {});
+
+        let q = Querier.getNewInstanceOrThrowError(undefined);
+
+        const callApi1 = async () => {
+            try {
+                await q.sendGetRequest(new NormalisedURLPath("/testing"), { id: "1" });
+            } catch (e) {
+                if (!e.message.includes("with status code: 429")) {
+                    throw e;
+                }
+            }
+        };
+
+        const callApi2 = async () => {
+            try {
+                await q.sendGetRequest(new NormalisedURLPath("/testing"), { id: "2" });
+            } catch (e) {
+                if (!e.message.includes("with status code: 429")) {
+                    throw e;
+                }
+            }
+        };
+
+        await Promise.all([callApi1(), callApi2()]);
+
+        // 1 initial request + 5 retries each
+        assert.equal(numberOfTimesFirstCalled, 6);
+        assert.equal(numberOfTimesSecondCalled, 6);
+
+        server.close();
+    });
+});


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] ...
