### PR TITLE
refactor: Add handling for when Saas returns 429 because of rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [11.3.1] - 2023-08-30
+
+-   Adds logic to retry network calls if the core returns status 429
+
 ## [11.3.0] - 2022-08-30
 
 ### Added:

--- a/addDevTag
+++ b/addDevTag
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-# check if we need to merge master into this branch------------
-if [[ $(git log origin/master ^HEAD) ]]; then
-    echo "You need to merge master into this branch. Exiting"
-    exit 1
-fi
-
 # get version------------
 version=`cat package.json | grep -e '"version":'`
 while IFS='"' read -ra ADDR; do

--- a/lib/build/constants.d.ts
+++ b/lib/build/constants.d.ts
@@ -1,3 +1,4 @@
 // @ts-nocheck
 export declare const HEADER_RID = "rid";
 export declare const HEADER_FDI = "fdi-version";
+export declare const RATE_LIMIT_STATUS_CODE = 429;

--- a/lib/build/constants.js
+++ b/lib/build/constants.js
@@ -16,3 +16,4 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.HEADER_RID = "rid";
 exports.HEADER_FDI = "fdi-version";
+exports.RATE_LIMIT_STATUS_CODE = 429;

--- a/lib/build/querier.js
+++ b/lib/build/querier.js
@@ -50,6 +50,7 @@ const utils_1 = require("./utils");
 const version_1 = require("./version");
 const normalisedURLPath_1 = require("./normalisedURLPath");
 const processState_1 = require("./processState");
+const constants_1 = require("./constants");
 class Querier {
     // we have rIdToCore so that recipes can force change the rId sent to core. This is a hack until the core is able
     // to support multiple rIds per API
@@ -214,7 +215,7 @@ class Querier {
                 );
             });
         // path should start with "/"
-        this.sendRequestHelper = (path, method, axiosFunction, numberOfTries) =>
+        this.sendRequestHelper = (path, method, axiosFunction, numberOfTries, retryInfoMap) =>
             __awaiter(this, void 0, void 0, function* () {
                 if (this.__hosts === undefined) {
                     throw Error(
@@ -226,13 +227,21 @@ class Querier {
                 }
                 let currentDomain = this.__hosts[Querier.lastTriedIndex].domain.getAsStringDangerous();
                 let currentBasePath = this.__hosts[Querier.lastTriedIndex].basePath.getAsStringDangerous();
+                const url = currentDomain + currentBasePath + path.getAsStringDangerous();
+                const maxRetries = 5;
+                if (retryInfoMap === undefined) {
+                    retryInfoMap = {};
+                }
+                if (retryInfoMap[url] === undefined) {
+                    retryInfoMap[url] = maxRetries;
+                }
                 Querier.lastTriedIndex++;
                 Querier.lastTriedIndex = Querier.lastTriedIndex % this.__hosts.length;
                 try {
                     processState_1.ProcessState.getInstance().addState(
                         processState_1.PROCESS_STATE.CALLING_SERVICE_IN_REQUEST_HELPER
                     );
-                    let response = yield axiosFunction(currentDomain + currentBasePath + path.getAsStringDangerous());
+                    let response = yield axiosFunction(url);
                     if (process.env.TEST_MODE === "testing") {
                         Querier.hostsAliveForTesting.add(currentDomain + currentBasePath);
                     }
@@ -242,7 +251,33 @@ class Querier {
                     return response.data;
                 } catch (err) {
                     if (err.message !== undefined && err.message.includes("ECONNREFUSED")) {
-                        return yield this.sendRequestHelper(path, method, axiosFunction, numberOfTries - 1);
+                        return yield this.sendRequestHelper(
+                            path,
+                            method,
+                            axiosFunction,
+                            numberOfTries - 1,
+                            retryInfoMap
+                        );
+                    }
+                    if (
+                        err.response !== undefined &&
+                        err.response.status !== undefined &&
+                        err.response.status === constants_1.RATE_LIMIT_STATUS_CODE
+                    ) {
+                        const retriesLeft = retryInfoMap[url];
+                        if (retriesLeft > 0) {
+                            retryInfoMap[url] = retriesLeft - 1;
+                            const attemptsMade = maxRetries - retriesLeft;
+                            const delay = 10 + 250 * attemptsMade;
+                            yield new Promise((resolve) => setTimeout(resolve, delay));
+                            return yield this.sendRequestHelper(
+                                path,
+                                method,
+                                axiosFunction,
+                                numberOfTries,
+                                retryInfoMap
+                            );
+                        }
                     }
                     if (
                         err.response !== undefined &&

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "11.3.0";
+export declare const version = "11.3.1";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.1";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -14,7 +14,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "11.3.0";
+exports.version = "11.3.1";
 exports.cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.1";

--- a/lib/ts/constants.ts
+++ b/lib/ts/constants.ts
@@ -15,3 +15,4 @@
 
 export const HEADER_RID = "rid";
 export const HEADER_FDI = "fdi-version";
+export const RATE_LIMIT_STATUS_CODE = 429;

--- a/lib/ts/querier.ts
+++ b/lib/ts/querier.ts
@@ -19,6 +19,7 @@ import { cdiSupported } from "./version";
 import NormalisedURLDomain from "./normalisedURLDomain";
 import NormalisedURLPath from "./normalisedURLPath";
 import { PROCESS_STATE, ProcessState } from "./processState";
+import { RATE_LIMIT_STATUS_CODE } from "./constants";
 
 export class Querier {
     private static initCalled = false;
@@ -237,7 +238,8 @@ export class Querier {
         path: NormalisedURLPath,
         method: string,
         axiosFunction: (url: string) => Promise<any>,
-        numberOfTries: number
+        numberOfTries: number,
+        retryInfoMap?: Record<string, number>
     ): Promise<any> => {
         if (this.__hosts === undefined) {
             throw Error(
@@ -249,11 +251,24 @@ export class Querier {
         }
         let currentDomain: string = this.__hosts[Querier.lastTriedIndex].domain.getAsStringDangerous();
         let currentBasePath: string = this.__hosts[Querier.lastTriedIndex].basePath.getAsStringDangerous();
+
+        const url = currentDomain + currentBasePath + path.getAsStringDangerous();
+
+        const maxRetries = 5;
+
+        if (retryInfoMap === undefined) {
+            retryInfoMap = {};
+        }
+
+        if (retryInfoMap[url] === undefined) {
+            retryInfoMap[url] = maxRetries;
+        }
+
         Querier.lastTriedIndex++;
         Querier.lastTriedIndex = Querier.lastTriedIndex % this.__hosts.length;
         try {
             ProcessState.getInstance().addState(PROCESS_STATE.CALLING_SERVICE_IN_REQUEST_HELPER);
-            let response = await axiosFunction(currentDomain + currentBasePath + path.getAsStringDangerous());
+            let response = await axiosFunction(url);
             if (process.env.TEST_MODE === "testing") {
                 Querier.hostsAliveForTesting.add(currentDomain + currentBasePath);
             }
@@ -263,8 +278,28 @@ export class Querier {
             return response.data;
         } catch (err) {
             if (err.message !== undefined && err.message.includes("ECONNREFUSED")) {
-                return await this.sendRequestHelper(path, method, axiosFunction, numberOfTries - 1);
+                return await this.sendRequestHelper(path, method, axiosFunction, numberOfTries - 1, retryInfoMap);
             }
+
+            if (
+                err.response !== undefined &&
+                err.response.status !== undefined &&
+                err.response.status === RATE_LIMIT_STATUS_CODE
+            ) {
+                const retriesLeft = retryInfoMap[url];
+
+                if (retriesLeft > 0) {
+                    retryInfoMap[url] = retriesLeft - 1;
+
+                    const attemptsMade = maxRetries - retriesLeft;
+                    const delay = 10 + 250 * attemptsMade;
+
+                    await new Promise((resolve) => setTimeout(resolve, delay));
+
+                    return await this.sendRequestHelper(path, method, axiosFunction, numberOfTries, retryInfoMap);
+                }
+            }
+
             if (err.response !== undefined && err.response.status !== undefined && err.response.data !== undefined) {
                 throw new Error(
                     "SuperTokens core threw an error for a " +

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "11.3.0";
+export const version = "11.3.1";
 
 export const cdiSupported = ["2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "11.3.0",
+    "version": "11.3.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "11.3.0",
+            "version": "11.3.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "axios": "0.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "11.3.0",
+    "version": "11.3.1",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {

--- a/test/frontendIntegration/index.js
+++ b/test/frontendIntegration/index.js
@@ -26,6 +26,8 @@ let noOfTimesRefreshAttemptedDuringTest = 0;
 let { verifySession } = require("../../recipe/session/framework/express");
 let { middleware, errorHandler } = require("../../framework/express");
 let supertokens_node_version = require("../../lib/build/version").version;
+const { Querier } = require("../../lib/build/querier");
+const { default: NormalisedURLPath } = require("../../lib/build/normalisedURLPath");
 
 let urlencodedParser = bodyParser.urlencoded({ limit: "20mb", extended: true, parameterLimit: 20000 });
 let jsonParser = bodyParser.json({ limit: "20mb" });
@@ -202,6 +204,41 @@ app.post("/login", async (req, res) => {
     let userId = req.body.userId;
     let session = await Session.createNewSession(res, userId);
     res.send(session.getUserId());
+});
+
+app.post("/login-2.18", async (req, res) => {
+    // This CDI version is no longer supported by this SDK, but we want to ensure that sessions keep working after the upgrade
+    // We can hard-code the structure of the request&response, since this is a fixed CDI version and it's not going to change
+    Querier.apiVersion = "2.18";
+    const payload = req.body.payload || {};
+    const userId = req.body.userId;
+    const legacySessionResp = await Querier.getNewInstanceOrThrowError().sendPostRequest(
+        new NormalisedURLPath("/recipe/session"),
+        {
+            userId,
+            enableAntiCsrf: false,
+            userDataInJWT: payload,
+            userDataInDatabase: {},
+        }
+    );
+    Querier.apiVersion = undefined;
+
+    const legacyAccessToken = legacySessionResp.accessToken.token;
+    const legacyRefreshToken = legacySessionResp.refreshToken.token;
+
+    res.set("st-access-token", legacyAccessToken)
+        .set("st-refresh-token", legacyRefreshToken)
+        .set(
+            "front-token",
+            Buffer.from(
+                JSON.stringify({
+                    uid: userId,
+                    ate: Date.now() + 3600000,
+                    up: payload,
+                })
+            ).toString("base64")
+        )
+        .send();
 });
 
 app.post("/beforeeach", async (req, res) => {

--- a/test/ratelimiting.test.js
+++ b/test/ratelimiting.test.js
@@ -1,0 +1,216 @@
+const { ProcessState } = require("../lib/build/processState");
+const { printPath, killAllST, setupST, cleanST, startST } = require("./utils");
+let STExpress = require("../");
+const express = require("express");
+let { middleware, errorHandler } = require("../framework/express");
+let Session = require("../recipe/session");
+let { Querier } = require("../lib/build/querier");
+const { default: NormalisedURLPath } = require("../lib/build/normalisedURLPath");
+let assert = require("assert");
+const RateLimitedStatus = 429;
+
+describe(`Querier rate limiting: ${printPath("[test/ratelimiting.test.js]")}`, () => {
+    beforeEach(async () => {
+        await killAllST();
+        await setupST();
+        ProcessState.getInstance().reset();
+    });
+
+    after(async function () {
+        await killAllST();
+        await cleanST();
+        Querier.apiVersion = undefined;
+    });
+
+    it("Test that network call is retried properly", async () => {
+        await startST();
+        STExpress.init({
+            supertokens: {
+                // Using 8083 because we need querier to call the test express server instead of the core
+                connectionURI: "http://localhost:8083",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [Session.init()],
+        });
+        Querier.apiVersion = "3.0";
+
+        let numbersOfTimesRetried = 0;
+        let numberOfTimesSecondCalled = 0;
+        let numberOfTimesThirdCalled = 0;
+
+        const app = express();
+
+        app.use(middleware());
+
+        app.get("/testing", async (_, res, __) => {
+            numbersOfTimesRetried++;
+            return res.status(RateLimitedStatus).json({});
+        });
+
+        app.get("/testing2", async (_, res, __) => {
+            numberOfTimesSecondCalled++;
+
+            if (numberOfTimesSecondCalled === 3) {
+                return res.status(200).json({});
+            }
+
+            return res.status(RateLimitedStatus).json({});
+        });
+
+        app.get("/testing3", async (_, res, __) => {
+            numberOfTimesThirdCalled++;
+            return res.status(200).json({});
+        });
+
+        app.use(errorHandler());
+
+        const server = app.listen(8083, () => {});
+
+        let q = Querier.getNewInstanceOrThrowError(undefined);
+
+        try {
+            await q.sendGetRequest(new NormalisedURLPath("/testing"), {});
+        } catch (e) {
+            if (!e.message.includes("with status code: 429")) {
+                throw e;
+            }
+        }
+
+        // 1 initial request + 5 retries
+        assert.equal(numbersOfTimesRetried, 6);
+
+        await q.sendGetRequest(new NormalisedURLPath("/testing2"), {});
+        assert.equal(numberOfTimesSecondCalled, 3);
+
+        await q.sendGetRequest(new NormalisedURLPath("/testing3"), {});
+        assert.equal(numberOfTimesThirdCalled, 1);
+
+        await new Promise((res) => {
+            server.close(() => {
+                res(undefined);
+            });
+        });
+    });
+
+    it("Test that rate limiting errors are thrown back to the user", async () => {
+        await startST();
+        STExpress.init({
+            supertokens: {
+                // Using 8083 because we need querier to call the test express server instead of the core
+                connectionURI: "http://localhost:8083",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [Session.init()],
+        });
+        Querier.apiVersion = "3.0";
+
+        const app = express();
+
+        app.use(middleware());
+
+        app.get("/testing", async (_, res, __) => {
+            return res.status(RateLimitedStatus).send('status: "RATE_ERROR"');
+        });
+
+        app.use(errorHandler());
+
+        const server = app.listen(8083, () => {});
+
+        let q = Querier.getNewInstanceOrThrowError(undefined);
+
+        try {
+            await q.sendGetRequest(new NormalisedURLPath("/testing"), {});
+        } catch (e) {
+            if (!e.message.includes("with status code: 429")) {
+                throw e;
+            }
+
+            assert.equal(e.message.includes('message: status: "RATE_ERROR"'), true);
+        }
+
+        await new Promise((res) => {
+            server.close(() => {
+                res(undefined);
+            });
+        });
+    });
+
+    it("Test that parallel calls have independent retry counters", async () => {
+        await startST();
+        STExpress.init({
+            supertokens: {
+                // Using 8083 because we need querier to call the test express server instead of the core
+                connectionURI: "http://localhost:8083",
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [Session.init()],
+        });
+        Querier.apiVersion = "3.0";
+
+        const app = express();
+
+        app.use(middleware());
+
+        let numberOfTimesFirstCalled = 0;
+        let numberOfTimesSecondCalled = 0;
+
+        app.get("/testing", async (req, res, __) => {
+            if (req.query.id === "1") {
+                numberOfTimesFirstCalled++;
+            } else {
+                numberOfTimesSecondCalled++;
+            }
+            return res.status(RateLimitedStatus).json({});
+        });
+
+        app.use(errorHandler());
+
+        const server = app.listen(8083, () => {});
+
+        let q = Querier.getNewInstanceOrThrowError(undefined);
+
+        const callApi1 = async () => {
+            try {
+                await q.sendGetRequest(new NormalisedURLPath("/testing"), { id: "1" });
+            } catch (e) {
+                if (!e.message.includes("with status code: 429")) {
+                    throw e;
+                }
+            }
+        };
+
+        const callApi2 = async () => {
+            try {
+                await q.sendGetRequest(new NormalisedURLPath("/testing"), { id: "2" });
+            } catch (e) {
+                if (!e.message.includes("with status code: 429")) {
+                    throw e;
+                }
+            }
+        };
+
+        await Promise.all([callApi1(), callApi2()]);
+
+        // 1 initial request + 5 retries each
+        assert.equal(numberOfTimesFirstCalled, 6);
+        assert.equal(numberOfTimesSecondCalled, 6);
+
+        await new Promise((res) => {
+            server.close(() => {
+                res(undefined);
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] ...
