### PR TITLE
refactor: replace raw-body dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [15.1.1] - 2023-08-14
+
+### Fixes
+
+-   Improve edge function compatibility by removing our `raw-body` dependency.
+
 ## [15.1.0] - 2023-08-14
 
 ### Changes

--- a/lib/build/framework/utils.js
+++ b/lib/build/framework/utils.js
@@ -56,7 +56,6 @@ const error_1 = __importDefault(require("../error"));
 const constants_1 = require("./constants");
 const utils_1 = require("../utils");
 const content_type_1 = __importDefault(require("content-type"));
-const raw_body_1 = __importDefault(require("raw-body"));
 const inflation_1 = __importDefault(require("inflation"));
 function getCookieValueFromHeaders(headers, key) {
     if (headers === undefined || headers === null) {
@@ -143,7 +142,8 @@ function parseJSONBodyFromRequest(req) {
         if (!encoding.startsWith("utf-")) {
             throw new Error(`unsupported charset ${encoding.toUpperCase()}`);
         }
-        const str = yield raw_body_1.default(inflation_1.default(req), { encoding });
+        const buffer = yield getBody(inflation_1.default(req));
+        const str = buffer.toString(encoding);
         if (str.length === 0) {
             return {};
         }
@@ -157,7 +157,8 @@ function parseURLEncodedFormData(req) {
         if (!encoding.startsWith("utf-")) {
             throw new Error(`unsupported charset ${encoding.toUpperCase()}`);
         }
-        const str = yield raw_body_1.default(inflation_1.default(req), { encoding });
+        const buffer = yield getBody(inflation_1.default(req));
+        const str = buffer.toString(encoding);
         let body = {};
         for (const [key, val] of new URLSearchParams(str).entries()) {
             if (key in body) {
@@ -347,3 +348,16 @@ function serializeCookieValue(key, value, domain, secure, httpOnly, expires, pat
     return cookie_1.serialize(key, value, opts);
 }
 exports.serializeCookieValue = serializeCookieValue;
+// based on https://nodejs.org/en/docs/guides/anatomy-of-an-http-transaction
+function getBody(request) {
+    return new Promise((resolve) => {
+        const bodyParts = [];
+        request
+            .on("data", (chunk) => {
+                bodyParts.push(chunk);
+            })
+            .on("end", () => {
+                resolve(Buffer.concat(bodyParts));
+            });
+    });
+}

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "15.1.0";
+export declare const version = "15.1.1";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.7";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "15.1.0";
+exports.version = "15.1.1";
 exports.cdiSupported = ["3.0"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.7";

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "15.1.0";
+export const version = "15.1.1";
 
 export const cdiSupported = ["3.0"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "15.1.0",
+    "version": "15.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "15.1.0",
+            "version": "15.1.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "content-type": "^1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
                 "nodemailer": "^6.7.2",
                 "pkce-challenge": "^3.0.0",
                 "psl": "1.8.0",
-                "raw-body": "^2.5.2",
                 "supertokens-js-override": "^0.0.4",
                 "twilio": "^4.7.2"
             },
@@ -4605,6 +4604,7 @@
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3"
             },
@@ -4672,7 +4672,8 @@
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
         },
         "node_modules/internal-slot": {
             "version": "1.0.3",
@@ -7501,64 +7502,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/raw-body": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-            "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-            "dependencies": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "unpipe": "1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/raw-body/node_modules/bytes": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/raw-body/node_modules/depd": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/raw-body/node_modules/http-errors": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-            "dependencies": {
-                "depd": "2.0.0",
-                "inherits": "2.0.4",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "toidentifier": "1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/raw-body/node_modules/setprototypeof": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
-        },
-        "node_modules/raw-body/node_modules/statuses": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/react": {
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
@@ -7721,7 +7664,8 @@
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "devOptional": true
         },
         "node_modules/sax": {
             "version": "1.2.1",
@@ -8602,6 +8546,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "dev": true,
             "engines": {
                 "node": ">=0.6"
             }
@@ -8797,6 +8742,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
             "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "dev": true,
             "engines": {
                 "node": ">= 0.8"
             }
@@ -13367,6 +13313,7 @@
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
             }
@@ -13416,7 +13363,8 @@
         "inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
         },
         "internal-slot": {
             "version": "1.0.3",
@@ -15641,51 +15589,6 @@
             "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
             "dev": true
         },
-        "raw-body": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-            "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-            "requires": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "unpipe": "1.0.0"
-            },
-            "dependencies": {
-                "bytes": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-                    "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
-                },
-                "depd": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-                    "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-                },
-                "http-errors": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-                    "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-                    "requires": {
-                        "depd": "2.0.0",
-                        "inherits": "2.0.4",
-                        "setprototypeof": "1.2.0",
-                        "statuses": "2.0.1",
-                        "toidentifier": "1.0.1"
-                    }
-                },
-                "setprototypeof": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-                    "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
-                },
-                "statuses": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-                    "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
-                }
-            }
-        },
         "react": {
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
@@ -15820,7 +15723,8 @@
         "safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "devOptional": true
         },
         "sax": {
             "version": "1.2.1",
@@ -16567,7 +16471,8 @@
         "toidentifier": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "dev": true
         },
         "toposort": {
             "version": "2.0.2",
@@ -16712,7 +16617,8 @@
         "unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "dev": true
         },
         "upper-case": {
             "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "15.1.0",
+    "version": "15.1.1",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
         "nodemailer": "^6.7.2",
         "pkce-challenge": "^3.0.0",
         "psl": "1.8.0",
-        "raw-body": "^2.5.2",
         "supertokens-js-override": "^0.0.4",
         "twilio": "^4.7.2"
     },


### PR DESCRIPTION
## Summary of change

Improve edge function compatibility by removing our `raw-body` dependency.

## Related issues

-   [Discord thread](https://discord.com/channels/603466164219281420/1141641603522494484)

## Test Plan

Manual test by deploying to vercel

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
