### PR TITLE
feat: Add validateAccessToken for third party providers

### DIFF
--- a/lib/build/recipe/thirdparty/api/implementation.js
+++ b/lib/build/recipe/thirdparty/api/implementation.js
@@ -63,13 +63,6 @@ function getAPIInterface() {
                 } else {
                     throw Error("should never come here");
                 }
-                if (provider.config.validateAccessToken !== undefined) {
-                    yield provider.config.validateAccessToken({
-                        accessToken: oAuthTokensToUse.access_token,
-                        clientConfig: provider.config,
-                        userContext,
-                    });
-                }
                 const userInfo = yield provider.getUserInfo({ oAuthTokens: oAuthTokensToUse, userContext });
                 if (userInfo.email === undefined && provider.config.requireEmail === false) {
                     userInfo.email = {

--- a/lib/build/recipe/thirdparty/api/implementation.js
+++ b/lib/build/recipe/thirdparty/api/implementation.js
@@ -63,6 +63,13 @@ function getAPIInterface() {
                 } else {
                     throw Error("should never come here");
                 }
+                if (provider.config.validateAccessToken !== undefined) {
+                    yield provider.config.validateAccessToken({
+                        accessToken: oAuthTokensToUse.access_token,
+                        clientConfig: provider.config,
+                        userContext,
+                    });
+                }
                 const userInfo = yield provider.getUserInfo({ oAuthTokens: oAuthTokensToUse, userContext });
                 if (userInfo.email === undefined && provider.config.requireEmail === false) {
                     userInfo.email = {

--- a/lib/build/recipe/thirdparty/providers/custom.js
+++ b/lib/build/recipe/thirdparty/providers/custom.js
@@ -347,6 +347,18 @@ function NewProvider(input) {
                     );
                     rawUserInfoFromProvider.fromUserInfoAPI = userInfoFromAccessToken;
                 }
+                /**
+                 * This is intentionally not part of the above if block. This is because the user may want to validate the access
+                 * token payload even if the user info API has not been provided by the provider. In this case they would get an
+                 * empty object and they can fail if they always expect a non-empty object.
+                 */
+                if (impl.config.validateAccessToken !== undefined) {
+                    yield impl.config.validateAccessToken({
+                        accessTokenPayload: rawUserInfoFromProvider.fromUserInfoAPI,
+                        clientConfig: impl.config,
+                        userContext,
+                    });
+                }
                 const userInfoResult = getSupertokensUserInfoResultFromRawUserInfo(
                     impl.config,
                     rawUserInfoFromProvider

--- a/lib/build/recipe/thirdparty/providers/custom.js
+++ b/lib/build/recipe/thirdparty/providers/custom.js
@@ -354,7 +354,7 @@ function NewProvider(input) {
                  */
                 if (impl.config.validateAccessToken !== undefined) {
                     yield impl.config.validateAccessToken({
-                        accessTokenPayload: rawUserInfoFromProvider.fromUserInfoAPI,
+                        accessToken: accessToken,
                         clientConfig: impl.config,
                         userContext,
                     });

--- a/lib/build/recipe/thirdparty/types.d.ts
+++ b/lib/build/recipe/thirdparty/types.d.ts
@@ -80,7 +80,9 @@ declare type CommonProviderConfig = {
      * @param input.userContext Refer to https://supertokens.com/docs/thirdparty/advanced-customizations/user-context
      */
     validateAccessToken?: (input: {
-        accessToken: string;
+        accessTokenPayload: {
+            [key: string]: any;
+        };
         clientConfig: ProviderConfigForClientType;
         userContext: any;
     }) => Promise<void>;

--- a/lib/build/recipe/thirdparty/types.d.ts
+++ b/lib/build/recipe/thirdparty/types.d.ts
@@ -69,6 +69,21 @@ declare type CommonProviderConfig = {
         clientConfig: ProviderConfigForClientType;
         userContext: any;
     }) => Promise<void>;
+    /**
+     * This function is responsible for validating the access token received from the third party provider.
+     * This check can include checking the expiry of the access token, checking the audience of the access token, etc.
+     *
+     * This function should throw an error if the access token should be considered invalid, or return nothing if it is valid
+     *
+     * @param input.accessToken The access token to be validated
+     * @param input.clientConfig The configuration provided for the third party provider when initialising SuperTokens
+     * @param input.userContext Refer to https://supertokens.com/docs/thirdparty/advanced-customizations/user-context
+     */
+    validateAccessToken?: (input: {
+        accessToken: string;
+        clientConfig: ProviderConfigForClientType;
+        userContext: any;
+    }) => Promise<void>;
     requireEmail?: boolean;
     generateFakeEmail?: (input: { thirdPartyUserId: string; tenantId: string; userContext: any }) => Promise<string>;
 };

--- a/lib/build/recipe/thirdparty/types.d.ts
+++ b/lib/build/recipe/thirdparty/types.d.ts
@@ -80,9 +80,7 @@ declare type CommonProviderConfig = {
      * @param input.userContext Refer to https://supertokens.com/docs/thirdparty/advanced-customizations/user-context
      */
     validateAccessToken?: (input: {
-        accessTokenPayload: {
-            [key: string]: any;
-        };
+        accessToken: string;
         clientConfig: ProviderConfigForClientType;
         userContext: any;
     }) => Promise<void>;

--- a/lib/ts/recipe/thirdparty/api/implementation.ts
+++ b/lib/ts/recipe/thirdparty/api/implementation.ts
@@ -31,6 +31,14 @@ export default function getAPIInterface(): APIInterface {
                 throw Error("should never come here");
             }
 
+            if (provider.config.validateAccessToken !== undefined) {
+                await provider.config.validateAccessToken({
+                    accessToken: oAuthTokensToUse.access_token,
+                    clientConfig: provider.config,
+                    userContext,
+                });
+            }
+
             const userInfo = await provider.getUserInfo({ oAuthTokens: oAuthTokensToUse, userContext });
 
             if (userInfo.email === undefined && provider.config.requireEmail === false) {

--- a/lib/ts/recipe/thirdparty/api/implementation.ts
+++ b/lib/ts/recipe/thirdparty/api/implementation.ts
@@ -31,14 +31,6 @@ export default function getAPIInterface(): APIInterface {
                 throw Error("should never come here");
             }
 
-            if (provider.config.validateAccessToken !== undefined) {
-                await provider.config.validateAccessToken({
-                    accessToken: oAuthTokensToUse.access_token,
-                    clientConfig: provider.config,
-                    userContext,
-                });
-            }
-
             const userInfo = await provider.getUserInfo({ oAuthTokens: oAuthTokensToUse, userContext });
 
             if (userInfo.email === undefined && provider.config.requireEmail === false) {

--- a/lib/ts/recipe/thirdparty/providers/custom.ts
+++ b/lib/ts/recipe/thirdparty/providers/custom.ts
@@ -342,7 +342,7 @@ export default function NewProvider(input: ProviderInput): TypeProvider {
              */
             if (impl.config.validateAccessToken !== undefined) {
                 await impl.config.validateAccessToken({
-                    accessTokenPayload: rawUserInfoFromProvider.fromUserInfoAPI,
+                    accessToken: accessToken,
                     clientConfig: impl.config,
                     userContext,
                 });

--- a/lib/ts/recipe/thirdparty/providers/custom.ts
+++ b/lib/ts/recipe/thirdparty/providers/custom.ts
@@ -335,6 +335,19 @@ export default function NewProvider(input: ProviderInput): TypeProvider {
                 rawUserInfoFromProvider.fromUserInfoAPI = userInfoFromAccessToken;
             }
 
+            /**
+             * This is intentionally not part of the above if block. This is because the user may want to validate the access
+             * token payload even if the user info API has not been provided by the provider. In this case they would get an
+             * empty object and they can fail if they always expect a non-empty object.
+             */
+            if (impl.config.validateAccessToken !== undefined) {
+                await impl.config.validateAccessToken({
+                    accessTokenPayload: rawUserInfoFromProvider.fromUserInfoAPI,
+                    clientConfig: impl.config,
+                    userContext,
+                });
+            }
+
             const userInfoResult = getSupertokensUserInfoResultFromRawUserInfo(impl.config, rawUserInfoFromProvider);
 
             return {

--- a/lib/ts/recipe/thirdparty/types.ts
+++ b/lib/ts/recipe/thirdparty/types.ts
@@ -77,7 +77,7 @@ type CommonProviderConfig = {
      * @param input.userContext Refer to https://supertokens.com/docs/thirdparty/advanced-customizations/user-context
      */
     validateAccessToken?: (input: {
-        accessToken: string;
+        accessTokenPayload: { [key: string]: any };
         clientConfig: ProviderConfigForClientType;
         userContext: any;
     }) => Promise<void>;

--- a/lib/ts/recipe/thirdparty/types.ts
+++ b/lib/ts/recipe/thirdparty/types.ts
@@ -77,7 +77,7 @@ type CommonProviderConfig = {
      * @param input.userContext Refer to https://supertokens.com/docs/thirdparty/advanced-customizations/user-context
      */
     validateAccessToken?: (input: {
-        accessTokenPayload: { [key: string]: any };
+        accessToken: string;
         clientConfig: ProviderConfigForClientType;
         userContext: any;
     }) => Promise<void>;

--- a/lib/ts/recipe/thirdparty/types.ts
+++ b/lib/ts/recipe/thirdparty/types.ts
@@ -66,6 +66,21 @@ type CommonProviderConfig = {
         clientConfig: ProviderConfigForClientType;
         userContext: any;
     }) => Promise<void>;
+    /**
+     * This function is responsible for validating the access token received from the third party provider.
+     * This check can include checking the expiry of the access token, checking the audience of the access token, etc.
+     *
+     * This function should throw an error if the access token should be considered invalid, or return nothing if it is valid
+     *
+     * @param input.accessToken The access token to be validated
+     * @param input.clientConfig The configuration provided for the third party provider when initialising SuperTokens
+     * @param input.userContext Refer to https://supertokens.com/docs/thirdparty/advanced-customizations/user-context
+     */
+    validateAccessToken?: (input: {
+        accessToken: string;
+        clientConfig: ProviderConfigForClientType;
+        userContext: any;
+    }) => Promise<void>;
     requireEmail?: boolean;
     generateFakeEmail?: (input: { thirdPartyUserId: string; tenantId: string; userContext: any }) => Promise<string>;
 };


### PR DESCRIPTION
## Summary of change

Adds a new optional function `validateAccessToken` to provider configs that allows users to validate the access token issued by third party providers during sign in or up

## Related issues

- 

## Test Plan

WIP

## Documentation changes

WIP

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] ...
