### PR TITLE
feat: ignore protected props in createNewSession*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Now supporting FDI 1.18
 -   removed the recipe specific `User` type, now all functions are using the new generic `User` type
 -   The `fetchValue` callback of claims now take a new `recipeUserId` param
+-   Now ignoring protected props in the payload in `createNewSession` and `createNewSessionWithoutRequestResponse`
 
 -   EmailPassword:
     -   removed `getUserById`, `getUserByEmail`

--- a/lib/build/recipe/session/constants.d.ts
+++ b/lib/build/recipe/session/constants.d.ts
@@ -4,3 +4,6 @@ export declare const REFRESH_API_PATH = "/session/refresh";
 export declare const SIGNOUT_API_PATH = "/signout";
 export declare const availableTokenTransferMethods: TokenTransferMethod[];
 export declare const hundredYearsInMs = 3153600000000;
+export declare const JWKCacheCooldownInMs = 500;
+export declare const JWKCacheMaxAgeInMs = 60000;
+export declare const protectedProps: string[];

--- a/lib/build/recipe/session/constants.js
+++ b/lib/build/recipe/session/constants.js
@@ -14,8 +14,21 @@
  * under the License.
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.hundredYearsInMs = exports.availableTokenTransferMethods = exports.SIGNOUT_API_PATH = exports.REFRESH_API_PATH = void 0;
+exports.protectedProps = exports.JWKCacheMaxAgeInMs = exports.JWKCacheCooldownInMs = exports.hundredYearsInMs = exports.availableTokenTransferMethods = exports.SIGNOUT_API_PATH = exports.REFRESH_API_PATH = void 0;
 exports.REFRESH_API_PATH = "/session/refresh";
 exports.SIGNOUT_API_PATH = "/signout";
 exports.availableTokenTransferMethods = ["cookie", "header"];
 exports.hundredYearsInMs = 3153600000000;
+exports.JWKCacheCooldownInMs = 500;
+exports.JWKCacheMaxAgeInMs = 60000;
+exports.protectedProps = [
+    "sub",
+    "iat",
+    "exp",
+    "sessionHandle",
+    "parentRefreshTokenHash1",
+    "refreshTokenHash1",
+    "antiCsrfToken",
+    "rsub",
+    "tId",
+];

--- a/lib/build/recipe/session/index.js
+++ b/lib/build/recipe/session/index.js
@@ -26,6 +26,7 @@ const utils_1 = require("./utils");
 const sessionRequestFunctions_1 = require("./sessionRequestFunctions");
 const __1 = require("../..");
 const constants_1 = require("../multitenancy/constants");
+const constants_2 = require("./constants");
 class SessionWrapper {
     static async createNewSession(
         req,
@@ -71,6 +72,9 @@ class SessionWrapper {
         const appInfo = recipeInstance.getAppInfo();
         const issuer = appInfo.apiDomain.getAsStringDangerous() + appInfo.apiBasePath.getAsStringDangerous();
         let finalAccessTokenPayload = Object.assign(Object.assign({}, accessTokenPayload), { iss: issuer });
+        for (const prop of constants_2.protectedProps) {
+            delete finalAccessTokenPayload[prop];
+        }
         let user = await __1.getUser(recipeUserId.getAsString(), userContext);
         let userId = recipeUserId.getAsString();
         if (user !== undefined) {

--- a/lib/build/recipe/session/recipeImplementation.d.ts
+++ b/lib/build/recipe/session/recipeImplementation.d.ts
@@ -10,8 +10,6 @@ export declare type Helpers = {
     appInfo: NormalisedAppinfo;
     getRecipeImpl: () => RecipeInterface;
 };
-export declare const JWKCacheMaxAgeInMs = 60000;
-export declare const protectedProps: string[];
 export default function getRecipeInterface(
     querier: Querier,
     config: TypeNormalisedInput,

--- a/lib/build/recipe/session/recipeImplementation.js
+++ b/lib/build/recipe/session/recipeImplementation.js
@@ -41,7 +41,6 @@ var __importDefault =
         return mod && mod.__esModule ? mod : { default: mod };
     };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.protectedProps = exports.JWKCacheMaxAgeInMs = void 0;
 const jose_1 = require("jose");
 const SessionFunctions = __importStar(require("./sessionFunctions"));
 const cookieAndHeaders_1 = require("./cookieAndHeaders");
@@ -54,24 +53,12 @@ const accessToken_1 = require("./accessToken");
 const error_1 = __importDefault(require("./error"));
 const recipeUserId_1 = __importDefault(require("../../recipeUserId"));
 const constants_1 = require("../multitenancy/constants");
-const JWKCacheCooldownInMs = 500;
-exports.JWKCacheMaxAgeInMs = 60000;
-exports.protectedProps = [
-    "sub",
-    "iat",
-    "exp",
-    "sessionHandle",
-    "parentRefreshTokenHash1",
-    "refreshTokenHash1",
-    "antiCsrfToken",
-    "rsub",
-    "tId",
-];
+const constants_2 = require("./constants");
 function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverrides) {
     const JWKS = querier.getAllCoreUrlsForPath("/.well-known/jwks.json").map((url) =>
         jose_1.createRemoteJWKSet(new URL(url), {
-            cooldownDuration: JWKCacheCooldownInMs,
-            cacheMaxAge: exports.JWKCacheMaxAgeInMs,
+            cooldownDuration: constants_2.JWKCacheCooldownInMs,
+            cacheMaxAge: constants_2.JWKCacheMaxAgeInMs,
         })
     );
     /**
@@ -362,7 +349,7 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                 return false;
             }
             let newAccessTokenPayload = Object.assign({}, sessionInfo.customClaimsInAccessTokenPayload);
-            for (const key of exports.protectedProps) {
+            for (const key of constants_2.protectedProps) {
                 delete newAccessTokenPayload[key];
             }
             newAccessTokenPayload = Object.assign(Object.assign({}, newAccessTokenPayload), accessTokenPayloadUpdate);

--- a/lib/build/recipe/session/sessionClass.js
+++ b/lib/build/recipe/session/sessionClass.js
@@ -21,10 +21,10 @@ Object.defineProperty(exports, "__esModule", { value: true });
  */
 const cookieAndHeaders_1 = require("./cookieAndHeaders");
 const error_1 = __importDefault(require("./error"));
-const recipeImplementation_1 = require("./recipeImplementation");
 const utils_1 = require("./utils");
 const jwt_1 = require("./jwt");
 const logger_1 = require("../../logger");
+const constants_1 = require("./constants");
 class Session {
     constructor(
         helpers,
@@ -132,7 +132,7 @@ class Session {
     // Any update to this function should also be reflected in the respective JWT version
     async mergeIntoAccessTokenPayload(accessTokenPayloadUpdate, userContext) {
         let newAccessTokenPayload = Object.assign({}, this.getAccessTokenPayload(userContext));
-        for (const key of recipeImplementation_1.protectedProps) {
+        for (const key of constants_1.protectedProps) {
             delete newAccessTokenPayload[key];
         }
         newAccessTokenPayload = Object.assign(Object.assign({}, newAccessTokenPayload), accessTokenPayloadUpdate);
@@ -220,7 +220,7 @@ class Session {
             userContext,
         });
         if (validateClaimResponse.accessTokenPayloadUpdate !== undefined) {
-            for (const key of recipeImplementation_1.protectedProps) {
+            for (const key of constants_1.protectedProps) {
                 delete validateClaimResponse.accessTokenPayloadUpdate[key];
             }
             await this.mergeIntoAccessTokenPayload(validateClaimResponse.accessTokenPayloadUpdate, userContext);

--- a/lib/build/recipe/session/sessionFunctions.js
+++ b/lib/build/recipe/session/sessionFunctions.js
@@ -24,11 +24,11 @@ const accessToken_1 = require("./accessToken");
 const error_1 = __importDefault(require("./error"));
 const processState_1 = require("../../processState");
 const normalisedURLPath_1 = __importDefault(require("../../normalisedURLPath"));
-const recipeImplementation_1 = require("./recipeImplementation");
 const utils_1 = require("../../utils");
 const logger_1 = require("../../logger");
 const recipeUserId_1 = __importDefault(require("../../recipeUserId"));
 const constants_1 = require("../multitenancy/constants");
+const constants_2 = require("./constants");
 /**
  * @description call this to "login" a user.
  */
@@ -129,7 +129,7 @@ async function getSession(helpers, parsedAccessToken, antiCsrfToken, doAntiCsrfC
             }
             // We check if the token was created since the last time we refreshed the keys from the core
             // Since we do not know the exact timing of the last refresh, we check against the max age
-            if (timeCreated <= Date.now() - recipeImplementation_1.JWKCacheMaxAgeInMs) {
+            if (timeCreated <= Date.now() - constants_2.JWKCacheMaxAgeInMs) {
                 throw err;
             }
         } else {

--- a/lib/build/recipe/session/sessionRequestFunctions.js
+++ b/lib/build/recipe/session/sessionRequestFunctions.js
@@ -295,6 +295,9 @@ async function createNewSessionInRequest({
     const claimsAddedByOtherRecipes = recipeInstance.getClaimsAddedByOtherRecipes();
     const issuer = appInfo.apiDomain.getAsStringDangerous() + appInfo.apiBasePath.getAsStringDangerous();
     let finalAccessTokenPayload = Object.assign(Object.assign({}, accessTokenPayload), { iss: issuer });
+    for (const prop of constants_1.protectedProps) {
+        delete finalAccessTokenPayload[prop];
+    }
     for (const claim of claimsAddedByOtherRecipes) {
         const update = await claim.build(userId, recipeUserId, tenantId, userContext);
         finalAccessTokenPayload = Object.assign(Object.assign({}, finalAccessTokenPayload), update);

--- a/lib/ts/recipe/session/constants.ts
+++ b/lib/ts/recipe/session/constants.ts
@@ -21,3 +21,18 @@ export const SIGNOUT_API_PATH = "/signout";
 export const availableTokenTransferMethods: TokenTransferMethod[] = ["cookie", "header"];
 
 export const hundredYearsInMs = 3153600000000;
+
+export const JWKCacheCooldownInMs = 500;
+export const JWKCacheMaxAgeInMs = 60000;
+
+export const protectedProps = [
+    "sub",
+    "iat",
+    "exp",
+    "sessionHandle",
+    "parentRefreshTokenHash1",
+    "refreshTokenHash1",
+    "antiCsrfToken",
+    "rsub",
+    "tId",
+];

--- a/lib/ts/recipe/session/index.ts
+++ b/lib/ts/recipe/session/index.ts
@@ -32,6 +32,7 @@ import { createNewSessionInRequest, getSessionFromRequest, refreshSessionInReque
 import RecipeUserId from "../../recipeUserId";
 import { getUser } from "../..";
 import { DEFAULT_TENANT_ID } from "../multitenancy/constants";
+import { protectedProps } from "./constants";
 
 export default class SessionWrapper {
     static init = Recipe.init;
@@ -89,6 +90,10 @@ export default class SessionWrapper {
             ...accessTokenPayload,
             iss: issuer,
         };
+
+        for (const prop of protectedProps) {
+            delete finalAccessTokenPayload[prop];
+        }
 
         let user = await getUser(recipeUserId.getAsString(), userContext);
         let userId = recipeUserId.getAsString();

--- a/lib/ts/recipe/session/recipeImplementation.ts
+++ b/lib/ts/recipe/session/recipeImplementation.ts
@@ -22,6 +22,7 @@ import { validateAccessTokenStructure } from "./accessToken";
 import SessionError from "./error";
 import RecipeUserId from "../../recipeUserId";
 import { DEFAULT_TENANT_ID } from "../multitenancy/constants";
+import { JWKCacheCooldownInMs, JWKCacheMaxAgeInMs, protectedProps } from "./constants";
 
 export type Helpers = {
     querier: Querier;
@@ -30,21 +31,6 @@ export type Helpers = {
     appInfo: NormalisedAppinfo;
     getRecipeImpl: () => RecipeInterface;
 };
-
-const JWKCacheCooldownInMs = 500;
-export const JWKCacheMaxAgeInMs = 60000;
-
-export const protectedProps = [
-    "sub",
-    "iat",
-    "exp",
-    "sessionHandle",
-    "parentRefreshTokenHash1",
-    "refreshTokenHash1",
-    "antiCsrfToken",
-    "rsub",
-    "tId",
-];
 
 export default function getRecipeInterface(
     querier: Querier,

--- a/lib/ts/recipe/session/sessionClass.ts
+++ b/lib/ts/recipe/session/sessionClass.ts
@@ -15,11 +15,12 @@
 import { buildFrontToken, clearSession, setAntiCsrfTokenInHeaders, setToken } from "./cookieAndHeaders";
 import STError from "./error";
 import { SessionClaim, SessionClaimValidator, SessionContainerInterface, ReqResInfo, TokenInfo } from "./types";
-import { Helpers, protectedProps } from "./recipeImplementation";
+import { Helpers } from "./recipeImplementation";
 import { setAccessTokenInResponse } from "./utils";
 import { parseJWTWithoutSignatureVerification } from "./jwt";
 import { logDebugMessage } from "../../logger";
 import RecipeUserId from "../../recipeUserId";
+import { protectedProps } from "./constants";
 
 export default class Session implements SessionContainerInterface {
     constructor(

--- a/lib/ts/recipe/session/sessionFunctions.ts
+++ b/lib/ts/recipe/session/sessionFunctions.ts
@@ -18,11 +18,12 @@ import STError from "./error";
 import { PROCESS_STATE, ProcessState } from "../../processState";
 import { CreateOrRefreshAPIResponse, SessionInformation } from "./types";
 import NormalisedURLPath from "../../normalisedURLPath";
-import { Helpers, JWKCacheMaxAgeInMs } from "./recipeImplementation";
+import { Helpers } from "./recipeImplementation";
 import { maxVersion } from "../../utils";
 import { logDebugMessage } from "../../logger";
 import RecipeUserId from "../../recipeUserId";
 import { DEFAULT_TENANT_ID } from "../multitenancy/constants";
+import { JWKCacheMaxAgeInMs } from "./constants";
 
 /**
  * @description call this to "login" a user.

--- a/lib/ts/recipe/session/sessionRequestFunctions.ts
+++ b/lib/ts/recipe/session/sessionRequestFunctions.ts
@@ -11,7 +11,7 @@ import SuperTokens from "../../supertokens";
 import { getRequiredClaimValidators } from "./utils";
 import { getRidFromHeader, isAnIpAddress, normaliseHttpMethod, setRequestInUserContextIfNotDefined } from "../../utils";
 import { logDebugMessage } from "../../logger";
-import { availableTokenTransferMethods } from "./constants";
+import { availableTokenTransferMethods, protectedProps } from "./constants";
 import { clearSession, getAntiCsrfTokenFromHeaders, getToken, setCookie } from "./cookieAndHeaders";
 import { ParsedJWTInfo, parseJWTWithoutSignatureVerification } from "./jwt";
 import { validateAccessTokenStructure } from "./accessToken";
@@ -358,6 +358,10 @@ export async function createNewSessionInRequest({
         ...accessTokenPayload,
         iss: issuer,
     };
+
+    for (const prop of protectedProps) {
+        delete finalAccessTokenPayload[prop];
+    }
 
     for (const claim of claimsAddedByOtherRecipes) {
         const update = await claim.build(userId, recipeUserId, tenantId, userContext);

--- a/test/accountlinking/session.test.js
+++ b/test/accountlinking/session.test.js
@@ -33,7 +33,7 @@ let EmailVerification = require("../../recipe/emailverification");
 const express = require("express");
 const request = require("supertest");
 let { middleware, errorHandler } = require("../../framework/express");
-let { protectedProps } = require("../../lib/build/recipe/session/recipeImplementation");
+let { protectedProps } = require("../../lib/build/recipe/session/constants");
 let { PrimitiveClaim } = require("../../lib/build/recipe/session/claimBaseClasses/primitiveClaim");
 
 describe(`sessionTests: ${printPath("[test/accountlinking/session.test.js]")}`, function () {

--- a/test/session/accessTokenVersions.test.js
+++ b/test/session/accessTokenVersions.test.js
@@ -129,7 +129,7 @@ describe(`AccessToken versions: ${printPath("[test/session/accessTokenVersions.t
             assert(parsedHeader.kid.startsWith("s-"));
         });
 
-        it("should throw an error when adding protected props", async function () {
+        it("should ignore protected props", async function () {
             const connectionURI = await startST();
             SuperTokens.init({
                 supertokens: {
@@ -156,7 +156,7 @@ describe(`AccessToken versions: ${printPath("[test/session/accessTokenVersions.t
                             },
                         })
                     )
-                    .expect(400)
+                    .expect(200)
                     .end((err, resp) => {
                         if (err) {
                             rej(err);
@@ -167,9 +167,12 @@ describe(`AccessToken versions: ${printPath("[test/session/accessTokenVersions.t
             );
 
             let cookies = extractInfoFromResponse(res);
-            assert.strictEqual(cookies.accessTokenFromAny, undefined);
-            assert.strictEqual(cookies.refreshTokenFromAny, undefined);
-            assert.strictEqual(cookies.frontToken, undefined);
+            assert.notEqual(cookies.accessTokenFromAny, undefined);
+            assert.notEqual(cookies.refreshTokenFromAny, undefined);
+            assert.notEqual(cookies.frontToken, undefined);
+
+            const parsedToken = parseJWTWithoutSignatureVerification(cookies.accessTokenFromAny);
+            assert.notEqual(parsedToken.payload.sub, "asdf");
         });
 
         it("should make sign in/up return a 500 when adding protected props", async function () {


### PR DESCRIPTION
## Summary of change

- ignore protected props in createNewSession*
- moved some constants into the separate constants file in `Session`

## Related issues

-   

## Test Plan

Modified existing tests

## Documentation changes

Done separately, some updates required

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
