### PR TITLE
fix: add tenant id into password reset links

### DIFF
--- a/lib/build/recipe/emailpassword/api/implementation.js
+++ b/lib/build/recipe/emailpassword/api/implementation.js
@@ -11,6 +11,7 @@ const __1 = require("../../../");
 const recipe_1 = __importDefault(require("../../accountlinking/recipe"));
 const recipe_2 = __importDefault(require("../../emailverification/recipe"));
 const recipeUserId_1 = __importDefault(require("../../../recipeUserId"));
+const utils_1 = require("../utils");
 function getAPIImplementation() {
     return {
         emailExistsGET: async function ({ email, tenantId }) {
@@ -57,13 +58,12 @@ function getAPIImplementation() {
                         status: "OK",
                     };
                 }
-                let passwordResetLink =
-                    options.appInfo.websiteDomain.getAsStringDangerous() +
-                    options.appInfo.websiteBasePath.getAsStringDangerous() +
-                    "/reset-password?token=" +
-                    response.token +
-                    "&rid=" +
-                    options.recipeId;
+                let passwordResetLink = utils_1.getPasswordResetLink({
+                    appInfo: options.appInfo,
+                    token: response.token,
+                    recipeId: options.recipeId,
+                    tenantId,
+                });
                 logger_1.logDebugMessage(`Sending password reset email to ${email}`);
                 await options.emailDelivery.ingredientInterfaceImpl.sendEmail({
                     tenantId,

--- a/lib/ts/recipe/emailpassword/api/implementation.ts
+++ b/lib/ts/recipe/emailpassword/api/implementation.ts
@@ -8,6 +8,7 @@ import AccountLinking from "../../accountlinking/recipe";
 import EmailVerification from "../../emailverification/recipe";
 import { RecipeLevelUser } from "../../accountlinking/types";
 import RecipeUserId from "../../../recipeUserId";
+import { getPasswordResetLink } from "../utils";
 
 export default function getAPIImplementation(): APIInterface {
     return {
@@ -100,13 +101,12 @@ export default function getAPIImplementation(): APIInterface {
                     };
                 }
 
-                let passwordResetLink =
-                    options.appInfo.websiteDomain.getAsStringDangerous() +
-                    options.appInfo.websiteBasePath.getAsStringDangerous() +
-                    "/reset-password?token=" +
-                    response.token +
-                    "&rid=" +
-                    options.recipeId;
+                let passwordResetLink = getPasswordResetLink({
+                    appInfo: options.appInfo,
+                    token: response.token,
+                    recipeId: options.recipeId,
+                    tenantId,
+                });
 
                 logDebugMessage(`Sending password reset email to ${email}`);
                 await options.emailDelivery.ingredientInterfaceImpl.sendEmail({


### PR DESCRIPTION
## Summary of change

fix: add tenant id into password reset links

## Related issues

-   CI test failures

## Test Plan

Already tested (caught in CI)

## Documentation changes

N/A, bugfix

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
