### PR TITLE
fix: Fix jwks body containing additional properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [15.2.1] - 2023-09-22
+
+### Fixes
+
+-   Fixes an issue where the response for the JWKs API would contain additional properties
+
 ## [15.2.0] - 2023-09-11
 
 ### Added

--- a/lib/build/recipe/jwt/api/implementation.js
+++ b/lib/build/recipe/jwt/api/implementation.js
@@ -53,7 +53,9 @@ function getAPIImplementation() {
                 if (resp.validityInSeconds !== undefined) {
                     options.res.setHeader("Cache-Control", `max-age=${resp.validityInSeconds}, must-revalidate`, false);
                 }
-                return resp;
+                return {
+                    keys: resp.keys,
+                };
             });
         },
     };

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "15.2.0";
+export declare const version = "15.2.1";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.7";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "15.2.0";
+exports.version = "15.2.1";
 exports.cdiSupported = ["3.0"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.7";

--- a/lib/ts/recipe/jwt/api/implementation.ts
+++ b/lib/ts/recipe/jwt/api/implementation.ts
@@ -31,7 +31,9 @@ export default function getAPIImplementation(): APIInterface {
                 options.res.setHeader("Cache-Control", `max-age=${resp.validityInSeconds}, must-revalidate`, false);
             }
 
-            return resp;
+            return {
+                keys: resp.keys,
+            };
         },
     };
 }

--- a/lib/ts/recipe/jwt/recipeImplementation.ts
+++ b/lib/ts/recipe/jwt/recipeImplementation.ts
@@ -68,7 +68,7 @@ export default function getRecipeInterface(
             }
         },
 
-        getJWKS: async function (): Promise<{ keys: JsonWebKey[]; validityInSeconds: number }> {
+        getJWKS: async function (): Promise<{ keys: JsonWebKey[]; validityInSeconds?: number }> {
             const { body, headers } = await querier.sendGetRequestWithResponseHeaders(
                 new NormalisedURLPath("/.well-known/jwks.json"),
                 {}

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "15.2.0";
+export const version = "15.2.1";
 
 export const cdiSupported = ["3.0"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "15.2.0",
+    "version": "15.2.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "15.2.0",
+            "version": "15.2.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "15.2.0",
+    "version": "15.2.1",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {

--- a/test/jwt/getJWKS.test.js
+++ b/test/jwt/getJWKS.test.js
@@ -115,6 +115,7 @@ describe(`getJWKS: ${printPath("[test/jwt/getJWKS.test.js]")}`, function () {
         });
 
         assert(response !== undefined);
+        assert(Object.keys(response).length === 1);
         assert(response.keys !== undefined);
         assert(response.keys.length > 0);
         assert.strictEqual(headers["cache-control"], "max-age=60, must-revalidate");


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] ...
