### PR TITLE
fix: update linkedin default scopes

### DIFF
--- a/lib/ts/recipe/thirdparty/providers/linkedin.ts
+++ b/lib/ts/recipe/thirdparty/providers/linkedin.ts
@@ -37,7 +37,7 @@ export default function Linkedin(input: ProviderInput): TypeProvider {
             const config = await oGetConfig(input);
 
             if (config.scope === undefined) {
-                config.scope = ["r_emailaddress", "r_liteprofile"];
+                config.scope = ["email", "profile"];
             }
 
             return config;


### PR DESCRIPTION

## Summary of change

Update to Linkedin new scopes picture attached

## Related issues

Error when using Linkedin SSO
```
http://localhost:3000/auth/callback/linkedin?error=unauthorized_scope_error&error_description=Scope+%26quot%3Br_emailaddress%26quot%3B+is+not+authorized+for+your+application&state=eyJzdGF0ZSI6IjJmMDg1MWFkMjFiYmQyMTkyOTYxZiJ9

```

![image](https://github.com/supertokens/supertokens-node/assets/1475778/b65ecfbd-46fc-446d-9a7a-f1f7caea7e5c)


