### PR TITLE
fix: Fixes logic for consuming errors from social providers

### DIFF
--- a/lib/build/recipe/thirdparty/providers/bitbucket.js
+++ b/lib/build/recipe/thirdparty/providers/bitbucket.js
@@ -68,12 +68,12 @@ function Bitbucket(input) {
                 logger_1.logDebugMessage(
                     `Received response with status ${
                         userInfoFromAccessToken.status
-                    } and body ${await userInfoFromAccessToken.rawResponse.text()}`
+                    } and body ${await userInfoFromAccessToken.stringResponse}`
                 );
                 throw new Error(
                     `Received response with status ${
                         userInfoFromAccessToken.status
-                    } and body ${await userInfoFromAccessToken.rawResponse.text()}`
+                    } and body ${await userInfoFromAccessToken.stringResponse}`
                 );
             }
             rawUserInfoFromProvider.fromUserInfoAPI = userInfoFromAccessToken.response;
@@ -86,12 +86,12 @@ function Bitbucket(input) {
                 logger_1.logDebugMessage(
                     `Received response with status ${
                         userInfoFromEmail.status
-                    } and body ${await userInfoFromEmail.rawResponse.text()}`
+                    } and body ${await userInfoFromEmail.stringResponse}`
                 );
                 throw new Error(
                     `Received response with status ${
                         userInfoFromEmail.status
-                    } and body ${await userInfoFromEmail.rawResponse.text()}`
+                    } and body ${await userInfoFromEmail.stringResponse}`
                 );
             }
             rawUserInfoFromProvider.fromUserInfoAPI.email = userInfoFromEmail.response;

--- a/lib/build/recipe/thirdparty/providers/custom.js
+++ b/lib/build/recipe/thirdparty/providers/custom.js
@@ -256,12 +256,12 @@ function NewProvider(input) {
                 logger_1.logDebugMessage(
                     `Received response with status ${
                         tokenResponse.status
-                    } and body ${await tokenResponse.rawResponse.text()}`
+                    } and body ${await tokenResponse.stringResponse}`
                 );
                 throw new Error(
                     `Received response with status ${
                         tokenResponse.status
-                    } and body ${await tokenResponse.rawResponse.text()}`
+                    } and body ${await tokenResponse.stringResponse}`
                 );
             }
             return tokenResponse.response;
@@ -331,12 +331,12 @@ function NewProvider(input) {
                     logger_1.logDebugMessage(
                         `Received response with status ${
                             userInfoFromAccessToken.status
-                        } and body ${await userInfoFromAccessToken.rawResponse.text()}`
+                        } and body ${await userInfoFromAccessToken.stringResponse}`
                     );
                     throw new Error(
                         `Received response with status ${
                             userInfoFromAccessToken.status
-                        } and body ${await userInfoFromAccessToken.rawResponse.text()}`
+                        } and body ${await userInfoFromAccessToken.stringResponse}`
                     );
                 }
                 rawUserInfoFromProvider.fromUserInfoAPI = userInfoFromAccessToken.response;

--- a/lib/build/recipe/thirdparty/providers/github.js
+++ b/lib/build/recipe/thirdparty/providers/github.js
@@ -84,14 +84,14 @@ function Github(input) {
             const emailInfoResp = await utils_1.doGetRequest("https://api.github.com/user/emails", undefined, headers);
             if (emailInfoResp.status >= 400) {
                 throw new Error(
-                    `Getting userInfo failed with ${emailInfoResp.status}: ${await emailInfoResp.rawResponse.text()}`
+                    `Getting userInfo failed with ${emailInfoResp.status}: ${await emailInfoResp.stringResponse}`
                 );
             }
             rawResponse.emails = emailInfoResp.response;
             const userInfoResp = await utils_1.doGetRequest("https://api.github.com/user", undefined, headers);
             if (userInfoResp.status >= 400) {
                 throw new Error(
-                    `Getting userInfo failed with ${userInfoResp.status}: ${await userInfoResp.rawResponse.text()}`
+                    `Getting userInfo failed with ${userInfoResp.status}: ${await userInfoResp.stringResponse}`
                 );
             }
             rawResponse.user = userInfoResp.response;

--- a/lib/build/recipe/thirdparty/providers/linkedin.js
+++ b/lib/build/recipe/thirdparty/providers/linkedin.js
@@ -64,12 +64,12 @@ function Linkedin(input) {
                 logger_1.logDebugMessage(
                     `Received response with status ${
                         userInfoFromAccessToken.status
-                    } and body ${await userInfoFromAccessToken.rawResponse.text()}`
+                    } and body ${await userInfoFromAccessToken.stringResponse}`
                 );
                 throw new Error(
                     `Received response with status ${
                         userInfoFromAccessToken.status
-                    } and body ${await userInfoFromAccessToken.rawResponse.text()}`
+                    } and body ${await userInfoFromAccessToken.stringResponse}`
                 );
             }
             const emailAPIURL = "https://api.linkedin.com/v2/emailAddress";
@@ -82,12 +82,12 @@ function Linkedin(input) {
                 logger_1.logDebugMessage(
                     `Received response with status ${
                         userInfoFromEmail.status
-                    } and body ${await userInfoFromEmail.rawResponse.text()}`
+                    } and body ${await userInfoFromEmail.stringResponse}`
                 );
                 throw new Error(
                     `Received response with status ${
                         userInfoFromEmail.status
-                    } and body ${await userInfoFromEmail.rawResponse.text()}`
+                    } and body ${await userInfoFromEmail.stringResponse}`
                 );
             }
             if (userInfoFromEmail.response.elements && userInfoFromEmail.response.elements.length > 0) {

--- a/lib/build/recipe/thirdparty/providers/twitter.js
+++ b/lib/build/recipe/thirdparty/providers/twitter.js
@@ -127,12 +127,12 @@ function Twitter(input) {
                 logger_1.logDebugMessage(
                     `Received response with status ${
                         tokenResponse.status
-                    } and body ${await tokenResponse.rawResponse.text()}`
+                    } and body ${await tokenResponse.stringResponse}`
                 );
                 throw new Error(
                     `Received response with status ${
                         tokenResponse.status
-                    } and body ${await tokenResponse.rawResponse.text()}`
+                    } and body ${await tokenResponse.stringResponse}`
                 );
             }
             return tokenResponse.response;

--- a/lib/build/recipe/thirdparty/providers/utils.d.ts
+++ b/lib/build/recipe/thirdparty/providers/utils.d.ts
@@ -10,9 +10,9 @@ export declare function doGetRequest(
         [key: string]: string;
     }
 ): Promise<{
-    response: any;
+    response: any | undefined;
     status: number;
-    rawResponse: Response;
+    stringResponse: string | undefined;
 }>;
 export declare function doPostRequest(
     url: string,
@@ -23,9 +23,9 @@ export declare function doPostRequest(
         [key: string]: string;
     }
 ): Promise<{
-    response: any;
+    response: any | undefined;
     status: number;
-    rawResponse: Response;
+    stringResponse: string | undefined;
 }>;
 export declare function verifyIdTokenFromJWKSEndpointAndGetPayload(
     idToken: string,

--- a/lib/build/recipe/thirdparty/providers/utils.js
+++ b/lib/build/recipe/thirdparty/providers/utils.js
@@ -59,13 +59,12 @@ async function doGetRequest(url, queryParams, headers) {
     let response = await cross_fetch_1.default(finalURL.toString(), {
         headers: headers,
     });
-    const rawResponse = response.clone();
     const respData = await response.clone().json();
     logger_1.logDebugMessage(`Received response with status ${response.status} and body ${JSON.stringify(respData)}`);
     return {
         response: respData,
         status: response.status,
-        rawResponse,
+        rawResponse: response,
     };
 }
 exports.doGetRequest = doGetRequest;
@@ -84,13 +83,12 @@ async function doPostRequest(url, params, headers) {
         body,
         headers,
     });
-    const rawResponse = response.clone();
     const respData = await response.clone().json();
     logger_1.logDebugMessage(`Received response with status ${response.status} and body ${JSON.stringify(respData)}`);
     return {
         response: respData,
         status: response.status,
-        rawResponse,
+        rawResponse: response,
     };
 }
 exports.doPostRequest = doPostRequest;

--- a/lib/build/recipe/thirdparty/providers/utils.js
+++ b/lib/build/recipe/thirdparty/providers/utils.js
@@ -59,12 +59,20 @@ async function doGetRequest(url, queryParams, headers) {
     let response = await cross_fetch_1.default(finalURL.toString(), {
         headers: headers,
     });
-    const respData = await response.clone().json();
-    logger_1.logDebugMessage(`Received response with status ${response.status} and body ${JSON.stringify(respData)}`);
+    let stringResponse = undefined;
+    let responseData = undefined;
+    if (response.status >= 400) {
+        stringResponse = await response.text();
+    } else {
+        responseData = await response.clone().json();
+    }
+    logger_1.logDebugMessage(
+        `Received response with status ${response.status} and body ${JSON.stringify(responseData)}`
+    );
     return {
-        response: respData,
+        response: responseData,
         status: response.status,
-        rawResponse: response,
+        stringResponse,
     };
 }
 exports.doGetRequest = doGetRequest;
@@ -83,12 +91,20 @@ async function doPostRequest(url, params, headers) {
         body,
         headers,
     });
-    const respData = await response.clone().json();
-    logger_1.logDebugMessage(`Received response with status ${response.status} and body ${JSON.stringify(respData)}`);
+    let stringResponse = undefined;
+    let responseData = undefined;
+    if (response.status >= 400) {
+        stringResponse = await response.text();
+    } else {
+        responseData = await response.clone().json();
+    }
+    logger_1.logDebugMessage(
+        `Received response with status ${response.status} and body ${JSON.stringify(responseData)}`
+    );
     return {
-        response: respData,
+        response: responseData,
         status: response.status,
-        rawResponse: response,
+        stringResponse,
     };
 }
 exports.doPostRequest = doPostRequest;
@@ -112,11 +128,9 @@ async function getOIDCDiscoveryInfo(issuer) {
     );
     if (oidcInfo.status >= 400) {
         logger_1.logDebugMessage(
-            `Received response with status ${oidcInfo.status} and body ${await oidcInfo.rawResponse.text()}`
+            `Received response with status ${oidcInfo.status} and body ${await oidcInfo.stringResponse}`
         );
-        throw new Error(
-            `Received response with status ${oidcInfo.status} and body ${await oidcInfo.rawResponse.text()}`
-        );
+        throw new Error(`Received response with status ${oidcInfo.status} and body ${await oidcInfo.stringResponse}`);
     }
     oidcInfoMap[issuer] = oidcInfo.response;
     return oidcInfo.response;

--- a/lib/build/recipe/thirdparty/providers/utils.js
+++ b/lib/build/recipe/thirdparty/providers/utils.js
@@ -59,12 +59,13 @@ async function doGetRequest(url, queryParams, headers) {
     let response = await cross_fetch_1.default(finalURL.toString(), {
         headers: headers,
     });
+    const rawResponse = response.clone();
     const respData = await response.clone().json();
     logger_1.logDebugMessage(`Received response with status ${response.status} and body ${JSON.stringify(respData)}`);
     return {
         response: respData,
         status: response.status,
-        rawResponse: response.clone(),
+        rawResponse,
     };
 }
 exports.doGetRequest = doGetRequest;
@@ -83,12 +84,13 @@ async function doPostRequest(url, params, headers) {
         body,
         headers,
     });
+    const rawResponse = response.clone();
     const respData = await response.clone().json();
     logger_1.logDebugMessage(`Received response with status ${response.status} and body ${JSON.stringify(respData)}`);
     return {
         response: respData,
         status: response.status,
-        rawResponse: response.clone(),
+        rawResponse,
     };
 }
 exports.doPostRequest = doPostRequest;

--- a/lib/ts/recipe/thirdparty/providers/bitbucket.ts
+++ b/lib/ts/recipe/thirdparty/providers/bitbucket.ts
@@ -80,12 +80,12 @@ export default function Bitbucket(input: ProviderInput): TypeProvider {
                 logDebugMessage(
                     `Received response with status ${
                         userInfoFromAccessToken.status
-                    } and body ${await userInfoFromAccessToken.rawResponse.text()}`
+                    } and body ${await userInfoFromAccessToken.stringResponse}`
                 );
                 throw new Error(
                     `Received response with status ${
                         userInfoFromAccessToken.status
-                    } and body ${await userInfoFromAccessToken.rawResponse.text()}`
+                    } and body ${await userInfoFromAccessToken.stringResponse}`
                 );
             }
             rawUserInfoFromProvider.fromUserInfoAPI = userInfoFromAccessToken.response;
@@ -100,12 +100,12 @@ export default function Bitbucket(input: ProviderInput): TypeProvider {
                 logDebugMessage(
                     `Received response with status ${
                         userInfoFromEmail.status
-                    } and body ${await userInfoFromEmail.rawResponse.text()}`
+                    } and body ${await userInfoFromEmail.stringResponse}`
                 );
                 throw new Error(
                     `Received response with status ${
                         userInfoFromEmail.status
-                    } and body ${await userInfoFromEmail.rawResponse.text()}`
+                    } and body ${await userInfoFromEmail.stringResponse}`
                 );
             }
 

--- a/lib/ts/recipe/thirdparty/providers/custom.ts
+++ b/lib/ts/recipe/thirdparty/providers/custom.ts
@@ -276,12 +276,12 @@ export default function NewProvider(input: ProviderInput): TypeProvider {
                 logDebugMessage(
                     `Received response with status ${
                         tokenResponse.status
-                    } and body ${await tokenResponse.rawResponse.text()}`
+                    } and body ${await tokenResponse.stringResponse}`
                 );
                 throw new Error(
                     `Received response with status ${
                         tokenResponse.status
-                    } and body ${await tokenResponse.rawResponse.text()}`
+                    } and body ${await tokenResponse.stringResponse}`
                 );
             }
 
@@ -361,12 +361,12 @@ export default function NewProvider(input: ProviderInput): TypeProvider {
                     logDebugMessage(
                         `Received response with status ${
                             userInfoFromAccessToken.status
-                        } and body ${await userInfoFromAccessToken.rawResponse.text()}`
+                        } and body ${await userInfoFromAccessToken.stringResponse}`
                     );
                     throw new Error(
                         `Received response with status ${
                             userInfoFromAccessToken.status
-                        } and body ${await userInfoFromAccessToken.rawResponse.text()}`
+                        } and body ${await userInfoFromAccessToken.stringResponse}`
                     );
                 }
 

--- a/lib/ts/recipe/thirdparty/providers/github.ts
+++ b/lib/ts/recipe/thirdparty/providers/github.ts
@@ -113,7 +113,7 @@ export default function Github(input: ProviderInput): TypeProvider {
 
             if (emailInfoResp.status >= 400) {
                 throw new Error(
-                    `Getting userInfo failed with ${emailInfoResp.status}: ${await emailInfoResp.rawResponse.text()}`
+                    `Getting userInfo failed with ${emailInfoResp.status}: ${await emailInfoResp.stringResponse}`
                 );
             }
 
@@ -123,7 +123,7 @@ export default function Github(input: ProviderInput): TypeProvider {
 
             if (userInfoResp.status >= 400) {
                 throw new Error(
-                    `Getting userInfo failed with ${userInfoResp.status}: ${await userInfoResp.rawResponse.text()}`
+                    `Getting userInfo failed with ${userInfoResp.status}: ${await userInfoResp.stringResponse}`
                 );
             }
 

--- a/lib/ts/recipe/thirdparty/providers/linkedin.ts
+++ b/lib/ts/recipe/thirdparty/providers/linkedin.ts
@@ -70,12 +70,12 @@ export default function Linkedin(input: ProviderInput): TypeProvider {
                 logDebugMessage(
                     `Received response with status ${
                         userInfoFromAccessToken.status
-                    } and body ${await userInfoFromAccessToken.rawResponse.text()}`
+                    } and body ${await userInfoFromAccessToken.stringResponse}`
                 );
                 throw new Error(
                     `Received response with status ${
                         userInfoFromAccessToken.status
-                    } and body ${await userInfoFromAccessToken.rawResponse.text()}`
+                    } and body ${await userInfoFromAccessToken.stringResponse}`
                 );
             }
 
@@ -90,12 +90,12 @@ export default function Linkedin(input: ProviderInput): TypeProvider {
                 logDebugMessage(
                     `Received response with status ${
                         userInfoFromEmail.status
-                    } and body ${await userInfoFromEmail.rawResponse.text()}`
+                    } and body ${await userInfoFromEmail.stringResponse}`
                 );
                 throw new Error(
                     `Received response with status ${
                         userInfoFromEmail.status
-                    } and body ${await userInfoFromEmail.rawResponse.text()}`
+                    } and body ${await userInfoFromEmail.stringResponse}`
                 );
             }
 

--- a/lib/ts/recipe/thirdparty/providers/twitter.ts
+++ b/lib/ts/recipe/thirdparty/providers/twitter.ts
@@ -105,12 +105,12 @@ export default function Twitter(input: ProviderInput): TypeProvider {
                 logDebugMessage(
                     `Received response with status ${
                         tokenResponse.status
-                    } and body ${await tokenResponse.rawResponse.text()}`
+                    } and body ${await tokenResponse.stringResponse}`
                 );
                 throw new Error(
                     `Received response with status ${
                         tokenResponse.status
-                    } and body ${await tokenResponse.rawResponse.text()}`
+                    } and body ${await tokenResponse.stringResponse}`
                 );
             }
 

--- a/lib/ts/recipe/thirdparty/providers/utils.ts
+++ b/lib/ts/recipe/thirdparty/providers/utils.ts
@@ -11,9 +11,9 @@ export async function doGetRequest(
     queryParams?: { [key: string]: string },
     headers?: { [key: string]: string }
 ): Promise<{
-    response: any;
+    response: any | undefined;
     status: number;
-    rawResponse: Response;
+    stringResponse: string | undefined;
 }> {
     logDebugMessage(
         `GET request to ${url}, with query params ${JSON.stringify(queryParams)} and headers ${JSON.stringify(headers)}`
@@ -30,13 +30,20 @@ export async function doGetRequest(
         headers: headers,
     });
 
-    const respData = await response.clone().json();
+    let stringResponse: string | undefined = undefined;
+    let responseData: any | undefined = undefined;
 
-    logDebugMessage(`Received response with status ${response.status} and body ${JSON.stringify(respData)}`);
+    if (response.status >= 400) {
+        stringResponse = await response.text();
+    } else {
+        responseData = await response.clone().json();
+    }
+
+    logDebugMessage(`Received response with status ${response.status} and body ${JSON.stringify(responseData)}`);
     return {
-        response: respData,
+        response: responseData,
         status: response.status,
-        rawResponse: response,
+        stringResponse,
     };
 }
 
@@ -45,9 +52,9 @@ export async function doPostRequest(
     params: { [key: string]: any },
     headers?: { [key: string]: string }
 ): Promise<{
-    response: any;
+    response: any | undefined;
     status: number;
-    rawResponse: Response;
+    stringResponse: string | undefined;
 }> {
     if (headers === undefined) {
         headers = {};
@@ -67,13 +74,20 @@ export async function doPostRequest(
         headers,
     });
 
-    const respData = await response.clone().json();
+    let stringResponse: string | undefined = undefined;
+    let responseData: any | undefined = undefined;
 
-    logDebugMessage(`Received response with status ${response.status} and body ${JSON.stringify(respData)}`);
+    if (response.status >= 400) {
+        stringResponse = await response.text();
+    } else {
+        responseData = await response.clone().json();
+    }
+
+    logDebugMessage(`Received response with status ${response.status} and body ${JSON.stringify(responseData)}`);
     return {
-        response: respData,
+        response: responseData,
         status: response.status,
-        rawResponse: response,
+        stringResponse,
     };
 }
 
@@ -105,12 +119,8 @@ async function getOIDCDiscoveryInfo(issuer: string): Promise<any> {
     );
 
     if (oidcInfo.status >= 400) {
-        logDebugMessage(
-            `Received response with status ${oidcInfo.status} and body ${await oidcInfo.rawResponse.text()}`
-        );
-        throw new Error(
-            `Received response with status ${oidcInfo.status} and body ${await oidcInfo.rawResponse.text()}`
-        );
+        logDebugMessage(`Received response with status ${oidcInfo.status} and body ${await oidcInfo.stringResponse}`);
+        throw new Error(`Received response with status ${oidcInfo.status} and body ${await oidcInfo.stringResponse}`);
     }
 
     oidcInfoMap[issuer] = oidcInfo.response;

--- a/lib/ts/recipe/thirdparty/providers/utils.ts
+++ b/lib/ts/recipe/thirdparty/providers/utils.ts
@@ -30,15 +30,13 @@ export async function doGetRequest(
         headers: headers,
     });
 
-    const rawResponse = response.clone();
-
     const respData = await response.clone().json();
 
     logDebugMessage(`Received response with status ${response.status} and body ${JSON.stringify(respData)}`);
     return {
         response: respData,
         status: response.status,
-        rawResponse,
+        rawResponse: response,
     };
 }
 
@@ -69,14 +67,13 @@ export async function doPostRequest(
         headers,
     });
 
-    const rawResponse = response.clone();
     const respData = await response.clone().json();
 
     logDebugMessage(`Received response with status ${response.status} and body ${JSON.stringify(respData)}`);
     return {
         response: respData,
         status: response.status,
-        rawResponse,
+        rawResponse: response,
     };
 }
 

--- a/lib/ts/recipe/thirdparty/providers/utils.ts
+++ b/lib/ts/recipe/thirdparty/providers/utils.ts
@@ -30,13 +30,15 @@ export async function doGetRequest(
         headers: headers,
     });
 
+    const rawResponse = response.clone();
+
     const respData = await response.clone().json();
 
     logDebugMessage(`Received response with status ${response.status} and body ${JSON.stringify(respData)}`);
     return {
         response: respData,
         status: response.status,
-        rawResponse: response.clone(),
+        rawResponse,
     };
 }
 
@@ -67,13 +69,14 @@ export async function doPostRequest(
         headers,
     });
 
+    const rawResponse = response.clone();
     const respData = await response.clone().json();
 
     logDebugMessage(`Received response with status ${response.status} and body ${JSON.stringify(respData)}`);
     return {
         response: respData,
         status: response.status,
-        rawResponse: response.clone(),
+        rawResponse,
     };
 }
 


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
