### PR TITLE
fix: handle ec2 public urls as apiDomain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [16.3.1] - 2023-10-12
+
+### Fixes
+
+-   Handle AWS Public URLs (ending with `.amazonaws.com`) separately while extracting TLDs for SameSite attribute.
+
 ## [16.3.0] - 2023-10-10
 
 ### Added

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -293,6 +293,9 @@ function getTopLevelDomainForSameSiteResolution(url) {
     }
     let parsedURL = psl.parse(hostname);
     if (parsedURL.domain === null) {
+        if (hostname.endsWith(".amazonaws.com") && parsedURL.tld === hostname) {
+            return hostname;
+        }
         throw new Error("Please make sure that the apiDomain and websiteDomain have correct values");
     }
     return parsedURL.domain;

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "16.3.0";
+export declare const version = "16.3.1";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.8";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "16.3.0";
+exports.version = "16.3.1";
 exports.cdiSupported = ["4.0"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.8";

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -280,8 +280,12 @@ export function getTopLevelDomainForSameSiteResolution(url: string): string {
         // we treat these as the same TLDs since we can use sameSite lax for all of them.
         return "localhost";
     }
+
     let parsedURL = psl.parse(hostname) as psl.ParsedDomain;
     if (parsedURL.domain === null) {
+        if (hostname.endsWith(".amazonaws.com") && parsedURL.tld === hostname) {
+            return hostname;
+        }
         throw new Error("Please make sure that the apiDomain and websiteDomain have correct values");
     }
     return parsedURL.domain;

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "16.3.0";
+export const version = "16.3.1";
 
 export const cdiSupported = ["4.0"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "16.3.0",
+    "version": "16.3.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "16.3.0",
+    "version": "16.3.1",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

fix: handle ec2 public urls as apiDomain

## Related issues

-   https://github.com/supertokens/supertokens-python/pull/449/files

## Test Plan

- Added test that getTopLevelDomainForSameSiteResolution returns the right value
- Added a test checking that we set the right cookie settings based on that

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.