### PR TITLE
test: update tests that check when the ev claim is updated

### DIFF
--- a/test/accountlinking/emailverificationapis.test.js
+++ b/test/accountlinking/emailverificationapis.test.js
@@ -478,7 +478,7 @@ describe(`emailverificationapiTests: ${printPath("[test/accountlinking/emailveri
     });
 
     describe("isEmailVerifiedGET tests", function () {
-        it("calling isEmailVerifiedGET  gives false for currently logged in user if email is not verified, and does not update session", async function () {
+        it("calling isEmailVerifiedGET  gives false for currently logged in user if email is not verified, and updates session", async function () {
             const connectionURI = await startSTWithMultitenancyAndAccountLinking();
             supertokens.init({
                 supertokens: {
@@ -555,12 +555,10 @@ describe(`emailverificationapiTests: ${printPath("[test/accountlinking/emailveri
             assert(response.body.isVerified === false);
 
             let tokens = extractInfoFromResponse(response);
-            assert(tokens.accessToken === undefined);
-            assert(tokens.accessTokenFromAny === undefined);
-            assert(tokens.accessTokenFromHeader === undefined);
+            assert.notStrictEqual(tokens.accessTokenFromAny, undefined);
         });
 
-        it("calling isEmailVerifiedGET gives true for currently logged in user if email is verified, and does not update session", async function () {
+        it("calling isEmailVerifiedGET gives true for currently logged in user if email is verified, and updates session", async function () {
             const connectionURI = await startSTWithMultitenancyAndAccountLinking();
             supertokens.init({
                 supertokens: {
@@ -643,9 +641,7 @@ describe(`emailverificationapiTests: ${printPath("[test/accountlinking/emailveri
             assert(response.body.isVerified === true);
 
             let tokens = extractInfoFromResponse(response);
-            assert(tokens.accessToken === undefined);
-            assert(tokens.accessTokenFromAny === undefined);
-            assert(tokens.accessTokenFromHeader === undefined);
+            assert.notStrictEqual(tokens.accessTokenFromAny, undefined);
         });
 
         it("calling isEmailVerifiedGET gives false for currently logged in user if email is not verified, and updates session if needed", async function () {
@@ -928,7 +924,7 @@ describe(`emailverificationapiTests: ${printPath("[test/accountlinking/emailveri
             assert(userInCallback.recipeUserId.getAsString() === epUser.loginMethods[0].recipeUserId.getAsString());
         });
 
-        it("calling generateEmailVerifyTokenPOST gives already verified for currently logged in user if email is verified, and does not update session", async function () {
+        it("calling generateEmailVerifyTokenPOST gives already verified for currently logged in user if email is verified, and updates session", async function () {
             let userInCallback = undefined;
             const connectionURI = await startSTWithMultitenancyAndAccountLinking();
             supertokens.init({
@@ -1021,9 +1017,7 @@ describe(`emailverificationapiTests: ${printPath("[test/accountlinking/emailveri
             assert(response.body.status === "EMAIL_ALREADY_VERIFIED_ERROR");
 
             let tokens = extractInfoFromResponse(response);
-            assert(tokens.accessToken === undefined);
-            assert(tokens.accessTokenFromAny === undefined);
-            assert(tokens.accessTokenFromHeader === undefined);
+            assert.notStrictEqual(tokens.accessTokenFromAny, undefined);
 
             assert(userInCallback === undefined);
         });

--- a/test/emailpassword/emailverify.test.js
+++ b/test/emailpassword/emailverify.test.js
@@ -1408,7 +1408,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         let infoFromResponse2 = extractInfoFromResponse(response);
         assert.strictEqual(response.statusCode, 200);
         assert.deepStrictEqual(response.body.status, "EMAIL_ALREADY_VERIFIED_ERROR");
-        assert.strictEqual(infoFromResponse2.frontToken, undefined);
+        assert.notStrictEqual(infoFromResponse2.frontToken, undefined);
 
         // now we mark the email as unverified and try again
         await EmailVerification.unverifyEmail(userId, emailId);


### PR DESCRIPTION
## Summary of change

Updates test cases related to #722 
Solves #721 

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
