### PR TITLE
feat: added `networkInterceptor` hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
-## [16.4.1] - 2023-11-09
+## [16.5.0] - 2023-11-10
 
 -   Added `networkInterceptor` to the `TypeInput` config.
     -   This can be used to capture/modify all the HTTP requests sent to the core.
-    -   Solves the issue - https://github.com/supertokens/supertokens-core/issues/865
+    -   Closes the issue - https://github.com/supertokens/supertokens-core/issues/865
 
 ## [16.4.0] - 2023-10-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [16.4.1] - 2023-11-09
+
+-   Added `networkInterceptor` to the `TypeInput` config.
+-   This can be used to capture/modify all the HTTP requests sent to the core.
+-   Solves the issue - https://github.com/supertokens/supertokens-core/issues/865
+
 ## [16.4.0] - 2023-10-26
 
 -   Added `debug` property to `TypeInput`. When set to `true`, it will enable debug logs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [16.4.1] - 2023-11-09
 
 -   Added `networkInterceptor` to the `TypeInput` config.
--   This can be used to capture/modify all the HTTP requests sent to the core.
--   Solves the issue - https://github.com/supertokens/supertokens-core/issues/865
+    -   This can be used to capture/modify all the HTTP requests sent to the core.
+    -   Solves the issue - https://github.com/supertokens/supertokens-core/issues/865
 
 ## [16.4.0] - 2023-10-26
 

--- a/lib/build/framework/fastify/index.d.ts
+++ b/lib/build/framework/fastify/index.d.ts
@@ -1,18 +1,21 @@
 // @ts-nocheck
 /// <reference types="node" />
 export type { SessionRequest } from "./framework";
-export declare const plugin: import("fastify").FastifyPluginCallback<Record<never, never>, import("http").Server>;
+export declare const plugin: import("fastify").FastifyPluginCallback<
+    Record<never, never>,
+    import("fastify").RawServerDefault
+>;
 export declare const errorHandler: () => (
     err: any,
     req: import("fastify").FastifyRequest<
         import("fastify/types/route").RouteGenericInterface,
-        import("http").Server,
+        import("fastify").RawServerDefault,
         import("http").IncomingMessage
     >,
     res: import("fastify").FastifyReply<
-        import("http").Server,
+        import("fastify").RawServerDefault,
         import("http").IncomingMessage,
-        import("http").ServerResponse,
+        import("http").ServerResponse<import("http").IncomingMessage>,
         import("fastify/types/route").RouteGenericInterface,
         unknown
     >

--- a/lib/build/framework/fastify/index.d.ts
+++ b/lib/build/framework/fastify/index.d.ts
@@ -1,21 +1,18 @@
 // @ts-nocheck
 /// <reference types="node" />
 export type { SessionRequest } from "./framework";
-export declare const plugin: import("fastify").FastifyPluginCallback<
-    Record<never, never>,
-    import("fastify").RawServerDefault
->;
+export declare const plugin: import("fastify").FastifyPluginCallback<Record<never, never>, import("http").Server>;
 export declare const errorHandler: () => (
     err: any,
     req: import("fastify").FastifyRequest<
         import("fastify/types/route").RouteGenericInterface,
-        import("fastify").RawServerDefault,
+        import("http").Server,
         import("http").IncomingMessage
     >,
     res: import("fastify").FastifyReply<
-        import("fastify").RawServerDefault,
+        import("http").Server,
         import("http").IncomingMessage,
-        import("http").ServerResponse<import("http").IncomingMessage>,
+        import("http").ServerResponse,
         import("fastify/types/route").RouteGenericInterface,
         unknown
     >

--- a/lib/build/framework/utils.d.ts
+++ b/lib/build/framework/utils.d.ts
@@ -45,7 +45,7 @@ export declare function setCookieForServerResponse(
     expires: number,
     path: string,
     sameSite: "strict" | "lax" | "none"
-): ServerResponse<IncomingMessage>;
+): ServerResponse;
 export declare function getCookieValueToSetInHeader(
     prev: string | string[] | undefined,
     val: string | string[],

--- a/lib/build/framework/utils.d.ts
+++ b/lib/build/framework/utils.d.ts
@@ -45,7 +45,7 @@ export declare function setCookieForServerResponse(
     expires: number,
     path: string,
     sameSite: "strict" | "lax" | "none"
-): ServerResponse;
+): ServerResponse<IncomingMessage>;
 export declare function getCookieValueToSetInHeader(
     prev: string | string[] | undefined,
     val: string | string[],

--- a/lib/build/index.d.ts
+++ b/lib/build/index.d.ts
@@ -11,7 +11,7 @@ export default class SuperTokensWrapper {
     static RecipeUserId: typeof RecipeUserId;
     static User: typeof User;
     static getAllCORSHeaders(): string[];
-    static getUserCount(includeRecipeIds?: string[], tenantId?: string): Promise<number>;
+    static getUserCount(includeRecipeIds?: string[], tenantId?: string, userContext?: any): Promise<number>;
     static getUsersOldestFirst(input: {
         tenantId: string;
         limit?: number;
@@ -20,6 +20,7 @@ export default class SuperTokensWrapper {
         query?: {
             [key: string]: string;
         };
+        userContext?: any;
     }): Promise<{
         users: UserType[];
         nextPaginationToken?: string;
@@ -32,6 +33,7 @@ export default class SuperTokensWrapper {
         query?: {
             [key: string]: string;
         };
+        userContext?: any;
     }): Promise<{
         users: UserType[];
         nextPaginationToken?: string;
@@ -41,6 +43,7 @@ export default class SuperTokensWrapper {
         externalUserId: string;
         externalUserIdInfo?: string;
         force?: boolean;
+        userContext?: any;
     }): Promise<
         | {
               status: "OK" | "UNKNOWN_SUPERTOKENS_USER_ID_ERROR";
@@ -54,6 +57,7 @@ export default class SuperTokensWrapper {
     static getUserIdMapping(input: {
         userId: string;
         userIdType?: "SUPERTOKENS" | "EXTERNAL" | "ANY";
+        userContext?: any;
     }): Promise<
         | {
               status: "OK";
@@ -69,6 +73,7 @@ export default class SuperTokensWrapper {
         userId: string;
         userIdType?: "SUPERTOKENS" | "EXTERNAL" | "ANY";
         force?: boolean;
+        userContext?: any;
     }): Promise<{
         status: "OK";
         didMappingExist: boolean;
@@ -77,6 +82,7 @@ export default class SuperTokensWrapper {
         userId: string;
         userIdType?: "SUPERTOKENS" | "EXTERNAL" | "ANY";
         externalUserIdInfo?: string;
+        userContext?: any;
     }): Promise<{
         status: "OK" | "UNKNOWN_MAPPING_ERROR";
     }>;

--- a/lib/build/index.js
+++ b/lib/build/index.js
@@ -30,22 +30,22 @@ class SuperTokensWrapper {
     static getAllCORSHeaders() {
         return supertokens_1.default.getInstanceOrThrowError().getAllCORSHeaders();
     }
-    static getUserCount(includeRecipeIds, tenantId) {
-        return supertokens_1.default.getInstanceOrThrowError().getUserCount(includeRecipeIds, tenantId);
+    static getUserCount(includeRecipeIds, tenantId, userContext) {
+        return supertokens_1.default.getInstanceOrThrowError().getUserCount(includeRecipeIds, tenantId, userContext);
     }
     static getUsersOldestFirst(input) {
-        return recipe_1.default
-            .getInstance()
-            .recipeInterfaceImpl.getUsers(
-                Object.assign(Object.assign({ timeJoinedOrder: "ASC" }, input), { userContext: undefined })
-            );
+        return recipe_1.default.getInstance().recipeInterfaceImpl.getUsers(
+            Object.assign(Object.assign({ timeJoinedOrder: "ASC" }, input), {
+                userContext: input.userContext === undefined ? {} : input.userContext,
+            })
+        );
     }
     static getUsersNewestFirst(input) {
-        return recipe_1.default
-            .getInstance()
-            .recipeInterfaceImpl.getUsers(
-                Object.assign(Object.assign({ timeJoinedOrder: "DESC" }, input), { userContext: undefined })
-            );
+        return recipe_1.default.getInstance().recipeInterfaceImpl.getUsers(
+            Object.assign(Object.assign({ timeJoinedOrder: "DESC" }, input), {
+                userContext: input.userContext === undefined ? {} : input.userContext,
+            })
+        );
     }
     static createUserIdMapping(input) {
         return supertokens_1.default.getInstanceOrThrowError().createUserIdMapping(input);

--- a/lib/build/querier.d.ts
+++ b/lib/build/querier.d.ts
@@ -26,7 +26,7 @@ export declare class Querier {
         networkInterceptor?: NetworkInterceptor
     ): void;
     sendPostRequest: <T = any>(path: NormalisedURLPath, body: any, userContext: any) => Promise<T>;
-    sendDeleteRequest: (path: NormalisedURLPath, body: any, userContext: any, params?: any) => Promise<any>;
+    sendDeleteRequest: (path: NormalisedURLPath, body: any, params: any, userContext: any) => Promise<any>;
     sendGetRequest: (
         path: NormalisedURLPath,
         params: Record<string, boolean | number | string | undefined>,

--- a/lib/build/querier.d.ts
+++ b/lib/build/querier.d.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import NormalisedURLDomain from "./normalisedURLDomain";
 import NormalisedURLPath from "./normalisedURLPath";
+import { NetworkInterceptor } from "./types";
 export declare class Querier {
     private static initCalled;
     private static hosts;
@@ -8,6 +9,7 @@ export declare class Querier {
     private static apiVersion;
     private static lastTriedIndex;
     private static hostsAliveForTesting;
+    private static networkInterceptor;
     private __hosts;
     private rIdToCore;
     private constructor();
@@ -20,22 +22,25 @@ export declare class Querier {
             domain: NormalisedURLDomain;
             basePath: NormalisedURLPath;
         }[],
-        apiKey?: string
+        apiKey?: string,
+        networkInterceptor?: NetworkInterceptor
     ): void;
-    sendPostRequest: <T = any>(path: NormalisedURLPath, body: any) => Promise<T>;
-    sendDeleteRequest: (path: NormalisedURLPath, body: any, params?: any) => Promise<any>;
+    sendPostRequest: <T = any>(path: NormalisedURLPath, body: any, userContext: any) => Promise<T>;
+    sendDeleteRequest: (path: NormalisedURLPath, body: any, userContext: any, params?: any) => Promise<any>;
     sendGetRequest: (
         path: NormalisedURLPath,
-        params: Record<string, boolean | number | string | undefined>
+        params: Record<string, boolean | number | string | undefined>,
+        userContext: any
     ) => Promise<any>;
     sendGetRequestWithResponseHeaders: (
         path: NormalisedURLPath,
-        params: Record<string, boolean | number | string | undefined>
+        params: Record<string, boolean | number | string | undefined>,
+        userContext: any
     ) => Promise<{
         body: any;
         headers: Headers;
     }>;
-    sendPutRequest: (path: NormalisedURLPath, body: any) => Promise<any>;
+    sendPutRequest: (path: NormalisedURLPath, body: any, userContext: any) => Promise<any>;
     getAllCoreUrlsForPath(path: string): string[];
     private sendRequestHelper;
 }

--- a/lib/build/querier.js
+++ b/lib/build/querier.js
@@ -25,6 +25,7 @@ const version_1 = require("./version");
 const normalisedURLPath_1 = __importDefault(require("./normalisedURLPath"));
 const processState_1 = require("./processState");
 const constants_1 = require("./constants");
+const logger_1 = require("./logger");
 class Querier {
     // we have rIdToCore so that recipes can force change the rId sent to core. This is a hack until the core is able
     // to support multiple rIds per API
@@ -75,7 +76,7 @@ class Querier {
             return Querier.hostsAliveForTesting;
         };
         // path should start with "/"
-        this.sendPostRequest = async (path, body) => {
+        this.sendPostRequest = async (path, body, userContext) => {
             var _a;
             const { body: respBody } = await this.sendRequestHelper(
                 path,
@@ -92,6 +93,22 @@ class Querier {
                     if (path.isARecipePath() && this.rIdToCore !== undefined) {
                         headers = Object.assign(Object.assign({}, headers), { rid: this.rIdToCore });
                     }
+                    if (Querier.networkInterceptor !== undefined) {
+                        let request = Querier.networkInterceptor(
+                            {
+                                url: url,
+                                method: "post",
+                                headers: headers,
+                                body: body,
+                            },
+                            userContext
+                        );
+                        url = request.url;
+                        headers = request.headers;
+                        if (request.body !== undefined) {
+                            body = request.body;
+                        }
+                    }
                     return utils_1.doFetch(url, {
                         method: "POST",
                         body: body !== undefined ? JSON.stringify(body) : undefined,
@@ -103,7 +120,7 @@ class Querier {
             return respBody;
         };
         // path should start with "/"
-        this.sendDeleteRequest = async (path, body, params) => {
+        this.sendDeleteRequest = async (path, body, userContext, params) => {
             var _a;
             const { body: respBody } = await this.sendRequestHelper(
                 path,
@@ -116,6 +133,26 @@ class Querier {
                     }
                     if (path.isARecipePath() && this.rIdToCore !== undefined) {
                         headers = Object.assign(Object.assign({}, headers), { rid: this.rIdToCore });
+                    }
+                    if (Querier.networkInterceptor !== undefined) {
+                        let request = Querier.networkInterceptor(
+                            {
+                                url: url,
+                                method: "delete",
+                                headers: headers,
+                                params: params,
+                                body: body,
+                            },
+                            userContext
+                        );
+                        url = request.url;
+                        headers = request.headers;
+                        if (request.body !== undefined) {
+                            body = request.body;
+                        }
+                        if (request.params !== undefined) {
+                            params = request.params;
+                        }
                     }
                     const finalURL = new URL(url);
                     const searchParams = new URLSearchParams(params);
@@ -131,7 +168,7 @@ class Querier {
             return respBody;
         };
         // path should start with "/"
-        this.sendGetRequest = async (path, params) => {
+        this.sendGetRequest = async (path, params, userContext) => {
             var _a;
             const { body: respBody } = await this.sendRequestHelper(
                 path,
@@ -144,6 +181,22 @@ class Querier {
                     }
                     if (path.isARecipePath() && this.rIdToCore !== undefined) {
                         headers = Object.assign(Object.assign({}, headers), { rid: this.rIdToCore });
+                    }
+                    if (Querier.networkInterceptor !== undefined) {
+                        let request = Querier.networkInterceptor(
+                            {
+                                url: url,
+                                method: "get",
+                                headers: headers,
+                                params: params,
+                            },
+                            userContext
+                        );
+                        url = request.url;
+                        headers = request.headers;
+                        if (request.params !== undefined) {
+                            params = request.params;
+                        }
                     }
                     const finalURL = new URL(url);
                     const searchParams = new URLSearchParams(
@@ -159,7 +212,7 @@ class Querier {
             );
             return respBody;
         };
-        this.sendGetRequestWithResponseHeaders = async (path, params) => {
+        this.sendGetRequestWithResponseHeaders = async (path, params, userContext) => {
             var _a;
             return await this.sendRequestHelper(
                 path,
@@ -172,6 +225,23 @@ class Querier {
                     }
                     if (path.isARecipePath() && this.rIdToCore !== undefined) {
                         headers = Object.assign(Object.assign({}, headers), { rid: this.rIdToCore });
+                    }
+                    if (Querier.networkInterceptor !== undefined) {
+                        let request = Querier.networkInterceptor(
+                            {
+                                url: url,
+                                method: "get",
+                                headers: headers,
+                                params: params,
+                                body: undefined,
+                            },
+                            userContext
+                        );
+                        url = request.url;
+                        headers = request.headers;
+                        if (request.params !== undefined) {
+                            params = request.params;
+                        }
                     }
                     const finalURL = new URL(url);
                     const searchParams = new URLSearchParams(
@@ -187,7 +257,7 @@ class Querier {
             );
         };
         // path should start with "/"
-        this.sendPutRequest = async (path, body) => {
+        this.sendPutRequest = async (path, body, userContext) => {
             var _a;
             const { body: respBody } = await this.sendRequestHelper(
                 path,
@@ -200,6 +270,23 @@ class Querier {
                     }
                     if (path.isARecipePath() && this.rIdToCore !== undefined) {
                         headers = Object.assign(Object.assign({}, headers), { rid: this.rIdToCore });
+                    }
+                    if (Querier.networkInterceptor !== undefined) {
+                        let request = Querier.networkInterceptor(
+                            {
+                                url: url,
+                                method: "put",
+                                headers: headers,
+                                params: undefined,
+                                body: body,
+                            },
+                            userContext
+                        );
+                        url = request.url;
+                        headers = request.headers;
+                        if (request.body !== undefined) {
+                            body = request.body;
+                        }
                     }
                     return utils_1.doFetch(url, {
                         method: "PUT",
@@ -302,14 +389,16 @@ class Querier {
         }
         return new Querier(Querier.hosts, rIdToCore);
     }
-    static init(hosts, apiKey) {
+    static init(hosts, apiKey, networkInterceptor) {
         if (!Querier.initCalled) {
+            logger_1.logDebugMessage("querier initialized");
             Querier.initCalled = true;
             Querier.hosts = hosts;
             Querier.apiKey = apiKey;
             Querier.apiVersion = undefined;
             Querier.lastTriedIndex = 0;
             Querier.hostsAliveForTesting = new Set();
+            Querier.networkInterceptor = networkInterceptor;
         }
     }
     getAllCoreUrlsForPath(path) {
@@ -331,3 +420,4 @@ Querier.apiKey = undefined;
 Querier.apiVersion = undefined;
 Querier.lastTriedIndex = 0;
 Querier.hostsAliveForTesting = new Set();
+Querier.networkInterceptor = undefined;

--- a/lib/build/querier.js
+++ b/lib/build/querier.js
@@ -120,7 +120,7 @@ class Querier {
             return respBody;
         };
         // path should start with "/"
-        this.sendDeleteRequest = async (path, body, userContext, params) => {
+        this.sendDeleteRequest = async (path, body, params, userContext) => {
             var _a;
             const { body: respBody } = await this.sendRequestHelper(
                 path,
@@ -233,7 +233,6 @@ class Querier {
                                 method: "get",
                                 headers: headers,
                                 params: params,
-                                body: undefined,
                             },
                             userContext
                         );
@@ -277,7 +276,6 @@ class Querier {
                                 url: url,
                                 method: "put",
                                 headers: headers,
-                                params: undefined,
                                 body: body,
                             },
                             userContext

--- a/lib/build/recipe/accountlinking/recipeImplementation.js
+++ b/lib/build/recipe/accountlinking/recipeImplementation.js
@@ -23,7 +23,15 @@ const normalisedURLPath_1 = __importDefault(require("../../normalisedURLPath"));
 const user_1 = require("../../user");
 function getRecipeImplementation(querier, config, recipeInstance) {
     return {
-        getUsers: async function ({ tenantId, timeJoinedOrder, limit, paginationToken, includeRecipeIds, query }) {
+        getUsers: async function ({
+            tenantId,
+            timeJoinedOrder,
+            limit,
+            paginationToken,
+            includeRecipeIds,
+            query,
+            userContext,
+        }) {
             let includeRecipeIdsStr = undefined;
             if (includeRecipeIds !== undefined) {
                 includeRecipeIdsStr = includeRecipeIds.join(",");
@@ -40,40 +48,44 @@ function getRecipeImplementation(querier, config, recipeInstance) {
                         paginationToken: paginationToken,
                     },
                     query
-                )
+                ),
+                userContext
             );
             return {
                 users: response.users.map((u) => new user_1.User(u)),
                 nextPaginationToken: response.nextPaginationToken,
             };
         },
-        canCreatePrimaryUser: async function ({ recipeUserId }) {
+        canCreatePrimaryUser: async function ({ recipeUserId, userContext }) {
             return await querier.sendGetRequest(
                 new normalisedURLPath_1.default("/recipe/accountlinking/user/primary/check"),
                 {
                     recipeUserId: recipeUserId.getAsString(),
-                }
+                },
+                userContext
             );
         },
-        createPrimaryUser: async function ({ recipeUserId }) {
+        createPrimaryUser: async function ({ recipeUserId, userContext }) {
             let response = await querier.sendPostRequest(
                 new normalisedURLPath_1.default("/recipe/accountlinking/user/primary"),
                 {
                     recipeUserId: recipeUserId.getAsString(),
-                }
+                },
+                userContext
             );
             if (response.status === "OK") {
                 response.user = new user_1.User(response.user);
             }
             return response;
         },
-        canLinkAccounts: async function ({ recipeUserId, primaryUserId }) {
+        canLinkAccounts: async function ({ recipeUserId, primaryUserId, userContext }) {
             let result = await querier.sendGetRequest(
                 new normalisedURLPath_1.default("/recipe/accountlinking/user/link/check"),
                 {
                     recipeUserId: recipeUserId.getAsString(),
                     primaryUserId,
-                }
+                },
+                userContext
             );
             return result;
         },
@@ -83,7 +95,8 @@ function getRecipeImplementation(querier, config, recipeInstance) {
                 {
                     recipeUserId: recipeUserId.getAsString(),
                     primaryUserId,
-                }
+                },
+                userContext
             );
             if (
                 ["OK", "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"].includes(
@@ -120,25 +133,30 @@ function getRecipeImplementation(querier, config, recipeInstance) {
             }
             return accountsLinkingResult;
         },
-        unlinkAccount: async function ({ recipeUserId }) {
+        unlinkAccount: async function ({ recipeUserId, userContext }) {
             let accountsUnlinkingResult = await querier.sendPostRequest(
                 new normalisedURLPath_1.default("/recipe/accountlinking/user/unlink"),
                 {
                     recipeUserId: recipeUserId.getAsString(),
-                }
+                },
+                userContext
             );
             return accountsUnlinkingResult;
         },
-        getUser: async function ({ userId }) {
-            let result = await querier.sendGetRequest(new normalisedURLPath_1.default("/user/id"), {
-                userId,
-            });
+        getUser: async function ({ userId, userContext }) {
+            let result = await querier.sendGetRequest(
+                new normalisedURLPath_1.default("/user/id"),
+                {
+                    userId,
+                },
+                userContext
+            );
             if (result.status === "OK") {
                 return new user_1.User(result.user);
             }
             return undefined;
         },
-        listUsersByAccountInfo: async function ({ tenantId, accountInfo, doUnionOfAccountInfo }) {
+        listUsersByAccountInfo: async function ({ tenantId, accountInfo, doUnionOfAccountInfo, userContext }) {
             var _a, _b;
             let result = await querier.sendGetRequest(
                 new normalisedURLPath_1.default(
@@ -150,15 +168,20 @@ function getRecipeImplementation(querier, config, recipeInstance) {
                     thirdPartyId: (_a = accountInfo.thirdParty) === null || _a === void 0 ? void 0 : _a.id,
                     thirdPartyUserId: (_b = accountInfo.thirdParty) === null || _b === void 0 ? void 0 : _b.userId,
                     doUnionOfAccountInfo,
-                }
+                },
+                userContext
             );
             return result.users.map((u) => new user_1.User(u));
         },
-        deleteUser: async function ({ userId, removeAllLinkedAccounts }) {
-            return await querier.sendPostRequest(new normalisedURLPath_1.default("/user/remove"), {
-                userId,
-                removeAllLinkedAccounts,
-            });
+        deleteUser: async function ({ userId, removeAllLinkedAccounts, userContext }) {
+            return await querier.sendPostRequest(
+                new normalisedURLPath_1.default("/user/remove"),
+                {
+                    userId,
+                    removeAllLinkedAccounts,
+                },
+                userContext
+            );
         },
     };
 }

--- a/lib/build/recipe/dashboard/api/analytics.d.ts
+++ b/lib/build/recipe/dashboard/api/analytics.d.ts
@@ -3,4 +3,9 @@ import { APIInterface, APIOptions } from "../types";
 export declare type Response = {
     status: "OK";
 };
-export default function analyticsPost(_: APIInterface, ___: string, options: APIOptions, __: any): Promise<Response>;
+export default function analyticsPost(
+    _: APIInterface,
+    ___: string,
+    options: APIOptions,
+    userContext: any
+): Promise<Response>;

--- a/lib/build/recipe/dashboard/api/analytics.js
+++ b/lib/build/recipe/dashboard/api/analytics.js
@@ -25,7 +25,7 @@ const normalisedURLPath_1 = __importDefault(require("../../../normalisedURLPath"
 const version_1 = require("../../../version");
 const error_1 = __importDefault(require("../../../error"));
 const utils_1 = require("../../../utils");
-async function analyticsPost(_, ___, options, __) {
+async function analyticsPost(_, ___, options, userContext) {
     // If telemetry is disabled, dont send any event
     if (!supertokens_1.default.getInstanceOrThrowError().telemetryEnabled) {
         return {
@@ -49,7 +49,7 @@ async function analyticsPost(_, ___, options, __) {
     let numberOfUsers;
     try {
         let querier = querier_1.Querier.getNewInstanceOrThrowError(options.recipeId);
-        let response = await querier.sendGetRequest(new normalisedURLPath_1.default("/telemetry"), {});
+        let response = await querier.sendGetRequest(new normalisedURLPath_1.default("/telemetry"), {}, userContext);
         if (response.exists) {
             telemetryId = response.telemetryId;
         }

--- a/lib/build/recipe/dashboard/api/search/tagsGet.d.ts
+++ b/lib/build/recipe/dashboard/api/search/tagsGet.d.ts
@@ -8,6 +8,6 @@ export declare const getSearchTags: (
     _: APIInterface,
     ___: string,
     options: APIOptions,
-    __: any
+    userContext: any
 ) => Promise<TagsResponse>;
 export {};

--- a/lib/build/recipe/dashboard/api/search/tagsGet.js
+++ b/lib/build/recipe/dashboard/api/search/tagsGet.js
@@ -22,9 +22,13 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.getSearchTags = void 0;
 const querier_1 = require("../../../../querier");
 const normalisedURLPath_1 = __importDefault(require("../../../../normalisedURLPath"));
-const getSearchTags = async (_, ___, options, __) => {
+const getSearchTags = async (_, ___, options, userContext) => {
     let querier = querier_1.Querier.getNewInstanceOrThrowError(options.recipeId);
-    let tagsResponse = await querier.sendGetRequest(new normalisedURLPath_1.default("/user/search/tags"), {});
+    let tagsResponse = await querier.sendGetRequest(
+        new normalisedURLPath_1.default("/user/search/tags"),
+        {},
+        userContext
+    );
     return tagsResponse;
 };
 exports.getSearchTags = getSearchTags;

--- a/lib/build/recipe/dashboard/api/signIn.d.ts
+++ b/lib/build/recipe/dashboard/api/signIn.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
 import { APIInterface, APIOptions } from "../types";
-export default function signIn(_: APIInterface, options: APIOptions, __: any): Promise<boolean>;
+export default function signIn(_: APIInterface, options: APIOptions, userContext: any): Promise<boolean>;

--- a/lib/build/recipe/dashboard/api/signIn.js
+++ b/lib/build/recipe/dashboard/api/signIn.js
@@ -23,7 +23,7 @@ const utils_1 = require("../../../utils");
 const error_1 = __importDefault(require("../../../error"));
 const querier_1 = require("../../../querier");
 const normalisedURLPath_1 = __importDefault(require("../../../normalisedURLPath"));
-async function signIn(_, options, __) {
+async function signIn(_, options, userContext) {
     const { email, password } = await options.req.getJSONBody();
     if (email === undefined) {
         throw new error_1.default({
@@ -38,10 +38,14 @@ async function signIn(_, options, __) {
         });
     }
     let querier = querier_1.Querier.getNewInstanceOrThrowError(undefined);
-    const signInResponse = await querier.sendPostRequest(new normalisedURLPath_1.default("/recipe/dashboard/signin"), {
-        email,
-        password,
-    });
+    const signInResponse = await querier.sendPostRequest(
+        new normalisedURLPath_1.default("/recipe/dashboard/signin"),
+        {
+            email,
+            password,
+        },
+        userContext
+    );
     utils_1.send200Response(options.res, signInResponse);
     return true;
 }

--- a/lib/build/recipe/dashboard/api/signOut.d.ts
+++ b/lib/build/recipe/dashboard/api/signOut.d.ts
@@ -1,3 +1,3 @@
 // @ts-nocheck
 import { APIInterface, APIOptions } from "../types";
-export default function signOut(_: APIInterface, ___: string, options: APIOptions, __: any): Promise<boolean>;
+export default function signOut(_: APIInterface, ___: string, options: APIOptions, userContext: any): Promise<boolean>;

--- a/lib/build/recipe/dashboard/api/signOut.js
+++ b/lib/build/recipe/dashboard/api/signOut.js
@@ -33,8 +33,8 @@ async function signOut(_, ___, options, userContext) {
         const sessionDeleteResponse = await querier.sendDeleteRequest(
             new normalisedURLPath_1.default("/recipe/dashboard/session"),
             {},
-            userContext,
-            { sessionId: sessionIdFormAuthHeader }
+            { sessionId: sessionIdFormAuthHeader },
+            userContext
         );
         utils_1.send200Response(options.res, sessionDeleteResponse);
     }

--- a/lib/build/recipe/dashboard/api/signOut.js
+++ b/lib/build/recipe/dashboard/api/signOut.js
@@ -22,7 +22,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = require("../../../utils");
 const querier_1 = require("../../../querier");
 const normalisedURLPath_1 = __importDefault(require("../../../normalisedURLPath"));
-async function signOut(_, ___, options, __) {
+async function signOut(_, ___, options, userContext) {
     var _a;
     if (options.config.authMode === "api-key") {
         utils_1.send200Response(options.res, { status: "OK" });
@@ -33,6 +33,7 @@ async function signOut(_, ___, options, __) {
         const sessionDeleteResponse = await querier.sendDeleteRequest(
             new normalisedURLPath_1.default("/recipe/dashboard/session"),
             {},
+            userContext,
             { sessionId: sessionIdFormAuthHeader }
         );
         utils_1.send200Response(options.res, sessionDeleteResponse);

--- a/lib/build/recipe/dashboard/recipeImplementation.js
+++ b/lib/build/recipe/dashboard/recipeImplementation.js
@@ -46,7 +46,8 @@ function getRecipeImplementation() {
                     new normalisedURLPath_1.default("/recipe/dashboard/session/verify"),
                     {
                         sessionId: authHeaderValue,
-                    }
+                    },
+                    input.userContext
                 );
                 if (sessionVerificationResponse.status !== "OK") {
                     return false;

--- a/lib/build/recipe/emailpassword/recipeImplementation.js
+++ b/lib/build/recipe/emailpassword/recipeImplementation.js
@@ -43,7 +43,8 @@ function getRecipeInterface(querier, getEmailPasswordConfig) {
                 {
                     email: input.email,
                     password: input.password,
-                }
+                },
+                input.userContext
             );
             if (resp.status === "OK") {
                 resp.user = new user_1.User(resp.user);
@@ -61,7 +62,8 @@ function getRecipeInterface(querier, getEmailPasswordConfig) {
                 {
                     email,
                     password,
-                }
+                },
+                userContext
             );
             if (response.status === "OK") {
                 response.user = new user_1.User(response.user);
@@ -91,7 +93,7 @@ function getRecipeInterface(querier, getEmailPasswordConfig) {
             }
             return response;
         },
-        createResetPasswordToken: async function ({ userId, email, tenantId }) {
+        createResetPasswordToken: async function ({ userId, email, tenantId, userContext }) {
             // the input user ID can be a recipe or a primary user ID.
             return await querier.sendPostRequest(
                 new normalisedURLPath_1.default(
@@ -102,10 +104,11 @@ function getRecipeInterface(querier, getEmailPasswordConfig) {
                 {
                     userId,
                     email,
-                }
+                },
+                userContext
             );
         },
-        consumePasswordResetToken: async function ({ token, tenantId }) {
+        consumePasswordResetToken: async function ({ token, tenantId, userContext }) {
             return await querier.sendPostRequest(
                 new normalisedURLPath_1.default(
                     `/${
@@ -115,7 +118,8 @@ function getRecipeInterface(querier, getEmailPasswordConfig) {
                 {
                     method: "token",
                     token,
-                }
+                },
+                userContext
             );
         },
         updateEmailOrPassword: async function (input) {
@@ -144,7 +148,8 @@ function getRecipeInterface(querier, getEmailPasswordConfig) {
                     recipeUserId: input.recipeUserId.getAsString(),
                     email: input.email,
                     password: input.password,
-                }
+                },
+                input.userContext
             );
             if (response.status === "OK") {
                 const user = await __1.getUser(input.recipeUserId.getAsString(), input.userContext);

--- a/lib/build/recipe/emailverification/recipeImplementation.js
+++ b/lib/build/recipe/emailverification/recipeImplementation.js
@@ -10,13 +10,14 @@ const recipeUserId_1 = __importDefault(require("../../recipeUserId"));
 const __1 = require("../..");
 function getRecipeInterface(querier, getEmailForRecipeUserId) {
     return {
-        createEmailVerificationToken: async function ({ recipeUserId, email, tenantId }) {
+        createEmailVerificationToken: async function ({ recipeUserId, email, tenantId, userContext }) {
             let response = await querier.sendPostRequest(
                 new normalisedURLPath_1.default(`/${tenantId}/recipe/user/email/verify/token`),
                 {
                     userId: recipeUserId.getAsString(),
                     email,
-                }
+                },
+                userContext
             );
             if (response.status === "OK") {
                 return {
@@ -35,7 +36,8 @@ function getRecipeInterface(querier, getEmailForRecipeUserId) {
                 {
                     method: "token",
                     token,
-                }
+                },
+                userContext
             );
             if (response.status === "OK") {
                 const recipeUserId = new recipeUserId_1.default(response.userId);
@@ -73,11 +75,15 @@ function getRecipeInterface(querier, getEmailForRecipeUserId) {
                 };
             }
         },
-        isEmailVerified: async function ({ recipeUserId, email }) {
-            let response = await querier.sendGetRequest(new normalisedURLPath_1.default("/recipe/user/email/verify"), {
-                userId: recipeUserId.getAsString(),
-                email,
-            });
+        isEmailVerified: async function ({ recipeUserId, email, userContext }) {
+            let response = await querier.sendGetRequest(
+                new normalisedURLPath_1.default("/recipe/user/email/verify"),
+                {
+                    userId: recipeUserId.getAsString(),
+                    email,
+                },
+                userContext
+            );
             return response.isVerified;
         },
         revokeEmailVerificationTokens: async function (input) {
@@ -86,15 +92,20 @@ function getRecipeInterface(querier, getEmailForRecipeUserId) {
                 {
                     userId: input.recipeUserId.getAsString(),
                     email: input.email,
-                }
+                },
+                input.userContext
             );
             return { status: "OK" };
         },
         unverifyEmail: async function (input) {
-            await querier.sendPostRequest(new normalisedURLPath_1.default("/recipe/user/email/verify/remove"), {
-                userId: input.recipeUserId.getAsString(),
-                email: input.email,
-            });
+            await querier.sendPostRequest(
+                new normalisedURLPath_1.default("/recipe/user/email/verify/remove"),
+                {
+                    userId: input.recipeUserId.getAsString(),
+                    email: input.email,
+                },
+                input.userContext
+            );
             return { status: "OK" };
         },
     };

--- a/lib/build/recipe/jwt/recipeImplementation.js
+++ b/lib/build/recipe/jwt/recipeImplementation.js
@@ -23,18 +23,22 @@ const normalisedURLPath_1 = __importDefault(require("../../normalisedURLPath"));
 const defaultJWKSMaxAge = 60; // This corresponds to the dynamicSigningKeyOverlapMS in the core
 function getRecipeInterface(querier, config, appInfo) {
     return {
-        createJWT: async function ({ payload, validitySeconds, useStaticSigningKey }) {
+        createJWT: async function ({ payload, validitySeconds, useStaticSigningKey, userContext }) {
             if (validitySeconds === undefined) {
                 // If the user does not provide a validity to this function and the config validity is also undefined, use 100 years (in seconds)
                 validitySeconds = config.jwtValiditySeconds;
             }
-            let response = await querier.sendPostRequest(new normalisedURLPath_1.default("/recipe/jwt"), {
-                payload: payload !== null && payload !== void 0 ? payload : {},
-                validity: validitySeconds,
-                useStaticSigningKey: useStaticSigningKey !== false,
-                algorithm: "RS256",
-                jwksDomain: appInfo.apiDomain.getAsStringDangerous(),
-            });
+            let response = await querier.sendPostRequest(
+                new normalisedURLPath_1.default("/recipe/jwt"),
+                {
+                    payload: payload !== null && payload !== void 0 ? payload : {},
+                    validity: validitySeconds,
+                    useStaticSigningKey: useStaticSigningKey !== false,
+                    algorithm: "RS256",
+                    jwksDomain: appInfo.apiDomain.getAsStringDangerous(),
+                },
+                userContext
+            );
             if (response.status === "OK") {
                 return {
                     status: "OK",
@@ -46,10 +50,11 @@ function getRecipeInterface(querier, config, appInfo) {
                 };
             }
         },
-        getJWKS: async function () {
+        getJWKS: async function (userContext) {
             const { body, headers } = await querier.sendGetRequestWithResponseHeaders(
                 new normalisedURLPath_1.default("/.well-known/jwks.json"),
-                {}
+                {},
+                userContext
             );
             let validityInSeconds = defaultJWKSMaxAge;
             const cacheControl = headers.get("Cache-Control");

--- a/lib/build/recipe/multitenancy/recipeImplementation.js
+++ b/lib/build/recipe/multitenancy/recipeImplementation.js
@@ -12,42 +12,46 @@ function getRecipeInterface(querier) {
         getTenantId: async function ({ tenantIdFromFrontend }) {
             return tenantIdFromFrontend;
         },
-        createOrUpdateTenant: async function ({ tenantId, config }) {
+        createOrUpdateTenant: async function ({ tenantId, config, userContext }) {
             let response = await querier.sendPutRequest(
                 new normalisedURLPath_1.default(`/recipe/multitenancy/tenant`),
-                Object.assign({ tenantId }, config)
+                Object.assign({ tenantId }, config),
+                userContext
             );
             return response;
         },
-        deleteTenant: async function ({ tenantId }) {
+        deleteTenant: async function ({ tenantId, userContext }) {
             let response = await querier.sendPostRequest(
                 new normalisedURLPath_1.default(`/recipe/multitenancy/tenant/remove`),
                 {
                     tenantId,
-                }
+                },
+                userContext
             );
             return response;
         },
-        getTenant: async function ({ tenantId }) {
+        getTenant: async function ({ tenantId, userContext }) {
             let response = await querier.sendGetRequest(
                 new normalisedURLPath_1.default(
                     `/${tenantId === undefined ? constants_1.DEFAULT_TENANT_ID : tenantId}/recipe/multitenancy/tenant`
                 ),
-                {}
+                {},
+                userContext
             );
             if (response.status === "TENANT_NOT_FOUND_ERROR") {
                 return undefined;
             }
             return response;
         },
-        listAllTenants: async function () {
+        listAllTenants: async function ({ userContext }) {
             let response = await querier.sendGetRequest(
                 new normalisedURLPath_1.default(`/recipe/multitenancy/tenant/list`),
-                {}
+                {},
+                userContext
             );
             return response;
         },
-        createOrUpdateThirdPartyConfig: async function ({ tenantId, config, skipValidation }) {
+        createOrUpdateThirdPartyConfig: async function ({ tenantId, config, skipValidation, userContext }) {
             let response = await querier.sendPutRequest(
                 new normalisedURLPath_1.default(
                     `/${
@@ -57,11 +61,12 @@ function getRecipeInterface(querier) {
                 {
                     config,
                     skipValidation,
-                }
+                },
+                userContext
             );
             return response;
         },
-        deleteThirdPartyConfig: async function ({ tenantId, thirdPartyId }) {
+        deleteThirdPartyConfig: async function ({ tenantId, thirdPartyId, userContext }) {
             let response = await querier.sendPostRequest(
                 new normalisedURLPath_1.default(
                     `/${
@@ -70,11 +75,12 @@ function getRecipeInterface(querier) {
                 ),
                 {
                     thirdPartyId,
-                }
+                },
+                userContext
             );
             return response;
         },
-        associateUserToTenant: async function ({ tenantId, recipeUserId }) {
+        associateUserToTenant: async function ({ tenantId, recipeUserId, userContext }) {
             let response = await querier.sendPostRequest(
                 new normalisedURLPath_1.default(
                     `/${
@@ -83,11 +89,12 @@ function getRecipeInterface(querier) {
                 ),
                 {
                     recipeUserId: recipeUserId.getAsString(),
-                }
+                },
+                userContext
             );
             return response;
         },
-        disassociateUserFromTenant: async function ({ tenantId, recipeUserId }) {
+        disassociateUserFromTenant: async function ({ tenantId, recipeUserId, userContext }) {
             let response = await querier.sendPostRequest(
                 new normalisedURLPath_1.default(
                     `/${
@@ -96,7 +103,8 @@ function getRecipeInterface(querier) {
                 ),
                 {
                     recipeUserId: recipeUserId.getAsString(),
-                }
+                },
+                userContext
             );
             return response;
         },

--- a/lib/build/recipe/passwordless/recipeImplementation.js
+++ b/lib/build/recipe/passwordless/recipeImplementation.js
@@ -25,7 +25,8 @@ function getRecipeInterface(querier) {
         consumeCode: async function (input) {
             let response = await querier.sendPostRequest(
                 new normalisedURLPath_1.default(`/${input.tenantId}/recipe/signinup/code/consume`),
-                copyAndRemoveUserContextAndTenantId(input)
+                copyAndRemoveUserContextAndTenantId(input),
+                input.userContext
             );
             if (response.status !== "OK") {
                 return response;
@@ -74,49 +75,56 @@ function getRecipeInterface(querier) {
         createCode: async function (input) {
             let response = await querier.sendPostRequest(
                 new normalisedURLPath_1.default(`/${input.tenantId}/recipe/signinup/code`),
-                copyAndRemoveUserContextAndTenantId(input)
+                copyAndRemoveUserContextAndTenantId(input),
+                input.userContext
             );
             return response;
         },
         createNewCodeForDevice: async function (input) {
             let response = await querier.sendPostRequest(
                 new normalisedURLPath_1.default(`/${input.tenantId}/recipe/signinup/code`),
-                copyAndRemoveUserContextAndTenantId(input)
+                copyAndRemoveUserContextAndTenantId(input),
+                input.userContext
             );
             return response;
         },
         listCodesByDeviceId: async function (input) {
             let response = await querier.sendGetRequest(
                 new normalisedURLPath_1.default(`/${input.tenantId}/recipe/signinup/codes`),
-                copyAndRemoveUserContextAndTenantId(input)
+                copyAndRemoveUserContextAndTenantId(input),
+                input.userContext
             );
             return response.devices.length === 1 ? response.devices[0] : undefined;
         },
         listCodesByEmail: async function (input) {
             let response = await querier.sendGetRequest(
                 new normalisedURLPath_1.default(`/${input.tenantId}/recipe/signinup/codes`),
-                copyAndRemoveUserContextAndTenantId(input)
+                copyAndRemoveUserContextAndTenantId(input),
+                input.userContext
             );
             return response.devices;
         },
         listCodesByPhoneNumber: async function (input) {
             let response = await querier.sendGetRequest(
                 new normalisedURLPath_1.default(`/${input.tenantId}/recipe/signinup/codes`),
-                copyAndRemoveUserContextAndTenantId(input)
+                copyAndRemoveUserContextAndTenantId(input),
+                input.userContext
             );
             return response.devices;
         },
         listCodesByPreAuthSessionId: async function (input) {
             let response = await querier.sendGetRequest(
                 new normalisedURLPath_1.default(`/${input.tenantId}/recipe/signinup/codes`),
-                copyAndRemoveUserContextAndTenantId(input)
+                copyAndRemoveUserContextAndTenantId(input),
+                input.userContext
             );
             return response.devices.length === 1 ? response.devices[0] : undefined;
         },
         revokeAllCodes: async function (input) {
             await querier.sendPostRequest(
                 new normalisedURLPath_1.default(`/${input.tenantId}/recipe/signinup/codes/remove`),
-                copyAndRemoveUserContextAndTenantId(input)
+                copyAndRemoveUserContextAndTenantId(input),
+                input.userContext
             );
             return {
                 status: "OK",
@@ -125,14 +133,16 @@ function getRecipeInterface(querier) {
         revokeCode: async function (input) {
             await querier.sendPostRequest(
                 new normalisedURLPath_1.default(`/${input.tenantId}/recipe/signinup/code/remove`),
-                copyAndRemoveUserContextAndTenantId(input)
+                copyAndRemoveUserContextAndTenantId(input),
+                input.userContext
             );
             return { status: "OK" };
         },
         updateUser: async function (input) {
             let response = await querier.sendPutRequest(
                 new normalisedURLPath_1.default(`/recipe/user`),
-                copyAndRemoveUserContextAndTenantId(input)
+                copyAndRemoveUserContextAndTenantId(input),
+                input.userContext
             );
             if (response.status !== "OK") {
                 return response;

--- a/lib/build/recipe/session/recipeImplementation.js
+++ b/lib/build/recipe/session/recipeImplementation.js
@@ -323,15 +323,12 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
             revokeSessionsForLinkedAccounts,
             userContext,
         }) {
-            if (tenantId === undefined) {
-                tenantId = constants_1.DEFAULT_TENANT_ID;
-            }
             return SessionFunctions.revokeAllSessionsForUser(
                 helpers,
                 userId,
                 revokeSessionsForLinkedAccounts,
                 tenantId,
-                revokeAcrossAllTenants !== null && revokeAcrossAllTenants !== void 0 ? revokeAcrossAllTenants : false,
+                revokeAcrossAllTenants,
                 userContext
             );
         },
@@ -342,15 +339,12 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
             fetchAcrossAllTenants,
             userContext,
         }) {
-            if (tenantId === undefined) {
-                tenantId = constants_1.DEFAULT_TENANT_ID;
-            }
             return SessionFunctions.getAllSessionHandlesForUser(
                 helpers,
                 userId,
                 fetchSessionsForAllLinkedAccounts,
                 tenantId,
-                fetchAcrossAllTenants !== null && fetchAcrossAllTenants !== void 0 ? fetchAcrossAllTenants : false,
+                fetchAcrossAllTenants,
                 userContext
             );
         },

--- a/lib/build/recipe/session/recipeImplementation.js
+++ b/lib/build/recipe/session/recipeImplementation.js
@@ -92,6 +92,7 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
             sessionDataInDatabase = {},
             disableAntiCsrf,
             tenantId,
+            userContext,
         }) {
             logger_1.logDebugMessage("createNewSession: Started");
             let response = await SessionFunctions.createNewSession(
@@ -99,6 +100,7 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                 tenantId,
                 recipeUserId,
                 disableAntiCsrf === true,
+                userContext,
                 accessTokenPayload,
                 sessionDataInDatabase
             );
@@ -122,7 +124,7 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
         getGlobalClaimValidators: async function (input) {
             return input.claimValidatorsAddedByOtherRecipes;
         },
-        getSession: async function ({ accessToken: accessTokenString, antiCsrfToken, options }) {
+        getSession: async function ({ accessToken: accessTokenString, antiCsrfToken, options, userContext }) {
             if (
                 (options === null || options === void 0 ? void 0 : options.antiCsrfCheck) !== false &&
                 typeof config.antiCsrfFunctionOrString === "string" &&
@@ -179,7 +181,8 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                 accessToken,
                 antiCsrfToken,
                 (options === null || options === void 0 ? void 0 : options.antiCsrfCheck) !== false,
-                (options === null || options === void 0 ? void 0 : options.checkDatabase) === true
+                (options === null || options === void 0 ? void 0 : options.checkDatabase) === true,
+                userContext
             );
             logger_1.logDebugMessage("getSession: Success!");
             const payload =
@@ -247,10 +250,10 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                 accessTokenPayloadUpdate,
             };
         },
-        getSessionInformation: async function ({ sessionHandle }) {
-            return SessionFunctions.getSessionInformation(helpers, sessionHandle);
+        getSessionInformation: async function ({ sessionHandle, userContext }) {
+            return SessionFunctions.getSessionInformation(helpers, sessionHandle, userContext);
         },
-        refreshSession: async function ({ refreshToken, antiCsrfToken, disableAntiCsrf }) {
+        refreshSession: async function ({ refreshToken, antiCsrfToken, disableAntiCsrf, userContext }) {
             if (
                 disableAntiCsrf !== true &&
                 typeof config.antiCsrfFunctionOrString === "string" &&
@@ -265,7 +268,8 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                 helpers,
                 refreshToken,
                 antiCsrfToken,
-                disableAntiCsrf
+                disableAntiCsrf,
+                userContext
             );
             logger_1.logDebugMessage("refreshSession: Success!");
             const payload = jwt_1.parseJWTWithoutSignatureVerification(response.accessToken.token).payload;
@@ -294,7 +298,8 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                 {
                     accessToken: input.accessToken,
                     userDataInJWT: newAccessTokenPayload,
-                }
+                },
+                input.userContext
             );
             if (response.status === "UNAUTHORISED") {
                 return undefined;
@@ -316,11 +321,13 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
             tenantId,
             revokeAcrossAllTenants,
             revokeSessionsForLinkedAccounts,
+            userContext,
         }) {
             return SessionFunctions.revokeAllSessionsForUser(
                 helpers,
                 userId,
                 revokeSessionsForLinkedAccounts,
+                userContext,
                 tenantId,
                 revokeAcrossAllTenants
             );
@@ -330,23 +337,25 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
             fetchSessionsForAllLinkedAccounts,
             tenantId,
             fetchAcrossAllTenants,
+            userContext,
         }) {
             return SessionFunctions.getAllSessionHandlesForUser(
                 helpers,
                 userId,
                 fetchSessionsForAllLinkedAccounts,
+                userContext,
                 tenantId,
                 fetchAcrossAllTenants
             );
         },
-        revokeSession: function ({ sessionHandle }) {
-            return SessionFunctions.revokeSession(helpers, sessionHandle);
+        revokeSession: function ({ sessionHandle, userContext }) {
+            return SessionFunctions.revokeSession(helpers, sessionHandle, userContext);
         },
-        revokeMultipleSessions: function ({ sessionHandles }) {
-            return SessionFunctions.revokeMultipleSessions(helpers, sessionHandles);
+        revokeMultipleSessions: function ({ sessionHandles, userContext }) {
+            return SessionFunctions.revokeMultipleSessions(helpers, sessionHandles, userContext);
         },
-        updateSessionDataInDatabase: function ({ sessionHandle, newSessionData }) {
-            return SessionFunctions.updateSessionDataInDatabase(helpers, sessionHandle, newSessionData);
+        updateSessionDataInDatabase: function ({ sessionHandle, newSessionData, userContext }) {
+            return SessionFunctions.updateSessionDataInDatabase(helpers, sessionHandle, newSessionData, userContext);
         },
         mergeIntoAccessTokenPayload: async function ({ sessionHandle, accessTokenPayloadUpdate, userContext }) {
             const sessionInfo = await this.getSessionInformation({ sessionHandle, userContext });
@@ -363,7 +372,12 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                     delete newAccessTokenPayload[key];
                 }
             }
-            return SessionFunctions.updateAccessTokenPayload(helpers, sessionHandle, newAccessTokenPayload);
+            return SessionFunctions.updateAccessTokenPayload(
+                helpers,
+                sessionHandle,
+                newAccessTokenPayload,
+                userContext
+            );
         },
         fetchAndSetClaim: async function (input) {
             const sessionInfo = await this.getSessionInformation({

--- a/lib/build/recipe/session/recipeImplementation.js
+++ b/lib/build/recipe/session/recipeImplementation.js
@@ -100,9 +100,9 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
                 tenantId,
                 recipeUserId,
                 disableAntiCsrf === true,
-                userContext,
                 accessTokenPayload,
-                sessionDataInDatabase
+                sessionDataInDatabase,
+                userContext
             );
             logger_1.logDebugMessage("createNewSession: Finished");
             const payload = jwt_1.parseJWTWithoutSignatureVerification(response.accessToken.token).payload;
@@ -323,13 +323,16 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
             revokeSessionsForLinkedAccounts,
             userContext,
         }) {
+            if (tenantId === undefined) {
+                tenantId = constants_1.DEFAULT_TENANT_ID;
+            }
             return SessionFunctions.revokeAllSessionsForUser(
                 helpers,
                 userId,
                 revokeSessionsForLinkedAccounts,
-                userContext,
                 tenantId,
-                revokeAcrossAllTenants
+                revokeAcrossAllTenants !== null && revokeAcrossAllTenants !== void 0 ? revokeAcrossAllTenants : false,
+                userContext
             );
         },
         getAllSessionHandlesForUser: function ({
@@ -339,13 +342,16 @@ function getRecipeInterface(querier, config, appInfo, getRecipeImplAfterOverride
             fetchAcrossAllTenants,
             userContext,
         }) {
+            if (tenantId === undefined) {
+                tenantId = constants_1.DEFAULT_TENANT_ID;
+            }
             return SessionFunctions.getAllSessionHandlesForUser(
                 helpers,
                 userId,
                 fetchSessionsForAllLinkedAccounts,
-                userContext,
                 tenantId,
-                fetchAcrossAllTenants
+                fetchAcrossAllTenants !== null && fetchAcrossAllTenants !== void 0 ? fetchAcrossAllTenants : false,
+                userContext
             );
         },
         revokeSession: function ({ sessionHandle, userContext }) {

--- a/lib/build/recipe/session/sessionFunctions.d.ts
+++ b/lib/build/recipe/session/sessionFunctions.d.ts
@@ -11,6 +11,7 @@ export declare function createNewSession(
     tenantId: string,
     recipeUserId: RecipeUserId,
     disableAntiCsrf: boolean,
+    userContext: any,
     accessTokenPayload?: any,
     sessionDataInDatabase?: any
 ): Promise<CreateOrRefreshAPIResponse>;
@@ -22,7 +23,8 @@ export declare function getSession(
     parsedAccessToken: ParsedJWTInfo,
     antiCsrfToken: string | undefined,
     doAntiCsrfCheck: boolean,
-    alwaysCheckCore: boolean
+    alwaysCheckCore: boolean,
+    userContext: any
 ): Promise<{
     session: {
         handle: string;
@@ -44,7 +46,8 @@ export declare function getSession(
  */
 export declare function getSessionInformation(
     helpers: Helpers,
-    sessionHandle: string
+    sessionHandle: string,
+    userContext: any
 ): Promise<SessionInformation | undefined>;
 /**
  * @description generates new access and refresh tokens for a given refresh token. Called when client's access token has expired.
@@ -54,7 +57,8 @@ export declare function refreshSession(
     helpers: Helpers,
     refreshToken: string,
     antiCsrfToken: string | undefined,
-    disableAntiCsrf: boolean
+    disableAntiCsrf: boolean,
+    userContext: any
 ): Promise<CreateOrRefreshAPIResponse>;
 /**
  * @description deletes session info of a user from db. This only invalidates the refresh token. Not the access token.
@@ -64,6 +68,7 @@ export declare function revokeAllSessionsForUser(
     helpers: Helpers,
     userId: string,
     revokeSessionsForLinkedAccounts: boolean,
+    userContext: any,
     tenantId?: string,
     revokeAcrossAllTenants?: boolean
 ): Promise<string[]>;
@@ -74,6 +79,7 @@ export declare function getAllSessionHandlesForUser(
     helpers: Helpers,
     userId: string,
     fetchSessionsForAllLinkedAccounts: boolean,
+    userContext: any,
     tenantId?: string,
     fetchAcrossAllTenants?: boolean
 ): Promise<string[]>;
@@ -81,22 +87,28 @@ export declare function getAllSessionHandlesForUser(
  * @description call to destroy one session
  * @returns true if session was deleted from db. Else false in case there was nothing to delete
  */
-export declare function revokeSession(helpers: Helpers, sessionHandle: string): Promise<boolean>;
+export declare function revokeSession(helpers: Helpers, sessionHandle: string, userContext: any): Promise<boolean>;
 /**
  * @description call to destroy multiple sessions
  * @returns list of sessions revoked
  */
-export declare function revokeMultipleSessions(helpers: Helpers, sessionHandles: string[]): Promise<string[]>;
+export declare function revokeMultipleSessions(
+    helpers: Helpers,
+    sessionHandles: string[],
+    userContext: any
+): Promise<string[]>;
 /**
  * @description: It provides no locking mechanism in case other processes are updating session data for this session as well.
  */
 export declare function updateSessionDataInDatabase(
     helpers: Helpers,
     sessionHandle: string,
-    newSessionData: any
+    newSessionData: any,
+    userContext: any
 ): Promise<boolean>;
 export declare function updateAccessTokenPayload(
     helpers: Helpers,
     sessionHandle: string,
-    newAccessTokenPayload: any
+    newAccessTokenPayload: any,
+    userContext: any
 ): Promise<boolean>;

--- a/lib/build/recipe/session/sessionFunctions.d.ts
+++ b/lib/build/recipe/session/sessionFunctions.d.ts
@@ -68,8 +68,8 @@ export declare function revokeAllSessionsForUser(
     helpers: Helpers,
     userId: string,
     revokeSessionsForLinkedAccounts: boolean,
-    tenantId: string,
-    revokeAcrossAllTenants: boolean,
+    tenantId: string | undefined,
+    revokeAcrossAllTenants: boolean | undefined,
     userContext: any
 ): Promise<string[]>;
 /**
@@ -79,8 +79,8 @@ export declare function getAllSessionHandlesForUser(
     helpers: Helpers,
     userId: string,
     fetchSessionsForAllLinkedAccounts: boolean,
-    tenantId: string,
-    fetchAcrossAllTenants: boolean,
+    tenantId: string | undefined,
+    fetchAcrossAllTenants: boolean | undefined,
     userContext: any
 ): Promise<string[]>;
 /**

--- a/lib/build/recipe/session/sessionFunctions.d.ts
+++ b/lib/build/recipe/session/sessionFunctions.d.ts
@@ -11,9 +11,9 @@ export declare function createNewSession(
     tenantId: string,
     recipeUserId: RecipeUserId,
     disableAntiCsrf: boolean,
-    userContext: any,
-    accessTokenPayload?: any,
-    sessionDataInDatabase?: any
+    accessTokenPayload: any,
+    sessionDataInDatabase: any,
+    userContext: any
 ): Promise<CreateOrRefreshAPIResponse>;
 /**
  * @description authenticates a session. To be used in APIs that require authentication
@@ -68,9 +68,9 @@ export declare function revokeAllSessionsForUser(
     helpers: Helpers,
     userId: string,
     revokeSessionsForLinkedAccounts: boolean,
-    userContext: any,
-    tenantId?: string,
-    revokeAcrossAllTenants?: boolean
+    tenantId: string,
+    revokeAcrossAllTenants: boolean,
+    userContext: any
 ): Promise<string[]>;
 /**
  * @description gets all session handles for current user. Please do not call this unless this user is authenticated.
@@ -79,9 +79,9 @@ export declare function getAllSessionHandlesForUser(
     helpers: Helpers,
     userId: string,
     fetchSessionsForAllLinkedAccounts: boolean,
-    userContext: any,
-    tenantId?: string,
-    fetchAcrossAllTenants?: boolean
+    tenantId: string,
+    fetchAcrossAllTenants: boolean,
+    userContext: any
 ): Promise<string[]>;
 /**
  * @description call to destroy one session

--- a/lib/build/recipe/session/sessionFunctions.js
+++ b/lib/build/recipe/session/sessionFunctions.js
@@ -359,6 +359,9 @@ async function revokeAllSessionsForUser(
     revokeAcrossAllTenants,
     userContext
 ) {
+    if (tenantId === undefined) {
+        tenantId = constants_1.DEFAULT_TENANT_ID;
+    }
     let response = await helpers.querier.sendPostRequest(
         new normalisedURLPath_1.default(`/${tenantId}/recipe/session/remove`),
         {
@@ -382,6 +385,9 @@ async function getAllSessionHandlesForUser(
     fetchAcrossAllTenants,
     userContext
 ) {
+    if (tenantId === undefined) {
+        tenantId = constants_1.DEFAULT_TENANT_ID;
+    }
     let response = await helpers.querier.sendGetRequest(
         new normalisedURLPath_1.default(`/${tenantId}/recipe/session/user`),
         {

--- a/lib/build/recipe/session/sessionFunctions.js
+++ b/lib/build/recipe/session/sessionFunctions.js
@@ -37,6 +37,7 @@ async function createNewSession(
     tenantId,
     recipeUserId,
     disableAntiCsrf,
+    userContext,
     accessTokenPayload = {},
     sessionDataInDatabase = {}
 ) {
@@ -53,7 +54,8 @@ async function createNewSession(
     };
     let response = await helpers.querier.sendPostRequest(
         new normalisedURLPath_1.default(`/${tenantId}/recipe/session`),
-        requestBody
+        requestBody,
+        userContext
     );
     return {
         session: {
@@ -80,7 +82,7 @@ exports.createNewSession = createNewSession;
 /**
  * @description authenticates a session. To be used in APIs that require authentication
  */
-async function getSession(helpers, parsedAccessToken, antiCsrfToken, doAntiCsrfCheck, alwaysCheckCore) {
+async function getSession(helpers, parsedAccessToken, antiCsrfToken, doAntiCsrfCheck, alwaysCheckCore, userContext) {
     var _a, _b;
     let accessTokenInfo;
     try {
@@ -211,7 +213,8 @@ async function getSession(helpers, parsedAccessToken, antiCsrfToken, doAntiCsrfC
     };
     let response = await helpers.querier.sendPostRequest(
         new normalisedURLPath_1.default("/recipe/session/verify"),
-        requestBody
+        requestBody,
+        userContext
     );
     if (response.status === "OK") {
         delete response.status;
@@ -250,14 +253,18 @@ exports.getSession = getSession;
  * @description Retrieves session information from storage for a given session handle
  * @returns session data stored in the database, including userData and access token payload, or undefined if sessionHandle is invalid
  */
-async function getSessionInformation(helpers, sessionHandle) {
+async function getSessionInformation(helpers, sessionHandle, userContext) {
     let apiVersion = await helpers.querier.getAPIVersion();
     if (utils_1.maxVersion(apiVersion, "2.7") === "2.7") {
         throw new Error("Please use core version >= 3.5 to call this function.");
     }
-    let response = await helpers.querier.sendGetRequest(new normalisedURLPath_1.default(`/recipe/session`), {
-        sessionHandle,
-    });
+    let response = await helpers.querier.sendGetRequest(
+        new normalisedURLPath_1.default(`/recipe/session`),
+        {
+            sessionHandle,
+        },
+        userContext
+    );
     if (response.status === "OK") {
         // Change keys to make them more readable
         return {
@@ -279,7 +286,7 @@ exports.getSessionInformation = getSessionInformation;
  * @description generates new access and refresh tokens for a given refresh token. Called when client's access token has expired.
  * @sideEffects calls onTokenTheftDetection if token theft is detected.
  */
-async function refreshSession(helpers, refreshToken, antiCsrfToken, disableAntiCsrf) {
+async function refreshSession(helpers, refreshToken, antiCsrfToken, disableAntiCsrf, userContext) {
     let requestBody = {
         refreshToken,
         antiCsrfToken,
@@ -296,7 +303,8 @@ async function refreshSession(helpers, refreshToken, antiCsrfToken, disableAntiC
     }
     let response = await helpers.querier.sendPostRequest(
         new normalisedURLPath_1.default("/recipe/session/refresh"),
-        requestBody
+        requestBody,
+        userContext
     );
     if (response.status === "OK") {
         return {
@@ -347,6 +355,7 @@ async function revokeAllSessionsForUser(
     helpers,
     userId,
     revokeSessionsForLinkedAccounts,
+    userContext,
     tenantId,
     revokeAcrossAllTenants
 ) {
@@ -359,7 +368,8 @@ async function revokeAllSessionsForUser(
             userId,
             revokeSessionsForLinkedAccounts,
             revokeAcrossAllTenants,
-        }
+        },
+        userContext
     );
     return response.sessionHandlesRevoked;
 }
@@ -371,6 +381,7 @@ async function getAllSessionHandlesForUser(
     helpers,
     userId,
     fetchSessionsForAllLinkedAccounts,
+    userContext,
     tenantId,
     fetchAcrossAllTenants
 ) {
@@ -383,7 +394,8 @@ async function getAllSessionHandlesForUser(
             userId,
             fetchSessionsForAllLinkedAccounts,
             fetchAcrossAllTenants,
-        }
+        },
+        userContext
     );
     return response.sessionHandles;
 }
@@ -392,10 +404,14 @@ exports.getAllSessionHandlesForUser = getAllSessionHandlesForUser;
  * @description call to destroy one session
  * @returns true if session was deleted from db. Else false in case there was nothing to delete
  */
-async function revokeSession(helpers, sessionHandle) {
-    let response = await helpers.querier.sendPostRequest(new normalisedURLPath_1.default("/recipe/session/remove"), {
-        sessionHandles: [sessionHandle],
-    });
+async function revokeSession(helpers, sessionHandle, userContext) {
+    let response = await helpers.querier.sendPostRequest(
+        new normalisedURLPath_1.default("/recipe/session/remove"),
+        {
+            sessionHandles: [sessionHandle],
+        },
+        userContext
+    );
     return response.sessionHandlesRevoked.length === 1;
 }
 exports.revokeSession = revokeSession;
@@ -403,35 +419,47 @@ exports.revokeSession = revokeSession;
  * @description call to destroy multiple sessions
  * @returns list of sessions revoked
  */
-async function revokeMultipleSessions(helpers, sessionHandles) {
-    let response = await helpers.querier.sendPostRequest(new normalisedURLPath_1.default(`/recipe/session/remove`), {
-        sessionHandles,
-    });
+async function revokeMultipleSessions(helpers, sessionHandles, userContext) {
+    let response = await helpers.querier.sendPostRequest(
+        new normalisedURLPath_1.default(`/recipe/session/remove`),
+        {
+            sessionHandles,
+        },
+        userContext
+    );
     return response.sessionHandlesRevoked;
 }
 exports.revokeMultipleSessions = revokeMultipleSessions;
 /**
  * @description: It provides no locking mechanism in case other processes are updating session data for this session as well.
  */
-async function updateSessionDataInDatabase(helpers, sessionHandle, newSessionData) {
+async function updateSessionDataInDatabase(helpers, sessionHandle, newSessionData, userContext) {
     newSessionData = newSessionData === null || newSessionData === undefined ? {} : newSessionData;
-    let response = await helpers.querier.sendPutRequest(new normalisedURLPath_1.default(`/recipe/session/data`), {
-        sessionHandle,
-        userDataInDatabase: newSessionData,
-    });
+    let response = await helpers.querier.sendPutRequest(
+        new normalisedURLPath_1.default(`/recipe/session/data`),
+        {
+            sessionHandle,
+            userDataInDatabase: newSessionData,
+        },
+        userContext
+    );
     if (response.status === "UNAUTHORISED") {
         return false;
     }
     return true;
 }
 exports.updateSessionDataInDatabase = updateSessionDataInDatabase;
-async function updateAccessTokenPayload(helpers, sessionHandle, newAccessTokenPayload) {
+async function updateAccessTokenPayload(helpers, sessionHandle, newAccessTokenPayload, userContext) {
     newAccessTokenPayload =
         newAccessTokenPayload === null || newAccessTokenPayload === undefined ? {} : newAccessTokenPayload;
-    let response = await helpers.querier.sendPutRequest(new normalisedURLPath_1.default("/recipe/jwt/data"), {
-        sessionHandle,
-        userDataInJWT: newAccessTokenPayload,
-    });
+    let response = await helpers.querier.sendPutRequest(
+        new normalisedURLPath_1.default("/recipe/jwt/data"),
+        {
+            sessionHandle,
+            userDataInJWT: newAccessTokenPayload,
+        },
+        userContext
+    );
     if (response.status === "UNAUTHORISED") {
         return false;
     }

--- a/lib/build/recipe/session/sessionFunctions.js
+++ b/lib/build/recipe/session/sessionFunctions.js
@@ -37,9 +37,9 @@ async function createNewSession(
     tenantId,
     recipeUserId,
     disableAntiCsrf,
-    userContext,
-    accessTokenPayload = {},
-    sessionDataInDatabase = {}
+    accessTokenPayload,
+    sessionDataInDatabase,
+    userContext
 ) {
     accessTokenPayload = accessTokenPayload === null || accessTokenPayload === undefined ? {} : accessTokenPayload;
     sessionDataInDatabase =
@@ -355,13 +355,10 @@ async function revokeAllSessionsForUser(
     helpers,
     userId,
     revokeSessionsForLinkedAccounts,
-    userContext,
     tenantId,
-    revokeAcrossAllTenants
+    revokeAcrossAllTenants,
+    userContext
 ) {
-    if (tenantId === undefined) {
-        tenantId = constants_1.DEFAULT_TENANT_ID;
-    }
     let response = await helpers.querier.sendPostRequest(
         new normalisedURLPath_1.default(`/${tenantId}/recipe/session/remove`),
         {
@@ -381,13 +378,10 @@ async function getAllSessionHandlesForUser(
     helpers,
     userId,
     fetchSessionsForAllLinkedAccounts,
-    userContext,
     tenantId,
-    fetchAcrossAllTenants
+    fetchAcrossAllTenants,
+    userContext
 ) {
-    if (tenantId === undefined) {
-        tenantId = constants_1.DEFAULT_TENANT_ID;
-    }
     let response = await helpers.querier.sendGetRequest(
         new normalisedURLPath_1.default(`/${tenantId}/recipe/session/user`),
         {

--- a/lib/build/recipe/thirdparty/recipeImplementation.js
+++ b/lib/build/recipe/thirdparty/recipeImplementation.js
@@ -28,7 +28,8 @@ function getRecipeImplementation(querier, providers) {
                     thirdPartyId,
                     thirdPartyUserId,
                     email: { id: email, isVerified },
-                }
+                },
+                userContext
             );
             if (response.status !== "OK") {
                 return response;

--- a/lib/build/recipe/usermetadata/recipeImplementation.js
+++ b/lib/build/recipe/usermetadata/recipeImplementation.js
@@ -22,19 +22,31 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const normalisedURLPath_1 = __importDefault(require("../../normalisedURLPath"));
 function getRecipeInterface(querier) {
     return {
-        getUserMetadata: function ({ userId }) {
-            return querier.sendGetRequest(new normalisedURLPath_1.default("/recipe/user/metadata"), { userId });
+        getUserMetadata: function ({ userId, userContext }) {
+            return querier.sendGetRequest(
+                new normalisedURLPath_1.default("/recipe/user/metadata"),
+                { userId },
+                userContext
+            );
         },
-        updateUserMetadata: function ({ userId, metadataUpdate }) {
-            return querier.sendPutRequest(new normalisedURLPath_1.default("/recipe/user/metadata"), {
-                userId,
-                metadataUpdate,
-            });
+        updateUserMetadata: function ({ userId, metadataUpdate, userContext }) {
+            return querier.sendPutRequest(
+                new normalisedURLPath_1.default("/recipe/user/metadata"),
+                {
+                    userId,
+                    metadataUpdate,
+                },
+                userContext
+            );
         },
-        clearUserMetadata: function ({ userId }) {
-            return querier.sendPostRequest(new normalisedURLPath_1.default("/recipe/user/metadata/remove"), {
-                userId,
-            });
+        clearUserMetadata: function ({ userId, userContext }) {
+            return querier.sendPostRequest(
+                new normalisedURLPath_1.default("/recipe/user/metadata/remove"),
+                {
+                    userId,
+                },
+                userContext
+            );
         },
     };
 }

--- a/lib/build/recipe/userroles/recipeImplementation.js
+++ b/lib/build/recipe/userroles/recipeImplementation.js
@@ -23,58 +23,82 @@ const normalisedURLPath_1 = __importDefault(require("../../normalisedURLPath"));
 const constants_1 = require("../multitenancy/constants");
 function getRecipeInterface(querier) {
     return {
-        addRoleToUser: function ({ userId, role, tenantId }) {
+        addRoleToUser: function ({ userId, role, tenantId, userContext }) {
             return querier.sendPutRequest(
                 new normalisedURLPath_1.default(
                     `/${tenantId === undefined ? constants_1.DEFAULT_TENANT_ID : tenantId}/recipe/user/role`
                 ),
-                { userId, role }
+                { userId, role },
+                userContext
             );
         },
-        removeUserRole: function ({ userId, role, tenantId }) {
+        removeUserRole: function ({ userId, role, tenantId, userContext }) {
             return querier.sendPostRequest(
                 new normalisedURLPath_1.default(
                     `/${tenantId === undefined ? constants_1.DEFAULT_TENANT_ID : tenantId}/recipe/user/role/remove`
                 ),
-                { userId, role }
+                { userId, role },
+                userContext
             );
         },
-        getRolesForUser: function ({ userId, tenantId }) {
+        getRolesForUser: function ({ userId, tenantId, userContext }) {
             return querier.sendGetRequest(
                 new normalisedURLPath_1.default(
                     `/${tenantId === undefined ? constants_1.DEFAULT_TENANT_ID : tenantId}/recipe/user/roles`
                 ),
-                { userId }
+                { userId },
+                userContext
             );
         },
-        getUsersThatHaveRole: function ({ role, tenantId }) {
+        getUsersThatHaveRole: function ({ role, tenantId, userContext }) {
             return querier.sendGetRequest(
                 new normalisedURLPath_1.default(
                     `/${tenantId === undefined ? constants_1.DEFAULT_TENANT_ID : tenantId}/recipe/role/users`
                 ),
-                { role }
+                { role },
+                userContext
             );
         },
-        createNewRoleOrAddPermissions: function ({ role, permissions }) {
-            return querier.sendPutRequest(new normalisedURLPath_1.default("/recipe/role"), { role, permissions });
+        createNewRoleOrAddPermissions: function ({ role, permissions, userContext }) {
+            return querier.sendPutRequest(
+                new normalisedURLPath_1.default("/recipe/role"),
+                { role, permissions },
+                userContext
+            );
         },
-        getPermissionsForRole: function ({ role }) {
-            return querier.sendGetRequest(new normalisedURLPath_1.default("/recipe/role/permissions"), { role });
+        getPermissionsForRole: function ({ role, userContext }) {
+            return querier.sendGetRequest(
+                new normalisedURLPath_1.default("/recipe/role/permissions"),
+                { role },
+                userContext
+            );
         },
-        removePermissionsFromRole: function ({ role, permissions }) {
-            return querier.sendPostRequest(new normalisedURLPath_1.default("/recipe/role/permissions/remove"), {
-                role,
-                permissions,
-            });
+        removePermissionsFromRole: function ({ role, permissions, userContext }) {
+            return querier.sendPostRequest(
+                new normalisedURLPath_1.default("/recipe/role/permissions/remove"),
+                {
+                    role,
+                    permissions,
+                },
+                userContext
+            );
         },
-        getRolesThatHavePermission: function ({ permission }) {
-            return querier.sendGetRequest(new normalisedURLPath_1.default("/recipe/permission/roles"), { permission });
+        getRolesThatHavePermission: function ({ permission, userContext }) {
+            return querier.sendGetRequest(
+                new normalisedURLPath_1.default("/recipe/permission/roles"),
+                { permission },
+                userContext
+            );
         },
-        deleteRole: function ({ role }) {
-            return querier.sendPostRequest(new normalisedURLPath_1.default("/recipe/role/remove"), { role });
+        deleteRole: function ({ role, userContext }) {
+            return querier.sendPostRequest(
+                new normalisedURLPath_1.default("/recipe/role/remove"),
+                { role },
+                userContext
+            );
         },
-        getAllRoles: function () {
-            return querier.sendGetRequest(new normalisedURLPath_1.default("/recipe/roles"), {});
+        getAllRoles: function (userContext) {
+            return querier.sendGetRequest(new normalisedURLPath_1.default("/recipe/roles"), {}, userContext);
         },
     };
 }

--- a/lib/build/supertokens.d.ts
+++ b/lib/build/supertokens.d.ts
@@ -27,12 +27,17 @@ export default class SuperTokens {
         userContext: any
     ) => Promise<boolean>;
     getAllCORSHeaders: () => string[];
-    getUserCount: (includeRecipeIds?: string[] | undefined, tenantId?: string | undefined) => Promise<number>;
+    getUserCount: (
+        includeRecipeIds?: string[] | undefined,
+        tenantId?: string | undefined,
+        userContext?: any
+    ) => Promise<number>;
     createUserIdMapping: (input: {
         superTokensUserId: string;
         externalUserId: string;
         externalUserIdInfo?: string;
         force?: boolean;
+        userContext?: any;
     }) => Promise<
         | {
               status: "OK" | "UNKNOWN_SUPERTOKENS_USER_ID_ERROR";
@@ -46,6 +51,7 @@ export default class SuperTokens {
     getUserIdMapping: (input: {
         userId: string;
         userIdType?: "SUPERTOKENS" | "EXTERNAL" | "ANY";
+        userContext?: any;
     }) => Promise<
         | {
               status: "OK";
@@ -61,6 +67,7 @@ export default class SuperTokens {
         userId: string;
         userIdType?: "SUPERTOKENS" | "EXTERNAL" | "ANY";
         force?: boolean;
+        userContext?: any;
     }) => Promise<{
         status: "OK";
         didMappingExist: boolean;
@@ -69,6 +76,7 @@ export default class SuperTokens {
         userId: string;
         userIdType?: "SUPERTOKENS" | "EXTERNAL" | "ANY";
         externalUserIdInfo?: string;
+        userContext?: any;
     }) => Promise<{
         status: "OK" | "UNKNOWN_MAPPING_ERROR";
     }>;

--- a/lib/build/supertokens.js
+++ b/lib/build/supertokens.js
@@ -46,7 +46,7 @@ class SuperTokens {
             });
             return Array.from(headerSet);
         };
-        this.getUserCount = async (includeRecipeIds, tenantId) => {
+        this.getUserCount = async (includeRecipeIds, tenantId, userContext) => {
             let querier = querier_1.Querier.getNewInstanceOrThrowError(undefined);
             let apiVersion = await querier.getAPIVersion();
             if (utils_1.maxVersion(apiVersion, "2.7") === "2.7") {
@@ -66,7 +66,7 @@ class SuperTokens {
                     includeRecipeIds: includeRecipeIdsStr,
                     includeAllTenants: tenantId === undefined,
                 },
-                undefined
+                userContext === undefined ? {} : userContext
             );
             return Number(response.count);
         };
@@ -83,7 +83,7 @@ class SuperTokens {
                         externalUserIdInfo: input.externalUserIdInfo,
                         force: input.force,
                     },
-                    undefined
+                    input.userContext === undefined ? {} : input.userContext
                 );
             } else {
                 throw new global.Error("Please upgrade the SuperTokens core to >= 3.15.0");
@@ -100,7 +100,7 @@ class SuperTokens {
                         userId: input.userId,
                         userIdType: input.userIdType,
                     },
-                    undefined
+                    input.userContext === undefined ? {} : input.userContext
                 );
                 return response;
             } else {
@@ -118,7 +118,7 @@ class SuperTokens {
                         userIdType: input.userIdType,
                         force: input.force,
                     },
-                    undefined
+                    input.userContext === undefined ? {} : input.userContext
                 );
             } else {
                 throw new global.Error("Please upgrade the SuperTokens core to >= 3.15.0");
@@ -135,7 +135,7 @@ class SuperTokens {
                         userIdType: input.userIdType,
                         externalUserIdInfo: input.externalUserIdInfo,
                     },
-                    undefined
+                    input.userContext === undefined ? {} : input.userContext
                 );
             } else {
                 throw new global.Error("Please upgrade the SuperTokens core to >= 3.15.0");

--- a/lib/build/supertokens.js
+++ b/lib/build/supertokens.js
@@ -30,7 +30,7 @@ const postSuperTokensInitCallbacks_1 = require("./postSuperTokensInitCallbacks")
 const constants_2 = require("./recipe/multitenancy/constants");
 class SuperTokens {
     constructor(config) {
-        var _a, _b;
+        var _a, _b, _c;
         this.handleAPI = async (matchedRecipe, id, tenantId, request, response, path, method, userContext) => {
             return await matchedRecipe.handleAPIRequest(id, tenantId, request, response, path, method, userContext);
         };
@@ -65,7 +65,8 @@ class SuperTokens {
                 {
                     includeRecipeIds: includeRecipeIdsStr,
                     includeAllTenants: tenantId === undefined,
-                }
+                },
+                undefined
             );
             return Number(response.count);
         };
@@ -74,12 +75,16 @@ class SuperTokens {
             let cdiVersion = await querier.getAPIVersion();
             if (utils_1.maxVersion("2.15", cdiVersion) === cdiVersion) {
                 // create userId mapping is only available >= CDI 2.15
-                return await querier.sendPostRequest(new normalisedURLPath_1.default("/recipe/userid/map"), {
-                    superTokensUserId: input.superTokensUserId,
-                    externalUserId: input.externalUserId,
-                    externalUserIdInfo: input.externalUserIdInfo,
-                    force: input.force,
-                });
+                return await querier.sendPostRequest(
+                    new normalisedURLPath_1.default("/recipe/userid/map"),
+                    {
+                        superTokensUserId: input.superTokensUserId,
+                        externalUserId: input.externalUserId,
+                        externalUserIdInfo: input.externalUserIdInfo,
+                        force: input.force,
+                    },
+                    undefined
+                );
             } else {
                 throw new global.Error("Please upgrade the SuperTokens core to >= 3.15.0");
             }
@@ -89,10 +94,14 @@ class SuperTokens {
             let cdiVersion = await querier.getAPIVersion();
             if (utils_1.maxVersion("2.15", cdiVersion) === cdiVersion) {
                 // create userId mapping is only available >= CDI 2.15
-                let response = await querier.sendGetRequest(new normalisedURLPath_1.default("/recipe/userid/map"), {
-                    userId: input.userId,
-                    userIdType: input.userIdType,
-                });
+                let response = await querier.sendGetRequest(
+                    new normalisedURLPath_1.default("/recipe/userid/map"),
+                    {
+                        userId: input.userId,
+                        userIdType: input.userIdType,
+                    },
+                    undefined
+                );
                 return response;
             } else {
                 throw new global.Error("Please upgrade the SuperTokens core to >= 3.15.0");
@@ -102,11 +111,15 @@ class SuperTokens {
             let querier = querier_1.Querier.getNewInstanceOrThrowError(undefined);
             let cdiVersion = await querier.getAPIVersion();
             if (utils_1.maxVersion("2.15", cdiVersion) === cdiVersion) {
-                return await querier.sendPostRequest(new normalisedURLPath_1.default("/recipe/userid/map/remove"), {
-                    userId: input.userId,
-                    userIdType: input.userIdType,
-                    force: input.force,
-                });
+                return await querier.sendPostRequest(
+                    new normalisedURLPath_1.default("/recipe/userid/map/remove"),
+                    {
+                        userId: input.userId,
+                        userIdType: input.userIdType,
+                        force: input.force,
+                    },
+                    undefined
+                );
             } else {
                 throw new global.Error("Please upgrade the SuperTokens core to >= 3.15.0");
             }
@@ -121,7 +134,8 @@ class SuperTokens {
                         userId: input.userId,
                         userIdType: input.userIdType,
                         externalUserIdInfo: input.externalUserIdInfo,
-                    }
+                    },
+                    undefined
                 );
             } else {
                 throw new global.Error("Please upgrade the SuperTokens core to >= 3.15.0");
@@ -291,7 +305,8 @@ class SuperTokens {
                               basePath: new normalisedURLPath_1.default(h.trim()),
                           };
                       }),
-            (_b = config.supertokens) === null || _b === void 0 ? void 0 : _b.apiKey
+            (_b = config.supertokens) === null || _b === void 0 ? void 0 : _b.apiKey,
+            (_c = config.supertokens) === null || _c === void 0 ? void 0 : _c.networkInterceptor
         );
         if (config.recipeList === undefined || config.recipeList.length === 0) {
             throw new Error("Please provide at least one recipe to the supertokens.init function call");

--- a/lib/build/types.d.ts
+++ b/lib/build/types.d.ts
@@ -27,6 +27,7 @@ export declare type NormalisedAppinfo = {
 export declare type SuperTokensInfo = {
     connectionURI: string;
     apiKey?: string;
+    networkInterceptor?: NetworkInterceptor;
 };
 export declare type TypeInput = {
     supertokens?: SuperTokensInfo;
@@ -37,6 +38,16 @@ export declare type TypeInput = {
     isInServerlessEnv?: boolean;
     debug?: boolean;
 };
+export declare type NetworkInterceptor = (request: HttpRequest, userContext: any) => HttpRequest;
+export interface HttpRequest {
+    url: string;
+    method: HTTPMethod;
+    headers: {
+        [key: string]: string | number | string[];
+    };
+    params?: Record<string, boolean | number | string | undefined>;
+    body?: any;
+}
 export declare type RecipeListFunction = (appInfo: NormalisedAppinfo, isInServerlessEnv: boolean) => RecipeModule;
 export declare type APIHandled = {
     pathWithoutApiBasePath: NormalisedURLPath;

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "16.4.1";
+export declare const version = "16.5.0";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.8";

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "16.4.0";
+export declare const version = "16.4.1";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.8";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "16.4.1";
+exports.version = "16.5.0";
 exports.cdiSupported = ["4.0"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.8";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "16.4.0";
+exports.version = "16.4.1";
 exports.cdiSupported = ["4.0"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.8";

--- a/lib/ts/index.ts
+++ b/lib/ts/index.ts
@@ -33,8 +33,8 @@ export default class SuperTokensWrapper {
         return SuperTokens.getInstanceOrThrowError().getAllCORSHeaders();
     }
 
-    static getUserCount(includeRecipeIds?: string[], tenantId?: string) {
-        return SuperTokens.getInstanceOrThrowError().getUserCount(includeRecipeIds, tenantId);
+    static getUserCount(includeRecipeIds?: string[], tenantId?: string, userContext?: any) {
+        return SuperTokens.getInstanceOrThrowError().getUserCount(includeRecipeIds, tenantId, userContext);
     }
 
     static getUsersOldestFirst(input: {
@@ -43,6 +43,7 @@ export default class SuperTokensWrapper {
         paginationToken?: string;
         includeRecipeIds?: string[];
         query?: { [key: string]: string };
+        userContext?: any;
     }): Promise<{
         users: UserType[];
         nextPaginationToken?: string;
@@ -50,7 +51,7 @@ export default class SuperTokensWrapper {
         return AccountLinking.getInstance().recipeInterfaceImpl.getUsers({
             timeJoinedOrder: "ASC",
             ...input,
-            userContext: undefined,
+            userContext: input.userContext === undefined ? {} : input.userContext,
         });
     }
 
@@ -60,6 +61,7 @@ export default class SuperTokensWrapper {
         paginationToken?: string;
         includeRecipeIds?: string[];
         query?: { [key: string]: string };
+        userContext?: any;
     }): Promise<{
         users: UserType[];
         nextPaginationToken?: string;
@@ -67,7 +69,7 @@ export default class SuperTokensWrapper {
         return AccountLinking.getInstance().recipeInterfaceImpl.getUsers({
             timeJoinedOrder: "DESC",
             ...input,
-            userContext: undefined,
+            userContext: input.userContext === undefined ? {} : input.userContext,
         });
     }
 
@@ -76,11 +78,16 @@ export default class SuperTokensWrapper {
         externalUserId: string;
         externalUserIdInfo?: string;
         force?: boolean;
+        userContext?: any;
     }) {
         return SuperTokens.getInstanceOrThrowError().createUserIdMapping(input);
     }
 
-    static getUserIdMapping(input: { userId: string; userIdType?: "SUPERTOKENS" | "EXTERNAL" | "ANY" }) {
+    static getUserIdMapping(input: {
+        userId: string;
+        userIdType?: "SUPERTOKENS" | "EXTERNAL" | "ANY";
+        userContext?: any;
+    }) {
         return SuperTokens.getInstanceOrThrowError().getUserIdMapping(input);
     }
 
@@ -88,6 +95,7 @@ export default class SuperTokensWrapper {
         userId: string;
         userIdType?: "SUPERTOKENS" | "EXTERNAL" | "ANY";
         force?: boolean;
+        userContext?: any;
     }) {
         return SuperTokens.getInstanceOrThrowError().deleteUserIdMapping(input);
     }
@@ -96,6 +104,7 @@ export default class SuperTokensWrapper {
         userId: string;
         userIdType?: "SUPERTOKENS" | "EXTERNAL" | "ANY";
         externalUserIdInfo?: string;
+        userContext?: any;
     }) {
         return SuperTokens.getInstanceOrThrowError().updateOrDeleteUserIdMappingInfo(input);
     }

--- a/lib/ts/querier.ts
+++ b/lib/ts/querier.ts
@@ -168,7 +168,7 @@ export class Querier {
     };
 
     // path should start with "/"
-    sendDeleteRequest = async (path: NormalisedURLPath, body: any, userContext: any, params?: any): Promise<any> => {
+    sendDeleteRequest = async (path: NormalisedURLPath, body: any, params: any, userContext: any): Promise<any> => {
         const { body: respBody } = await this.sendRequestHelper(
             path,
             "DELETE",
@@ -308,7 +308,6 @@ export class Querier {
                             method: "get",
                             headers: headers,
                             params: params,
-                            body: undefined,
                         },
                         userContext
                     );
@@ -358,7 +357,6 @@ export class Querier {
                             url: url,
                             method: "put",
                             headers: headers,
-                            params: undefined,
                             body: body,
                         },
                         userContext

--- a/lib/ts/recipe/accountlinking/recipeImplementation.ts
+++ b/lib/ts/recipe/accountlinking/recipeImplementation.ts
@@ -36,6 +36,7 @@ export default function getRecipeImplementation(
                 paginationToken,
                 includeRecipeIds,
                 query,
+                userContext,
             }: {
                 tenantId: string;
                 timeJoinedOrder: "ASC" | "DESC";
@@ -43,6 +44,7 @@ export default function getRecipeImplementation(
                 paginationToken?: string;
                 includeRecipeIds?: string[];
                 query?: { [key: string]: string };
+                userContext: any;
             }
         ): Promise<{
             users: UserType[];
@@ -52,13 +54,17 @@ export default function getRecipeImplementation(
             if (includeRecipeIds !== undefined) {
                 includeRecipeIdsStr = includeRecipeIds.join(",");
             }
-            let response = await querier.sendGetRequest(new NormalisedURLPath(`${tenantId ?? "public"}/users`), {
-                includeRecipeIds: includeRecipeIdsStr,
-                timeJoinedOrder: timeJoinedOrder,
-                limit: limit,
-                paginationToken: paginationToken,
-                ...query,
-            });
+            let response = await querier.sendGetRequest(
+                new NormalisedURLPath(`${tenantId ?? "public"}/users`),
+                {
+                    includeRecipeIds: includeRecipeIdsStr,
+                    timeJoinedOrder: timeJoinedOrder,
+                    limit: limit,
+                    paginationToken: paginationToken,
+                    ...query,
+                },
+                userContext
+            );
             return {
                 users: response.users.map((u: any) => new User(u)),
                 nextPaginationToken: response.nextPaginationToken,
@@ -68,8 +74,10 @@ export default function getRecipeImplementation(
             this: RecipeInterface,
             {
                 recipeUserId,
+                userContext,
             }: {
                 recipeUserId: RecipeUserId;
+                userContext: any;
             }
         ): Promise<
             | {
@@ -84,15 +92,20 @@ export default function getRecipeImplementation(
                   description: string;
               }
         > {
-            return await querier.sendGetRequest(new NormalisedURLPath("/recipe/accountlinking/user/primary/check"), {
-                recipeUserId: recipeUserId.getAsString(),
-            });
+            return await querier.sendGetRequest(
+                new NormalisedURLPath("/recipe/accountlinking/user/primary/check"),
+                {
+                    recipeUserId: recipeUserId.getAsString(),
+                },
+                userContext
+            );
         },
 
         createPrimaryUser: async function (
             this: RecipeInterface,
             {
                 recipeUserId,
+                userContext,
             }: {
                 recipeUserId: RecipeUserId;
                 userContext: any;
@@ -113,9 +126,13 @@ export default function getRecipeImplementation(
                   description: string;
               }
         > {
-            let response = await querier.sendPostRequest(new NormalisedURLPath("/recipe/accountlinking/user/primary"), {
-                recipeUserId: recipeUserId.getAsString(),
-            });
+            let response = await querier.sendPostRequest(
+                new NormalisedURLPath("/recipe/accountlinking/user/primary"),
+                {
+                    recipeUserId: recipeUserId.getAsString(),
+                },
+                userContext
+            );
             if (response.status === "OK") {
                 response.user = new User(response.user);
             }
@@ -127,9 +144,11 @@ export default function getRecipeImplementation(
             {
                 recipeUserId,
                 primaryUserId,
+                userContext,
             }: {
                 recipeUserId: RecipeUserId;
                 primaryUserId: string;
+                userContext: any;
             }
         ): Promise<
             | {
@@ -150,10 +169,14 @@ export default function getRecipeImplementation(
                   status: "INPUT_USER_IS_NOT_A_PRIMARY_USER";
               }
         > {
-            let result = await querier.sendGetRequest(new NormalisedURLPath("/recipe/accountlinking/user/link/check"), {
-                recipeUserId: recipeUserId.getAsString(),
-                primaryUserId,
-            });
+            let result = await querier.sendGetRequest(
+                new NormalisedURLPath("/recipe/accountlinking/user/link/check"),
+                {
+                    recipeUserId: recipeUserId.getAsString(),
+                    primaryUserId,
+                },
+                userContext
+            );
 
             return result;
         },
@@ -194,7 +217,8 @@ export default function getRecipeImplementation(
                 {
                     recipeUserId: recipeUserId.getAsString(),
                     primaryUserId,
-                }
+                },
+                userContext
             );
 
             if (
@@ -241,8 +265,10 @@ export default function getRecipeImplementation(
             this: RecipeInterface,
             {
                 recipeUserId,
+                userContext,
             }: {
                 recipeUserId: RecipeUserId;
+                userContext: any;
             }
         ): Promise<{
             status: "OK";
@@ -253,15 +279,23 @@ export default function getRecipeImplementation(
                 new NormalisedURLPath("/recipe/accountlinking/user/unlink"),
                 {
                     recipeUserId: recipeUserId.getAsString(),
-                }
+                },
+                userContext
             );
             return accountsUnlinkingResult;
         },
 
-        getUser: async function (this: RecipeInterface, { userId }: { userId: string }): Promise<User | undefined> {
-            let result = await querier.sendGetRequest(new NormalisedURLPath("/user/id"), {
-                userId,
-            });
+        getUser: async function (
+            this: RecipeInterface,
+            { userId, userContext }: { userId: string; userContext: any }
+        ): Promise<User | undefined> {
+            let result = await querier.sendGetRequest(
+                new NormalisedURLPath("/user/id"),
+                {
+                    userId,
+                },
+                userContext
+            );
             if (result.status === "OK") {
                 return new User(result.user);
             }
@@ -274,7 +308,8 @@ export default function getRecipeImplementation(
                 tenantId,
                 accountInfo,
                 doUnionOfAccountInfo,
-            }: { tenantId: string; accountInfo: AccountInfo; doUnionOfAccountInfo: boolean }
+                userContext,
+            }: { tenantId: string; accountInfo: AccountInfo; doUnionOfAccountInfo: boolean; userContext: any }
         ): Promise<UserType[]> {
             let result = await querier.sendGetRequest(
                 new NormalisedURLPath(`${tenantId ?? "public"}/users/by-accountinfo`),
@@ -284,7 +319,8 @@ export default function getRecipeImplementation(
                     thirdPartyId: accountInfo.thirdParty?.id,
                     thirdPartyUserId: accountInfo.thirdParty?.userId,
                     doUnionOfAccountInfo,
-                }
+                },
+                userContext
             );
             return result.users.map((u: any) => new User(u));
         },
@@ -294,17 +330,23 @@ export default function getRecipeImplementation(
             {
                 userId,
                 removeAllLinkedAccounts,
+                userContext,
             }: {
                 userId: string;
                 removeAllLinkedAccounts: boolean;
+                userContext: any;
             }
         ): Promise<{
             status: "OK";
         }> {
-            return await querier.sendPostRequest(new NormalisedURLPath("/user/remove"), {
-                userId,
-                removeAllLinkedAccounts,
-            });
+            return await querier.sendPostRequest(
+                new NormalisedURLPath("/user/remove"),
+                {
+                    userId,
+                    removeAllLinkedAccounts,
+                },
+                userContext
+            );
         },
     };
 }

--- a/lib/ts/recipe/dashboard/api/analytics.ts
+++ b/lib/ts/recipe/dashboard/api/analytics.ts
@@ -29,7 +29,7 @@ export default async function analyticsPost(
     _: APIInterface,
     ___: string,
     options: APIOptions,
-    __: any
+    userContext: any
 ): Promise<Response> {
     // If telemetry is disabled, dont send any event
     if (!SuperTokens.getInstanceOrThrowError().telemetryEnabled) {
@@ -58,7 +58,7 @@ export default async function analyticsPost(
     let numberOfUsers: number;
     try {
         let querier = Querier.getNewInstanceOrThrowError(options.recipeId);
-        let response = await querier.sendGetRequest(new NormalisedURLPath("/telemetry"), {});
+        let response = await querier.sendGetRequest(new NormalisedURLPath("/telemetry"), {}, userContext);
         if (response.exists) {
             telemetryId = response.telemetryId;
         }

--- a/lib/ts/recipe/dashboard/api/search/tagsGet.ts
+++ b/lib/ts/recipe/dashboard/api/search/tagsGet.ts
@@ -23,9 +23,9 @@ export const getSearchTags = async (
     _: APIInterface,
     ___: string,
     options: APIOptions,
-    __: any
+    userContext: any
 ): Promise<TagsResponse> => {
     let querier = Querier.getNewInstanceOrThrowError(options.recipeId);
-    let tagsResponse = await querier.sendGetRequest(new NormalisedURLPath("/user/search/tags"), {});
+    let tagsResponse = await querier.sendGetRequest(new NormalisedURLPath("/user/search/tags"), {}, userContext);
     return tagsResponse;
 };

--- a/lib/ts/recipe/dashboard/api/signIn.ts
+++ b/lib/ts/recipe/dashboard/api/signIn.ts
@@ -24,7 +24,7 @@ type SignInResponse =
     | { status: "INVALID_CREDENTIALS_ERROR" }
     | { status: "USER_SUSPENDED_ERROR" };
 
-export default async function signIn(_: APIInterface, options: APIOptions, __: any): Promise<boolean> {
+export default async function signIn(_: APIInterface, options: APIOptions, userContext: any): Promise<boolean> {
     const { email, password } = await options.req.getJSONBody();
 
     if (email === undefined) {
@@ -47,7 +47,8 @@ export default async function signIn(_: APIInterface, options: APIOptions, __: a
         {
             email,
             password,
-        }
+        },
+        userContext
     );
 
     send200Response(options.res, signInResponse);

--- a/lib/ts/recipe/dashboard/api/signOut.ts
+++ b/lib/ts/recipe/dashboard/api/signOut.ts
@@ -18,7 +18,12 @@ import { send200Response } from "../../../utils";
 import { Querier } from "../../../querier";
 import NormalisedURLPath from "../../../normalisedURLPath";
 
-export default async function signOut(_: APIInterface, ___: string, options: APIOptions, __: any): Promise<boolean> {
+export default async function signOut(
+    _: APIInterface,
+    ___: string,
+    options: APIOptions,
+    userContext: any
+): Promise<boolean> {
     if (options.config.authMode === "api-key") {
         send200Response(options.res, { status: "OK" });
     } else {
@@ -27,6 +32,7 @@ export default async function signOut(_: APIInterface, ___: string, options: API
         const sessionDeleteResponse = await querier.sendDeleteRequest(
             new NormalisedURLPath("/recipe/dashboard/session"),
             {},
+            userContext,
             { sessionId: sessionIdFormAuthHeader }
         );
         send200Response(options.res, sessionDeleteResponse);

--- a/lib/ts/recipe/dashboard/api/signOut.ts
+++ b/lib/ts/recipe/dashboard/api/signOut.ts
@@ -32,8 +32,8 @@ export default async function signOut(
         const sessionDeleteResponse = await querier.sendDeleteRequest(
             new NormalisedURLPath("/recipe/dashboard/session"),
             {},
-            userContext,
-            { sessionId: sessionIdFormAuthHeader }
+            { sessionId: sessionIdFormAuthHeader },
+            userContext
         );
         send200Response(options.res, sessionDeleteResponse);
     }

--- a/lib/ts/recipe/dashboard/recipeImplementation.ts
+++ b/lib/ts/recipe/dashboard/recipeImplementation.ts
@@ -38,7 +38,8 @@ export default function getRecipeImplementation(): RecipeInterface {
                     new NormalisedURLPath("/recipe/dashboard/session/verify"),
                     {
                         sessionId: authHeaderValue,
-                    }
+                    },
+                    input.userContext
                 );
 
                 if (sessionVerificationResponse.status !== "OK") {

--- a/lib/ts/recipe/emailpassword/recipeImplementation.ts
+++ b/lib/ts/recipe/emailpassword/recipeImplementation.ts
@@ -73,7 +73,8 @@ export default function getRecipeInterface(
                 {
                     email: input.email,
                     password: input.password,
-                }
+                },
+                input.userContext
             );
             if (resp.status === "OK") {
                 resp.user = new User(resp.user);
@@ -103,7 +104,8 @@ export default function getRecipeInterface(
                 {
                     email,
                     password,
-                }
+                },
+                userContext
             );
 
             if (response.status === "OK") {
@@ -144,10 +146,12 @@ export default function getRecipeInterface(
             userId,
             email,
             tenantId,
+            userContext,
         }: {
             userId: string;
             email: string;
             tenantId: string;
+            userContext: any;
         }): Promise<{ status: "OK"; token: string } | { status: "UNKNOWN_USER_ID_ERROR" }> {
             // the input user ID can be a recipe or a primary user ID.
             return await querier.sendPostRequest(
@@ -157,16 +161,19 @@ export default function getRecipeInterface(
                 {
                     userId,
                     email,
-                }
+                },
+                userContext
             );
         },
 
         consumePasswordResetToken: async function ({
             token,
             tenantId,
+            userContext,
         }: {
             token: string;
             tenantId: string;
+            userContext: any;
         }): Promise<
             | {
                   status: "OK";
@@ -182,7 +189,8 @@ export default function getRecipeInterface(
                 {
                     method: "token",
                     token,
-                }
+                },
+                userContext
             );
         },
 
@@ -230,7 +238,8 @@ export default function getRecipeInterface(
                     recipeUserId: input.recipeUserId.getAsString(),
                     email: input.email,
                     password: input.password,
-                }
+                },
+                input.userContext
             );
 
             if (response.status === "OK") {

--- a/lib/ts/recipe/emailverification/recipeImplementation.ts
+++ b/lib/ts/recipe/emailverification/recipeImplementation.ts
@@ -15,10 +15,12 @@ export default function getRecipeInterface(
             recipeUserId,
             email,
             tenantId,
+            userContext,
         }: {
             recipeUserId: RecipeUserId;
             email: string;
             tenantId: string;
+            userContext: any;
         }): Promise<
             | {
                   status: "OK";
@@ -31,7 +33,8 @@ export default function getRecipeInterface(
                 {
                     userId: recipeUserId.getAsString(),
                     email,
-                }
+                },
+                userContext
             );
             if (response.status === "OK") {
                 return {
@@ -61,7 +64,8 @@ export default function getRecipeInterface(
                 {
                     method: "token",
                     token,
-                }
+                },
+                userContext
             );
             if (response.status === "OK") {
                 const recipeUserId = new RecipeUserId(response.userId);
@@ -105,14 +109,20 @@ export default function getRecipeInterface(
         isEmailVerified: async function ({
             recipeUserId,
             email,
+            userContext,
         }: {
             recipeUserId: RecipeUserId;
             email: string;
+            userContext: any;
         }): Promise<boolean> {
-            let response = await querier.sendGetRequest(new NormalisedURLPath("/recipe/user/email/verify"), {
-                userId: recipeUserId.getAsString(),
-                email,
-            });
+            let response = await querier.sendGetRequest(
+                new NormalisedURLPath("/recipe/user/email/verify"),
+                {
+                    userId: recipeUserId.getAsString(),
+                    email,
+                },
+                userContext
+            );
             return response.isVerified;
         },
 
@@ -120,13 +130,15 @@ export default function getRecipeInterface(
             recipeUserId: RecipeUserId;
             email: string;
             tenantId: string;
+            userContext: any;
         }): Promise<{ status: "OK" }> {
             await querier.sendPostRequest(
                 new NormalisedURLPath(`/${input.tenantId}/recipe/user/email/verify/token/remove`),
                 {
                     userId: input.recipeUserId.getAsString(),
                     email: input.email,
-                }
+                },
+                input.userContext
             );
             return { status: "OK" };
         },
@@ -134,11 +146,16 @@ export default function getRecipeInterface(
         unverifyEmail: async function (input: {
             recipeUserId: RecipeUserId;
             email: string;
+            userContext: any;
         }): Promise<{ status: "OK" }> {
-            await querier.sendPostRequest(new NormalisedURLPath("/recipe/user/email/verify/remove"), {
-                userId: input.recipeUserId.getAsString(),
-                email: input.email,
-            });
+            await querier.sendPostRequest(
+                new NormalisedURLPath("/recipe/user/email/verify/remove"),
+                {
+                    userId: input.recipeUserId.getAsString(),
+                    email: input.email,
+                },
+                input.userContext
+            );
             return { status: "OK" };
         },
     };

--- a/lib/ts/recipe/jwt/recipeImplementation.ts
+++ b/lib/ts/recipe/jwt/recipeImplementation.ts
@@ -30,10 +30,12 @@ export default function getRecipeInterface(
             payload,
             validitySeconds,
             useStaticSigningKey,
+            userContext,
         }: {
             payload?: any;
             useStaticSigningKey?: boolean;
             validitySeconds?: number;
+            userContext: any;
         }): Promise<
             | {
                   status: "OK";
@@ -48,13 +50,17 @@ export default function getRecipeInterface(
                 validitySeconds = config.jwtValiditySeconds;
             }
 
-            let response = await querier.sendPostRequest(new NormalisedURLPath("/recipe/jwt"), {
-                payload: payload ?? {},
-                validity: validitySeconds,
-                useStaticSigningKey: useStaticSigningKey !== false,
-                algorithm: "RS256",
-                jwksDomain: appInfo.apiDomain.getAsStringDangerous(),
-            });
+            let response = await querier.sendPostRequest(
+                new NormalisedURLPath("/recipe/jwt"),
+                {
+                    payload: payload ?? {},
+                    validity: validitySeconds,
+                    useStaticSigningKey: useStaticSigningKey !== false,
+                    algorithm: "RS256",
+                    jwksDomain: appInfo.apiDomain.getAsStringDangerous(),
+                },
+                userContext
+            );
 
             if (response.status === "OK") {
                 return {
@@ -68,10 +74,11 @@ export default function getRecipeInterface(
             }
         },
 
-        getJWKS: async function (): Promise<{ keys: JsonWebKey[]; validityInSeconds?: number }> {
+        getJWKS: async function (userContext: any): Promise<{ keys: JsonWebKey[]; validityInSeconds?: number }> {
             const { body, headers } = await querier.sendGetRequestWithResponseHeaders(
                 new NormalisedURLPath("/.well-known/jwks.json"),
-                {}
+                {},
+                userContext
             );
             let validityInSeconds = defaultJWKSMaxAge;
             const cacheControl = headers.get("Cache-Control");

--- a/lib/ts/recipe/multitenancy/recipeImplementation.ts
+++ b/lib/ts/recipe/multitenancy/recipeImplementation.ts
@@ -9,29 +9,38 @@ export default function getRecipeInterface(querier: Querier): RecipeInterface {
             return tenantIdFromFrontend;
         },
 
-        createOrUpdateTenant: async function ({ tenantId, config }) {
-            let response = await querier.sendPutRequest(new NormalisedURLPath(`/recipe/multitenancy/tenant`), {
-                tenantId,
-                ...config,
-            });
+        createOrUpdateTenant: async function ({ tenantId, config, userContext }) {
+            let response = await querier.sendPutRequest(
+                new NormalisedURLPath(`/recipe/multitenancy/tenant`),
+                {
+                    tenantId,
+                    ...config,
+                },
+                userContext
+            );
 
             return response;
         },
 
-        deleteTenant: async function ({ tenantId }) {
-            let response = await querier.sendPostRequest(new NormalisedURLPath(`/recipe/multitenancy/tenant/remove`), {
-                tenantId,
-            });
+        deleteTenant: async function ({ tenantId, userContext }) {
+            let response = await querier.sendPostRequest(
+                new NormalisedURLPath(`/recipe/multitenancy/tenant/remove`),
+                {
+                    tenantId,
+                },
+                userContext
+            );
 
             return response;
         },
 
-        getTenant: async function ({ tenantId }) {
+        getTenant: async function ({ tenantId, userContext }) {
             let response = await querier.sendGetRequest(
                 new NormalisedURLPath(
                     `/${tenantId === undefined ? DEFAULT_TENANT_ID : tenantId}/recipe/multitenancy/tenant`
                 ),
-                {}
+                {},
+                userContext
             );
 
             if (response.status === "TENANT_NOT_FOUND_ERROR") {
@@ -41,12 +50,16 @@ export default function getRecipeInterface(querier: Querier): RecipeInterface {
             return response;
         },
 
-        listAllTenants: async function () {
-            let response = await querier.sendGetRequest(new NormalisedURLPath(`/recipe/multitenancy/tenant/list`), {});
+        listAllTenants: async function ({ userContext }) {
+            let response = await querier.sendGetRequest(
+                new NormalisedURLPath(`/recipe/multitenancy/tenant/list`),
+                {},
+                userContext
+            );
             return response;
         },
 
-        createOrUpdateThirdPartyConfig: async function ({ tenantId, config, skipValidation }) {
+        createOrUpdateThirdPartyConfig: async function ({ tenantId, config, skipValidation, userContext }) {
             let response = await querier.sendPutRequest(
                 new NormalisedURLPath(
                     `/${tenantId === undefined ? DEFAULT_TENANT_ID : tenantId}/recipe/multitenancy/config/thirdparty`
@@ -54,12 +67,13 @@ export default function getRecipeInterface(querier: Querier): RecipeInterface {
                 {
                     config,
                     skipValidation,
-                }
+                },
+                userContext
             );
             return response;
         },
 
-        deleteThirdPartyConfig: async function ({ tenantId, thirdPartyId }) {
+        deleteThirdPartyConfig: async function ({ tenantId, thirdPartyId, userContext }) {
             let response = await querier.sendPostRequest(
                 new NormalisedURLPath(
                     `/${
@@ -68,31 +82,34 @@ export default function getRecipeInterface(querier: Querier): RecipeInterface {
                 ),
                 {
                     thirdPartyId,
-                }
+                },
+                userContext
             );
             return response;
         },
 
-        associateUserToTenant: async function ({ tenantId, recipeUserId }) {
+        associateUserToTenant: async function ({ tenantId, recipeUserId, userContext }) {
             let response = await querier.sendPostRequest(
                 new NormalisedURLPath(
                     `/${tenantId === undefined ? DEFAULT_TENANT_ID : tenantId}/recipe/multitenancy/tenant/user`
                 ),
                 {
                     recipeUserId: recipeUserId.getAsString(),
-                }
+                },
+                userContext
             );
             return response;
         },
 
-        disassociateUserFromTenant: async function ({ tenantId, recipeUserId }) {
+        disassociateUserFromTenant: async function ({ tenantId, recipeUserId, userContext }) {
             let response = await querier.sendPostRequest(
                 new NormalisedURLPath(
                     `/${tenantId === undefined ? DEFAULT_TENANT_ID : tenantId}/recipe/multitenancy/tenant/user/remove`
                 ),
                 {
                     recipeUserId: recipeUserId.getAsString(),
-                }
+                },
+                userContext
             );
             return response;
         },

--- a/lib/ts/recipe/passwordless/recipeImplementation.ts
+++ b/lib/ts/recipe/passwordless/recipeImplementation.ts
@@ -24,7 +24,8 @@ export default function getRecipeInterface(querier: Querier): RecipeInterface {
         consumeCode: async function (this: RecipeInterface, input) {
             let response = await querier.sendPostRequest(
                 new NormalisedURLPath(`/${input.tenantId}/recipe/signinup/code/consume`),
-                copyAndRemoveUserContextAndTenantId(input)
+                copyAndRemoveUserContextAndTenantId(input),
+                input.userContext
             );
 
             if (response.status !== "OK") {
@@ -79,49 +80,56 @@ export default function getRecipeInterface(querier: Querier): RecipeInterface {
         createCode: async function (input) {
             let response = await querier.sendPostRequest(
                 new NormalisedURLPath(`/${input.tenantId}/recipe/signinup/code`),
-                copyAndRemoveUserContextAndTenantId(input)
+                copyAndRemoveUserContextAndTenantId(input),
+                input.userContext
             );
             return response;
         },
         createNewCodeForDevice: async function (input) {
             let response = await querier.sendPostRequest(
                 new NormalisedURLPath(`/${input.tenantId}/recipe/signinup/code`),
-                copyAndRemoveUserContextAndTenantId(input)
+                copyAndRemoveUserContextAndTenantId(input),
+                input.userContext
             );
             return response;
         },
         listCodesByDeviceId: async function (input) {
             let response = await querier.sendGetRequest(
                 new NormalisedURLPath(`/${input.tenantId}/recipe/signinup/codes`),
-                copyAndRemoveUserContextAndTenantId(input)
+                copyAndRemoveUserContextAndTenantId(input),
+                input.userContext
             );
             return response.devices.length === 1 ? response.devices[0] : undefined;
         },
         listCodesByEmail: async function (input) {
             let response = await querier.sendGetRequest(
                 new NormalisedURLPath(`/${input.tenantId}/recipe/signinup/codes`),
-                copyAndRemoveUserContextAndTenantId(input)
+                copyAndRemoveUserContextAndTenantId(input),
+                input.userContext
             );
             return response.devices;
         },
         listCodesByPhoneNumber: async function (input) {
             let response = await querier.sendGetRequest(
                 new NormalisedURLPath(`/${input.tenantId}/recipe/signinup/codes`),
-                copyAndRemoveUserContextAndTenantId(input)
+                copyAndRemoveUserContextAndTenantId(input),
+                input.userContext
             );
             return response.devices;
         },
         listCodesByPreAuthSessionId: async function (input) {
             let response = await querier.sendGetRequest(
                 new NormalisedURLPath(`/${input.tenantId}/recipe/signinup/codes`),
-                copyAndRemoveUserContextAndTenantId(input)
+                copyAndRemoveUserContextAndTenantId(input),
+                input.userContext
             );
             return response.devices.length === 1 ? response.devices[0] : undefined;
         },
         revokeAllCodes: async function (input) {
             await querier.sendPostRequest(
                 new NormalisedURLPath(`/${input.tenantId}/recipe/signinup/codes/remove`),
-                copyAndRemoveUserContextAndTenantId(input)
+                copyAndRemoveUserContextAndTenantId(input),
+                input.userContext
             );
             return {
                 status: "OK",
@@ -130,14 +138,16 @@ export default function getRecipeInterface(querier: Querier): RecipeInterface {
         revokeCode: async function (input) {
             await querier.sendPostRequest(
                 new NormalisedURLPath(`/${input.tenantId}/recipe/signinup/code/remove`),
-                copyAndRemoveUserContextAndTenantId(input)
+                copyAndRemoveUserContextAndTenantId(input),
+                input.userContext
             );
             return { status: "OK" };
         },
         updateUser: async function (input) {
             let response = await querier.sendPutRequest(
                 new NormalisedURLPath(`/recipe/user`),
-                copyAndRemoveUserContextAndTenantId(input)
+                copyAndRemoveUserContextAndTenantId(input),
+                input.userContext
             );
             if (response.status !== "OK") {
                 return response;

--- a/lib/ts/recipe/session/recipeImplementation.ts
+++ b/lib/ts/recipe/session/recipeImplementation.ts
@@ -96,9 +96,9 @@ export default function getRecipeInterface(
                 tenantId,
                 recipeUserId,
                 disableAntiCsrf === true,
-                userContext,
                 accessTokenPayload,
-                sessionDataInDatabase
+                sessionDataInDatabase,
+                userContext
             );
             logDebugMessage("createNewSession: Finished");
 
@@ -408,13 +408,16 @@ export default function getRecipeInterface(
             revokeAcrossAllTenants?: boolean;
             userContext: any;
         }) {
+            if (tenantId === undefined) {
+                tenantId = DEFAULT_TENANT_ID;
+            }
             return SessionFunctions.revokeAllSessionsForUser(
                 helpers,
                 userId,
                 revokeSessionsForLinkedAccounts,
-                userContext,
                 tenantId,
-                revokeAcrossAllTenants
+                revokeAcrossAllTenants ?? false,
+                userContext
             );
         },
 
@@ -431,13 +434,16 @@ export default function getRecipeInterface(
             fetchAcrossAllTenants?: boolean;
             userContext: any;
         }): Promise<string[]> {
+            if (tenantId === undefined) {
+                tenantId = DEFAULT_TENANT_ID;
+            }
             return SessionFunctions.getAllSessionHandlesForUser(
                 helpers,
                 userId,
                 fetchSessionsForAllLinkedAccounts,
-                userContext,
                 tenantId,
-                fetchAcrossAllTenants
+                fetchAcrossAllTenants ?? false,
+                userContext
             );
         },
 

--- a/lib/ts/recipe/session/recipeImplementation.ts
+++ b/lib/ts/recipe/session/recipeImplementation.ts
@@ -79,6 +79,7 @@ export default function getRecipeInterface(
             sessionDataInDatabase = {},
             disableAntiCsrf,
             tenantId,
+            userContext,
         }: {
             userId: string;
             recipeUserId: RecipeUserId;
@@ -95,6 +96,7 @@ export default function getRecipeInterface(
                 tenantId,
                 recipeUserId,
                 disableAntiCsrf === true,
+                userContext,
                 accessTokenPayload,
                 sessionDataInDatabase
             );
@@ -127,6 +129,7 @@ export default function getRecipeInterface(
             accessToken: accessTokenString,
             antiCsrfToken,
             options,
+            userContext,
         }: {
             accessToken: string;
             antiCsrfToken?: string;
@@ -192,7 +195,8 @@ export default function getRecipeInterface(
                 accessToken,
                 antiCsrfToken,
                 options?.antiCsrfCheck !== false,
-                options?.checkDatabase === true
+                options?.checkDatabase === true,
+                userContext
             );
 
             logDebugMessage("getSession: Success!");
@@ -282,10 +286,12 @@ export default function getRecipeInterface(
 
         getSessionInformation: async function ({
             sessionHandle,
+            userContext,
         }: {
             sessionHandle: string;
+            userContext: any;
         }): Promise<SessionInformation | undefined> {
-            return SessionFunctions.getSessionInformation(helpers, sessionHandle);
+            return SessionFunctions.getSessionInformation(helpers, sessionHandle, userContext);
         },
 
         refreshSession: async function (
@@ -294,6 +300,7 @@ export default function getRecipeInterface(
                 refreshToken,
                 antiCsrfToken,
                 disableAntiCsrf,
+                userContext,
             }: { refreshToken: string; antiCsrfToken?: string; disableAntiCsrf: boolean; userContext: any }
         ): Promise<SessionContainerInterface> {
             if (
@@ -311,7 +318,8 @@ export default function getRecipeInterface(
                 helpers,
                 refreshToken,
                 antiCsrfToken,
-                disableAntiCsrf
+                disableAntiCsrf,
+                userContext
             );
 
             logDebugMessage("refreshSession: Success!");
@@ -363,10 +371,14 @@ export default function getRecipeInterface(
                     ? {}
                     : input.newAccessTokenPayload;
 
-            let response = await querier.sendPostRequest(new NormalisedURLPath("/recipe/session/regenerate"), {
-                accessToken: input.accessToken,
-                userDataInJWT: newAccessTokenPayload,
-            });
+            let response = await querier.sendPostRequest(
+                new NormalisedURLPath("/recipe/session/regenerate"),
+                {
+                    accessToken: input.accessToken,
+                    userDataInJWT: newAccessTokenPayload,
+                },
+                input.userContext
+            );
             if (response.status === "UNAUTHORISED") {
                 return undefined;
             }
@@ -388,16 +400,19 @@ export default function getRecipeInterface(
             tenantId,
             revokeAcrossAllTenants,
             revokeSessionsForLinkedAccounts,
+            userContext,
         }: {
             userId: string;
             revokeSessionsForLinkedAccounts: boolean;
             tenantId?: string;
             revokeAcrossAllTenants?: boolean;
+            userContext: any;
         }) {
             return SessionFunctions.revokeAllSessionsForUser(
                 helpers,
                 userId,
                 revokeSessionsForLinkedAccounts,
+                userContext,
                 tenantId,
                 revokeAcrossAllTenants
             );
@@ -408,6 +423,7 @@ export default function getRecipeInterface(
             fetchSessionsForAllLinkedAccounts,
             tenantId,
             fetchAcrossAllTenants,
+            userContext,
         }: {
             userId: string;
             fetchSessionsForAllLinkedAccounts: boolean;
@@ -419,27 +435,42 @@ export default function getRecipeInterface(
                 helpers,
                 userId,
                 fetchSessionsForAllLinkedAccounts,
+                userContext,
                 tenantId,
                 fetchAcrossAllTenants
             );
         },
 
-        revokeSession: function ({ sessionHandle }: { sessionHandle: string }): Promise<boolean> {
-            return SessionFunctions.revokeSession(helpers, sessionHandle);
+        revokeSession: function ({
+            sessionHandle,
+            userContext,
+        }: {
+            sessionHandle: string;
+            userContext: any;
+        }): Promise<boolean> {
+            return SessionFunctions.revokeSession(helpers, sessionHandle, userContext);
         },
 
-        revokeMultipleSessions: function ({ sessionHandles }: { sessionHandles: string[] }) {
-            return SessionFunctions.revokeMultipleSessions(helpers, sessionHandles);
+        revokeMultipleSessions: function ({
+            sessionHandles,
+            userContext,
+        }: {
+            sessionHandles: string[];
+            userContext: any;
+        }) {
+            return SessionFunctions.revokeMultipleSessions(helpers, sessionHandles, userContext);
         },
 
         updateSessionDataInDatabase: function ({
             sessionHandle,
             newSessionData,
+            userContext,
         }: {
             sessionHandle: string;
             newSessionData: any;
+            userContext: any;
         }): Promise<boolean> {
-            return SessionFunctions.updateSessionDataInDatabase(helpers, sessionHandle, newSessionData);
+            return SessionFunctions.updateSessionDataInDatabase(helpers, sessionHandle, newSessionData, userContext);
         },
 
         mergeIntoAccessTokenPayload: async function (
@@ -470,7 +501,12 @@ export default function getRecipeInterface(
                 }
             }
 
-            return SessionFunctions.updateAccessTokenPayload(helpers, sessionHandle, newAccessTokenPayload);
+            return SessionFunctions.updateAccessTokenPayload(
+                helpers,
+                sessionHandle,
+                newAccessTokenPayload,
+                userContext
+            );
         },
 
         fetchAndSetClaim: async function <T>(

--- a/lib/ts/recipe/session/recipeImplementation.ts
+++ b/lib/ts/recipe/session/recipeImplementation.ts
@@ -408,15 +408,12 @@ export default function getRecipeInterface(
             revokeAcrossAllTenants?: boolean;
             userContext: any;
         }) {
-            if (tenantId === undefined) {
-                tenantId = DEFAULT_TENANT_ID;
-            }
             return SessionFunctions.revokeAllSessionsForUser(
                 helpers,
                 userId,
                 revokeSessionsForLinkedAccounts,
                 tenantId,
-                revokeAcrossAllTenants ?? false,
+                revokeAcrossAllTenants,
                 userContext
             );
         },
@@ -434,15 +431,12 @@ export default function getRecipeInterface(
             fetchAcrossAllTenants?: boolean;
             userContext: any;
         }): Promise<string[]> {
-            if (tenantId === undefined) {
-                tenantId = DEFAULT_TENANT_ID;
-            }
             return SessionFunctions.getAllSessionHandlesForUser(
                 helpers,
                 userId,
                 fetchSessionsForAllLinkedAccounts,
                 tenantId,
-                fetchAcrossAllTenants ?? false,
+                fetchAcrossAllTenants,
                 userContext
             );
         },

--- a/lib/ts/recipe/session/sessionFunctions.ts
+++ b/lib/ts/recipe/session/sessionFunctions.ts
@@ -33,9 +33,9 @@ export async function createNewSession(
     tenantId: string,
     recipeUserId: RecipeUserId,
     disableAntiCsrf: boolean,
-    userContext: any,
-    accessTokenPayload: any = {},
-    sessionDataInDatabase: any = {}
+    accessTokenPayload: any,
+    sessionDataInDatabase: any,
+    userContext: any
 ): Promise<CreateOrRefreshAPIResponse> {
     accessTokenPayload = accessTokenPayload === null || accessTokenPayload === undefined ? {} : accessTokenPayload;
     sessionDataInDatabase =
@@ -401,13 +401,10 @@ export async function revokeAllSessionsForUser(
     helpers: Helpers,
     userId: string,
     revokeSessionsForLinkedAccounts: boolean,
-    userContext: any,
-    tenantId?: string,
-    revokeAcrossAllTenants?: boolean
+    tenantId: string,
+    revokeAcrossAllTenants: boolean,
+    userContext: any
 ): Promise<string[]> {
-    if (tenantId === undefined) {
-        tenantId = DEFAULT_TENANT_ID;
-    }
     let response = await helpers.querier.sendPostRequest(
         new NormalisedURLPath(`/${tenantId}/recipe/session/remove`),
         {
@@ -427,13 +424,10 @@ export async function getAllSessionHandlesForUser(
     helpers: Helpers,
     userId: string,
     fetchSessionsForAllLinkedAccounts: boolean,
-    userContext: any,
-    tenantId?: string,
-    fetchAcrossAllTenants?: boolean
+    tenantId: string,
+    fetchAcrossAllTenants: boolean,
+    userContext: any
 ): Promise<string[]> {
-    if (tenantId === undefined) {
-        tenantId = DEFAULT_TENANT_ID;
-    }
     let response = await helpers.querier.sendGetRequest(
         new NormalisedURLPath(`/${tenantId}/recipe/session/user`),
         {

--- a/lib/ts/recipe/session/sessionFunctions.ts
+++ b/lib/ts/recipe/session/sessionFunctions.ts
@@ -401,10 +401,13 @@ export async function revokeAllSessionsForUser(
     helpers: Helpers,
     userId: string,
     revokeSessionsForLinkedAccounts: boolean,
-    tenantId: string,
-    revokeAcrossAllTenants: boolean,
+    tenantId: string | undefined,
+    revokeAcrossAllTenants: boolean | undefined,
     userContext: any
 ): Promise<string[]> {
+    if (tenantId === undefined) {
+        tenantId = DEFAULT_TENANT_ID;
+    }
     let response = await helpers.querier.sendPostRequest(
         new NormalisedURLPath(`/${tenantId}/recipe/session/remove`),
         {
@@ -424,10 +427,13 @@ export async function getAllSessionHandlesForUser(
     helpers: Helpers,
     userId: string,
     fetchSessionsForAllLinkedAccounts: boolean,
-    tenantId: string,
-    fetchAcrossAllTenants: boolean,
+    tenantId: string | undefined,
+    fetchAcrossAllTenants: boolean | undefined,
     userContext: any
 ): Promise<string[]> {
+    if (tenantId === undefined) {
+        tenantId = DEFAULT_TENANT_ID;
+    }
     let response = await helpers.querier.sendGetRequest(
         new NormalisedURLPath(`/${tenantId}/recipe/session/user`),
         {

--- a/lib/ts/recipe/thirdparty/recipeImplementation.ts
+++ b/lib/ts/recipe/thirdparty/recipeImplementation.ts
@@ -39,11 +39,15 @@ export default function getRecipeImplementation(querier: Querier, providers: Pro
                   reason: string;
               }
         > {
-            let response = await querier.sendPostRequest(new NormalisedURLPath(`/${tenantId}/recipe/signinup`), {
-                thirdPartyId,
-                thirdPartyUserId,
-                email: { id: email, isVerified },
-            });
+            let response = await querier.sendPostRequest(
+                new NormalisedURLPath(`/${tenantId}/recipe/signinup`),
+                {
+                    thirdPartyId,
+                    thirdPartyUserId,
+                    email: { id: email, isVerified },
+                },
+                userContext
+            );
 
             if (response.status !== "OK") {
                 return response;

--- a/lib/ts/recipe/usermetadata/recipeImplementation.ts
+++ b/lib/ts/recipe/usermetadata/recipeImplementation.ts
@@ -19,21 +19,29 @@ import { Querier } from "../../querier";
 
 export default function getRecipeInterface(querier: Querier): RecipeInterface {
     return {
-        getUserMetadata: function ({ userId }) {
-            return querier.sendGetRequest(new NormalisedURLPath("/recipe/user/metadata"), { userId });
+        getUserMetadata: function ({ userId, userContext }) {
+            return querier.sendGetRequest(new NormalisedURLPath("/recipe/user/metadata"), { userId }, userContext);
         },
 
-        updateUserMetadata: function ({ userId, metadataUpdate }) {
-            return querier.sendPutRequest(new NormalisedURLPath("/recipe/user/metadata"), {
-                userId,
-                metadataUpdate,
-            });
+        updateUserMetadata: function ({ userId, metadataUpdate, userContext }) {
+            return querier.sendPutRequest(
+                new NormalisedURLPath("/recipe/user/metadata"),
+                {
+                    userId,
+                    metadataUpdate,
+                },
+                userContext
+            );
         },
 
-        clearUserMetadata: function ({ userId }) {
-            return querier.sendPostRequest(new NormalisedURLPath("/recipe/user/metadata/remove"), {
-                userId,
-            });
+        clearUserMetadata: function ({ userId, userContext }) {
+            return querier.sendPostRequest(
+                new NormalisedURLPath("/recipe/user/metadata/remove"),
+                {
+                    userId,
+                },
+                userContext
+            );
         },
     };
 }

--- a/lib/ts/recipe/userroles/recipeImplementation.ts
+++ b/lib/ts/recipe/userroles/recipeImplementation.ts
@@ -20,61 +20,73 @@ import { DEFAULT_TENANT_ID } from "../multitenancy/constants";
 
 export default function getRecipeInterface(querier: Querier): RecipeInterface {
     return {
-        addRoleToUser: function ({ userId, role, tenantId }) {
+        addRoleToUser: function ({ userId, role, tenantId, userContext }) {
             return querier.sendPutRequest(
                 new NormalisedURLPath(`/${tenantId === undefined ? DEFAULT_TENANT_ID : tenantId}/recipe/user/role`),
-                { userId, role }
+                { userId, role },
+                userContext
             );
         },
 
-        removeUserRole: function ({ userId, role, tenantId }) {
+        removeUserRole: function ({ userId, role, tenantId, userContext }) {
             return querier.sendPostRequest(
                 new NormalisedURLPath(
                     `/${tenantId === undefined ? DEFAULT_TENANT_ID : tenantId}/recipe/user/role/remove`
                 ),
-                { userId, role }
+                { userId, role },
+                userContext
             );
         },
 
-        getRolesForUser: function ({ userId, tenantId }) {
+        getRolesForUser: function ({ userId, tenantId, userContext }) {
             return querier.sendGetRequest(
                 new NormalisedURLPath(`/${tenantId === undefined ? DEFAULT_TENANT_ID : tenantId}/recipe/user/roles`),
-                { userId }
+                { userId },
+                userContext
             );
         },
 
-        getUsersThatHaveRole: function ({ role, tenantId }) {
+        getUsersThatHaveRole: function ({ role, tenantId, userContext }) {
             return querier.sendGetRequest(
                 new NormalisedURLPath(`/${tenantId === undefined ? DEFAULT_TENANT_ID : tenantId}/recipe/role/users`),
-                { role }
+                { role },
+                userContext
             );
         },
 
-        createNewRoleOrAddPermissions: function ({ role, permissions }) {
-            return querier.sendPutRequest(new NormalisedURLPath("/recipe/role"), { role, permissions });
+        createNewRoleOrAddPermissions: function ({ role, permissions, userContext }) {
+            return querier.sendPutRequest(new NormalisedURLPath("/recipe/role"), { role, permissions }, userContext);
         },
 
-        getPermissionsForRole: function ({ role }) {
-            return querier.sendGetRequest(new NormalisedURLPath("/recipe/role/permissions"), { role });
+        getPermissionsForRole: function ({ role, userContext }) {
+            return querier.sendGetRequest(new NormalisedURLPath("/recipe/role/permissions"), { role }, userContext);
         },
 
-        removePermissionsFromRole: function ({ role, permissions }) {
-            return querier.sendPostRequest(new NormalisedURLPath("/recipe/role/permissions/remove"), {
-                role,
-                permissions,
-            });
+        removePermissionsFromRole: function ({ role, permissions, userContext }) {
+            return querier.sendPostRequest(
+                new NormalisedURLPath("/recipe/role/permissions/remove"),
+                {
+                    role,
+                    permissions,
+                },
+                userContext
+            );
         },
 
-        getRolesThatHavePermission: function ({ permission }) {
-            return querier.sendGetRequest(new NormalisedURLPath("/recipe/permission/roles"), { permission });
+        getRolesThatHavePermission: function ({ permission, userContext }) {
+            return querier.sendGetRequest(
+                new NormalisedURLPath("/recipe/permission/roles"),
+                { permission },
+                userContext
+            );
         },
 
-        deleteRole: function ({ role }) {
-            return querier.sendPostRequest(new NormalisedURLPath("/recipe/role/remove"), { role });
+        deleteRole: function ({ role, userContext }) {
+            return querier.sendPostRequest(new NormalisedURLPath("/recipe/role/remove"), { role }, userContext);
         },
 
-        getAllRoles: function () {
-            return querier.sendGetRequest(new NormalisedURLPath("/recipe/roles"), {});
+        getAllRoles: function (userContext) {
+            return querier.sendGetRequest(new NormalisedURLPath("/recipe/roles"), {}, userContext);
         },
     };
 }

--- a/lib/ts/supertokens.ts
+++ b/lib/ts/supertokens.ts
@@ -166,7 +166,7 @@ export default class SuperTokens {
         return Array.from(headerSet);
     };
 
-    getUserCount = async (includeRecipeIds?: string[], tenantId?: string): Promise<number> => {
+    getUserCount = async (includeRecipeIds?: string[], tenantId?: string, userContext?: any): Promise<number> => {
         let querier = Querier.getNewInstanceOrThrowError(undefined);
         let apiVersion = await querier.getAPIVersion();
         if (maxVersion(apiVersion, "2.7") === "2.7") {
@@ -185,7 +185,7 @@ export default class SuperTokens {
                 includeRecipeIds: includeRecipeIdsStr,
                 includeAllTenants: tenantId === undefined,
             },
-            undefined
+            userContext === undefined ? {} : userContext
         );
         return Number(response.count);
     };
@@ -195,6 +195,7 @@ export default class SuperTokens {
         externalUserId: string;
         externalUserIdInfo?: string;
         force?: boolean;
+        userContext?: any;
     }): Promise<
         | {
               status: "OK" | "UNKNOWN_SUPERTOKENS_USER_ID_ERROR";
@@ -217,7 +218,7 @@ export default class SuperTokens {
                     externalUserIdInfo: input.externalUserIdInfo,
                     force: input.force,
                 },
-                undefined
+                input.userContext === undefined ? {} : input.userContext
             );
         } else {
             throw new global.Error("Please upgrade the SuperTokens core to >= 3.15.0");
@@ -227,6 +228,7 @@ export default class SuperTokens {
     getUserIdMapping = async function (input: {
         userId: string;
         userIdType?: "SUPERTOKENS" | "EXTERNAL" | "ANY";
+        userContext?: any;
     }): Promise<
         | {
               status: "OK";
@@ -248,7 +250,7 @@ export default class SuperTokens {
                     userId: input.userId,
                     userIdType: input.userIdType,
                 },
-                undefined
+                input.userContext === undefined ? {} : input.userContext
             );
             return response;
         } else {
@@ -260,6 +262,7 @@ export default class SuperTokens {
         userId: string;
         userIdType?: "SUPERTOKENS" | "EXTERNAL" | "ANY";
         force?: boolean;
+        userContext?: any;
     }): Promise<{
         status: "OK";
         didMappingExist: boolean;
@@ -274,7 +277,7 @@ export default class SuperTokens {
                     userIdType: input.userIdType,
                     force: input.force,
                 },
-                undefined
+                input.userContext === undefined ? {} : input.userContext
             );
         } else {
             throw new global.Error("Please upgrade the SuperTokens core to >= 3.15.0");
@@ -285,6 +288,7 @@ export default class SuperTokens {
         userId: string;
         userIdType?: "SUPERTOKENS" | "EXTERNAL" | "ANY";
         externalUserIdInfo?: string;
+        userContext?: any;
     }): Promise<{
         status: "OK" | "UNKNOWN_MAPPING_ERROR";
     }> {
@@ -298,7 +302,7 @@ export default class SuperTokens {
                     userIdType: input.userIdType,
                     externalUserIdInfo: input.externalUserIdInfo,
                 },
-                undefined
+                input.userContext === undefined ? {} : input.userContext
             );
         } else {
             throw new global.Error("Please upgrade the SuperTokens core to >= 3.15.0");

--- a/lib/ts/supertokens.ts
+++ b/lib/ts/supertokens.ts
@@ -83,7 +83,8 @@ export default class SuperTokens {
                         basePath: new NormalisedURLPath(h.trim()),
                     };
                 }),
-            config.supertokens?.apiKey
+            config.supertokens?.apiKey,
+            config.supertokens?.networkInterceptor
         );
         if (config.recipeList === undefined || config.recipeList.length === 0) {
             throw new Error("Please provide at least one recipe to the supertokens.init function call");
@@ -183,7 +184,8 @@ export default class SuperTokens {
             {
                 includeRecipeIds: includeRecipeIdsStr,
                 includeAllTenants: tenantId === undefined,
-            }
+            },
+            undefined
         );
         return Number(response.count);
     };
@@ -207,12 +209,16 @@ export default class SuperTokens {
         let cdiVersion = await querier.getAPIVersion();
         if (maxVersion("2.15", cdiVersion) === cdiVersion) {
             // create userId mapping is only available >= CDI 2.15
-            return await querier.sendPostRequest(new NormalisedURLPath("/recipe/userid/map"), {
-                superTokensUserId: input.superTokensUserId,
-                externalUserId: input.externalUserId,
-                externalUserIdInfo: input.externalUserIdInfo,
-                force: input.force,
-            });
+            return await querier.sendPostRequest(
+                new NormalisedURLPath("/recipe/userid/map"),
+                {
+                    superTokensUserId: input.superTokensUserId,
+                    externalUserId: input.externalUserId,
+                    externalUserIdInfo: input.externalUserIdInfo,
+                    force: input.force,
+                },
+                undefined
+            );
         } else {
             throw new global.Error("Please upgrade the SuperTokens core to >= 3.15.0");
         }
@@ -236,10 +242,14 @@ export default class SuperTokens {
         let cdiVersion = await querier.getAPIVersion();
         if (maxVersion("2.15", cdiVersion) === cdiVersion) {
             // create userId mapping is only available >= CDI 2.15
-            let response = await querier.sendGetRequest(new NormalisedURLPath("/recipe/userid/map"), {
-                userId: input.userId,
-                userIdType: input.userIdType,
-            });
+            let response = await querier.sendGetRequest(
+                new NormalisedURLPath("/recipe/userid/map"),
+                {
+                    userId: input.userId,
+                    userIdType: input.userIdType,
+                },
+                undefined
+            );
             return response;
         } else {
             throw new global.Error("Please upgrade the SuperTokens core to >= 3.15.0");
@@ -257,11 +267,15 @@ export default class SuperTokens {
         let querier = Querier.getNewInstanceOrThrowError(undefined);
         let cdiVersion = await querier.getAPIVersion();
         if (maxVersion("2.15", cdiVersion) === cdiVersion) {
-            return await querier.sendPostRequest(new NormalisedURLPath("/recipe/userid/map/remove"), {
-                userId: input.userId,
-                userIdType: input.userIdType,
-                force: input.force,
-            });
+            return await querier.sendPostRequest(
+                new NormalisedURLPath("/recipe/userid/map/remove"),
+                {
+                    userId: input.userId,
+                    userIdType: input.userIdType,
+                    force: input.force,
+                },
+                undefined
+            );
         } else {
             throw new global.Error("Please upgrade the SuperTokens core to >= 3.15.0");
         }
@@ -277,11 +291,15 @@ export default class SuperTokens {
         let querier = Querier.getNewInstanceOrThrowError(undefined);
         let cdiVersion = await querier.getAPIVersion();
         if (maxVersion("2.15", cdiVersion) === cdiVersion) {
-            return await querier.sendPutRequest(new NormalisedURLPath("/recipe/userid/external-user-id-info"), {
-                userId: input.userId,
-                userIdType: input.userIdType,
-                externalUserIdInfo: input.externalUserIdInfo,
-            });
+            return await querier.sendPutRequest(
+                new NormalisedURLPath("/recipe/userid/external-user-id-info"),
+                {
+                    userId: input.userId,
+                    userIdType: input.userIdType,
+                    externalUserIdInfo: input.externalUserIdInfo,
+                },
+                undefined
+            );
         } else {
             throw new global.Error("Please upgrade the SuperTokens core to >= 3.15.0");
         }

--- a/lib/ts/types.ts
+++ b/lib/ts/types.ts
@@ -44,6 +44,7 @@ export type NormalisedAppinfo = {
 export type SuperTokensInfo = {
     connectionURI: string;
     apiKey?: string;
+    networkInterceptor?: NetworkInterceptor;
 };
 
 export type TypeInput = {
@@ -55,6 +56,16 @@ export type TypeInput = {
     isInServerlessEnv?: boolean;
     debug?: boolean;
 };
+
+export type NetworkInterceptor = (request: HttpRequest, userContext: any) => HttpRequest;
+
+export interface HttpRequest {
+    url: string;
+    method: HTTPMethod;
+    headers: { [key: string]: string | number | string[] };
+    params?: Record<string, boolean | number | string | undefined>;
+    body?: any;
+}
 
 export type RecipeListFunction = (appInfo: NormalisedAppinfo, isInServerlessEnv: boolean) => RecipeModule;
 

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "16.4.0";
+export const version = "16.4.1";
 
 export const cdiSupported = ["4.0"];
 

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "16.4.1";
+export const version = "16.5.0";
 
 export const cdiSupported = ["4.0"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "16.4.0",
+    "version": "16.4.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "16.4.0",
+            "version": "16.5.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "content-type": "^1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "16.4.1",
+    "version": "16.5.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "16.4.1",
+    "version": "16.5.0",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "16.4.0",
+    "version": "16.4.1",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {

--- a/test/interceptor.test.js
+++ b/test/interceptor.test.js
@@ -1,0 +1,187 @@
+const {
+    printPath,
+    setupST,
+    startST,
+    killAllST,
+    cleanST,
+    extractInfoFromResponse,
+    setKeyValueInConfig,
+    killAllSTCoresOnly,
+    mockResponse,
+    mockRequest,
+    signUPRequest,
+    assertJSONEquals,
+} = require("./utils");
+let { ProcessState } = require("../lib/build/processState");
+
+let SuperTokens = require("../");
+let Session = require("../recipe/session");
+let EmailPassword = require("../recipe/emailpassword");
+let UserRoles = require("../recipe/userroles");
+
+let assert = require("assert");
+const express = require("express");
+let { middleware, errorHandler } = require("../framework/express");
+
+describe(`interceptor: ${printPath("[test/interceptor.test.js]")}`, function () {
+    beforeEach(async function () {
+        await killAllST();
+        await setupST();
+        ProcessState.getInstance().reset();
+    });
+
+    after(async function () {
+        await killAllST();
+        await cleanST();
+    });
+
+    it("network interceptor sanity", async function () {
+        let isNetworkIntercepted = false;
+        const connectionURI = await startST();
+        SuperTokens.init({
+            supertokens: {
+                connectionURI,
+                networkInterceptor: (request, __) => {
+                    isNetworkIntercepted = true;
+                    return request;
+                },
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                EmailPassword.init(),
+                Session.init({ getTokenTransferMethod: () => "cookie", antiCsrf: "VIA_TOKEN" }),
+            ],
+        });
+
+        const app = express();
+
+        app.use(middleware());
+
+        app.use(errorHandler());
+
+        let response = await signUPRequest(app, "random@gmail.com", "validpass123");
+
+        assert(JSON.parse(response.text).status === "OK");
+        assert(response.status === 200);
+        assert(isNetworkIntercepted === true);
+    });
+
+    it("network interceptor - incorrect core url", async function () {
+        let isNetworkIntercepted = false;
+        const connectionURI = await startST();
+        SuperTokens.init({
+            supertokens: {
+                connectionURI,
+                networkInterceptor: (request, __) => {
+                    isNetworkIntercepted = true;
+                    newRequest = request;
+                    newRequest.url = newRequest.url + "/incorrect/path";
+                    return newRequest;
+                },
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                EmailPassword.init(),
+                Session.init({ getTokenTransferMethod: () => "cookie", antiCsrf: "VIA_TOKEN" }),
+            ],
+        });
+
+        const app = express();
+
+        app.use(middleware());
+
+        app.use(errorHandler());
+
+        let response = await signUPRequest(app, "random@gmail.com", "validpass123");
+
+        assert(isNetworkIntercepted === true);
+        assert(response.text.includes("status code: 404"));
+    });
+
+    it("network interceptor - incorrect query params", async function () {
+        let isNetworkIntercepted = false;
+        const connectionURI = await startST();
+        SuperTokens.init({
+            supertokens: {
+                connectionURI,
+                networkInterceptor: (request, __) => {
+                    isNetworkIntercepted = true;
+                    newRequest = request;
+                    newRequest.params = { incorrect: "param" };
+                    return newRequest;
+                },
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                EmailPassword.init(),
+                UserRoles.init(),
+                Session.init({ getTokenTransferMethod: () => "cookie", antiCsrf: "VIA_TOKEN" }),
+            ],
+        });
+
+        const app = express();
+
+        app.use(middleware());
+
+        app.use(errorHandler());
+
+        let isErr = false;
+        try {
+            await UserRoles.getRolesForUser("public", "someUserID");
+        } catch (err) {
+            isErr = true;
+            assert(err.message.includes("status code: 400"));
+        }
+
+        assert(isNetworkIntercepted === true);
+        assert(isErr === true);
+    });
+
+    it("network interceptor - incorrect request body", async function () {
+        let isNetworkIntercepted = false;
+        const connectionURI = await startST();
+        SuperTokens.init({
+            supertokens: {
+                connectionURI,
+                networkInterceptor: (request, __) => {
+                    isNetworkIntercepted = true;
+                    newRequest = request;
+                    newRequest.body = { incorrect: "body" };
+                    return newRequest;
+                },
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                EmailPassword.init(),
+                Session.init({ getTokenTransferMethod: () => "cookie", antiCsrf: "VIA_TOKEN" }),
+            ],
+        });
+
+        const app = express();
+
+        app.use(middleware());
+
+        app.use(errorHandler());
+
+        let response = await signUPRequest(app, "random@gmail.com", "validpass123");
+
+        assert(isNetworkIntercepted === true);
+        assert(response.text.includes("status code: 400"));
+    });
+});


### PR DESCRIPTION
## Summary

this hook can be used to capture all requests sent to the core

-   Added `networkInterceptor` to the `TypeInput` config.
  - This can be used to capture/modify all the HTTP requests sent to the core.

## Related issues

-   https://github.com/supertokens/supertokens-core/issues/865

## Test Plan

Added unit tests

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] Documentation
