### PR TITLE
fix: Cache getJSONBody and getFormData response (Fixes #746)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [16.5.2] - 2023-11-21
+
+-   Fixes issue with `passwordReset` in emailpassword recipe for custom frameworks ([#746](https://github.com/supertokens/supertokens-node/issues/746))
+
 ## [16.5.1] - 2023-11-15
 
 -   Fixes issue with `createResetPasswordLink` and `sendResetPasswordEmail` in thirdpartyemailpassword recipe.

--- a/examples/aws/with-emailpassword/test/helpers/lambda-layer.sh
+++ b/examples/aws/with-emailpassword/test/helpers/lambda-layer.sh
@@ -1,6 +1,6 @@
 mkdir lambda && cd lambda
 npm init -y
-npm i -s @middy/core@4.5.5 @middy/http-cors@4.5.5
+npm i -s @middy/core @middy/http-cors
 npm i --save git+ssh://git@github.com:supertokens/supertokens-node.git#$GITHUB_REF_NAME
 mkdir nodejs
 cp -r node_modules nodejs

--- a/examples/aws/with-emailpassword/test/helpers/lambda-layer.sh
+++ b/examples/aws/with-emailpassword/test/helpers/lambda-layer.sh
@@ -1,6 +1,6 @@
 mkdir lambda && cd lambda
 npm init -y
-npm i -s @middy/core @middy/http-cors
+npm i -s @middy/core@4.5.5 @middy/http-cors@4.5.5
 npm i --save git+ssh://git@github.com:supertokens/supertokens-node.git#$GITHUB_REF_NAME
 mkdir nodejs
 cp -r node_modules nodejs

--- a/lib/build/framework/awsLambda/framework.d.ts
+++ b/lib/build/framework/awsLambda/framework.d.ts
@@ -14,8 +14,8 @@ import { Framework } from "../types";
 export declare class AWSRequest extends BaseRequest {
     private event;
     constructor(event: APIGatewayProxyEventV2 | APIGatewayProxyEvent);
-    protected getFormDataFromRequestBody(): Promise<any>;
-    protected getJSONFromRequestBody(): Promise<any>;
+    protected getFormDataFromRequestBody: () => Promise<any>;
+    protected getJSONFromRequestBody: () => Promise<any>;
     getKeyValueFromQuery: (key: string) => string | undefined;
     getMethod: () => HTTPMethod;
     getCookieValue: (key: string) => string | undefined;

--- a/lib/build/framework/awsLambda/framework.d.ts
+++ b/lib/build/framework/awsLambda/framework.d.ts
@@ -13,12 +13,10 @@ import { SessionContainerInterface } from "../../recipe/session/types";
 import { Framework } from "../types";
 export declare class AWSRequest extends BaseRequest {
     private event;
-    private parsedJSONBody;
-    private parsedUrlEncodedFormData;
     constructor(event: APIGatewayProxyEventV2 | APIGatewayProxyEvent);
-    getFormData: () => Promise<any>;
+    protected getFormDataFromRequestBody(): Promise<any>;
+    protected getJSONFromRequestBody(): Promise<any>;
     getKeyValueFromQuery: (key: string) => string | undefined;
-    getJSONBody: () => Promise<any>;
     getMethod: () => HTTPMethod;
     getCookieValue: (key: string) => string | undefined;
     getHeaderValue: (key: string) => string | undefined;

--- a/lib/build/framework/awsLambda/framework.js
+++ b/lib/build/framework/awsLambda/framework.js
@@ -16,19 +16,6 @@ const querystring_1 = require("querystring");
 class AWSRequest extends request_1.BaseRequest {
     constructor(event) {
         super();
-        this.getFormData = async () => {
-            if (this.parsedUrlEncodedFormData === undefined) {
-                if (this.event.body === null || this.event.body === undefined) {
-                    this.parsedUrlEncodedFormData = {};
-                } else {
-                    this.parsedUrlEncodedFormData = querystring_1.parse(this.event.body);
-                    if (this.parsedUrlEncodedFormData === undefined) {
-                        this.parsedUrlEncodedFormData = {};
-                    }
-                }
-            }
-            return this.parsedUrlEncodedFormData;
-        };
         this.getKeyValueFromQuery = (key) => {
             if (this.event.queryStringParameters === undefined || this.event.queryStringParameters === null) {
                 return undefined;
@@ -38,19 +25,6 @@ class AWSRequest extends request_1.BaseRequest {
                 return undefined;
             }
             return value;
-        };
-        this.getJSONBody = async () => {
-            if (this.parsedJSONBody === undefined) {
-                if (this.event.body === null || this.event.body === undefined) {
-                    this.parsedJSONBody = {};
-                } else {
-                    this.parsedJSONBody = JSON.parse(this.event.body);
-                    if (this.parsedJSONBody === undefined) {
-                        this.parsedJSONBody = {};
-                    }
-                }
-            }
-            return this.parsedJSONBody;
         };
         this.getMethod = () => {
             let rawMethod = this.event.httpMethod;
@@ -104,8 +78,22 @@ class AWSRequest extends request_1.BaseRequest {
         };
         this.original = event;
         this.event = event;
-        this.parsedJSONBody = undefined;
-        this.parsedUrlEncodedFormData = undefined;
+    }
+    async getFormDataFromRequestBody() {
+        if (this.event.body === null || this.event.body === undefined) {
+            return {};
+        } else {
+            const parsedUrlEncodedFormData = querystring_1.parse(this.event.body);
+            return parsedUrlEncodedFormData === undefined ? {} : parsedUrlEncodedFormData;
+        }
+    }
+    async getJSONFromRequestBody() {
+        if (this.event.body === null || this.event.body === undefined) {
+            return {};
+        } else {
+            const parsedJSONBody = JSON.parse(this.event.body);
+            return parsedJSONBody === undefined ? {} : parsedJSONBody;
+        }
     }
 }
 exports.AWSRequest = AWSRequest;

--- a/lib/build/framework/awsLambda/framework.js
+++ b/lib/build/framework/awsLambda/framework.js
@@ -16,6 +16,22 @@ const querystring_1 = require("querystring");
 class AWSRequest extends request_1.BaseRequest {
     constructor(event) {
         super();
+        this.getFormDataFromRequestBody = async () => {
+            if (this.event.body === null || this.event.body === undefined) {
+                return {};
+            } else {
+                const parsedUrlEncodedFormData = querystring_1.parse(this.event.body);
+                return parsedUrlEncodedFormData === undefined ? {} : parsedUrlEncodedFormData;
+            }
+        };
+        this.getJSONFromRequestBody = async () => {
+            if (this.event.body === null || this.event.body === undefined) {
+                return {};
+            } else {
+                const parsedJSONBody = JSON.parse(this.event.body);
+                return parsedJSONBody === undefined ? {} : parsedJSONBody;
+            }
+        };
         this.getKeyValueFromQuery = (key) => {
             if (this.event.queryStringParameters === undefined || this.event.queryStringParameters === null) {
                 return undefined;
@@ -78,22 +94,6 @@ class AWSRequest extends request_1.BaseRequest {
         };
         this.original = event;
         this.event = event;
-    }
-    async getFormDataFromRequestBody() {
-        if (this.event.body === null || this.event.body === undefined) {
-            return {};
-        } else {
-            const parsedUrlEncodedFormData = querystring_1.parse(this.event.body);
-            return parsedUrlEncodedFormData === undefined ? {} : parsedUrlEncodedFormData;
-        }
-    }
-    async getJSONFromRequestBody() {
-        if (this.event.body === null || this.event.body === undefined) {
-            return {};
-        } else {
-            const parsedJSONBody = JSON.parse(this.event.body);
-            return parsedJSONBody === undefined ? {} : parsedJSONBody;
-        }
     }
 }
 exports.AWSRequest = AWSRequest;

--- a/lib/build/framework/custom/framework.d.ts
+++ b/lib/build/framework/custom/framework.d.ts
@@ -15,6 +15,8 @@ declare type RequestInfo = {
 };
 export declare class PreParsedRequest extends BaseRequest {
     private request;
+    private parsedJSONBody;
+    private parsedUrlEncodedFormData;
     private _session?;
     get session(): SessionContainerInterface | undefined;
     set session(value: SessionContainerInterface | undefined);

--- a/lib/build/framework/custom/framework.d.ts
+++ b/lib/build/framework/custom/framework.d.ts
@@ -15,15 +15,13 @@ declare type RequestInfo = {
 };
 export declare class PreParsedRequest extends BaseRequest {
     private request;
-    private parsedJSONBody;
-    private parsedUrlEncodedFormData;
     private _session?;
     get session(): SessionContainerInterface | undefined;
     set session(value: SessionContainerInterface | undefined);
     constructor(request: RequestInfo);
-    getFormData: () => Promise<any>;
+    protected getJSONFromRequestBody(): Promise<any>;
+    protected getFormDataFromRequestBody(): Promise<any>;
     getKeyValueFromQuery: (key: string) => string | undefined;
-    getJSONBody: () => Promise<any>;
     getMethod: () => HTTPMethod;
     getCookieValue: (key: string) => string | undefined;
     getHeaderValue: (key: string) => string | undefined;

--- a/lib/build/framework/custom/framework.d.ts
+++ b/lib/build/framework/custom/framework.d.ts
@@ -19,8 +19,8 @@ export declare class PreParsedRequest extends BaseRequest {
     get session(): SessionContainerInterface | undefined;
     set session(value: SessionContainerInterface | undefined);
     constructor(request: RequestInfo);
-    protected getJSONFromRequestBody(): Promise<any>;
-    protected getFormDataFromRequestBody(): Promise<any>;
+    protected getJSONFromRequestBody: () => Promise<any>;
+    protected getFormDataFromRequestBody: () => Promise<any>;
     getKeyValueFromQuery: (key: string) => string | undefined;
     getMethod: () => HTTPMethod;
     getCookieValue: (key: string) => string | undefined;

--- a/lib/build/framework/custom/framework.js
+++ b/lib/build/framework/custom/framework.js
@@ -27,6 +27,12 @@ const supertokens_1 = __importDefault(require("../../supertokens"));
 class PreParsedRequest extends request_1.BaseRequest {
     constructor(request) {
         super();
+        this.getJSONFromRequestBody = () => {
+            return this.request.getJSONBody();
+        };
+        this.getFormDataFromRequestBody = () => {
+            return this.request.getFormBody();
+        };
         this.getKeyValueFromQuery = (key) => {
             if (this.request.query === undefined) {
                 return undefined;
@@ -61,12 +67,6 @@ class PreParsedRequest extends request_1.BaseRequest {
         if (value !== undefined && this.request.setSession !== undefined) {
             this.request.setSession(value);
         }
-    }
-    getJSONFromRequestBody() {
-        return this.request.getJSONBody();
-    }
-    getFormDataFromRequestBody() {
-        return this.request.getFormBody();
     }
 }
 exports.PreParsedRequest = PreParsedRequest;

--- a/lib/build/framework/custom/framework.js
+++ b/lib/build/framework/custom/framework.js
@@ -28,7 +28,10 @@ class PreParsedRequest extends request_1.BaseRequest {
     constructor(request) {
         super();
         this.getFormData = async () => {
-            return this.request.getFormBody();
+            if (this.parsedUrlEncodedFormData === undefined) {
+                this.parsedUrlEncodedFormData = await this.request.getFormBody();
+            }
+            return this.parsedUrlEncodedFormData;
         };
         this.getKeyValueFromQuery = (key) => {
             if (this.request.query === undefined) {
@@ -41,7 +44,10 @@ class PreParsedRequest extends request_1.BaseRequest {
             return value;
         };
         this.getJSONBody = async () => {
-            return this.request.getJSONBody();
+            if (this.parsedJSONBody === undefined) {
+                this.parsedJSONBody = await this.request.getJSONBody();
+            }
+            return this.parsedJSONBody;
         };
         this.getMethod = () => {
             return utils_1.normaliseHttpMethod(this.request.method);
@@ -58,6 +64,8 @@ class PreParsedRequest extends request_1.BaseRequest {
         };
         this.original = request;
         this.request = request;
+        this.parsedJSONBody = undefined;
+        this.parsedUrlEncodedFormData = undefined;
     }
     get session() {
         return this._session;

--- a/lib/build/framework/custom/framework.js
+++ b/lib/build/framework/custom/framework.js
@@ -27,12 +27,6 @@ const supertokens_1 = __importDefault(require("../../supertokens"));
 class PreParsedRequest extends request_1.BaseRequest {
     constructor(request) {
         super();
-        this.getFormData = async () => {
-            if (this.parsedUrlEncodedFormData === undefined) {
-                this.parsedUrlEncodedFormData = await this.request.getFormBody();
-            }
-            return this.parsedUrlEncodedFormData;
-        };
         this.getKeyValueFromQuery = (key) => {
             if (this.request.query === undefined) {
                 return undefined;
@@ -42,12 +36,6 @@ class PreParsedRequest extends request_1.BaseRequest {
                 return undefined;
             }
             return value;
-        };
-        this.getJSONBody = async () => {
-            if (this.parsedJSONBody === undefined) {
-                this.parsedJSONBody = await this.request.getJSONBody();
-            }
-            return this.parsedJSONBody;
         };
         this.getMethod = () => {
             return utils_1.normaliseHttpMethod(this.request.method);
@@ -64,8 +52,6 @@ class PreParsedRequest extends request_1.BaseRequest {
         };
         this.original = request;
         this.request = request;
-        this.parsedJSONBody = undefined;
-        this.parsedUrlEncodedFormData = undefined;
     }
     get session() {
         return this._session;
@@ -75,6 +61,12 @@ class PreParsedRequest extends request_1.BaseRequest {
         if (value !== undefined && this.request.setSession !== undefined) {
             this.request.setSession(value);
         }
+    }
+    getJSONFromRequestBody() {
+        return this.request.getJSONBody();
+    }
+    getFormDataFromRequestBody() {
+        return this.request.getFormBody();
     }
 }
 exports.PreParsedRequest = PreParsedRequest;

--- a/lib/build/framework/express/framework.d.ts
+++ b/lib/build/framework/express/framework.d.ts
@@ -8,8 +8,8 @@ import type { SessionContainerInterface } from "../../recipe/session/types";
 export declare class ExpressRequest extends BaseRequest {
     private request;
     constructor(request: Request);
-    protected getFormDataFromRequestBody(): Promise<any>;
-    protected getJSONFromRequestBody(): Promise<any>;
+    protected getFormDataFromRequestBody: () => Promise<any>;
+    protected getJSONFromRequestBody: () => Promise<any>;
     getKeyValueFromQuery: (key: string) => string | undefined;
     getMethod: () => HTTPMethod;
     getCookieValue: (key: string) => string | undefined;

--- a/lib/build/framework/express/framework.d.ts
+++ b/lib/build/framework/express/framework.d.ts
@@ -7,12 +7,10 @@ import type { Framework } from "../types";
 import type { SessionContainerInterface } from "../../recipe/session/types";
 export declare class ExpressRequest extends BaseRequest {
     private request;
-    private parserChecked;
-    private formDataParserChecked;
     constructor(request: Request);
-    getFormData: () => Promise<any>;
+    protected getFormDataFromRequestBody(): Promise<any>;
+    protected getJSONFromRequestBody(): Promise<any>;
     getKeyValueFromQuery: (key: string) => string | undefined;
-    getJSONBody: () => Promise<any>;
     getMethod: () => HTTPMethod;
     getCookieValue: (key: string) => string | undefined;
     getHeaderValue: (key: string) => string | undefined;

--- a/lib/build/framework/express/framework.js
+++ b/lib/build/framework/express/framework.js
@@ -28,6 +28,14 @@ const supertokens_1 = __importDefault(require("../../supertokens"));
 class ExpressRequest extends request_1.BaseRequest {
     constructor(request) {
         super();
+        this.getFormDataFromRequestBody = async () => {
+            await utils_2.assertFormDataBodyParserHasBeenUsedForExpressLikeRequest(this.request);
+            return this.request.body;
+        };
+        this.getJSONFromRequestBody = async () => {
+            await utils_2.assertThatBodyParserHasBeenUsedForExpressLikeRequest(this.getMethod(), this.request);
+            return this.request.body;
+        };
         this.getKeyValueFromQuery = (key) => {
             if (this.request.query === undefined) {
                 return undefined;
@@ -52,14 +60,6 @@ class ExpressRequest extends request_1.BaseRequest {
         };
         this.original = request;
         this.request = request;
-    }
-    async getFormDataFromRequestBody() {
-        await utils_2.assertFormDataBodyParserHasBeenUsedForExpressLikeRequest(this.request);
-        return this.request.body;
-    }
-    async getJSONFromRequestBody() {
-        await utils_2.assertThatBodyParserHasBeenUsedForExpressLikeRequest(this.getMethod(), this.request);
-        return this.request.body;
     }
 }
 exports.ExpressRequest = ExpressRequest;

--- a/lib/build/framework/express/framework.js
+++ b/lib/build/framework/express/framework.js
@@ -28,13 +28,6 @@ const supertokens_1 = __importDefault(require("../../supertokens"));
 class ExpressRequest extends request_1.BaseRequest {
     constructor(request) {
         super();
-        this.getFormData = async () => {
-            if (!this.formDataParserChecked) {
-                await utils_2.assertFormDataBodyParserHasBeenUsedForExpressLikeRequest(this.request);
-                this.formDataParserChecked = true;
-            }
-            return this.request.body;
-        };
         this.getKeyValueFromQuery = (key) => {
             if (this.request.query === undefined) {
                 return undefined;
@@ -44,13 +37,6 @@ class ExpressRequest extends request_1.BaseRequest {
                 return undefined;
             }
             return value;
-        };
-        this.getJSONBody = async () => {
-            if (!this.parserChecked) {
-                await utils_2.assertThatBodyParserHasBeenUsedForExpressLikeRequest(this.getMethod(), this.request);
-                this.parserChecked = true;
-            }
-            return this.request.body;
         };
         this.getMethod = () => {
             return utils_1.normaliseHttpMethod(this.request.method);
@@ -66,8 +52,14 @@ class ExpressRequest extends request_1.BaseRequest {
         };
         this.original = request;
         this.request = request;
-        this.parserChecked = false;
-        this.formDataParserChecked = false;
+    }
+    async getFormDataFromRequestBody() {
+        await utils_2.assertFormDataBodyParserHasBeenUsedForExpressLikeRequest(this.request);
+        return this.request.body;
+    }
+    async getJSONFromRequestBody() {
+        await utils_2.assertThatBodyParserHasBeenUsedForExpressLikeRequest(this.getMethod(), this.request);
+        return this.request.body;
     }
 }
 exports.ExpressRequest = ExpressRequest;

--- a/lib/build/framework/fastify/framework.d.ts
+++ b/lib/build/framework/fastify/framework.d.ts
@@ -8,8 +8,8 @@ import type { SessionContainerInterface } from "../../recipe/session/types";
 export declare class FastifyRequest extends BaseRequest {
     private request;
     constructor(request: OriginalFastifyRequest);
-    protected getFormDataFromRequestBody(): Promise<any>;
-    protected getJSONFromRequestBody(): Promise<any>;
+    protected getFormDataFromRequestBody: () => Promise<any>;
+    protected getJSONFromRequestBody: () => Promise<any>;
     getKeyValueFromQuery: (key: string) => string | undefined;
     getMethod: () => HTTPMethod;
     getCookieValue: (key: string) => string | undefined;

--- a/lib/build/framework/fastify/framework.d.ts
+++ b/lib/build/framework/fastify/framework.d.ts
@@ -7,12 +7,10 @@ import type { Framework } from "../types";
 import type { SessionContainerInterface } from "../../recipe/session/types";
 export declare class FastifyRequest extends BaseRequest {
     private request;
-    private parsedJSONBody;
-    private parsedUrlEncodedFormData;
     constructor(request: OriginalFastifyRequest);
-    getFormData: () => Promise<any>;
+    protected getFormDataFromRequestBody(): Promise<any>;
+    protected getJSONFromRequestBody(): Promise<any>;
     getKeyValueFromQuery: (key: string) => string | undefined;
-    getJSONBody: () => Promise<any>;
     getMethod: () => HTTPMethod;
     getCookieValue: (key: string) => string | undefined;
     getHeaderValue: (key: string) => string | undefined;

--- a/lib/build/framework/fastify/framework.d.ts
+++ b/lib/build/framework/fastify/framework.d.ts
@@ -7,6 +7,8 @@ import type { Framework } from "../types";
 import type { SessionContainerInterface } from "../../recipe/session/types";
 export declare class FastifyRequest extends BaseRequest {
     private request;
+    private parsedJSONBody;
+    private parsedUrlEncodedFormData;
     constructor(request: OriginalFastifyRequest);
     getFormData: () => Promise<any>;
     getKeyValueFromQuery: (key: string) => string | undefined;

--- a/lib/build/framework/fastify/framework.js
+++ b/lib/build/framework/fastify/framework.js
@@ -30,7 +30,10 @@ class FastifyRequest extends request_1.BaseRequest {
     constructor(request) {
         super();
         this.getFormData = async () => {
-            return this.request.body; // NOTE: ask user to add require('fastify-formbody')
+            if (this.parsedUrlEncodedFormData === undefined) {
+                this.parsedUrlEncodedFormData = await this.request.body; // NOTE: ask user to add require('fastify-formbody')
+            }
+            return this.parsedUrlEncodedFormData;
         };
         this.getKeyValueFromQuery = (key) => {
             if (this.request.query === undefined) {
@@ -43,7 +46,10 @@ class FastifyRequest extends request_1.BaseRequest {
             return value;
         };
         this.getJSONBody = async () => {
-            return this.request.body;
+            if (this.parsedJSONBody === undefined) {
+                this.parsedJSONBody = await this.request.body;
+            }
+            return this.parsedJSONBody;
         };
         this.getMethod = () => {
             return utils_1.normaliseHttpMethod(this.request.method);
@@ -59,6 +65,8 @@ class FastifyRequest extends request_1.BaseRequest {
         };
         this.original = request;
         this.request = request;
+        this.parsedJSONBody = undefined;
+        this.parsedUrlEncodedFormData = undefined;
     }
 }
 exports.FastifyRequest = FastifyRequest;

--- a/lib/build/framework/fastify/framework.js
+++ b/lib/build/framework/fastify/framework.js
@@ -29,6 +29,12 @@ const constants_1 = require("../constants");
 class FastifyRequest extends request_1.BaseRequest {
     constructor(request) {
         super();
+        this.getFormDataFromRequestBody = async () => {
+            return this.request.body; // NOTE: ask user to add require('fastify-formbody')
+        };
+        this.getJSONFromRequestBody = async () => {
+            return this.request.body;
+        };
         this.getKeyValueFromQuery = (key) => {
             if (this.request.query === undefined) {
                 return undefined;
@@ -53,12 +59,6 @@ class FastifyRequest extends request_1.BaseRequest {
         };
         this.original = request;
         this.request = request;
-    }
-    async getFormDataFromRequestBody() {
-        return this.request.body; // NOTE: ask user to add require('fastify-formbody')
-    }
-    async getJSONFromRequestBody() {
-        return this.request.body;
     }
 }
 exports.FastifyRequest = FastifyRequest;

--- a/lib/build/framework/fastify/framework.js
+++ b/lib/build/framework/fastify/framework.js
@@ -29,12 +29,6 @@ const constants_1 = require("../constants");
 class FastifyRequest extends request_1.BaseRequest {
     constructor(request) {
         super();
-        this.getFormData = async () => {
-            if (this.parsedUrlEncodedFormData === undefined) {
-                this.parsedUrlEncodedFormData = await this.request.body; // NOTE: ask user to add require('fastify-formbody')
-            }
-            return this.parsedUrlEncodedFormData;
-        };
         this.getKeyValueFromQuery = (key) => {
             if (this.request.query === undefined) {
                 return undefined;
@@ -44,12 +38,6 @@ class FastifyRequest extends request_1.BaseRequest {
                 return undefined;
             }
             return value;
-        };
-        this.getJSONBody = async () => {
-            if (this.parsedJSONBody === undefined) {
-                this.parsedJSONBody = await this.request.body;
-            }
-            return this.parsedJSONBody;
         };
         this.getMethod = () => {
             return utils_1.normaliseHttpMethod(this.request.method);
@@ -65,8 +53,12 @@ class FastifyRequest extends request_1.BaseRequest {
         };
         this.original = request;
         this.request = request;
-        this.parsedJSONBody = undefined;
-        this.parsedUrlEncodedFormData = undefined;
+    }
+    async getFormDataFromRequestBody() {
+        return this.request.body; // NOTE: ask user to add require('fastify-formbody')
+    }
+    async getJSONFromRequestBody() {
+        return this.request.body;
     }
 }
 exports.FastifyRequest = FastifyRequest;

--- a/lib/build/framework/fastify/index.d.ts
+++ b/lib/build/framework/fastify/index.d.ts
@@ -1,18 +1,21 @@
 // @ts-nocheck
 /// <reference types="node" />
 export type { SessionRequest } from "./framework";
-export declare const plugin: import("fastify").FastifyPluginCallback<Record<never, never>, import("http").Server>;
+export declare const plugin: import("fastify").FastifyPluginCallback<
+    Record<never, never>,
+    import("fastify").RawServerDefault
+>;
 export declare const errorHandler: () => (
     err: any,
     req: import("fastify").FastifyRequest<
         import("fastify/types/route").RouteGenericInterface,
-        import("http").Server,
+        import("fastify").RawServerDefault,
         import("http").IncomingMessage
     >,
     res: import("fastify").FastifyReply<
-        import("http").Server,
+        import("fastify").RawServerDefault,
         import("http").IncomingMessage,
-        import("http").ServerResponse,
+        import("http").ServerResponse<import("http").IncomingMessage>,
         import("fastify/types/route").RouteGenericInterface,
         unknown
     >

--- a/lib/build/framework/hapi/framework.d.ts
+++ b/lib/build/framework/hapi/framework.d.ts
@@ -8,8 +8,8 @@ import type { SessionContainerInterface } from "../../recipe/session/types";
 export declare class HapiRequest extends BaseRequest {
     private request;
     constructor(request: Request);
-    protected getFormDataFromRequestBody(): Promise<any>;
-    protected getJSONFromRequestBody(): Promise<any>;
+    protected getFormDataFromRequestBody: () => Promise<any>;
+    protected getJSONFromRequestBody: () => Promise<any>;
     getKeyValueFromQuery: (key: string) => string | undefined;
     getMethod: () => HTTPMethod;
     getCookieValue: (key: string) => string | undefined;

--- a/lib/build/framework/hapi/framework.d.ts
+++ b/lib/build/framework/hapi/framework.d.ts
@@ -7,12 +7,10 @@ import type { Framework } from "../types";
 import type { SessionContainerInterface } from "../../recipe/session/types";
 export declare class HapiRequest extends BaseRequest {
     private request;
-    private parsedJSONBody;
-    private parsedUrlEncodedFormData;
     constructor(request: Request);
-    getFormData: () => Promise<any>;
+    protected getFormDataFromRequestBody(): Promise<any>;
+    protected getJSONFromRequestBody(): Promise<any>;
     getKeyValueFromQuery: (key: string) => string | undefined;
-    getJSONBody: () => Promise<any>;
     getMethod: () => HTTPMethod;
     getCookieValue: (key: string) => string | undefined;
     getHeaderValue: (key: string) => string | undefined;

--- a/lib/build/framework/hapi/framework.d.ts
+++ b/lib/build/framework/hapi/framework.d.ts
@@ -7,6 +7,8 @@ import type { Framework } from "../types";
 import type { SessionContainerInterface } from "../../recipe/session/types";
 export declare class HapiRequest extends BaseRequest {
     private request;
+    private parsedJSONBody;
+    private parsedUrlEncodedFormData;
     constructor(request: Request);
     getFormData: () => Promise<any>;
     getKeyValueFromQuery: (key: string) => string | undefined;

--- a/lib/build/framework/hapi/framework.js
+++ b/lib/build/framework/hapi/framework.js
@@ -28,13 +28,6 @@ const supertokens_1 = __importDefault(require("../../supertokens"));
 class HapiRequest extends request_1.BaseRequest {
     constructor(request) {
         super();
-        this.getFormData = async () => {
-            if (this.parsedUrlEncodedFormData === undefined) {
-                this.parsedUrlEncodedFormData =
-                    this.request.payload === undefined || this.request.payload === null ? {} : this.request.payload;
-            }
-            return this.parsedUrlEncodedFormData;
-        };
         this.getKeyValueFromQuery = (key) => {
             if (this.request.query === undefined) {
                 return undefined;
@@ -44,13 +37,6 @@ class HapiRequest extends request_1.BaseRequest {
                 return undefined;
             }
             return value;
-        };
-        this.getJSONBody = async () => {
-            if (this.parsedJSONBody === undefined) {
-                this.parsedJSONBody =
-                    this.request.payload === undefined || this.request.payload === null ? {} : this.request.payload;
-            }
-            return this.parsedJSONBody;
         };
         this.getMethod = () => {
             return utils_1.normaliseHttpMethod(this.request.method);
@@ -66,8 +52,12 @@ class HapiRequest extends request_1.BaseRequest {
         };
         this.original = request;
         this.request = request;
-        this.parsedJSONBody = undefined;
-        this.parsedUrlEncodedFormData = undefined;
+    }
+    async getFormDataFromRequestBody() {
+        return this.request.payload === undefined || this.request.payload === null ? {} : this.request.payload;
+    }
+    async getJSONFromRequestBody() {
+        return this.request.payload === undefined || this.request.payload === null ? {} : this.request.payload;
     }
 }
 exports.HapiRequest = HapiRequest;

--- a/lib/build/framework/hapi/framework.js
+++ b/lib/build/framework/hapi/framework.js
@@ -29,7 +29,11 @@ class HapiRequest extends request_1.BaseRequest {
     constructor(request) {
         super();
         this.getFormData = async () => {
-            return this.request.payload === undefined || this.request.payload === null ? {} : this.request.payload;
+            if (this.parsedUrlEncodedFormData === undefined) {
+                this.parsedUrlEncodedFormData =
+                    this.request.payload === undefined || this.request.payload === null ? {} : this.request.payload;
+            }
+            return this.parsedUrlEncodedFormData;
         };
         this.getKeyValueFromQuery = (key) => {
             if (this.request.query === undefined) {
@@ -42,7 +46,11 @@ class HapiRequest extends request_1.BaseRequest {
             return value;
         };
         this.getJSONBody = async () => {
-            return this.request.payload === undefined || this.request.payload === null ? {} : this.request.payload;
+            if (this.parsedJSONBody === undefined) {
+                this.parsedJSONBody =
+                    this.request.payload === undefined || this.request.payload === null ? {} : this.request.payload;
+            }
+            return this.parsedJSONBody;
         };
         this.getMethod = () => {
             return utils_1.normaliseHttpMethod(this.request.method);
@@ -58,6 +66,8 @@ class HapiRequest extends request_1.BaseRequest {
         };
         this.original = request;
         this.request = request;
+        this.parsedJSONBody = undefined;
+        this.parsedUrlEncodedFormData = undefined;
     }
 }
 exports.HapiRequest = HapiRequest;

--- a/lib/build/framework/hapi/framework.js
+++ b/lib/build/framework/hapi/framework.js
@@ -28,6 +28,12 @@ const supertokens_1 = __importDefault(require("../../supertokens"));
 class HapiRequest extends request_1.BaseRequest {
     constructor(request) {
         super();
+        this.getFormDataFromRequestBody = async () => {
+            return this.request.payload === undefined || this.request.payload === null ? {} : this.request.payload;
+        };
+        this.getJSONFromRequestBody = async () => {
+            return this.request.payload === undefined || this.request.payload === null ? {} : this.request.payload;
+        };
         this.getKeyValueFromQuery = (key) => {
             if (this.request.query === undefined) {
                 return undefined;
@@ -52,12 +58,6 @@ class HapiRequest extends request_1.BaseRequest {
         };
         this.original = request;
         this.request = request;
-    }
-    async getFormDataFromRequestBody() {
-        return this.request.payload === undefined || this.request.payload === null ? {} : this.request.payload;
-    }
-    async getJSONFromRequestBody() {
-        return this.request.payload === undefined || this.request.payload === null ? {} : this.request.payload;
     }
 }
 exports.HapiRequest = HapiRequest;

--- a/lib/build/framework/koa/framework.d.ts
+++ b/lib/build/framework/koa/framework.d.ts
@@ -8,8 +8,8 @@ import { Framework } from "../types";
 export declare class KoaRequest extends BaseRequest {
     private ctx;
     constructor(ctx: Context);
-    protected getFormDataFromRequestBody(): Promise<any>;
-    protected getJSONFromRequestBody(): Promise<any>;
+    protected getFormDataFromRequestBody: () => Promise<any>;
+    protected getJSONFromRequestBody: () => Promise<any>;
     getKeyValueFromQuery: (key: string) => string | undefined;
     getMethod: () => HTTPMethod;
     getCookieValue: (key: string) => string | undefined;

--- a/lib/build/framework/koa/framework.d.ts
+++ b/lib/build/framework/koa/framework.d.ts
@@ -7,12 +7,10 @@ import { SessionContainerInterface } from "../../recipe/session/types";
 import { Framework } from "../types";
 export declare class KoaRequest extends BaseRequest {
     private ctx;
-    private parsedJSONBody;
-    private parsedUrlEncodedFormData;
     constructor(ctx: Context);
-    getFormData: () => Promise<any>;
+    protected getFormDataFromRequestBody(): Promise<any>;
+    protected getJSONFromRequestBody(): Promise<any>;
     getKeyValueFromQuery: (key: string) => string | undefined;
-    getJSONBody: () => Promise<any>;
     getMethod: () => HTTPMethod;
     getCookieValue: (key: string) => string | undefined;
     getHeaderValue: (key: string) => string | undefined;

--- a/lib/build/framework/koa/framework.js
+++ b/lib/build/framework/koa/framework.js
@@ -28,12 +28,6 @@ const supertokens_1 = __importDefault(require("../../supertokens"));
 class KoaRequest extends request_1.BaseRequest {
     constructor(ctx) {
         super();
-        this.getFormData = async () => {
-            if (this.parsedUrlEncodedFormData === undefined) {
-                this.parsedUrlEncodedFormData = await utils_2.parseURLEncodedFormData(this.ctx.req);
-            }
-            return this.parsedUrlEncodedFormData;
-        };
         this.getKeyValueFromQuery = (key) => {
             if (this.ctx.query === undefined) {
                 return undefined;
@@ -43,12 +37,6 @@ class KoaRequest extends request_1.BaseRequest {
                 return undefined;
             }
             return value;
-        };
-        this.getJSONBody = async () => {
-            if (this.parsedJSONBody === undefined) {
-                this.parsedJSONBody = await utils_2.parseJSONBodyFromRequest(this.ctx.req);
-            }
-            return this.parsedJSONBody === undefined ? {} : this.parsedJSONBody;
         };
         this.getMethod = () => {
             return utils_1.normaliseHttpMethod(this.ctx.request.method);
@@ -64,8 +52,13 @@ class KoaRequest extends request_1.BaseRequest {
         };
         this.original = ctx;
         this.ctx = ctx;
-        this.parsedJSONBody = undefined;
-        this.parsedUrlEncodedFormData = undefined;
+    }
+    async getFormDataFromRequestBody() {
+        return utils_2.parseURLEncodedFormData(this.ctx.req);
+    }
+    async getJSONFromRequestBody() {
+        const parsedJSONBody = await utils_2.parseJSONBodyFromRequest(this.ctx.req);
+        return parsedJSONBody === undefined ? {} : parsedJSONBody;
     }
 }
 exports.KoaRequest = KoaRequest;

--- a/lib/build/framework/koa/framework.js
+++ b/lib/build/framework/koa/framework.js
@@ -28,6 +28,13 @@ const supertokens_1 = __importDefault(require("../../supertokens"));
 class KoaRequest extends request_1.BaseRequest {
     constructor(ctx) {
         super();
+        this.getFormDataFromRequestBody = async () => {
+            return utils_2.parseURLEncodedFormData(this.ctx.req);
+        };
+        this.getJSONFromRequestBody = async () => {
+            const parsedJSONBody = await utils_2.parseJSONBodyFromRequest(this.ctx.req);
+            return parsedJSONBody === undefined ? {} : parsedJSONBody;
+        };
         this.getKeyValueFromQuery = (key) => {
             if (this.ctx.query === undefined) {
                 return undefined;
@@ -52,13 +59,6 @@ class KoaRequest extends request_1.BaseRequest {
         };
         this.original = ctx;
         this.ctx = ctx;
-    }
-    async getFormDataFromRequestBody() {
-        return utils_2.parseURLEncodedFormData(this.ctx.req);
-    }
-    async getJSONFromRequestBody() {
-        const parsedJSONBody = await utils_2.parseJSONBodyFromRequest(this.ctx.req);
-        return parsedJSONBody === undefined ? {} : parsedJSONBody;
     }
 }
 exports.KoaRequest = KoaRequest;

--- a/lib/build/framework/loopback/framework.d.ts
+++ b/lib/build/framework/loopback/framework.d.ts
@@ -8,8 +8,8 @@ import type { Framework } from "../types";
 export declare class LoopbackRequest extends BaseRequest {
     private request;
     constructor(ctx: MiddlewareContext);
-    protected getFormDataFromRequestBody(): Promise<any>;
-    protected getJSONFromRequestBody(): Promise<any>;
+    protected getFormDataFromRequestBody: () => Promise<any>;
+    protected getJSONFromRequestBody: () => Promise<any>;
     getKeyValueFromQuery: (key: string) => string | undefined;
     getMethod: () => HTTPMethod;
     getCookieValue: (key: string) => string | undefined;

--- a/lib/build/framework/loopback/framework.d.ts
+++ b/lib/build/framework/loopback/framework.d.ts
@@ -7,12 +7,10 @@ import { BaseResponse } from "../response";
 import type { Framework } from "../types";
 export declare class LoopbackRequest extends BaseRequest {
     private request;
-    private parserChecked;
-    private formDataParserChecked;
     constructor(ctx: MiddlewareContext);
-    getFormData: () => Promise<any>;
+    protected getFormDataFromRequestBody(): Promise<any>;
+    protected getJSONFromRequestBody(): Promise<any>;
     getKeyValueFromQuery: (key: string) => string | undefined;
-    getJSONBody: () => Promise<any>;
     getMethod: () => HTTPMethod;
     getCookieValue: (key: string) => string | undefined;
     getHeaderValue: (key: string) => string | undefined;

--- a/lib/build/framework/loopback/framework.js
+++ b/lib/build/framework/loopback/framework.js
@@ -28,6 +28,14 @@ const supertokens_1 = __importDefault(require("../../supertokens"));
 class LoopbackRequest extends request_1.BaseRequest {
     constructor(ctx) {
         super();
+        this.getFormDataFromRequestBody = async () => {
+            await utils_2.assertFormDataBodyParserHasBeenUsedForExpressLikeRequest(this.request);
+            return this.request.body;
+        };
+        this.getJSONFromRequestBody = async () => {
+            await utils_2.assertThatBodyParserHasBeenUsedForExpressLikeRequest(this.getMethod(), this.request);
+            return this.request.body;
+        };
         this.getKeyValueFromQuery = (key) => {
             if (this.request.query === undefined) {
                 return undefined;
@@ -52,14 +60,6 @@ class LoopbackRequest extends request_1.BaseRequest {
         };
         this.original = ctx.request;
         this.request = ctx.request;
-    }
-    async getFormDataFromRequestBody() {
-        await utils_2.assertFormDataBodyParserHasBeenUsedForExpressLikeRequest(this.request);
-        return this.request.body;
-    }
-    async getJSONFromRequestBody() {
-        await utils_2.assertThatBodyParserHasBeenUsedForExpressLikeRequest(this.getMethod(), this.request);
-        return this.request.body;
     }
 }
 exports.LoopbackRequest = LoopbackRequest;

--- a/lib/build/framework/loopback/framework.js
+++ b/lib/build/framework/loopback/framework.js
@@ -28,13 +28,6 @@ const supertokens_1 = __importDefault(require("../../supertokens"));
 class LoopbackRequest extends request_1.BaseRequest {
     constructor(ctx) {
         super();
-        this.getFormData = async () => {
-            if (!this.formDataParserChecked) {
-                await utils_2.assertFormDataBodyParserHasBeenUsedForExpressLikeRequest(this.request);
-                this.formDataParserChecked = true;
-            }
-            return this.request.body;
-        };
         this.getKeyValueFromQuery = (key) => {
             if (this.request.query === undefined) {
                 return undefined;
@@ -44,13 +37,6 @@ class LoopbackRequest extends request_1.BaseRequest {
                 return undefined;
             }
             return value;
-        };
-        this.getJSONBody = async () => {
-            if (!this.parserChecked) {
-                await utils_2.assertThatBodyParserHasBeenUsedForExpressLikeRequest(this.getMethod(), this.request);
-                this.parserChecked = true;
-            }
-            return this.request.body;
         };
         this.getMethod = () => {
             return utils_1.normaliseHttpMethod(this.request.method);
@@ -66,8 +52,14 @@ class LoopbackRequest extends request_1.BaseRequest {
         };
         this.original = ctx.request;
         this.request = ctx.request;
-        this.parserChecked = false;
-        this.formDataParserChecked = false;
+    }
+    async getFormDataFromRequestBody() {
+        await utils_2.assertFormDataBodyParserHasBeenUsedForExpressLikeRequest(this.request);
+        return this.request.body;
+    }
+    async getJSONFromRequestBody() {
+        await utils_2.assertThatBodyParserHasBeenUsedForExpressLikeRequest(this.getMethod(), this.request);
+        return this.request.body;
     }
 }
 exports.LoopbackRequest = LoopbackRequest;

--- a/lib/build/framework/request.d.ts
+++ b/lib/build/framework/request.d.ts
@@ -1,14 +1,18 @@
 // @ts-nocheck
 import { HTTPMethod } from "../types";
 export declare abstract class BaseRequest {
+    private parsedJSONBody;
+    private parsedUrlEncodedFormData;
     wrapperUsed: boolean;
     original: any;
     constructor();
+    protected abstract getJSONFromRequestBody(): Promise<any>;
+    protected abstract getFormDataFromRequestBody(): Promise<any>;
     abstract getKeyValueFromQuery: (key: string) => string | undefined;
-    abstract getJSONBody: () => Promise<any>;
     abstract getMethod: () => HTTPMethod;
     abstract getCookieValue: (key_: string) => string | undefined;
     abstract getHeaderValue: (key: string) => string | undefined;
     abstract getOriginalURL: () => string;
-    abstract getFormData: () => Promise<any>;
+    getFormData(): Promise<any>;
+    getJSONBody(): Promise<any>;
 }

--- a/lib/build/framework/request.d.ts
+++ b/lib/build/framework/request.d.ts
@@ -13,6 +13,6 @@ export declare abstract class BaseRequest {
     abstract getCookieValue: (key_: string) => string | undefined;
     abstract getHeaderValue: (key: string) => string | undefined;
     abstract getOriginalURL: () => string;
-    getFormData(): Promise<any>;
-    getJSONBody(): Promise<any>;
+    getFormData: () => Promise<any>;
+    getJSONBody: () => Promise<any>;
 }

--- a/lib/build/framework/request.js
+++ b/lib/build/framework/request.js
@@ -18,6 +18,24 @@ exports.BaseRequest = void 0;
 class BaseRequest {
     constructor() {
         this.wrapperUsed = true;
+        this.parsedJSONBody = undefined;
+        this.parsedUrlEncodedFormData = undefined;
+    }
+    // Note: While it's not recommended to override this method in child classes,
+    // if necessary, implement a similar caching strategy to ensure that `getFormDataFromRequestBody` is called only once.
+    async getFormData() {
+        if (this.parsedUrlEncodedFormData === undefined) {
+            this.parsedUrlEncodedFormData = await this.getFormDataFromRequestBody();
+        }
+        return this.parsedUrlEncodedFormData;
+    }
+    // Note: While it's not recommended to override this method in child classes,
+    // if necessary, implement a similar caching strategy to ensure that `getJSONFromRequestBody` is called only once.
+    async getJSONBody() {
+        if (this.parsedJSONBody === undefined) {
+            this.parsedJSONBody = await this.getJSONFromRequestBody();
+        }
+        return this.parsedJSONBody;
     }
 }
 exports.BaseRequest = BaseRequest;

--- a/lib/build/framework/request.js
+++ b/lib/build/framework/request.js
@@ -17,25 +17,25 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.BaseRequest = void 0;
 class BaseRequest {
     constructor() {
+        // Note: While it's not recommended to override this method in child classes,
+        // if necessary, implement a similar caching strategy to ensure that `getFormDataFromRequestBody` is called only once.
+        this.getFormData = async () => {
+            if (this.parsedUrlEncodedFormData === undefined) {
+                this.parsedUrlEncodedFormData = await this.getFormDataFromRequestBody();
+            }
+            return this.parsedUrlEncodedFormData;
+        };
+        // Note: While it's not recommended to override this method in child classes,
+        // if necessary, implement a similar caching strategy to ensure that `getJSONFromRequestBody` is called only once.
+        this.getJSONBody = async () => {
+            if (this.parsedJSONBody === undefined) {
+                this.parsedJSONBody = await this.getJSONFromRequestBody();
+            }
+            return this.parsedJSONBody;
+        };
         this.wrapperUsed = true;
         this.parsedJSONBody = undefined;
         this.parsedUrlEncodedFormData = undefined;
-    }
-    // Note: While it's not recommended to override this method in child classes,
-    // if necessary, implement a similar caching strategy to ensure that `getFormDataFromRequestBody` is called only once.
-    async getFormData() {
-        if (this.parsedUrlEncodedFormData === undefined) {
-            this.parsedUrlEncodedFormData = await this.getFormDataFromRequestBody();
-        }
-        return this.parsedUrlEncodedFormData;
-    }
-    // Note: While it's not recommended to override this method in child classes,
-    // if necessary, implement a similar caching strategy to ensure that `getJSONFromRequestBody` is called only once.
-    async getJSONBody() {
-        if (this.parsedJSONBody === undefined) {
-            this.parsedJSONBody = await this.getJSONFromRequestBody();
-        }
-        return this.parsedJSONBody;
     }
 }
 exports.BaseRequest = BaseRequest;

--- a/lib/build/framework/utils.d.ts
+++ b/lib/build/framework/utils.d.ts
@@ -45,7 +45,7 @@ export declare function setCookieForServerResponse(
     expires: number,
     path: string,
     sameSite: "strict" | "lax" | "none"
-): ServerResponse;
+): ServerResponse<IncomingMessage>;
 export declare function getCookieValueToSetInHeader(
     prev: string | string[] | undefined,
     val: string | string[],

--- a/lib/build/recipe/emailpassword/api/generatePasswordResetToken.js
+++ b/lib/build/recipe/emailpassword/api/generatePasswordResetToken.js
@@ -21,10 +21,11 @@ async function generatePasswordResetToken(apiImplementation, tenantId, options, 
     if (apiImplementation.generatePasswordResetTokenPOST === undefined) {
         return false;
     }
+    const requestBody = await options.req.getJSONBody();
     // step 1
     let formFields = await utils_2.validateFormFieldsOrThrowError(
         options.config.resetPasswordUsingTokenFeature.formFieldsForGenerateTokenForm,
-        (await options.req.getJSONBody()).formFields,
+        requestBody.formFields,
         tenantId
     );
     let result = await apiImplementation.generatePasswordResetTokenPOST({

--- a/lib/build/recipe/emailpassword/api/passwordReset.js
+++ b/lib/build/recipe/emailpassword/api/passwordReset.js
@@ -27,16 +27,17 @@ async function passwordReset(apiImplementation, tenantId, options, userContext) 
     if (apiImplementation.passwordResetPOST === undefined) {
         return false;
     }
+    const requestBody = await options.req.getJSONBody();
     // step 1: We need to do this here even though the update emailpassword recipe function would do this cause:
     // - we want to throw this error before consuming the token, so that the user can try again
     // - there is a case in the api impl where we create a new user, and we want to assign
     //      a password that meets the password policy.
     let formFields = await utils_2.validateFormFieldsOrThrowError(
         options.config.resetPasswordUsingTokenFeature.formFieldsForPasswordResetForm,
-        (await options.req.getJSONBody()).formFields,
+        requestBody.formFields,
         tenantId
     );
-    let token = (await options.req.getJSONBody()).token;
+    let token = requestBody.token;
     if (token === undefined) {
         throw new error_1.default({
             type: error_1.default.BAD_INPUT_ERROR,

--- a/lib/build/recipe/emailpassword/api/signup.js
+++ b/lib/build/recipe/emailpassword/api/signup.js
@@ -27,10 +27,11 @@ async function signUpAPI(apiImplementation, tenantId, options, userContext) {
     if (apiImplementation.signUpPOST === undefined) {
         return false;
     }
+    const requestBody = await options.req.getJSONBody();
     // step 1
     let formFields = await utils_2.validateFormFieldsOrThrowError(
         options.config.signUpFeature.formFields,
-        (await options.req.getJSONBody()).formFields,
+        requestBody.formFields,
         tenantId
     );
     let result = await apiImplementation.signUpPOST({

--- a/lib/build/recipe/emailverification/api/emailVerify.js
+++ b/lib/build/recipe/emailverification/api/emailVerify.js
@@ -29,7 +29,8 @@ async function emailVerify(apiImplementation, tenantId, options, userContext) {
         if (apiImplementation.verifyEmailPOST === undefined) {
             return false;
         }
-        let token = (await options.req.getJSONBody()).token;
+        const requestBody = await options.req.getJSONBody();
+        let token = requestBody.token;
         if (token === undefined || token === null) {
             throw new error_1.default({
                 type: error_1.default.BAD_INPUT_ERROR,

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "16.5.1";
+export declare const version = "16.5.2";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.8";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "16.5.1";
+exports.version = "16.5.2";
 exports.cdiSupported = ["4.0"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.8";

--- a/lib/ts/framework/awsLambda/framework.ts
+++ b/lib/ts/framework/awsLambda/framework.ts
@@ -34,30 +34,30 @@ import { parse } from "querystring";
 
 export class AWSRequest extends BaseRequest {
     private event: APIGatewayProxyEventV2 | APIGatewayProxyEvent;
-    private parsedJSONBody: Object | undefined;
-    private parsedUrlEncodedFormData: Object | undefined;
 
     constructor(event: APIGatewayProxyEventV2 | APIGatewayProxyEvent) {
         super();
         this.original = event;
         this.event = event;
-        this.parsedJSONBody = undefined;
-        this.parsedUrlEncodedFormData = undefined;
     }
 
-    getFormData = async (): Promise<any> => {
-        if (this.parsedUrlEncodedFormData === undefined) {
-            if (this.event.body === null || this.event.body === undefined) {
-                this.parsedUrlEncodedFormData = {};
-            } else {
-                this.parsedUrlEncodedFormData = parse(this.event.body);
-                if (this.parsedUrlEncodedFormData === undefined) {
-                    this.parsedUrlEncodedFormData = {};
-                }
-            }
+    protected async getFormDataFromRequestBody(): Promise<any> {
+        if (this.event.body === null || this.event.body === undefined) {
+            return {};
+        } else {
+            const parsedUrlEncodedFormData = parse(this.event.body);
+            return parsedUrlEncodedFormData === undefined ? {} : parsedUrlEncodedFormData;
         }
-        return this.parsedUrlEncodedFormData;
-    };
+    }
+
+    protected async getJSONFromRequestBody(): Promise<any> {
+        if (this.event.body === null || this.event.body === undefined) {
+            return {};
+        } else {
+            const parsedJSONBody = JSON.parse(this.event.body);
+            return parsedJSONBody === undefined ? {} : parsedJSONBody;
+        }
+    }
 
     getKeyValueFromQuery = (key: string): string | undefined => {
         if (this.event.queryStringParameters === undefined || this.event.queryStringParameters === null) {
@@ -68,20 +68,6 @@ export class AWSRequest extends BaseRequest {
             return undefined;
         }
         return value;
-    };
-
-    getJSONBody = async (): Promise<any> => {
-        if (this.parsedJSONBody === undefined) {
-            if (this.event.body === null || this.event.body === undefined) {
-                this.parsedJSONBody = {};
-            } else {
-                this.parsedJSONBody = JSON.parse(this.event.body);
-                if (this.parsedJSONBody === undefined) {
-                    this.parsedJSONBody = {};
-                }
-            }
-        }
-        return this.parsedJSONBody;
     };
 
     getMethod = (): HTTPMethod => {

--- a/lib/ts/framework/awsLambda/framework.ts
+++ b/lib/ts/framework/awsLambda/framework.ts
@@ -41,23 +41,23 @@ export class AWSRequest extends BaseRequest {
         this.event = event;
     }
 
-    protected async getFormDataFromRequestBody(): Promise<any> {
+    protected getFormDataFromRequestBody = async (): Promise<any> => {
         if (this.event.body === null || this.event.body === undefined) {
             return {};
         } else {
             const parsedUrlEncodedFormData = parse(this.event.body);
             return parsedUrlEncodedFormData === undefined ? {} : parsedUrlEncodedFormData;
         }
-    }
+    };
 
-    protected async getJSONFromRequestBody(): Promise<any> {
+    protected getJSONFromRequestBody = async (): Promise<any> => {
         if (this.event.body === null || this.event.body === undefined) {
             return {};
         } else {
             const parsedJSONBody = JSON.parse(this.event.body);
             return parsedJSONBody === undefined ? {} : parsedJSONBody;
         }
-    }
+    };
 
     getKeyValueFromQuery = (key: string): string | undefined => {
         if (this.event.queryStringParameters === undefined || this.event.queryStringParameters === null) {

--- a/lib/ts/framework/custom/framework.ts
+++ b/lib/ts/framework/custom/framework.ts
@@ -50,13 +50,13 @@ export class PreParsedRequest extends BaseRequest {
         this.request = request;
     }
 
-    protected getJSONFromRequestBody(): Promise<any> {
+    protected getJSONFromRequestBody = (): Promise<any> => {
         return this.request.getJSONBody();
-    }
+    };
 
-    protected getFormDataFromRequestBody(): Promise<any> {
+    protected getFormDataFromRequestBody = (): Promise<any> => {
         return this.request.getFormBody();
-    }
+    };
 
     getKeyValueFromQuery = (key: string): string | undefined => {
         if (this.request.query === undefined) {

--- a/lib/ts/framework/custom/framework.ts
+++ b/lib/ts/framework/custom/framework.ts
@@ -33,6 +33,8 @@ type RequestInfo = {
 
 export class PreParsedRequest extends BaseRequest {
     private request: RequestInfo;
+    private parsedJSONBody: any;
+    private parsedUrlEncodedFormData: any;
 
     private _session?: SessionContainerInterface | undefined;
     public get session(): SessionContainerInterface | undefined {
@@ -49,10 +51,15 @@ export class PreParsedRequest extends BaseRequest {
         super();
         this.original = request;
         this.request = request;
+        this.parsedJSONBody = undefined;
+        this.parsedUrlEncodedFormData = undefined;
     }
 
     getFormData = async (): Promise<any> => {
-        return this.request.getFormBody();
+        if (this.parsedUrlEncodedFormData === undefined) {
+            this.parsedUrlEncodedFormData = await this.request.getFormBody();
+        }
+        return this.parsedUrlEncodedFormData;
     };
 
     getKeyValueFromQuery = (key: string): string | undefined => {
@@ -67,7 +74,10 @@ export class PreParsedRequest extends BaseRequest {
     };
 
     getJSONBody = async (): Promise<any> => {
-        return this.request.getJSONBody();
+        if (this.parsedJSONBody === undefined) {
+            this.parsedJSONBody = await this.request.getJSONBody();
+        }
+        return this.parsedJSONBody;
     };
 
     getMethod = (): HTTPMethod => {

--- a/lib/ts/framework/custom/framework.ts
+++ b/lib/ts/framework/custom/framework.ts
@@ -33,9 +33,6 @@ type RequestInfo = {
 
 export class PreParsedRequest extends BaseRequest {
     private request: RequestInfo;
-    private parsedJSONBody: any;
-    private parsedUrlEncodedFormData: any;
-
     private _session?: SessionContainerInterface | undefined;
     public get session(): SessionContainerInterface | undefined {
         return this._session;
@@ -51,16 +48,15 @@ export class PreParsedRequest extends BaseRequest {
         super();
         this.original = request;
         this.request = request;
-        this.parsedJSONBody = undefined;
-        this.parsedUrlEncodedFormData = undefined;
     }
 
-    getFormData = async (): Promise<any> => {
-        if (this.parsedUrlEncodedFormData === undefined) {
-            this.parsedUrlEncodedFormData = await this.request.getFormBody();
-        }
-        return this.parsedUrlEncodedFormData;
-    };
+    protected getJSONFromRequestBody(): Promise<any> {
+        return this.request.getJSONBody();
+    }
+
+    protected getFormDataFromRequestBody(): Promise<any> {
+        return this.request.getFormBody();
+    }
 
     getKeyValueFromQuery = (key: string): string | undefined => {
         if (this.request.query === undefined) {
@@ -71,13 +67,6 @@ export class PreParsedRequest extends BaseRequest {
             return undefined;
         }
         return value;
-    };
-
-    getJSONBody = async (): Promise<any> => {
-        if (this.parsedJSONBody === undefined) {
-            this.parsedJSONBody = await this.request.getJSONBody();
-        }
-        return this.parsedJSONBody;
     };
 
     getMethod = (): HTTPMethod => {

--- a/lib/ts/framework/express/framework.ts
+++ b/lib/ts/framework/express/framework.ts
@@ -32,24 +32,22 @@ import type { SessionContainerInterface } from "../../recipe/session/types";
 
 export class ExpressRequest extends BaseRequest {
     private request: Request;
-    private parserChecked: boolean;
-    private formDataParserChecked: boolean;
 
     constructor(request: Request) {
         super();
         this.original = request;
         this.request = request;
-        this.parserChecked = false;
-        this.formDataParserChecked = false;
     }
 
-    getFormData = async (): Promise<any> => {
-        if (!this.formDataParserChecked) {
-            await assertFormDataBodyParserHasBeenUsedForExpressLikeRequest(this.request);
-            this.formDataParserChecked = true;
-        }
+    protected async getFormDataFromRequestBody(): Promise<any> {
+        await assertFormDataBodyParserHasBeenUsedForExpressLikeRequest(this.request);
         return this.request.body;
-    };
+    }
+
+    protected async getJSONFromRequestBody(): Promise<any> {
+        await assertThatBodyParserHasBeenUsedForExpressLikeRequest(this.getMethod(), this.request);
+        return this.request.body;
+    }
 
     getKeyValueFromQuery = (key: string): string | undefined => {
         if (this.request.query === undefined) {
@@ -60,14 +58,6 @@ export class ExpressRequest extends BaseRequest {
             return undefined;
         }
         return value;
-    };
-
-    getJSONBody = async (): Promise<any> => {
-        if (!this.parserChecked) {
-            await assertThatBodyParserHasBeenUsedForExpressLikeRequest(this.getMethod(), this.request);
-            this.parserChecked = true;
-        }
-        return this.request.body;
     };
 
     getMethod = (): HTTPMethod => {

--- a/lib/ts/framework/express/framework.ts
+++ b/lib/ts/framework/express/framework.ts
@@ -39,15 +39,15 @@ export class ExpressRequest extends BaseRequest {
         this.request = request;
     }
 
-    protected async getFormDataFromRequestBody(): Promise<any> {
+    protected getFormDataFromRequestBody = async (): Promise<any> => {
         await assertFormDataBodyParserHasBeenUsedForExpressLikeRequest(this.request);
         return this.request.body;
-    }
+    };
 
-    protected async getJSONFromRequestBody(): Promise<any> {
+    protected getJSONFromRequestBody = async (): Promise<any> => {
         await assertThatBodyParserHasBeenUsedForExpressLikeRequest(this.getMethod(), this.request);
         return this.request.body;
-    }
+    };
 
     getKeyValueFromQuery = (key: string): string | undefined => {
         if (this.request.query === undefined) {

--- a/lib/ts/framework/fastify/framework.ts
+++ b/lib/ts/framework/fastify/framework.ts
@@ -31,23 +31,20 @@ import { COOKIE_HEADER } from "../constants";
 
 export class FastifyRequest extends BaseRequest {
     private request: OriginalFastifyRequest;
-    private parsedJSONBody: any;
-    private parsedUrlEncodedFormData: any;
 
     constructor(request: OriginalFastifyRequest) {
         super();
         this.original = request;
         this.request = request;
-        this.parsedJSONBody = undefined;
-        this.parsedUrlEncodedFormData = undefined;
     }
 
-    getFormData = async (): Promise<any> => {
-        if (this.parsedUrlEncodedFormData === undefined) {
-            this.parsedUrlEncodedFormData = await this.request.body; // NOTE: ask user to add require('fastify-formbody')
-        }
-        return this.parsedUrlEncodedFormData;
-    };
+    protected async getFormDataFromRequestBody(): Promise<any> {
+        return this.request.body; // NOTE: ask user to add require('fastify-formbody')
+    }
+
+    protected async getJSONFromRequestBody(): Promise<any> {
+        return this.request.body;
+    }
 
     getKeyValueFromQuery = (key: string): string | undefined => {
         if (this.request.query === undefined) {
@@ -58,13 +55,6 @@ export class FastifyRequest extends BaseRequest {
             return undefined;
         }
         return value;
-    };
-
-    getJSONBody = async (): Promise<any> => {
-        if (this.parsedJSONBody === undefined) {
-            this.parsedJSONBody = await this.request.body;
-        }
-        return this.parsedJSONBody;
     };
 
     getMethod = (): HTTPMethod => {

--- a/lib/ts/framework/fastify/framework.ts
+++ b/lib/ts/framework/fastify/framework.ts
@@ -31,15 +31,22 @@ import { COOKIE_HEADER } from "../constants";
 
 export class FastifyRequest extends BaseRequest {
     private request: OriginalFastifyRequest;
+    private parsedJSONBody: any;
+    private parsedUrlEncodedFormData: any;
 
     constructor(request: OriginalFastifyRequest) {
         super();
         this.original = request;
         this.request = request;
+        this.parsedJSONBody = undefined;
+        this.parsedUrlEncodedFormData = undefined;
     }
 
     getFormData = async (): Promise<any> => {
-        return this.request.body; // NOTE: ask user to add require('fastify-formbody')
+        if (this.parsedUrlEncodedFormData === undefined) {
+            this.parsedUrlEncodedFormData = await this.request.body; // NOTE: ask user to add require('fastify-formbody')
+        }
+        return this.parsedUrlEncodedFormData;
     };
 
     getKeyValueFromQuery = (key: string): string | undefined => {
@@ -54,7 +61,10 @@ export class FastifyRequest extends BaseRequest {
     };
 
     getJSONBody = async (): Promise<any> => {
-        return this.request.body;
+        if (this.parsedJSONBody === undefined) {
+            this.parsedJSONBody = await this.request.body;
+        }
+        return this.parsedJSONBody;
     };
 
     getMethod = (): HTTPMethod => {

--- a/lib/ts/framework/fastify/framework.ts
+++ b/lib/ts/framework/fastify/framework.ts
@@ -38,13 +38,13 @@ export class FastifyRequest extends BaseRequest {
         this.request = request;
     }
 
-    protected async getFormDataFromRequestBody(): Promise<any> {
+    protected getFormDataFromRequestBody = async (): Promise<any> => {
         return this.request.body; // NOTE: ask user to add require('fastify-formbody')
-    }
+    };
 
-    protected async getJSONFromRequestBody(): Promise<any> {
+    protected getJSONFromRequestBody = async (): Promise<any> => {
         return this.request.body;
-    }
+    };
 
     getKeyValueFromQuery = (key: string): string | undefined => {
         if (this.request.query === undefined) {

--- a/lib/ts/framework/hapi/framework.ts
+++ b/lib/ts/framework/hapi/framework.ts
@@ -26,24 +26,20 @@ import type { SessionContainerInterface } from "../../recipe/session/types";
 
 export class HapiRequest extends BaseRequest {
     private request: Request;
-    private parsedJSONBody: any;
-    private parsedUrlEncodedFormData: any;
 
     constructor(request: Request) {
         super();
         this.original = request;
         this.request = request;
-        this.parsedJSONBody = undefined;
-        this.parsedUrlEncodedFormData = undefined;
     }
 
-    getFormData = async (): Promise<any> => {
-        if (this.parsedUrlEncodedFormData === undefined) {
-            this.parsedUrlEncodedFormData =
-                this.request.payload === undefined || this.request.payload === null ? {} : this.request.payload;
-        }
-        return this.parsedUrlEncodedFormData;
-    };
+    protected async getFormDataFromRequestBody(): Promise<any> {
+        return this.request.payload === undefined || this.request.payload === null ? {} : this.request.payload;
+    }
+
+    protected async getJSONFromRequestBody(): Promise<any> {
+        return this.request.payload === undefined || this.request.payload === null ? {} : this.request.payload;
+    }
 
     getKeyValueFromQuery = (key: string): string | undefined => {
         if (this.request.query === undefined) {
@@ -54,14 +50,6 @@ export class HapiRequest extends BaseRequest {
             return undefined;
         }
         return value;
-    };
-
-    getJSONBody = async (): Promise<any> => {
-        if (this.parsedJSONBody === undefined) {
-            this.parsedJSONBody =
-                this.request.payload === undefined || this.request.payload === null ? {} : this.request.payload;
-        }
-        return this.parsedJSONBody;
     };
 
     getMethod = (): HTTPMethod => {

--- a/lib/ts/framework/hapi/framework.ts
+++ b/lib/ts/framework/hapi/framework.ts
@@ -26,15 +26,23 @@ import type { SessionContainerInterface } from "../../recipe/session/types";
 
 export class HapiRequest extends BaseRequest {
     private request: Request;
+    private parsedJSONBody: any;
+    private parsedUrlEncodedFormData: any;
 
     constructor(request: Request) {
         super();
         this.original = request;
         this.request = request;
+        this.parsedJSONBody = undefined;
+        this.parsedUrlEncodedFormData = undefined;
     }
 
     getFormData = async (): Promise<any> => {
-        return this.request.payload === undefined || this.request.payload === null ? {} : this.request.payload;
+        if (this.parsedUrlEncodedFormData === undefined) {
+            this.parsedUrlEncodedFormData =
+                this.request.payload === undefined || this.request.payload === null ? {} : this.request.payload;
+        }
+        return this.parsedUrlEncodedFormData;
     };
 
     getKeyValueFromQuery = (key: string): string | undefined => {
@@ -49,7 +57,11 @@ export class HapiRequest extends BaseRequest {
     };
 
     getJSONBody = async (): Promise<any> => {
-        return this.request.payload === undefined || this.request.payload === null ? {} : this.request.payload;
+        if (this.parsedJSONBody === undefined) {
+            this.parsedJSONBody =
+                this.request.payload === undefined || this.request.payload === null ? {} : this.request.payload;
+        }
+        return this.parsedJSONBody;
     };
 
     getMethod = (): HTTPMethod => {

--- a/lib/ts/framework/hapi/framework.ts
+++ b/lib/ts/framework/hapi/framework.ts
@@ -33,13 +33,13 @@ export class HapiRequest extends BaseRequest {
         this.request = request;
     }
 
-    protected async getFormDataFromRequestBody(): Promise<any> {
+    protected getFormDataFromRequestBody = async (): Promise<any> => {
         return this.request.payload === undefined || this.request.payload === null ? {} : this.request.payload;
-    }
+    };
 
-    protected async getJSONFromRequestBody(): Promise<any> {
+    protected getJSONFromRequestBody = async (): Promise<any> => {
         return this.request.payload === undefined || this.request.payload === null ? {} : this.request.payload;
-    }
+    };
 
     getKeyValueFromQuery = (key: string): string | undefined => {
         if (this.request.query === undefined) {

--- a/lib/ts/framework/koa/framework.ts
+++ b/lib/ts/framework/koa/framework.ts
@@ -32,14 +32,14 @@ export class KoaRequest extends BaseRequest {
         this.ctx = ctx;
     }
 
-    protected async getFormDataFromRequestBody(): Promise<any> {
+    protected getFormDataFromRequestBody = async (): Promise<any> => {
         return parseURLEncodedFormData(this.ctx.req);
-    }
+    };
 
-    protected async getJSONFromRequestBody(): Promise<any> {
+    protected getJSONFromRequestBody = async (): Promise<any> => {
         const parsedJSONBody = await parseJSONBodyFromRequest(this.ctx.req);
         return parsedJSONBody === undefined ? {} : parsedJSONBody;
-    }
+    };
 
     getKeyValueFromQuery = (key: string): string | undefined => {
         if (this.ctx.query === undefined) {

--- a/lib/ts/framework/koa/framework.ts
+++ b/lib/ts/framework/koa/framework.ts
@@ -25,23 +25,21 @@ import { Framework } from "../types";
 
 export class KoaRequest extends BaseRequest {
     private ctx: Context;
-    private parsedJSONBody: Object | undefined;
-    private parsedUrlEncodedFormData: Object | undefined;
 
     constructor(ctx: Context) {
         super();
         this.original = ctx;
         this.ctx = ctx;
-        this.parsedJSONBody = undefined;
-        this.parsedUrlEncodedFormData = undefined;
     }
 
-    getFormData = async (): Promise<any> => {
-        if (this.parsedUrlEncodedFormData === undefined) {
-            this.parsedUrlEncodedFormData = (await parseURLEncodedFormData(this.ctx.req)) as any;
-        }
-        return this.parsedUrlEncodedFormData;
-    };
+    protected async getFormDataFromRequestBody(): Promise<any> {
+        return parseURLEncodedFormData(this.ctx.req);
+    }
+
+    protected async getJSONFromRequestBody(): Promise<any> {
+        const parsedJSONBody = await parseJSONBodyFromRequest(this.ctx.req);
+        return parsedJSONBody === undefined ? {} : parsedJSONBody;
+    }
 
     getKeyValueFromQuery = (key: string): string | undefined => {
         if (this.ctx.query === undefined) {
@@ -52,13 +50,6 @@ export class KoaRequest extends BaseRequest {
             return undefined;
         }
         return value;
-    };
-
-    getJSONBody = async (): Promise<any> => {
-        if (this.parsedJSONBody === undefined) {
-            this.parsedJSONBody = await parseJSONBodyFromRequest(this.ctx.req);
-        }
-        return this.parsedJSONBody === undefined ? {} : this.parsedJSONBody;
     };
 
     getMethod = (): HTTPMethod => {

--- a/lib/ts/framework/loopback/framework.ts
+++ b/lib/ts/framework/loopback/framework.ts
@@ -33,24 +33,22 @@ import type { Framework } from "../types";
 
 export class LoopbackRequest extends BaseRequest {
     private request: Request;
-    private parserChecked: boolean;
-    private formDataParserChecked: boolean;
 
     constructor(ctx: MiddlewareContext) {
         super();
         this.original = ctx.request;
         this.request = ctx.request;
-        this.parserChecked = false;
-        this.formDataParserChecked = false;
     }
 
-    getFormData = async (): Promise<any> => {
-        if (!this.formDataParserChecked) {
-            await assertFormDataBodyParserHasBeenUsedForExpressLikeRequest(this.request);
-            this.formDataParserChecked = true;
-        }
+    protected async getFormDataFromRequestBody(): Promise<any> {
+        await assertFormDataBodyParserHasBeenUsedForExpressLikeRequest(this.request);
         return this.request.body;
-    };
+    }
+
+    protected async getJSONFromRequestBody(): Promise<any> {
+        await assertThatBodyParserHasBeenUsedForExpressLikeRequest(this.getMethod(), this.request);
+        return this.request.body;
+    }
 
     getKeyValueFromQuery = (key: string): string | undefined => {
         if (this.request.query === undefined) {
@@ -61,14 +59,6 @@ export class LoopbackRequest extends BaseRequest {
             return undefined;
         }
         return value;
-    };
-
-    getJSONBody = async (): Promise<any> => {
-        if (!this.parserChecked) {
-            await assertThatBodyParserHasBeenUsedForExpressLikeRequest(this.getMethod(), this.request);
-            this.parserChecked = true;
-        }
-        return this.request.body;
     };
 
     getMethod = (): HTTPMethod => {

--- a/lib/ts/framework/loopback/framework.ts
+++ b/lib/ts/framework/loopback/framework.ts
@@ -40,15 +40,15 @@ export class LoopbackRequest extends BaseRequest {
         this.request = ctx.request;
     }
 
-    protected async getFormDataFromRequestBody(): Promise<any> {
+    protected getFormDataFromRequestBody = async (): Promise<any> => {
         await assertFormDataBodyParserHasBeenUsedForExpressLikeRequest(this.request);
         return this.request.body;
-    }
+    };
 
-    protected async getJSONFromRequestBody(): Promise<any> {
+    protected getJSONFromRequestBody = async (): Promise<any> => {
         await assertThatBodyParserHasBeenUsedForExpressLikeRequest(this.getMethod(), this.request);
         return this.request.body;
-    }
+    };
 
     getKeyValueFromQuery = (key: string): string | undefined => {
         if (this.request.query === undefined) {

--- a/lib/ts/framework/request.ts
+++ b/lib/ts/framework/request.ts
@@ -38,19 +38,19 @@ export abstract class BaseRequest {
 
     // Note: While it's not recommended to override this method in child classes,
     // if necessary, implement a similar caching strategy to ensure that `getFormDataFromRequestBody` is called only once.
-    async getFormData(): Promise<any> {
+    getFormData = async (): Promise<any> => {
         if (this.parsedUrlEncodedFormData === undefined) {
             this.parsedUrlEncodedFormData = await this.getFormDataFromRequestBody();
         }
         return this.parsedUrlEncodedFormData;
-    }
+    };
 
     // Note: While it's not recommended to override this method in child classes,
     // if necessary, implement a similar caching strategy to ensure that `getJSONFromRequestBody` is called only once.
-    async getJSONBody(): Promise<any> {
+    getJSONBody = async (): Promise<any> => {
         if (this.parsedJSONBody === undefined) {
             this.parsedJSONBody = await this.getJSONFromRequestBody();
         }
         return this.parsedJSONBody;
-    }
+    };
 }

--- a/lib/ts/framework/request.ts
+++ b/lib/ts/framework/request.ts
@@ -16,16 +16,41 @@
 import { HTTPMethod } from "../types";
 
 export abstract class BaseRequest {
+    private parsedJSONBody: any;
+    private parsedUrlEncodedFormData: any;
     wrapperUsed: boolean;
     original: any;
+
     constructor() {
         this.wrapperUsed = true;
+        this.parsedJSONBody = undefined;
+        this.parsedUrlEncodedFormData = undefined;
     }
+
+    protected abstract getJSONFromRequestBody(): Promise<any>;
+    protected abstract getFormDataFromRequestBody(): Promise<any>;
+
     abstract getKeyValueFromQuery: (key: string) => string | undefined;
-    abstract getJSONBody: () => Promise<any>;
     abstract getMethod: () => HTTPMethod;
     abstract getCookieValue: (key_: string) => string | undefined;
     abstract getHeaderValue: (key: string) => string | undefined;
     abstract getOriginalURL: () => string;
-    abstract getFormData: () => Promise<any>;
+
+    // Note: While it's not recommended to override this method in child classes,
+    // if necessary, implement a similar caching strategy to ensure that `getFormDataFromRequestBody` is called only once.
+    async getFormData(): Promise<any> {
+        if (this.parsedUrlEncodedFormData === undefined) {
+            this.parsedUrlEncodedFormData = await this.getFormDataFromRequestBody();
+        }
+        return this.parsedUrlEncodedFormData;
+    }
+
+    // Note: While it's not recommended to override this method in child classes,
+    // if necessary, implement a similar caching strategy to ensure that `getJSONFromRequestBody` is called only once.
+    async getJSONBody(): Promise<any> {
+        if (this.parsedJSONBody === undefined) {
+            this.parsedJSONBody = await this.getJSONFromRequestBody();
+        }
+        return this.parsedJSONBody;
+    }
 }

--- a/lib/ts/recipe/emailpassword/api/generatePasswordResetToken.ts
+++ b/lib/ts/recipe/emailpassword/api/generatePasswordResetToken.ts
@@ -29,13 +29,15 @@ export default async function generatePasswordResetToken(
         return false;
     }
 
+    const requestBody = await options.req.getJSONBody();
+
     // step 1
     let formFields: {
         id: string;
         value: string;
     }[] = await validateFormFieldsOrThrowError(
         options.config.resetPasswordUsingTokenFeature.formFieldsForGenerateTokenForm,
-        (await options.req.getJSONBody()).formFields,
+        requestBody.formFields,
         tenantId
     );
 

--- a/lib/ts/recipe/emailpassword/api/passwordReset.ts
+++ b/lib/ts/recipe/emailpassword/api/passwordReset.ts
@@ -30,6 +30,8 @@ export default async function passwordReset(
         return false;
     }
 
+    const requestBody = await options.req.getJSONBody();
+
     // step 1: We need to do this here even though the update emailpassword recipe function would do this cause:
     // - we want to throw this error before consuming the token, so that the user can try again
     // - there is a case in the api impl where we create a new user, and we want to assign
@@ -39,11 +41,11 @@ export default async function passwordReset(
         value: string;
     }[] = await validateFormFieldsOrThrowError(
         options.config.resetPasswordUsingTokenFeature.formFieldsForPasswordResetForm,
-        (await options.req.getJSONBody()).formFields,
+        requestBody.formFields,
         tenantId
     );
 
-    let token = (await options.req.getJSONBody()).token;
+    let token = requestBody.token;
     if (token === undefined) {
         throw new STError({
             type: STError.BAD_INPUT_ERROR,

--- a/lib/ts/recipe/emailpassword/api/signup.ts
+++ b/lib/ts/recipe/emailpassword/api/signup.ts
@@ -30,13 +30,15 @@ export default async function signUpAPI(
         return false;
     }
 
+    const requestBody = await options.req.getJSONBody();
+
     // step 1
     let formFields: {
         id: string;
         value: string;
     }[] = await validateFormFieldsOrThrowError(
         options.config.signUpFeature.formFields,
-        (await options.req.getJSONBody()).formFields,
+        requestBody.formFields,
         tenantId
     );
 

--- a/lib/ts/recipe/emailverification/api/emailVerify.ts
+++ b/lib/ts/recipe/emailverification/api/emailVerify.ts
@@ -33,7 +33,9 @@ export default async function emailVerify(
             return false;
         }
 
-        let token = (await options.req.getJSONBody()).token;
+        const requestBody = await options.req.getJSONBody();
+
+        let token = requestBody.token;
         if (token === undefined || token === null) {
             throw new STError({
                 type: STError.BAD_INPUT_ERROR,

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "16.5.1";
+export const version = "16.5.2";
 
 export const cdiSupported = ["4.0"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "16.5.1",
+    "version": "16.5.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "16.5.1",
+            "version": "16.5.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "16.5.1",
+    "version": "16.5.2",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {
@@ -9,7 +9,7 @@
         "build": "cd lib && rm -rf build && npx tsc -p tsconfig.json && cd ../test/with-typescript && npx tsc -p tsconfig.json --noEmit && cd ../.. && npm run post-build",
         "pretty": "npx pretty-quick .",
         "post-build": "node add-ts-no-check.js",
-        "build-pretty": "npm run build && npm run pretty",
+        "build-pretty": "npm run build && npm run pretty && npm run pretty",
         "pretty-check": "npx pretty-quick --check .",
         "set-up-hooks": "cp hooks/pre-commit.sh .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit",
         "build-docs": "rm -rf ./docs && npx typedoc --out ./docs --tsconfig ./lib/tsconfig.json ./lib/ts/index.ts ./lib/ts/**/index.ts ./lib/ts/**/*/index.ts"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "build": "cd lib && rm -rf build && npx tsc -p tsconfig.json && cd ../test/with-typescript && npx tsc -p tsconfig.json --noEmit && cd ../.. && npm run post-build",
         "pretty": "npx pretty-quick .",
         "post-build": "node add-ts-no-check.js",
-        "build-pretty": "npm run build && npm run pretty && npm run pretty",
+        "build-pretty": "npm run build && npm run pretty",
         "pretty-check": "npx pretty-quick --check .",
         "set-up-hooks": "cp hooks/pre-commit.sh .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit",
         "build-docs": "rm -rf ./docs && npx typedoc --out ./docs --tsconfig ./lib/tsconfig.json ./lib/ts/index.ts ./lib/ts/**/index.ts ./lib/ts/**/*/index.ts"

--- a/test/framework/awsLambda.test.js
+++ b/test/framework/awsLambda.test.js
@@ -1265,14 +1265,12 @@ describe(`AWS Lambda: ${printPath("[test/framework/awsLambda.test.js]")}`, funct
 describe(`AWSRequest`, function () {
     it("AWSRequest.getJSONFromRequestBody should be called only once", async function () {
         const mockJSONData = { key: "value" };
-        const getJSONFromRequestBodyStub = sinon
-            .stub(AWSRequest.prototype, "getJSONFromRequestBody")
-            .resolves(mockJSONData);
 
         const req = new AWSRequest({});
+        const getJSONFromRequestBodyStub = sinon.stub(req, "getJSONFromRequestBody").callsFake(() => mockJSONData);
 
-        // Call getJSONBody multiple times
-        const jsonData = await req.getJSONBody();
+        const getJsonBody = req.getJSONBody;
+        const jsonData = await getJsonBody();
         const jsonData2 = await req.getJSONBody();
 
         sinon.assert.calledOnce(getJSONFromRequestBodyStub);
@@ -1283,14 +1281,15 @@ describe(`AWSRequest`, function () {
 
     it("AWSRequest.getFormDataFromRequestBody should be called only once", async function () {
         const mockFormData = { key: "value" };
-        const getFormDataFromRequestBodyStub = sinon
-            .stub(AWSRequest.prototype, "getFormDataFromRequestBody")
-            .resolves(mockFormData);
-
         const req = new AWSRequest({});
 
+        let getFormDataFromRequestBodyStub = sinon
+            .stub(req, "getFormDataFromRequestBody")
+            .callsFake(() => mockFormData);
+
         // Call getFormData multiple times
-        const formData = await req.getFormData();
+        const getFormData = req.getFormData;
+        const formData = await getFormData();
         const formData2 = await req.getFormData();
 
         sinon.assert.calledOnce(getFormDataFromRequestBodyStub);

--- a/test/framework/awsLambda.test.js
+++ b/test/framework/awsLambda.test.js
@@ -35,6 +35,8 @@ let Dashboard = require("../../recipe/dashboard");
 let { createUsers } = require("../utils");
 const { Querier } = require("../../lib/build/querier");
 const { maxVersion } = require("../../lib/build/utils");
+const { AWSRequest } = require("../../lib/build/framework/awsLambda/framework");
+const sinon = require("sinon");
 
 describe(`AWS Lambda: ${printPath("[test/framework/awsLambda.test.js]")}`, function () {
     beforeEach(async function () {
@@ -1257,5 +1259,43 @@ describe(`AWS Lambda: ${printPath("[test/framework/awsLambda.test.js]")}`, funct
         assert(result.statusCode === 200);
         const body = JSON.parse(result.body);
         assert(body.users.length === 0);
+    });
+});
+
+describe(`AWSRequest`, function () {
+    it("AWSRequest.getJSONFromRequestBody should be called only once", async function () {
+        const mockJSONData = { key: "value" };
+        const getJSONFromRequestBodyStub = sinon
+            .stub(AWSRequest.prototype, "getJSONFromRequestBody")
+            .resolves(mockJSONData);
+
+        const req = new AWSRequest({});
+
+        // Call getJSONBody multiple times
+        const jsonData = await req.getJSONBody();
+        const jsonData2 = await req.getJSONBody();
+
+        sinon.assert.calledOnce(getJSONFromRequestBodyStub);
+
+        assert(JSON.stringify(jsonData) === JSON.stringify(mockJSONData));
+        assert(JSON.stringify(jsonData2) === JSON.stringify(mockJSONData));
+    });
+
+    it("AWSRequest.getFormDataFromRequestBody should be called only once", async function () {
+        const mockFormData = { key: "value" };
+        const getFormDataFromRequestBodyStub = sinon
+            .stub(AWSRequest.prototype, "getFormDataFromRequestBody")
+            .resolves(mockFormData);
+
+        const req = new AWSRequest({});
+
+        // Call getFormData multiple times
+        const formData = await req.getFormData();
+        const formData2 = await req.getFormData();
+
+        sinon.assert.calledOnce(getFormDataFromRequestBodyStub);
+
+        assert(JSON.stringify(formData) === JSON.stringify(mockFormData));
+        assert(JSON.stringify(formData2) === JSON.stringify(mockFormData));
     });
 });

--- a/test/framework/custom.test.js
+++ b/test/framework/custom.test.js
@@ -20,6 +20,7 @@ let CustomFramework = require("../../framework/custom");
 let Session = require("../../recipe/session");
 let { verifySession } = require("../../recipe/session/framework/custom");
 let { Headers } = require("cross-fetch");
+const sinon = require("sinon");
 
 describe(`Custom framework: ${printPath("[test/framework/custom.test.js]")}`, function () {
     beforeEach(async function () {
@@ -190,5 +191,43 @@ describe(`Custom framework: ${printPath("[test/framework/custom.test.js]")}`, fu
         assert.strictEqual(sessionRevokedResponseExtracted.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
         assert.strictEqual(sessionRevokedResponseExtracted.accessToken, "");
         assert.strictEqual(sessionRevokedResponseExtracted.refreshToken, "");
+    });
+});
+
+describe(`PreParsedRequest`, function () {
+    it("User's getJSONBody implementation should be called only once", async function () {
+        const mockJSONData = { key: "value" };
+        const getJSONBodyUserImplementationStub = sinon.stub().resolves(mockJSONData);
+
+        const req = new CustomFramework.PreParsedRequest({
+            getJSONBody: getJSONBodyUserImplementationStub,
+        });
+
+        // Call getJSONBody multiple times
+        const jsonData = await req.getJSONBody();
+        const jsonData2 = await req.getJSONBody();
+
+        sinon.assert.calledOnce(getJSONBodyUserImplementationStub);
+
+        assert(JSON.stringify(jsonData) === JSON.stringify(mockJSONData));
+        assert(JSON.stringify(jsonData2) === JSON.stringify(mockJSONData));
+    });
+
+    it("User's getFormData implementation should be called only once", async function () {
+        const mockFormData = { key: "value" };
+        const getFormDataUserImplementationStub = sinon.stub().resolves(mockFormData);
+
+        const req = new CustomFramework.PreParsedRequest({
+            getFormBody: getFormDataUserImplementationStub,
+        });
+
+        // Call getFormData multiple times
+        const formData = await req.getFormData();
+        const formData2 = await req.getFormData();
+
+        sinon.assert.calledOnce(getFormDataUserImplementationStub);
+
+        assert(JSON.stringify(formData) === JSON.stringify(mockFormData));
+        assert(JSON.stringify(formData2) === JSON.stringify(mockFormData));
     });
 });

--- a/test/framework/custom.test.js
+++ b/test/framework/custom.test.js
@@ -204,7 +204,8 @@ describe(`PreParsedRequest`, function () {
         });
 
         // Call getJSONBody multiple times
-        const jsonData = await req.getJSONBody();
+        const getJsonBody = req.getJSONBody;
+        const jsonData = await getJsonBody();
         const jsonData2 = await req.getJSONBody();
 
         sinon.assert.calledOnce(getJSONBodyUserImplementationStub);
@@ -222,7 +223,8 @@ describe(`PreParsedRequest`, function () {
         });
 
         // Call getFormData multiple times
-        const formData = await req.getFormData();
+        const getFormData = req.getFormData;
+        const formData = await getFormData();
         const formData2 = await req.getFormData();
 
         sinon.assert.calledOnce(getFormDataUserImplementationStub);

--- a/test/framework/express.test.js
+++ b/test/framework/express.test.js
@@ -19,14 +19,13 @@ const sinon = require("sinon");
 describe(`ExpressRequest`, function () {
     it("ExpressRequest.getJSONFromRequestBody should be called only once", async function () {
         const mockJSONData = { key: "value" };
-        const getJSONFromRequestBodyStub = sinon
-            .stub(ExpressRequest.prototype, "getJSONFromRequestBody")
-            .resolves(mockJSONData);
-
         const req = new ExpressRequest({});
 
+        const getJSONFromRequestBodyStub = sinon.stub(req, "getJSONFromRequestBody").callsFake(() => mockJSONData);
+
         // Call getJSONBody multiple times
-        const jsonData = await req.getJSONBody();
+        const getJsonBody = req.getJSONBody;
+        const jsonData = await getJsonBody();
         const jsonData2 = await req.getJSONBody();
 
         sinon.assert.calledOnce(getJSONFromRequestBodyStub);
@@ -37,14 +36,15 @@ describe(`ExpressRequest`, function () {
 
     it("ExpressRequest.getFormDataFromRequestBody should be called only once", async function () {
         const mockFormData = { key: "value" };
-        const getFormDataFromRequestBodyStub = sinon
-            .stub(ExpressRequest.prototype, "getFormDataFromRequestBody")
-            .resolves(mockFormData);
-
         const req = new ExpressRequest({});
 
+        let getFormDataFromRequestBodyStub = sinon
+            .stub(req, "getFormDataFromRequestBody")
+            .callsFake(() => mockFormData);
+
         // Call getFormData multiple times
-        const formData = await req.getFormData();
+        const getFormData = req.getFormData;
+        const formData = await getFormData();
         const formData2 = await req.getFormData();
 
         sinon.assert.calledOnce(getFormDataFromRequestBodyStub);

--- a/test/framework/express.test.js
+++ b/test/framework/express.test.js
@@ -1,0 +1,55 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+let assert = require("assert");
+const { ExpressRequest } = require("../../lib/build/framework/express/framework");
+const sinon = require("sinon");
+
+describe(`ExpressRequest`, function () {
+    it("ExpressRequest.getJSONFromRequestBody should be called only once", async function () {
+        const mockJSONData = { key: "value" };
+        const getJSONFromRequestBodyStub = sinon
+            .stub(ExpressRequest.prototype, "getJSONFromRequestBody")
+            .resolves(mockJSONData);
+
+        const req = new ExpressRequest({});
+
+        // Call getJSONBody multiple times
+        const jsonData = await req.getJSONBody();
+        const jsonData2 = await req.getJSONBody();
+
+        sinon.assert.calledOnce(getJSONFromRequestBodyStub);
+
+        assert(JSON.stringify(jsonData) === JSON.stringify(mockJSONData));
+        assert(JSON.stringify(jsonData2) === JSON.stringify(mockJSONData));
+    });
+
+    it("ExpressRequest.getFormDataFromRequestBody should be called only once", async function () {
+        const mockFormData = { key: "value" };
+        const getFormDataFromRequestBodyStub = sinon
+            .stub(ExpressRequest.prototype, "getFormDataFromRequestBody")
+            .resolves(mockFormData);
+
+        const req = new ExpressRequest({});
+
+        // Call getFormData multiple times
+        const formData = await req.getFormData();
+        const formData2 = await req.getFormData();
+
+        sinon.assert.calledOnce(getFormDataFromRequestBodyStub);
+
+        assert(JSON.stringify(formData) === JSON.stringify(mockFormData));
+        assert(JSON.stringify(formData2) === JSON.stringify(mockFormData));
+    });
+});

--- a/test/framework/fastify.test.js
+++ b/test/framework/fastify.test.js
@@ -36,6 +36,8 @@ const { Querier } = require("../../lib/build/querier");
 const { maxVersion } = require("../../lib/build/utils");
 const Passwordless = require("../../recipe/passwordless");
 const ThirdParty = require("../../recipe/thirdparty");
+const { FastifyRequest } = require("../../lib/build/framework/fastify/framework");
+const sinon = require("sinon");
 
 describe(`Fastify: ${printPath("[test/framework/fastify.test.js]")}`, function () {
     beforeEach(async function () {
@@ -1955,5 +1957,43 @@ describe(`Fastify: ${printPath("[test/framework/fastify.test.js]")}`, function (
         assert(resp.statusCode === 200);
         const body = resp.json();
         assert(body.users.length === 0);
+    });
+});
+
+describe(`FastifyRequest`, function () {
+    it("FastifyRequest.getJSONFromRequestBody should be called only once", async function () {
+        const mockJSONData = { key: "value" };
+        const getJSONFromRequestBodyStub = sinon
+            .stub(FastifyRequest.prototype, "getJSONFromRequestBody")
+            .resolves(mockJSONData);
+
+        const req = new FastifyRequest({});
+
+        // Call getJSONBody multiple times
+        const jsonData = await req.getJSONBody();
+        const jsonData2 = await req.getJSONBody();
+
+        sinon.assert.calledOnce(getJSONFromRequestBodyStub);
+
+        assert(JSON.stringify(jsonData) === JSON.stringify(mockJSONData));
+        assert(JSON.stringify(jsonData2) === JSON.stringify(mockJSONData));
+    });
+
+    it("FastifyRequest.getFormDataFromRequestBody should be called only once", async function () {
+        const mockFormData = { key: "value" };
+        const getFormDataFromRequestBodyStub = sinon
+            .stub(FastifyRequest.prototype, "getFormDataFromRequestBody")
+            .resolves(mockFormData);
+
+        const req = new FastifyRequest({});
+
+        // Call getFormData multiple times
+        const formData = await req.getFormData();
+        const formData2 = await req.getFormData();
+
+        sinon.assert.calledOnce(getFormDataFromRequestBodyStub);
+
+        assert(JSON.stringify(formData) === JSON.stringify(mockFormData));
+        assert(JSON.stringify(formData2) === JSON.stringify(mockFormData));
     });
 });

--- a/test/framework/fastify.test.js
+++ b/test/framework/fastify.test.js
@@ -1963,14 +1963,13 @@ describe(`Fastify: ${printPath("[test/framework/fastify.test.js]")}`, function (
 describe(`FastifyRequest`, function () {
     it("FastifyRequest.getJSONFromRequestBody should be called only once", async function () {
         const mockJSONData = { key: "value" };
-        const getJSONFromRequestBodyStub = sinon
-            .stub(FastifyRequest.prototype, "getJSONFromRequestBody")
-            .resolves(mockJSONData);
-
         const req = new FastifyRequest({});
 
+        const getJSONFromRequestBodyStub = sinon.stub(req, "getJSONFromRequestBody").callsFake(() => mockJSONData);
+
         // Call getJSONBody multiple times
-        const jsonData = await req.getJSONBody();
+        const getJsonBody = req.getJSONBody;
+        const jsonData = await getJsonBody();
         const jsonData2 = await req.getJSONBody();
 
         sinon.assert.calledOnce(getJSONFromRequestBodyStub);
@@ -1981,14 +1980,15 @@ describe(`FastifyRequest`, function () {
 
     it("FastifyRequest.getFormDataFromRequestBody should be called only once", async function () {
         const mockFormData = { key: "value" };
-        const getFormDataFromRequestBodyStub = sinon
-            .stub(FastifyRequest.prototype, "getFormDataFromRequestBody")
-            .resolves(mockFormData);
-
         const req = new FastifyRequest({});
 
+        let getFormDataFromRequestBodyStub = sinon
+            .stub(req, "getFormDataFromRequestBody")
+            .callsFake(() => mockFormData);
+
         // Call getFormData multiple times
-        const formData = await req.getFormData();
+        const getFormData = req.getFormData;
+        const formData = await getFormData();
         const formData2 = await req.getFormData();
 
         sinon.assert.calledOnce(getFormDataFromRequestBodyStub);

--- a/test/framework/hapi.test.js
+++ b/test/framework/hapi.test.js
@@ -1982,14 +1982,13 @@ describe(`Hapi: ${printPath("[test/framework/hapi.test.js]")}`, function () {
 describe(`HapiRequest`, function () {
     it("HapiRequest.getJSONFromRequestBody should be called only once", async function () {
         const mockJSONData = { key: "value" };
-        const getJSONFromRequestBodyStub = sinon
-            .stub(HapiRequest.prototype, "getJSONFromRequestBody")
-            .resolves(mockJSONData);
-
         const req = new HapiRequest({});
 
+        const getJSONFromRequestBodyStub = sinon.stub(req, "getJSONFromRequestBody").callsFake(() => mockJSONData);
+
         // Call getJSONBody multiple times
-        const jsonData = await req.getJSONBody();
+        const getJsonBody = req.getJSONBody;
+        const jsonData = await getJsonBody();
         const jsonData2 = await req.getJSONBody();
 
         sinon.assert.calledOnce(getJSONFromRequestBodyStub);
@@ -2000,14 +1999,15 @@ describe(`HapiRequest`, function () {
 
     it("HapiRequest.getFormDataFromRequestBody should be called only once", async function () {
         const mockFormData = { key: "value" };
-        const getFormDataFromRequestBodyStub = sinon
-            .stub(HapiRequest.prototype, "getFormDataFromRequestBody")
-            .resolves(mockFormData);
-
         const req = new HapiRequest({});
 
+        let getFormDataFromRequestBodyStub = sinon
+            .stub(req, "getFormDataFromRequestBody")
+            .callsFake(() => mockFormData);
+
         // Call getFormData multiple times
-        const formData = await req.getFormData();
+        const getFormData = req.getFormData;
+        const formData = await getFormData();
         const formData2 = await req.getFormData();
 
         sinon.assert.calledOnce(getFormDataFromRequestBodyStub);

--- a/test/framework/hapi.test.js
+++ b/test/framework/hapi.test.js
@@ -28,6 +28,8 @@ const { Querier } = require("../../lib/build/querier");
 const { maxVersion } = require("../../lib/build/utils");
 const Passwordless = require("../../recipe/passwordless");
 const ThirdParty = require("../../recipe/thirdparty");
+const { HapiRequest } = require("../../lib/build/framework/hapi/framework");
+const sinon = require("sinon");
 
 describe(`Hapi: ${printPath("[test/framework/hapi.test.js]")}`, function () {
     beforeEach(async function () {
@@ -1974,5 +1976,43 @@ describe(`Hapi: ${printPath("[test/framework/hapi.test.js]")}`, function () {
         });
         assert(resp.statusCode === 200);
         assert(resp.result.users.length === 3);
+    });
+});
+
+describe(`HapiRequest`, function () {
+    it("HapiRequest.getJSONFromRequestBody should be called only once", async function () {
+        const mockJSONData = { key: "value" };
+        const getJSONFromRequestBodyStub = sinon
+            .stub(HapiRequest.prototype, "getJSONFromRequestBody")
+            .resolves(mockJSONData);
+
+        const req = new HapiRequest({});
+
+        // Call getJSONBody multiple times
+        const jsonData = await req.getJSONBody();
+        const jsonData2 = await req.getJSONBody();
+
+        sinon.assert.calledOnce(getJSONFromRequestBodyStub);
+
+        assert(JSON.stringify(jsonData) === JSON.stringify(mockJSONData));
+        assert(JSON.stringify(jsonData2) === JSON.stringify(mockJSONData));
+    });
+
+    it("HapiRequest.getFormDataFromRequestBody should be called only once", async function () {
+        const mockFormData = { key: "value" };
+        const getFormDataFromRequestBodyStub = sinon
+            .stub(HapiRequest.prototype, "getFormDataFromRequestBody")
+            .resolves(mockFormData);
+
+        const req = new HapiRequest({});
+
+        // Call getFormData multiple times
+        const formData = await req.getFormData();
+        const formData2 = await req.getFormData();
+
+        sinon.assert.calledOnce(getFormDataFromRequestBodyStub);
+
+        assert(JSON.stringify(formData) === JSON.stringify(mockFormData));
+        assert(JSON.stringify(formData2) === JSON.stringify(mockFormData));
     });
 });

--- a/test/framework/koa.test.js
+++ b/test/framework/koa.test.js
@@ -29,6 +29,8 @@ const { Querier } = require("../../lib/build/querier");
 const { maxVersion } = require("../../lib/build/utils");
 const Passwordless = require("../../recipe/passwordless");
 const ThirdParty = require("../../recipe/thirdparty");
+const { KoaRequest } = require("../../lib/build/framework/koa/framework");
+const sinon = require("sinon");
 
 describe(`Koa: ${printPath("[test/framework/koa.test.js]")}`, function () {
     beforeEach(async function () {
@@ -2172,5 +2174,43 @@ describe(`Koa: ${printPath("[test/framework/koa.test.js]")}`, function () {
         );
         assert(res.statusCode === 200);
         assert(res.body.users.length === 0);
+    });
+});
+
+describe(`KoaRequest`, function () {
+    it("KoaRequest.getJSONFromRequestBody should be called only once", async function () {
+        const mockJSONData = { key: "value" };
+        const getJSONFromRequestBodyStub = sinon
+            .stub(KoaRequest.prototype, "getJSONFromRequestBody")
+            .resolves(mockJSONData);
+
+        const req = new KoaRequest({});
+
+        // Call getJSONBody multiple times
+        const jsonData = await req.getJSONBody();
+        const jsonData2 = await req.getJSONBody();
+
+        sinon.assert.calledOnce(getJSONFromRequestBodyStub);
+
+        assert(JSON.stringify(jsonData) === JSON.stringify(mockJSONData));
+        assert(JSON.stringify(jsonData2) === JSON.stringify(mockJSONData));
+    });
+
+    it("KoaRequest.getFormDataFromRequestBody should be called only once", async function () {
+        const mockFormData = { key: "value" };
+        const getFormDataFromRequestBodyStub = sinon
+            .stub(KoaRequest.prototype, "getFormDataFromRequestBody")
+            .resolves(mockFormData);
+
+        const req = new KoaRequest({});
+
+        // Call getFormData multiple times
+        const formData = await req.getFormData();
+        const formData2 = await req.getFormData();
+
+        sinon.assert.calledOnce(getFormDataFromRequestBodyStub);
+
+        assert(JSON.stringify(formData) === JSON.stringify(mockFormData));
+        assert(JSON.stringify(formData2) === JSON.stringify(mockFormData));
     });
 });

--- a/test/framework/koa.test.js
+++ b/test/framework/koa.test.js
@@ -2180,14 +2180,13 @@ describe(`Koa: ${printPath("[test/framework/koa.test.js]")}`, function () {
 describe(`KoaRequest`, function () {
     it("KoaRequest.getJSONFromRequestBody should be called only once", async function () {
         const mockJSONData = { key: "value" };
-        const getJSONFromRequestBodyStub = sinon
-            .stub(KoaRequest.prototype, "getJSONFromRequestBody")
-            .resolves(mockJSONData);
-
         const req = new KoaRequest({});
 
+        const getJSONFromRequestBodyStub = sinon.stub(req, "getJSONFromRequestBody").callsFake(() => mockJSONData);
+
         // Call getJSONBody multiple times
-        const jsonData = await req.getJSONBody();
+        const getJsonBody = req.getJSONBody;
+        const jsonData = await getJsonBody();
         const jsonData2 = await req.getJSONBody();
 
         sinon.assert.calledOnce(getJSONFromRequestBodyStub);
@@ -2198,14 +2197,15 @@ describe(`KoaRequest`, function () {
 
     it("KoaRequest.getFormDataFromRequestBody should be called only once", async function () {
         const mockFormData = { key: "value" };
-        const getFormDataFromRequestBodyStub = sinon
-            .stub(KoaRequest.prototype, "getFormDataFromRequestBody")
-            .resolves(mockFormData);
-
         const req = new KoaRequest({});
 
+        let getFormDataFromRequestBodyStub = sinon
+            .stub(req, "getFormDataFromRequestBody")
+            .callsFake(() => mockFormData);
+
         // Call getFormData multiple times
-        const formData = await req.getFormData();
+        const getFormData = req.getFormData;
+        const formData = await getFormData();
         const formData2 = await req.getFormData();
 
         sinon.assert.calledOnce(getFormDataFromRequestBodyStub);

--- a/test/framework/loopback.test.js
+++ b/test/framework/loopback.test.js
@@ -879,14 +879,13 @@ async function request(init) {
 describe(`LoopbackRequest`, function () {
     it("LoopbackRequest.getJSONFromRequestBody should be called only once", async function () {
         const mockJSONData = { key: "value" };
-        const getJSONFromRequestBodyStub = sinon
-            .stub(LoopbackRequest.prototype, "getJSONFromRequestBody")
-            .resolves(mockJSONData);
-
         const req = new LoopbackRequest({});
 
+        const getJSONFromRequestBodyStub = sinon.stub(req, "getJSONFromRequestBody").callsFake(() => mockJSONData);
+
         // Call getJSONBody multiple times
-        const jsonData = await req.getJSONBody();
+        const getJsonBody = req.getJSONBody;
+        const jsonData = await getJsonBody();
         const jsonData2 = await req.getJSONBody();
 
         sinon.assert.calledOnce(getJSONFromRequestBodyStub);
@@ -897,14 +896,15 @@ describe(`LoopbackRequest`, function () {
 
     it("LoopbackRequest.getFormDataFromRequestBody should be called only once", async function () {
         const mockFormData = { key: "value" };
-        const getFormDataFromRequestBodyStub = sinon
-            .stub(LoopbackRequest.prototype, "getFormDataFromRequestBody")
-            .resolves(mockFormData);
-
         const req = new LoopbackRequest({});
 
+        let getFormDataFromRequestBodyStub = sinon
+            .stub(req, "getFormDataFromRequestBody")
+            .callsFake(() => mockFormData);
+
         // Call getFormData multiple times
-        const formData = await req.getFormData();
+        const getFormData = req.getFormData;
+        const formData = await getFormData();
         const formData2 = await req.getFormData();
 
         sinon.assert.calledOnce(getFormDataFromRequestBodyStub);

--- a/test/framework/loopback.test.js
+++ b/test/framework/loopback.test.js
@@ -27,6 +27,8 @@ const { maxVersion } = require("../../lib/build/utils");
 const Passwordless = require("../../recipe/passwordless");
 const ThirdParty = require("../../recipe/thirdparty");
 const { default: fetch } = require("cross-fetch");
+const { LoopbackRequest } = require("../../lib/build/framework/loopback/framework");
+const sinon = require("sinon");
 
 describe(`Loopback: ${printPath("[test/framework/loopback.test.js]")}`, function () {
     beforeEach(async function () {
@@ -873,3 +875,41 @@ async function request(init) {
         headers,
     };
 }
+
+describe(`LoopbackRequest`, function () {
+    it("LoopbackRequest.getJSONFromRequestBody should be called only once", async function () {
+        const mockJSONData = { key: "value" };
+        const getJSONFromRequestBodyStub = sinon
+            .stub(LoopbackRequest.prototype, "getJSONFromRequestBody")
+            .resolves(mockJSONData);
+
+        const req = new LoopbackRequest({});
+
+        // Call getJSONBody multiple times
+        const jsonData = await req.getJSONBody();
+        const jsonData2 = await req.getJSONBody();
+
+        sinon.assert.calledOnce(getJSONFromRequestBodyStub);
+
+        assert(JSON.stringify(jsonData) === JSON.stringify(mockJSONData));
+        assert(JSON.stringify(jsonData2) === JSON.stringify(mockJSONData));
+    });
+
+    it("LoopbackRequest.getFormDataFromRequestBody should be called only once", async function () {
+        const mockFormData = { key: "value" };
+        const getFormDataFromRequestBodyStub = sinon
+            .stub(LoopbackRequest.prototype, "getFormDataFromRequestBody")
+            .resolves(mockFormData);
+
+        const req = new LoopbackRequest({});
+
+        // Call getFormData multiple times
+        const formData = await req.getFormData();
+        const formData2 = await req.getFormData();
+
+        sinon.assert.calledOnce(getFormDataFromRequestBodyStub);
+
+        assert(JSON.stringify(formData) === JSON.stringify(mockFormData));
+        assert(JSON.stringify(formData2) === JSON.stringify(mockFormData));
+    });
+});


### PR DESCRIPTION
## Summary of change

In many frameworks, calling `req.body` or `req.formData` is limited to a single use due to their nature as readable streams. Our framework classes have `getJSONBody` and `getFormData` functions, designed to invoke the appropriate method on the `req` object.

Calling these functions multiple times can lead to issues, as observed in #746. For instance, the `getJSONBody` was mistakenly called twice in the passwordReset API implementation. Although combining these calls into one resolved the specific case in #746, it does not prevent users from inadvertently triggering the same error by calling `getJSONBody` multiple times.

To address this, we now cache the response of `req.body` or `req.formData` directly in the recipe implementation.

## Related issues

-   https://github.com/supertokens/supertokens-node/issues/746

## Test Plan

Tests were added to ensure that `getJSONFromRequestBody` and `getFormDataFromRequestBody` are invoked only once, regardless of the number of calls to `getJSONData` or `getFormData`. If any framework class overrides the implementation of `getJSONData` or `getFormData` from the `BaseRequest` class, these tests would fail.

## Documentation changes


## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

