### PR TITLE
feat: Remove crypto usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [16.6.1] - 2023-11-29
+
+-   Removed dependency on the `crypto` library to enable Apple OAuth usage in Cloudflare Workers.
+
 ## [16.6.0] - 2023-11-23
 
 ### Added

--- a/examples/aws/with-emailpassword/test/helpers/lambda-layer.sh
+++ b/examples/aws/with-emailpassword/test/helpers/lambda-layer.sh
@@ -1,6 +1,6 @@
 mkdir lambda && cd lambda
 npm init -y
-npm i -s @middy/core @middy/http-cors
+npm i -s @middy/core@4.5.5 @middy/http-cors@4.5.5
 npm i --save git+ssh://git@github.com:supertokens/supertokens-node.git#$GITHUB_REF_NAME
 mkdir nodejs
 cp -r node_modules nodejs

--- a/lib/build/recipe/thirdparty/providers/apple.js
+++ b/lib/build/recipe/thirdparty/providers/apple.js
@@ -49,17 +49,12 @@ var __importStar =
         __setModuleDefault(result, mod);
         return result;
     };
-var __importDefault =
-    (this && this.__importDefault) ||
-    function (mod) {
-        return mod && mod.__esModule ? mod : { default: mod };
-    };
 Object.defineProperty(exports, "__esModule", { value: true });
 const custom_1 = __importStar(require("./custom"));
 const jose = __importStar(require("jose"));
-const crypto_1 = __importDefault(require("crypto"));
 async function getClientSecret(clientId, keyId, teamId, privateKey) {
     const alg = "ES256";
+    const key = await jose.importPKCS8(privateKey.replace(/\\n/g, "\n"), alg);
     return new jose.SignJWT({})
         .setProtectedHeader({ alg, kid: keyId, typ: "JWT" })
         .setIssuer(teamId)
@@ -67,7 +62,7 @@ async function getClientSecret(clientId, keyId, teamId, privateKey) {
         .setExpirationTime("180days")
         .setAudience("https://appleid.apple.com")
         .setSubject(custom_1.getActualClientIdFromDevelopmentClientId(clientId))
-        .sign(crypto_1.default.createPrivateKey(privateKey.replace(/\\n/g, "\n")));
+        .sign(key);
 }
 function Apple(input) {
     if (input.config.name === undefined) {

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "16.6.0";
+export declare const version = "16.6.1";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.9";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "16.6.0";
+exports.version = "16.6.1";
 exports.cdiSupported = ["4.0"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.9";

--- a/lib/ts/recipe/thirdparty/providers/apple.ts
+++ b/lib/ts/recipe/thirdparty/providers/apple.ts
@@ -16,10 +16,10 @@
 import { ProviderInput, TypeProvider } from "../types";
 import NewProvider, { getActualClientIdFromDevelopmentClientId } from "./custom";
 import * as jose from "jose";
-import crypto from "crypto";
 
 async function getClientSecret(clientId: string, keyId: string, teamId: string, privateKey: string): Promise<string> {
     const alg = "ES256";
+    const key = await jose.importPKCS8(privateKey.replace(/\\n/g, "\n"), alg);
 
     return new jose.SignJWT({})
         .setProtectedHeader({ alg, kid: keyId, typ: "JWT" })
@@ -28,7 +28,7 @@ async function getClientSecret(clientId: string, keyId: string, teamId: string, 
         .setExpirationTime("180days")
         .setAudience("https://appleid.apple.com")
         .setSubject(getActualClientIdFromDevelopmentClientId(clientId))
-        .sign(crypto.createPrivateKey(privateKey.replace(/\\n/g, "\n")));
+        .sign(key);
 }
 
 export default function Apple(input: ProviderInput): TypeProvider {

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "16.6.0";
+export const version = "16.6.1";
 
 export const cdiSupported = ["4.0"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "16.6.0",
+    "version": "16.6.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "16.6.0",
+            "version": "16.6.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "16.6.0",
+    "version": "16.6.1",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

This PR removes usage of `crypto` library. This will enable us to support Apple OAuth on other runtime environments like Cloudflare workers.


## Test Plan

I have tested Apple OAuth flow manually on web.

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

