### PR TITLE
fixes impl of getBackwardsCompatibleUserInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [16.6.2] - 2023-12-02
+
+-   Fixes implementation of `getBackwardsCompatibleUserInfo` to not throw an error in case of session and user id mismatch.
+
 ## [16.6.1] - 2023-11-29
 
 -   Removed dependency on the `crypto` library to enable Apple OAuth usage in Cloudflare Workers.

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -201,14 +201,26 @@ function getBackwardsCompatibleUserInfo(req, result) {
         }
         return resp;
     } else {
-        const loginMethod = result.user.loginMethods.find(
+        let loginMethod = result.user.loginMethods.find(
             (lm) => lm.recipeUserId.getAsString() === result.session.getRecipeUserId().getAsString()
         );
         if (loginMethod === undefined) {
-            throw new Error("This should never happen: session and user mismatch");
+            // we pick the oldest login method here for the user.
+            // this can happen in case the user is implementing something like
+            // MFA where the session remains the same during the second factor as well.
+            for (let i = 0; i < result.user.loginMethods.length; i++) {
+                if (loginMethod === undefined) {
+                    loginMethod = result.user.loginMethods[i];
+                } else if (loginMethod.timeJoined > result.user.loginMethods[i].timeJoined) {
+                    loginMethod = result.user.loginMethods[i];
+                }
+            }
+        }
+        if (loginMethod === undefined) {
+            throw new Error("This should never happen - user has no login methods");
         }
         const userObj = {
-            id: result.session.getUserId(),
+            id: loginMethod.recipeUserId.getAsString(),
             timeJoined: result.user.timeJoined,
         };
         if (loginMethod.thirdParty) {

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "16.6.1";
+export declare const version = "16.6.2";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.9";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "16.6.1";
+exports.version = "16.6.2";
 exports.cdiSupported = ["4.0"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.9";

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -7,7 +7,7 @@ import type { BaseRequest, BaseResponse } from "./framework";
 import { logDebugMessage } from "./logger";
 import { HEADER_FDI, HEADER_RID } from "./constants";
 import crossFetch from "cross-fetch";
-import { User } from "./user";
+import { LoginMethod, User } from "./user";
 import { SessionContainer } from "./recipe/session";
 
 export const doFetch: typeof fetch = (...args) => {
@@ -182,16 +182,29 @@ export function getBackwardsCompatibleUserInfo(
         }
         return resp;
     } else {
-        const loginMethod = result.user.loginMethods.find(
+        let loginMethod: undefined | LoginMethod = result.user.loginMethods.find(
             (lm) => lm.recipeUserId.getAsString() === result.session.getRecipeUserId().getAsString()
         );
 
         if (loginMethod === undefined) {
-            throw new Error("This should never happen: session and user mismatch");
+            // we pick the oldest login method here for the user.
+            // this can happen in case the user is implementing something like
+            // MFA where the session remains the same during the second factor as well.
+            for (let i = 0; i < result.user.loginMethods.length; i++) {
+                if (loginMethod === undefined) {
+                    loginMethod = result.user.loginMethods[i];
+                } else if (loginMethod.timeJoined > result.user.loginMethods[i].timeJoined) {
+                    loginMethod = result.user.loginMethods[i];
+                }
+            }
+        }
+
+        if (loginMethod === undefined) {
+            throw new Error("This should never happen - user has no login methods");
         }
 
         const userObj: JSONObject = {
-            id: result.session.getUserId(),
+            id: loginMethod.recipeUserId.getAsString(),
             timeJoined: result.user.timeJoined,
         };
         if (loginMethod.thirdParty) {

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "16.6.1";
+export const version = "16.6.2";
 
 export const cdiSupported = ["4.0"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "16.6.1",
+    "version": "16.6.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "16.6.1",
+            "version": "16.6.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "16.6.1",
+    "version": "16.6.2",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

Earlier, `getBackwardsCompatibleUserInfo` would throw an error in case the session and user id did not match. This would cause an issue when using MFA since the session user id would not change during the second factor (and if the frontend SDK being used has 1.17 as the max CDI)


## Test Plan

- Added a test that simulates the 2fa scenario and makes sure no error is thrown
- Added a test that queries the login API (of linked user) with the older FDI and makes sure that the returned user matches the session user ID.

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
