### PR TITLE
fix: Update aws example to use esm imports

### DIFF
--- a/examples/aws/with-emailpassword/backend/config.mjs
+++ b/examples/aws/with-emailpassword/backend/config.mjs
@@ -1,8 +1,8 @@
-let Session = require("supertokens-node/recipe/session");
-let EmailPassword = require("supertokens-node/recipe/emailpassword");
-let Dashboard = require("supertokens-node/recipe/dashboard");
+import Session from "supertokens-node/recipe/session";
+import EmailPassword from "supertokens-node/recipe/emailpassword";
+import Dashboard from "supertokens-node/recipe/dashboard";
 
-module.exports.getBackendConfig = () => {
+export const getBackendConfig = () => {
     return {
         framework: "awsLambda",
         supertokens: {

--- a/examples/aws/with-emailpassword/backend/index.mjs
+++ b/examples/aws/with-emailpassword/backend/index.mjs
@@ -1,16 +1,16 @@
-let supertokens = require("supertokens-node");
-let { middleware } = require("supertokens-node/framework/awsLambda/");
-let { getBackendConfig } = require("./config");
-let middy = require("@middy/core");
-let cors = require("@middy/http-cors");
-let { handler } = require("./user");
+import supertokens from "supertokens-node";
+import { middleware } from "supertokens-node/framework/awsLambda";
+import { getBackendConfig } from "./config.mjs";
+import middy from "@middy/core";
+import cors from "@middy/http-cors";
+import { handler as userHandler } from "./user.mjs";
 
 supertokens.init(getBackendConfig());
 
-module.exports.handler = middy(
+export const handler = middy(
     middleware((event) => {
         if (event.path === "/user") {
-            return handler(event);
+            return userHandler(event);
         } else {
             return {
                 body: JSON.stringify({

--- a/examples/aws/with-emailpassword/backend/user.mjs
+++ b/examples/aws/with-emailpassword/backend/user.mjs
@@ -1,13 +1,12 @@
-let supertokens = require("supertokens-node");
-let { middleware } = require("supertokens-node/framework/awsLambda/");
-let { getBackendConfig } = require("./config");
-let middy = require("@middy/core");
-let cors = require("@middy/http-cors");
-let { verifySession } = require("supertokens-node/recipe/session/framework/awsLambda");
+import supertokens from "supertokens-node";
+import { getBackendConfig } from "./config.mjs";
+import middy from "@middy/core";
+import cors from "@middy/http-cors";
+import { verifySession } from "supertokens-node/recipe/session/framework/awsLambda";
 
 supertokens.init(getBackendConfig());
 
-const handler = async (event) => {
+const lambdaHandler = async (event) => {
     let count = 0;
     let currPayload = event.session.getAccessTokenPayload();
     if (currPayload.count !== undefined) {
@@ -26,7 +25,7 @@ const handler = async (event) => {
     };
 };
 
-module.exports.handler = middy(verifySession(handler))
+export const handler = middy(verifySession(lambdaHandler))
     .use(
         cors({
             origin: getBackendConfig().appInfo.websiteDomain,

--- a/examples/aws/with-emailpassword/package-lock.json
+++ b/examples/aws/with-emailpassword/package-lock.json
@@ -10,8 +10,8 @@
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-lambda": "^3.363.0",
-                "@middy/core": "^4.5.5",
-                "@middy/http-cors": "^4.5.5",
+                "@middy/core": "^5.1.0",
+                "@middy/http-cors": "^5.1.0",
                 "@testing-library/jest-dom": "^5.16.5",
                 "@testing-library/react": "^13.4.0",
                 "@testing-library/user-event": "^13.5.0",
@@ -2806,6 +2806,17 @@
                 "postcss-selector-parser": "^6.0.10"
             }
         },
+        "node_modules/@datastream/core": {
+            "version": "0.0.35",
+            "resolved": "https://registry.npmjs.org/@datastream/core/-/core-0.0.35.tgz",
+            "integrity": "sha512-jmKFcDTYqtDy8DHPahaheg3MlLBiQboYX4jYX8oxE1tO5x7cfLl5M6bqR/o46RCEFZ3M9yMVfEEh0hy5raErEw==",
+            "dependencies": {
+                "cloneable-readable": "3.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -3655,11 +3666,14 @@
             "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
         },
         "node_modules/@middy/core": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/@middy/core/-/core-4.5.5.tgz",
-            "integrity": "sha512-aufpLnrpIcGrpd1cjqWR1fc5iSbO2K63GPkUooT+jtI/M7mofqSkr1dtfPx7fRtAFlZVuAjHCF52wJxGgfj1Ng==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@middy/core/-/core-5.1.0.tgz",
+            "integrity": "sha512-JpQ5vEPvFBbmGtUyVeeMHlxFCqam2oHND7ZAti/xm80p9ioN5Ps7uNUIrb+cUH6PEc5y+uP3Opnjn5UkGLWiWg==",
+            "dependencies": {
+                "@datastream/core": "0.0.35"
+            },
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
             },
             "funding": {
                 "type": "github",
@@ -3667,14 +3681,14 @@
             }
         },
         "node_modules/@middy/http-cors": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/@middy/http-cors/-/http-cors-4.5.5.tgz",
-            "integrity": "sha512-gbbduePUTismeQwDtXJC4Gxg+3fbyhNRjr8zjxcuqPiSm57NLyTPk67m0O3CpZy13kpM2GIvsW5/8oYR8UTihw==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@middy/http-cors/-/http-cors-5.1.0.tgz",
+            "integrity": "sha512-8CYRmmieJ0e8pcTUENALPCh28tElc/ly5XnyOfX7ftUeRLdfUqGiBIC3Id+qdsshJzDha5LMxTPQQOty5YXVIg==",
             "dependencies": {
-                "@middy/util": "4.5.5"
+                "@middy/util": "5.1.0"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
             },
             "funding": {
                 "type": "github",
@@ -3682,11 +3696,11 @@
             }
         },
         "node_modules/@middy/util": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/@middy/util/-/util-4.5.5.tgz",
-            "integrity": "sha512-Dx4L/8cAvKqHKo7VA2oS3fv5nvGsDgGsgFfsvMZ/1p7+WkPCCyS2tWD0o/aioZiuLy0DTq8u1W6U0+8k8nQgpQ==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@middy/util/-/util-5.1.0.tgz",
+            "integrity": "sha512-llQ7bslGANeDBfby9lkByv995fF8vHW7czVWVOAcxMXkqYShZzbN89aoNSsf21N4k8FWCwod7N+zED/3NKsesA==",
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
             },
             "funding": {
                 "type": "github",
@@ -5783,6 +5797,17 @@
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
             "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
         },
+        "node_modules/abort-controller": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+            "dependencies": {
+                "event-target-shim": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=6.5"
+            }
+        },
         "node_modules/accepts": {
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -6514,7 +6539,6 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -7008,6 +7032,52 @@
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
                 "wrap-ansi": "^7.0.0"
+            }
+        },
+        "node_modules/cloneable-readable": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-3.0.0.tgz",
+            "integrity": "sha512-Lkfd9IRx1nfiBr7UHNxJSl/x7DOeUfYmxzCkxYJC2tyc/9vKgV75msgLGurGQsak/NvJDHMWcshzEXRlxfvhqg==",
+            "dependencies": {
+                "readable-stream": "^4.0.0"
+            }
+        },
+        "node_modules/cloneable-readable/node_modules/buffer": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
+            }
+        },
+        "node_modules/cloneable-readable/node_modules/readable-stream": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+            "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "buffer": "^6.0.3",
+                "events": "^3.3.0",
+                "process": "^0.11.10",
+                "string_decoder": "^1.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
         "node_modules/co": {
@@ -9136,6 +9206,14 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/event-target-shim": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/eventemitter3": {
             "version": "4.0.7",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -10552,7 +10630,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
             "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -19415,6 +19492,14 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/process": {
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -25438,6 +25523,14 @@
             "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
             "requires": {}
         },
+        "@datastream/core": {
+            "version": "0.0.35",
+            "resolved": "https://registry.npmjs.org/@datastream/core/-/core-0.0.35.tgz",
+            "integrity": "sha512-jmKFcDTYqtDy8DHPahaheg3MlLBiQboYX4jYX8oxE1tO5x7cfLl5M6bqR/o46RCEFZ3M9yMVfEEh0hy5raErEw==",
+            "requires": {
+                "cloneable-readable": "3.0.0"
+            }
+        },
         "@eslint-community/eslint-utils": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -26063,22 +26156,25 @@
             "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
         },
         "@middy/core": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/@middy/core/-/core-4.5.5.tgz",
-            "integrity": "sha512-aufpLnrpIcGrpd1cjqWR1fc5iSbO2K63GPkUooT+jtI/M7mofqSkr1dtfPx7fRtAFlZVuAjHCF52wJxGgfj1Ng=="
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@middy/core/-/core-5.1.0.tgz",
+            "integrity": "sha512-JpQ5vEPvFBbmGtUyVeeMHlxFCqam2oHND7ZAti/xm80p9ioN5Ps7uNUIrb+cUH6PEc5y+uP3Opnjn5UkGLWiWg==",
+            "requires": {
+                "@datastream/core": "0.0.35"
+            }
         },
         "@middy/http-cors": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/@middy/http-cors/-/http-cors-4.5.5.tgz",
-            "integrity": "sha512-gbbduePUTismeQwDtXJC4Gxg+3fbyhNRjr8zjxcuqPiSm57NLyTPk67m0O3CpZy13kpM2GIvsW5/8oYR8UTihw==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@middy/http-cors/-/http-cors-5.1.0.tgz",
+            "integrity": "sha512-8CYRmmieJ0e8pcTUENALPCh28tElc/ly5XnyOfX7ftUeRLdfUqGiBIC3Id+qdsshJzDha5LMxTPQQOty5YXVIg==",
             "requires": {
-                "@middy/util": "4.5.5"
+                "@middy/util": "5.1.0"
             }
         },
         "@middy/util": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/@middy/util/-/util-4.5.5.tgz",
-            "integrity": "sha512-Dx4L/8cAvKqHKo7VA2oS3fv5nvGsDgGsgFfsvMZ/1p7+WkPCCyS2tWD0o/aioZiuLy0DTq8u1W6U0+8k8nQgpQ=="
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@middy/util/-/util-5.1.0.tgz",
+            "integrity": "sha512-llQ7bslGANeDBfby9lkByv995fF8vHW7czVWVOAcxMXkqYShZzbN89aoNSsf21N4k8FWCwod7N+zED/3NKsesA=="
         },
         "@nicolo-ribaudo/eslint-scope-5-internals": {
             "version": "5.1.1-v1",
@@ -27669,6 +27765,14 @@
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
             "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
         },
+        "abort-controller": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+            "requires": {
+                "event-target-shim": "^5.0.0"
+            }
+        },
         "accepts": {
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -28202,8 +28306,7 @@
         "base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
         "batch": {
             "version": "0.6.1",
@@ -28550,6 +28653,37 @@
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
                 "wrap-ansi": "^7.0.0"
+            }
+        },
+        "cloneable-readable": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-3.0.0.tgz",
+            "integrity": "sha512-Lkfd9IRx1nfiBr7UHNxJSl/x7DOeUfYmxzCkxYJC2tyc/9vKgV75msgLGurGQsak/NvJDHMWcshzEXRlxfvhqg==",
+            "requires": {
+                "readable-stream": "^4.0.0"
+            },
+            "dependencies": {
+                "buffer": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+                    "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+                    "requires": {
+                        "base64-js": "^1.3.1",
+                        "ieee754": "^1.2.1"
+                    }
+                },
+                "readable-stream": {
+                    "version": "4.4.2",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+                    "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+                    "requires": {
+                        "abort-controller": "^3.0.0",
+                        "buffer": "^6.0.3",
+                        "events": "^3.3.0",
+                        "process": "^0.11.10",
+                        "string_decoder": "^1.3.0"
+                    }
+                }
             }
         },
         "co": {
@@ -30096,6 +30230,11 @@
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
             "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
         },
+        "event-target-shim": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+        },
         "eventemitter3": {
             "version": "4.0.7",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -31112,8 +31251,7 @@
         "ieee754": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "dev": true
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
         },
         "ignore": {
             "version": "5.2.4",
@@ -37110,6 +37248,11 @@
                     "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="
                 }
             }
+        },
+        "process": {
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
         },
         "process-nextick-args": {
             "version": "2.0.1",

--- a/examples/aws/with-emailpassword/package.json
+++ b/examples/aws/with-emailpassword/package.json
@@ -16,8 +16,8 @@
     "license": "ISC",
     "dependencies": {
         "@aws-sdk/client-lambda": "^3.363.0",
-        "@middy/core": "^4.5.5",
-        "@middy/http-cors": "^4.5.5",
+        "@middy/core": "^5.1.0",
+        "@middy/http-cors": "^5.1.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",

--- a/examples/aws/with-emailpassword/test/helpers/aws-lambda.js
+++ b/examples/aws/with-emailpassword/test/helpers/aws-lambda.js
@@ -119,6 +119,11 @@ const setup_aws = async () => {
             // CompatibleArchitectures
             "arm64",
         ],
+        Environment: {
+            Variables: {
+                NODE_OPTIONS: "--experimental-specifier-resolution=node", // For more info - https://nodejs.org/docs/latest-v16.x/api/esm.html#customizing-esm-specifier-resolution-algorithm
+            },
+        },
     });
 
     const updateConfigResp = await client.send(updateConfig);

--- a/examples/aws/with-emailpassword/test/helpers/lambda-layer.sh
+++ b/examples/aws/with-emailpassword/test/helpers/lambda-layer.sh
@@ -1,6 +1,6 @@
 mkdir lambda && cd lambda
 npm init -y
-npm i -s @middy/core@4.5.5 @middy/http-cors@4.5.5
+npm i -s @middy/core @middy/http-cors
 npm i --save git+ssh://git@github.com:supertokens/supertokens-node.git#$GITHUB_REF_NAME
 mkdir nodejs
 cp -r node_modules nodejs


### PR DESCRIPTION
## Summary of change

This PR updates the AWS example to use esm imports allowing us to use the latest version of `middy`.


## Test Plan

No new tests needed to be added.

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

