### PR TITLE
Adds user context to validate function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [16.6.6] - 2023-12-17
+
+-   Adds `userContext` input to the `validate` function in form fields. You can use this to fetch the request object from the `userContext`, read the request body, and then read the other form fields from there. If doing so, keep in mind that for the email and password validators, the request object may not always be available in the `validate` function, and even if it's available, it may not have the request body of the sign up API since the `validate` functions are also called from other operations (like in password reset API). For custom form fields that you have added to the sign up API, the request object will always be there in the `userContext`.
+
 ## [16.6.5] - 2023-12-12
 
 -   CI/CD changes

--- a/lib/build/recipe/dashboard/api/userdetails/userPut.js
+++ b/lib/build/recipe/dashboard/api/userdetails/userPut.js
@@ -26,7 +26,7 @@ const updateEmailForRecipeId = async (recipeId, recipeUserId, email, tenantId, u
         let emailFormFields = recipe_1.default
             .getInstanceOrThrowError()
             .config.signUpFeature.formFields.filter((field) => field.id === constants_1.FORM_FIELD_EMAIL_ID);
-        let validationError = await emailFormFields[0].validate(email, tenantId);
+        let validationError = await emailFormFields[0].validate(email, tenantId, userContext);
         if (validationError !== undefined) {
             return {
                 status: "INVALID_EMAIL_ERROR",
@@ -58,7 +58,7 @@ const updateEmailForRecipeId = async (recipeId, recipeUserId, email, tenantId, u
         let emailFormFields = recipe_2.default
             .getInstanceOrThrowError()
             .config.signUpFeature.formFields.filter((field) => field.id === constants_1.FORM_FIELD_EMAIL_ID);
-        let validationError = await emailFormFields[0].validate(email, tenantId);
+        let validationError = await emailFormFields[0].validate(email, tenantId, userContext);
         if (validationError !== undefined) {
             return {
                 status: "INVALID_EMAIL_ERROR",

--- a/lib/build/recipe/emailpassword/api/generatePasswordResetToken.js
+++ b/lib/build/recipe/emailpassword/api/generatePasswordResetToken.js
@@ -26,7 +26,8 @@ async function generatePasswordResetToken(apiImplementation, tenantId, options, 
     let formFields = await utils_2.validateFormFieldsOrThrowError(
         options.config.resetPasswordUsingTokenFeature.formFieldsForGenerateTokenForm,
         requestBody.formFields,
-        tenantId
+        tenantId,
+        userContext
     );
     let result = await apiImplementation.generatePasswordResetTokenPOST({
         formFields,

--- a/lib/build/recipe/emailpassword/api/passwordReset.js
+++ b/lib/build/recipe/emailpassword/api/passwordReset.js
@@ -35,7 +35,8 @@ async function passwordReset(apiImplementation, tenantId, options, userContext) 
     let formFields = await utils_2.validateFormFieldsOrThrowError(
         options.config.resetPasswordUsingTokenFeature.formFieldsForPasswordResetForm,
         requestBody.formFields,
-        tenantId
+        tenantId,
+        userContext
     );
     let token = requestBody.token;
     if (token === undefined) {

--- a/lib/build/recipe/emailpassword/api/signin.js
+++ b/lib/build/recipe/emailpassword/api/signin.js
@@ -25,7 +25,8 @@ async function signInAPI(apiImplementation, tenantId, options, userContext) {
     let formFields = await utils_2.validateFormFieldsOrThrowError(
         options.config.signInFeature.formFields,
         (await options.req.getJSONBody()).formFields,
-        tenantId
+        tenantId,
+        userContext
     );
     let result = await apiImplementation.signInPOST({
         formFields,

--- a/lib/build/recipe/emailpassword/api/signup.js
+++ b/lib/build/recipe/emailpassword/api/signup.js
@@ -32,7 +32,8 @@ async function signUpAPI(apiImplementation, tenantId, options, userContext) {
     let formFields = await utils_2.validateFormFieldsOrThrowError(
         options.config.signUpFeature.formFields,
         requestBody.formFields,
-        tenantId
+        tenantId,
+        userContext
     );
     let result = await apiImplementation.signUpPOST({
         formFields,

--- a/lib/build/recipe/emailpassword/api/utils.d.ts
+++ b/lib/build/recipe/emailpassword/api/utils.d.ts
@@ -3,7 +3,8 @@ import { NormalisedFormField } from "../types";
 export declare function validateFormFieldsOrThrowError(
     configFormFields: NormalisedFormField[],
     formFieldsRaw: any,
-    tenantId: string
+    tenantId: string,
+    userContext: any
 ): Promise<
     {
         id: string;

--- a/lib/build/recipe/emailpassword/api/utils.js
+++ b/lib/build/recipe/emailpassword/api/utils.js
@@ -8,7 +8,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.validateFormFieldsOrThrowError = void 0;
 const error_1 = __importDefault(require("../error"));
 const constants_1 = require("../constants");
-async function validateFormFieldsOrThrowError(configFormFields, formFieldsRaw, tenantId) {
+async function validateFormFieldsOrThrowError(configFormFields, formFieldsRaw, tenantId, userContext) {
     // first we check syntax ----------------------------
     if (formFieldsRaw === undefined) {
         throw newBadRequestError("Missing input param: formFields");
@@ -40,7 +40,7 @@ async function validateFormFieldsOrThrowError(configFormFields, formFieldsRaw, t
         return field;
     });
     // then run validators through them-----------------------
-    await validateFormOrThrowError(formFields, configFormFields, tenantId);
+    await validateFormOrThrowError(formFields, configFormFields, tenantId, userContext);
     return formFields;
 }
 exports.validateFormFieldsOrThrowError = validateFormFieldsOrThrowError;
@@ -52,7 +52,7 @@ function newBadRequestError(message) {
 }
 // We check that the number of fields in input and config form field is the same.
 // We check that each item in the config form field is also present in the input form field
-async function validateFormOrThrowError(inputs, configFormFields, tenantId) {
+async function validateFormOrThrowError(inputs, configFormFields, tenantId, userContext) {
     let validationErrors = [];
     if (configFormFields.length !== inputs.length) {
         throw newBadRequestError("Are you sending too many / too few formFields?");
@@ -70,7 +70,7 @@ async function validateFormOrThrowError(inputs, configFormFields, tenantId) {
             });
         } else {
             // Otherwise, use validate function.
-            const error = await field.validate(input.value, tenantId);
+            const error = await field.validate(input.value, tenantId, userContext);
             // If error, add it.
             if (error !== undefined) {
                 validationErrors.push({

--- a/lib/build/recipe/emailpassword/recipeImplementation.js
+++ b/lib/build/recipe/emailpassword/recipeImplementation.js
@@ -127,7 +127,11 @@ function getRecipeInterface(querier, getEmailPasswordConfig) {
                 let formFields = getEmailPasswordConfig().signUpFeature.formFields;
                 if (input.password !== undefined) {
                     const passwordField = formFields.filter((el) => el.id === constants_1.FORM_FIELD_PASSWORD_ID)[0];
-                    const error = await passwordField.validate(input.password, input.tenantIdForPasswordPolicy);
+                    const error = await passwordField.validate(
+                        input.password,
+                        input.tenantIdForPasswordPolicy,
+                        input.userContext
+                    );
                     if (error !== undefined) {
                         return {
                             status: "PASSWORD_POLICY_VIOLATED_ERROR",

--- a/lib/build/recipe/emailpassword/types.d.ts
+++ b/lib/build/recipe/emailpassword/types.d.ts
@@ -26,7 +26,7 @@ export declare type TypeNormalisedInput = {
 };
 export declare type TypeInputFormField = {
     id: string;
-    validate?: (value: any, tenantId: string) => Promise<string | undefined>;
+    validate?: (value: any, tenantId: string, userContext: any) => Promise<string | undefined>;
     optional?: boolean;
 };
 export declare type TypeFormField = {
@@ -38,7 +38,7 @@ export declare type TypeInputSignUp = {
 };
 export declare type NormalisedFormField = {
     id: string;
-    validate: (value: any, tenantId: string) => Promise<string | undefined>;
+    validate: (value: any, tenantId: string, userContext: any) => Promise<string | undefined>;
     optional: boolean;
 };
 export declare type TypeNormalisedInputSignUp = {

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "16.6.5";
+export declare const version = "16.6.6";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.9";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "16.6.5";
+exports.version = "16.6.6";
 exports.cdiSupported = ["4.0"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.9";

--- a/lib/ts/recipe/dashboard/api/userdetails/userPut.ts
+++ b/lib/ts/recipe/dashboard/api/userdetails/userPut.ts
@@ -69,7 +69,7 @@ const updateEmailForRecipeId = async (
             (field) => field.id === FORM_FIELD_EMAIL_ID
         );
 
-        let validationError = await emailFormFields[0].validate(email, tenantId);
+        let validationError = await emailFormFields[0].validate(email, tenantId, userContext);
 
         if (validationError !== undefined) {
             return {
@@ -107,7 +107,7 @@ const updateEmailForRecipeId = async (
             (field) => field.id === FORM_FIELD_EMAIL_ID
         );
 
-        let validationError = await emailFormFields[0].validate(email, tenantId);
+        let validationError = await emailFormFields[0].validate(email, tenantId, userContext);
 
         if (validationError !== undefined) {
             return {

--- a/lib/ts/recipe/emailpassword/api/generatePasswordResetToken.ts
+++ b/lib/ts/recipe/emailpassword/api/generatePasswordResetToken.ts
@@ -38,7 +38,8 @@ export default async function generatePasswordResetToken(
     }[] = await validateFormFieldsOrThrowError(
         options.config.resetPasswordUsingTokenFeature.formFieldsForGenerateTokenForm,
         requestBody.formFields,
-        tenantId
+        tenantId,
+        userContext
     );
 
     let result = await apiImplementation.generatePasswordResetTokenPOST({

--- a/lib/ts/recipe/emailpassword/api/passwordReset.ts
+++ b/lib/ts/recipe/emailpassword/api/passwordReset.ts
@@ -42,7 +42,8 @@ export default async function passwordReset(
     }[] = await validateFormFieldsOrThrowError(
         options.config.resetPasswordUsingTokenFeature.formFieldsForPasswordResetForm,
         requestBody.formFields,
-        tenantId
+        tenantId,
+        userContext
     );
 
     let token = requestBody.token;

--- a/lib/ts/recipe/emailpassword/api/signin.ts
+++ b/lib/ts/recipe/emailpassword/api/signin.ts
@@ -35,7 +35,8 @@ export default async function signInAPI(
     }[] = await validateFormFieldsOrThrowError(
         options.config.signInFeature.formFields,
         (await options.req.getJSONBody()).formFields,
-        tenantId
+        tenantId,
+        userContext
     );
 
     let result = await apiImplementation.signInPOST({

--- a/lib/ts/recipe/emailpassword/api/signup.ts
+++ b/lib/ts/recipe/emailpassword/api/signup.ts
@@ -39,7 +39,8 @@ export default async function signUpAPI(
     }[] = await validateFormFieldsOrThrowError(
         options.config.signUpFeature.formFields,
         requestBody.formFields,
-        tenantId
+        tenantId,
+        userContext
     );
 
     let result = await apiImplementation.signUpPOST({

--- a/lib/ts/recipe/emailpassword/api/utils.ts
+++ b/lib/ts/recipe/emailpassword/api/utils.ts
@@ -19,7 +19,8 @@ import { FORM_FIELD_EMAIL_ID, FORM_FIELD_PASSWORD_ID } from "../constants";
 export async function validateFormFieldsOrThrowError(
     configFormFields: NormalisedFormField[],
     formFieldsRaw: any,
-    tenantId: string
+    tenantId: string,
+    userContext: any
 ): Promise<
     {
         id: string;
@@ -68,7 +69,7 @@ export async function validateFormFieldsOrThrowError(
     });
 
     // then run validators through them-----------------------
-    await validateFormOrThrowError(formFields, configFormFields, tenantId);
+    await validateFormOrThrowError(formFields, configFormFields, tenantId, userContext);
 
     return formFields;
 }
@@ -88,7 +89,8 @@ async function validateFormOrThrowError(
         value: string;
     }[],
     configFormFields: NormalisedFormField[],
-    tenantId: string
+    tenantId: string,
+    userContext: any
 ) {
     let validationErrors: { id: string; error: string }[] = [];
 
@@ -111,7 +113,7 @@ async function validateFormOrThrowError(
             });
         } else {
             // Otherwise, use validate function.
-            const error = await field.validate(input.value, tenantId);
+            const error = await field.validate(input.value, tenantId, userContext);
             // If error, add it.
             if (error !== undefined) {
                 validationErrors.push({

--- a/lib/ts/recipe/emailpassword/recipeImplementation.ts
+++ b/lib/ts/recipe/emailpassword/recipeImplementation.ts
@@ -215,7 +215,11 @@ export default function getRecipeInterface(
                 let formFields = getEmailPasswordConfig().signUpFeature.formFields;
                 if (input.password !== undefined) {
                     const passwordField = formFields.filter((el) => el.id === FORM_FIELD_PASSWORD_ID)[0];
-                    const error = await passwordField.validate(input.password, input.tenantIdForPasswordPolicy);
+                    const error = await passwordField.validate(
+                        input.password,
+                        input.tenantIdForPasswordPolicy,
+                        input.userContext
+                    );
                     if (error !== undefined) {
                         return {
                             status: "PASSWORD_POLICY_VIOLATED_ERROR",

--- a/lib/ts/recipe/emailpassword/types.ts
+++ b/lib/ts/recipe/emailpassword/types.ts
@@ -42,7 +42,7 @@ export type TypeNormalisedInput = {
 
 export type TypeInputFormField = {
     id: string;
-    validate?: (value: any, tenantId: string) => Promise<string | undefined>;
+    validate?: (value: any, tenantId: string, userContext: any) => Promise<string | undefined>;
     optional?: boolean;
 };
 
@@ -54,7 +54,7 @@ export type TypeInputSignUp = {
 
 export type NormalisedFormField = {
     id: string;
-    validate: (value: any, tenantId: string) => Promise<string | undefined>;
+    validate: (value: any, tenantId: string, userContext: any) => Promise<string | undefined>;
     optional: boolean;
 };
 

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "16.6.5";
+export const version = "16.6.6";
 
 export const cdiSupported = ["4.0"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "16.6.5",
+    "version": "16.6.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "16.6.5",
+            "version": "16.6.6",
             "license": "Apache-2.0",
             "dependencies": {
                 "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "16.6.5",
+    "version": "16.6.6",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {

--- a/test/with-typescript/index.ts
+++ b/test/with-typescript/index.ts
@@ -1279,6 +1279,22 @@ async function f() {
 }
 
 EmailPassword.init({
+    signUpFeature: {
+        formFields: [
+            {
+                id: "abc",
+                validate: async (value, tenantId) => {
+                    return "";
+                },
+            },
+            {
+                id: "abc",
+                validate: async (value, tenantId, userContext) => {
+                    return undefined;
+                },
+            },
+        ],
+    },
     override: {
         apis: (originalImplementation) => {
             return {
@@ -1747,7 +1763,24 @@ async function refreshSessionWithoutRequestResponse(req: express.Request, resp: 
 }
 
 ThirdParty.init();
-ThirdPartyEmailPassword.init();
+ThirdPartyEmailPassword.init({
+    signUpFeature: {
+        formFields: [
+            {
+                id: "abc",
+                validate: async (value, tenantId) => {
+                    return "";
+                },
+            },
+            {
+                id: "abc",
+                validate: async (value, tenantId, userContext) => {
+                    return undefined;
+                },
+            },
+        ],
+    },
+});
 ThirdPartyPasswordless.init({
     contactMethod: "EMAIL",
     flowType: "MAGIC_LINK",


### PR DESCRIPTION
## Summary of change

Adds userContext to validate function in the form field validators, so that users can read other form fields from the request body whilst validating one form field.

## Test Plan

Added a tests in email password recipe to check other form field and return an error

## Documentation changes

TODO

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
