### PR TITLE
fix: use custom impl for Headers class when no built-in is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [16.6.6] - 2023-12-17
 
 -   Adds `userContext` input to the `validate` function in form fields. You can use this to fetch the request object from the `userContext`, read the request body, and then read the other form fields from there. If doing so, keep in mind that for the email and password validators, the request object may not always be available in the `validate` function, and even if it's available, it may not have the request body of the sign up API since the `validate` functions are also called from other operations (like in password reset API). For custom form fields that you have added to the sign up API, the request object will always be there in the `userContext`.
+-   Fixes support for the custom framework on node 16 by optionally using an implementation of the Headers class (from `node-fetch`)
 
 ## [16.6.5] - 2023-12-12
 

--- a/lib/build/framework/custom/framework.js
+++ b/lib/build/framework/custom/framework.js
@@ -24,6 +24,7 @@ const utils_1 = require("../../utils");
 const request_1 = require("../request");
 const response_1 = require("../response");
 const supertokens_1 = __importDefault(require("../../supertokens"));
+const nodeHeaders_1 = __importDefault(require("./nodeHeaders"));
 class PreParsedRequest extends request_1.BaseRequest {
     constructor(request) {
         super();
@@ -108,7 +109,13 @@ class CollectingResponse extends response_1.BaseResponse {
             this.headers.set("Content-Type", "application/json");
             this.body = JSON.stringify(content);
         };
-        this.headers = new Headers();
+        // In node16 the Headers class is only supported behind an experimental flag, so we sometimes need to add an implementation for it
+        // Still, if available we are using the built-in (node 18+)
+        if (typeof Headers === "undefined") {
+            this.headers = new nodeHeaders_1.default(null);
+        } else {
+            this.headers = new Headers();
+        }
         this.statusCode = 200;
         this.cookies = [];
     }

--- a/lib/build/framework/custom/nodeHeaders.d.ts
+++ b/lib/build/framework/custom/nodeHeaders.d.ts
@@ -1,0 +1,43 @@
+// @ts-nocheck
+/**
+ * @typedef {Headers | Record<string, string> | Iterable<readonly [string, string]> | Iterable<Iterable<string>>} HeadersInit
+ */
+/**
+ * This Fetch API interface allows you to perform various actions on HTTP request and response headers.
+ * These actions include retrieving, setting, adding to, and removing.
+ * A Headers object has an associated header list, which is initially empty and consists of zero or more name and value pairs.
+ * You can add to this using methods like append() (see Examples.)
+ * In all methods of this interface, header names are matched by case-insensitive byte sequence.
+ *
+ */
+export default class Headers extends URLSearchParams {
+    /**
+     * Headers class
+     *
+     * @constructor
+     * @param {HeadersInit} [init] - Response headers
+     */
+    constructor(init: any);
+    get [Symbol.toStringTag](): string;
+    toString(): string;
+    get(name: any): string | null;
+    forEach(callback: any, thisArg?: undefined): void;
+    values(): Generator<string | null, void, unknown>;
+    /**
+     * @type {() => IterableIterator<[string, string]>}
+     */
+    entries(): Generator<(string | null)[], void, unknown>;
+    [Symbol.iterator](): Generator<(string | null)[], void, unknown>;
+    /**
+     * Node-fetch non-spec method
+     * returning all headers and their values as array
+     * @returns {Record<string, string[]>}
+     */
+    raw(): {};
+}
+/**
+ * Create a Headers object from an http.IncomingMessage.rawHeaders, ignoring those that do
+ * not conform to HTTP grammar productions.
+ * @param {import('http').IncomingMessage['rawHeaders']} headers
+ */
+export declare function fromRawHeaders(headers?: never[]): Headers;

--- a/lib/build/framework/custom/nodeHeaders.js
+++ b/lib/build/framework/custom/nodeHeaders.js
@@ -1,0 +1,255 @@
+"use strict";
+// @ts-nocheck This is basically plain JS from another lib
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.fromRawHeaders = void 0;
+/* From https://github.com/lquixada/node-fetch/blob/master/src/headers.js */
+/* License:
+The MIT License (MIT)
+
+Copyright (c) 2016 - 2020 Node Fetch Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+const util_1 = require("util");
+const http_1 = __importDefault(require("http"));
+const validateHeaderName =
+    typeof http_1.default.validateHeaderName === "function"
+        ? http_1.default.validateHeaderName
+        : (name) => {
+              if (!/^[\^`\-\w!#$%&'*+.|~]+$/.test(name)) {
+                  const err = new TypeError(`Header name must be a valid HTTP token [${name}]`);
+                  Object.defineProperty(err, "code", { value: "ERR_INVALID_HTTP_TOKEN" });
+                  throw err;
+              }
+          };
+const validateHeaderValue =
+    typeof http_1.default.validateHeaderValue === "function"
+        ? http_1.default.validateHeaderValue
+        : (name, value) => {
+              if (/[^\t\u0020-\u007E\u0080-\u00FF]/.test(value)) {
+                  const err = new TypeError(`Invalid character in header content ["${name}"]`);
+                  Object.defineProperty(err, "code", { value: "ERR_INVALID_CHAR" });
+                  throw err;
+              }
+          };
+/**
+ * @typedef {Headers | Record<string, string> | Iterable<readonly [string, string]> | Iterable<Iterable<string>>} HeadersInit
+ */
+/**
+ * This Fetch API interface allows you to perform various actions on HTTP request and response headers.
+ * These actions include retrieving, setting, adding to, and removing.
+ * A Headers object has an associated header list, which is initially empty and consists of zero or more name and value pairs.
+ * You can add to this using methods like append() (see Examples.)
+ * In all methods of this interface, header names are matched by case-insensitive byte sequence.
+ *
+ */
+class Headers extends URLSearchParams {
+    /**
+     * Headers class
+     *
+     * @constructor
+     * @param {HeadersInit} [init] - Response headers
+     */
+    constructor(init) {
+        // Validate and normalize init object in [name, value(s)][]
+        /** @type {string[][]} */
+        let result = [];
+        if (init instanceof Headers) {
+            const raw = init.raw();
+            for (const [name, values] of Object.entries(raw)) {
+                result.push(...values.map((value) => [name, value]));
+            }
+        } else if (init == null) {
+            // eslint-disable-line no-eq-null, eqeqeq
+            // No op
+        } else if (typeof init === "object" && !util_1.types.isBoxedPrimitive(init)) {
+            const method = init[Symbol.iterator];
+            // eslint-disable-next-line no-eq-null, eqeqeq
+            if (method == null) {
+                // Record<ByteString, ByteString>
+                result.push(...Object.entries(init));
+            } else {
+                if (typeof method !== "function") {
+                    throw new TypeError("Header pairs must be iterable");
+                }
+                // Sequence<sequence<ByteString>>
+                // Note: per spec we have to first exhaust the lists then process them
+                result = [...init]
+                    .map((pair) => {
+                        if (typeof pair !== "object" || util_1.types.isBoxedPrimitive(pair)) {
+                            throw new TypeError("Each header pair must be an iterable object");
+                        }
+                        return [...pair];
+                    })
+                    .map((pair) => {
+                        if (pair.length !== 2) {
+                            throw new TypeError("Each header pair must be a name/value tuple");
+                        }
+                        return [...pair];
+                    });
+            }
+        } else {
+            throw new TypeError(
+                "Failed to construct 'Headers': The provided value is not of type '(sequence<sequence<ByteString>> or record<ByteString, ByteString>)"
+            );
+        }
+        // Validate and lowercase
+        result =
+            result.length > 0
+                ? result.map(([name, value]) => {
+                      validateHeaderName(name);
+                      validateHeaderValue(name, String(value));
+                      return [String(name).toLowerCase(), String(value)];
+                  })
+                : undefined;
+        super(result);
+        // Returning a Proxy that will lowercase key names, validate parameters and sort keys
+        // eslint-disable-next-line no-constructor-return
+        return new Proxy(this, {
+            get(target, p, receiver) {
+                switch (p) {
+                    case "append":
+                    case "set":
+                        return (name, value) => {
+                            validateHeaderName(name);
+                            validateHeaderValue(name, String(value));
+                            return URLSearchParams.prototype[p].call(
+                                receiver,
+                                String(name).toLowerCase(),
+                                String(value)
+                            );
+                        };
+                    case "delete":
+                    case "has":
+                    case "getAll":
+                        return (name) => {
+                            validateHeaderName(name);
+                            return URLSearchParams.prototype[p].call(receiver, String(name).toLowerCase());
+                        };
+                    case "keys":
+                        return () => {
+                            target.sort();
+                            return new Set(URLSearchParams.prototype.keys.call(target)).keys();
+                        };
+                    default:
+                        return Reflect.get(target, p, receiver);
+                }
+            },
+            /* c8 ignore next */
+        });
+    }
+    get [Symbol.toStringTag]() {
+        return this.constructor.name;
+    }
+    toString() {
+        return Object.prototype.toString.call(this);
+    }
+    get(name) {
+        const values = this.getAll(name);
+        if (values.length === 0) {
+            return null;
+        }
+        let value = values.join(", ");
+        if (/^content-encoding$/i.test(name)) {
+            value = value.toLowerCase();
+        }
+        return value;
+    }
+    forEach(callback, thisArg = undefined) {
+        for (const name of this.keys()) {
+            Reflect.apply(callback, thisArg, [this.get(name), name, this]);
+        }
+    }
+    *values() {
+        for (const name of this.keys()) {
+            yield this.get(name);
+        }
+    }
+    /**
+     * @type {() => IterableIterator<[string, string]>}
+     */
+    *entries() {
+        for (const name of this.keys()) {
+            yield [name, this.get(name)];
+        }
+    }
+    [Symbol.iterator]() {
+        return this.entries();
+    }
+    /**
+     * Node-fetch non-spec method
+     * returning all headers and their values as array
+     * @returns {Record<string, string[]>}
+     */
+    raw() {
+        return [...this.keys()].reduce((result, key) => {
+            result[key] = this.getAll(key);
+            return result;
+        }, {});
+    }
+    /**
+     * For better console.log(headers) and also to convert Headers into Node.js Request compatible format
+     */
+    [Symbol.for("nodejs.util.inspect.custom")]() {
+        return [...this.keys()].reduce((result, key) => {
+            const values = this.getAll(key);
+            // Http.request() only supports string as Host header.
+            // This hack makes specifying custom Host header possible.
+            if (key === "host") {
+                result[key] = values[0];
+            } else {
+                result[key] = values.length > 1 ? values : values[0];
+            }
+            return result;
+        }, {});
+    }
+}
+exports.default = Headers;
+/**
+ * Re-shaping object for Web IDL tests
+ * Only need to do it for overridden methods
+ */
+Object.defineProperties(
+    Headers.prototype,
+    ["get", "entries", "forEach", "values"].reduce((result, property) => {
+        result[property] = { enumerable: true };
+        return result;
+    }, {})
+);
+/**
+ * Create a Headers object from an http.IncomingMessage.rawHeaders, ignoring those that do
+ * not conform to HTTP grammar productions.
+ * @param {import('http').IncomingMessage['rawHeaders']} headers
+ */
+function fromRawHeaders(headers = []) {
+    return new Headers(
+        headers
+            // Split into pairs
+            .reduce((result, value, index, array) => {
+                if (index % 2 === 0) {
+                    result.push(array.slice(index, index + 2));
+                }
+                return result;
+            }, [])
+            .filter(([name, value]) => {
+                try {
+                    validateHeaderName(name);
+                    validateHeaderValue(name, String(value));
+                    return true;
+                } catch (_a) {
+                    return false;
+                }
+            })
+    );
+}
+exports.fromRawHeaders = fromRawHeaders;

--- a/lib/ts/framework/custom/framework.ts
+++ b/lib/ts/framework/custom/framework.ts
@@ -19,6 +19,7 @@ import { BaseRequest } from "../request";
 import { BaseResponse } from "../response";
 import SuperTokens from "../../supertokens";
 import { SessionContainerInterface } from "../../recipe/session/types";
+import NodeHeaders from "./nodeHeaders";
 
 type RequestInfo = {
     url: string;
@@ -105,7 +106,13 @@ export class CollectingResponse extends BaseResponse {
 
     constructor() {
         super();
-        this.headers = new Headers();
+        // In node16 the Headers class is only supported behind an experimental flag, so we sometimes need to add an implementation for it
+        // Still, if available we are using the built-in (node 18+)
+        if (typeof Headers === "undefined") {
+            this.headers = new NodeHeaders(null) as any;
+        } else {
+            this.headers = new Headers();
+        }
         this.statusCode = 200;
         this.cookies = [];
     }

--- a/lib/ts/framework/custom/nodeHeaders.ts
+++ b/lib/ts/framework/custom/nodeHeaders.ts
@@ -1,0 +1,276 @@
+// @ts-nocheck This is basically plain JS from another lib
+
+/* From https://github.com/lquixada/node-fetch/blob/master/src/headers.js */
+
+/* License:
+The MIT License (MIT)
+
+Copyright (c) 2016 - 2020 Node Fetch Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+import { types } from "util";
+import http from "http";
+
+const validateHeaderName =
+    typeof http.validateHeaderName === "function"
+        ? http.validateHeaderName
+        : (name) => {
+              if (!/^[\^`\-\w!#$%&'*+.|~]+$/.test(name)) {
+                  const err = new TypeError(`Header name must be a valid HTTP token [${name}]`);
+                  Object.defineProperty(err, "code", { value: "ERR_INVALID_HTTP_TOKEN" });
+                  throw err;
+              }
+          };
+
+const validateHeaderValue =
+    typeof http.validateHeaderValue === "function"
+        ? http.validateHeaderValue
+        : (name, value) => {
+              if (/[^\t\u0020-\u007E\u0080-\u00FF]/.test(value)) {
+                  const err = new TypeError(`Invalid character in header content ["${name}"]`);
+                  Object.defineProperty(err, "code", { value: "ERR_INVALID_CHAR" });
+                  throw err;
+              }
+          };
+
+/**
+ * @typedef {Headers | Record<string, string> | Iterable<readonly [string, string]> | Iterable<Iterable<string>>} HeadersInit
+ */
+
+/**
+ * This Fetch API interface allows you to perform various actions on HTTP request and response headers.
+ * These actions include retrieving, setting, adding to, and removing.
+ * A Headers object has an associated header list, which is initially empty and consists of zero or more name and value pairs.
+ * You can add to this using methods like append() (see Examples.)
+ * In all methods of this interface, header names are matched by case-insensitive byte sequence.
+ *
+ */
+export default class Headers extends URLSearchParams {
+    /**
+     * Headers class
+     *
+     * @constructor
+     * @param {HeadersInit} [init] - Response headers
+     */
+    constructor(init) {
+        // Validate and normalize init object in [name, value(s)][]
+        /** @type {string[][]} */
+        let result = [];
+        if (init instanceof Headers) {
+            const raw = init.raw();
+            for (const [name, values] of Object.entries(raw)) {
+                result.push(...values.map((value) => [name, value]));
+            }
+        } else if (init == null) {
+            // eslint-disable-line no-eq-null, eqeqeq
+            // No op
+        } else if (typeof init === "object" && !types.isBoxedPrimitive(init)) {
+            const method = init[Symbol.iterator];
+            // eslint-disable-next-line no-eq-null, eqeqeq
+            if (method == null) {
+                // Record<ByteString, ByteString>
+                result.push(...Object.entries(init));
+            } else {
+                if (typeof method !== "function") {
+                    throw new TypeError("Header pairs must be iterable");
+                }
+
+                // Sequence<sequence<ByteString>>
+                // Note: per spec we have to first exhaust the lists then process them
+                result = [...init]
+                    .map((pair) => {
+                        if (typeof pair !== "object" || types.isBoxedPrimitive(pair)) {
+                            throw new TypeError("Each header pair must be an iterable object");
+                        }
+
+                        return [...pair];
+                    })
+                    .map((pair) => {
+                        if (pair.length !== 2) {
+                            throw new TypeError("Each header pair must be a name/value tuple");
+                        }
+
+                        return [...pair];
+                    });
+            }
+        } else {
+            throw new TypeError(
+                "Failed to construct 'Headers': The provided value is not of type '(sequence<sequence<ByteString>> or record<ByteString, ByteString>)"
+            );
+        }
+
+        // Validate and lowercase
+        result =
+            result.length > 0
+                ? result.map(([name, value]) => {
+                      validateHeaderName(name);
+                      validateHeaderValue(name, String(value));
+                      return [String(name).toLowerCase(), String(value)];
+                  })
+                : undefined;
+
+        super(result);
+
+        // Returning a Proxy that will lowercase key names, validate parameters and sort keys
+        // eslint-disable-next-line no-constructor-return
+        return new Proxy(this, {
+            get(target, p, receiver) {
+                switch (p) {
+                    case "append":
+                    case "set":
+                        return (name, value) => {
+                            validateHeaderName(name);
+                            validateHeaderValue(name, String(value));
+                            return URLSearchParams.prototype[p].call(
+                                receiver,
+                                String(name).toLowerCase(),
+                                String(value)
+                            );
+                        };
+
+                    case "delete":
+                    case "has":
+                    case "getAll":
+                        return (name) => {
+                            validateHeaderName(name);
+                            return URLSearchParams.prototype[p].call(receiver, String(name).toLowerCase());
+                        };
+
+                    case "keys":
+                        return () => {
+                            target.sort();
+                            return new Set(URLSearchParams.prototype.keys.call(target)).keys();
+                        };
+
+                    default:
+                        return Reflect.get(target, p, receiver);
+                }
+            },
+            /* c8 ignore next */
+        });
+    }
+
+    get [Symbol.toStringTag]() {
+        return this.constructor.name;
+    }
+
+    toString() {
+        return Object.prototype.toString.call(this);
+    }
+
+    get(name) {
+        const values = this.getAll(name);
+        if (values.length === 0) {
+            return null;
+        }
+
+        let value = values.join(", ");
+        if (/^content-encoding$/i.test(name)) {
+            value = value.toLowerCase();
+        }
+
+        return value;
+    }
+
+    forEach(callback, thisArg = undefined) {
+        for (const name of this.keys()) {
+            Reflect.apply(callback, thisArg, [this.get(name), name, this]);
+        }
+    }
+
+    *values() {
+        for (const name of this.keys()) {
+            yield this.get(name);
+        }
+    }
+
+    /**
+     * @type {() => IterableIterator<[string, string]>}
+     */
+    *entries() {
+        for (const name of this.keys()) {
+            yield [name, this.get(name)];
+        }
+    }
+
+    [Symbol.iterator]() {
+        return this.entries();
+    }
+
+    /**
+     * Node-fetch non-spec method
+     * returning all headers and their values as array
+     * @returns {Record<string, string[]>}
+     */
+    raw() {
+        return [...this.keys()].reduce((result, key) => {
+            result[key] = this.getAll(key);
+            return result;
+        }, {});
+    }
+
+    /**
+     * For better console.log(headers) and also to convert Headers into Node.js Request compatible format
+     */
+    [Symbol.for("nodejs.util.inspect.custom")]() {
+        return [...this.keys()].reduce((result, key) => {
+            const values = this.getAll(key);
+            // Http.request() only supports string as Host header.
+            // This hack makes specifying custom Host header possible.
+            if (key === "host") {
+                result[key] = values[0];
+            } else {
+                result[key] = values.length > 1 ? values : values[0];
+            }
+
+            return result;
+        }, {});
+    }
+}
+
+/**
+ * Re-shaping object for Web IDL tests
+ * Only need to do it for overridden methods
+ */
+Object.defineProperties(
+    Headers.prototype,
+    ["get", "entries", "forEach", "values"].reduce((result, property) => {
+        result[property] = { enumerable: true };
+        return result;
+    }, {})
+);
+
+/**
+ * Create a Headers object from an http.IncomingMessage.rawHeaders, ignoring those that do
+ * not conform to HTTP grammar productions.
+ * @param {import('http').IncomingMessage['rawHeaders']} headers
+ */
+export function fromRawHeaders(headers = []) {
+    return new Headers(
+        headers
+            // Split into pairs
+            .reduce((result, value, index, array) => {
+                if (index % 2 === 0) {
+                    result.push(array.slice(index, index + 2));
+                }
+
+                return result;
+            }, [])
+            .filter(([name, value]) => {
+                try {
+                    validateHeaderName(name);
+                    validateHeaderValue(name, String(value));
+                    return true;
+                } catch {
+                    return false;
+                }
+            })
+    );
+}


### PR DESCRIPTION
## Summary of change

Add&use custom impl for Headers class when no built-in is available

## Related issues

-   https://app.circleci.com/pipelines/github/supertokens/supertokens-node/4865/workflows/9f3722bd-3070-454e-80e8-f7a019e4d8b5/jobs/2441

## Test Plan

Already tested

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
