### PR TITLE
fix: remove http dep to fix app dir support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [16.6.8] - 2023-12-18
+
+-   Fix App dir support by removing the import of the "http" module
+
 ## [16.6.7] - 2023-12-18
 
 -   Adds facebook user data by checking the scopes provided in the config

--- a/lib/build/framework/custom/nodeHeaders.js
+++ b/lib/build/framework/custom/nodeHeaders.js
@@ -1,10 +1,5 @@
 "use strict";
 // @ts-nocheck This is basically plain JS from another lib
-var __importDefault =
-    (this && this.__importDefault) ||
-    function (mod) {
-        return mod && mod.__esModule ? mod : { default: mod };
-    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.fromRawHeaders = void 0;
 /* From https://github.com/lquixada/node-fetch/blob/master/src/headers.js */
@@ -21,27 +16,20 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 */
 const util_1 = require("util");
-const http_1 = __importDefault(require("http"));
-const validateHeaderName =
-    typeof http_1.default.validateHeaderName === "function"
-        ? http_1.default.validateHeaderName
-        : (name) => {
-              if (!/^[\^`\-\w!#$%&'*+.|~]+$/.test(name)) {
-                  const err = new TypeError(`Header name must be a valid HTTP token [${name}]`);
-                  Object.defineProperty(err, "code", { value: "ERR_INVALID_HTTP_TOKEN" });
-                  throw err;
-              }
-          };
-const validateHeaderValue =
-    typeof http_1.default.validateHeaderValue === "function"
-        ? http_1.default.validateHeaderValue
-        : (name, value) => {
-              if (/[^\t\u0020-\u007E\u0080-\u00FF]/.test(value)) {
-                  const err = new TypeError(`Invalid character in header content ["${name}"]`);
-                  Object.defineProperty(err, "code", { value: "ERR_INVALID_CHAR" });
-                  throw err;
-              }
-          };
+const validateHeaderName = (name) => {
+    if (!/^[\^`\-\w!#$%&'*+.|~]+$/.test(name)) {
+        const err = new TypeError(`Header name must be a valid HTTP token [${name}]`);
+        Object.defineProperty(err, "code", { value: "ERR_INVALID_HTTP_TOKEN" });
+        throw err;
+    }
+};
+const validateHeaderValue = (name, value) => {
+    if (/[^\t\u0020-\u007E\u0080-\u00FF]/.test(value)) {
+        const err = new TypeError(`Invalid character in header content ["${name}"]`);
+        Object.defineProperty(err, "code", { value: "ERR_INVALID_CHAR" });
+        throw err;
+    }
+};
 /**
  * @typedef {Headers | Record<string, string> | Iterable<readonly [string, string]> | Iterable<Iterable<string>>} HeadersInit
  */

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "16.6.7";
+export declare const version = "16.6.8";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.9";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "16.6.7";
+exports.version = "16.6.8";
 exports.cdiSupported = ["4.0"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.9";

--- a/lib/ts/framework/custom/nodeHeaders.ts
+++ b/lib/ts/framework/custom/nodeHeaders.ts
@@ -16,29 +16,22 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 */
 
 import { types } from "util";
-import http from "http";
 
-const validateHeaderName =
-    typeof http.validateHeaderName === "function"
-        ? http.validateHeaderName
-        : (name) => {
-              if (!/^[\^`\-\w!#$%&'*+.|~]+$/.test(name)) {
-                  const err = new TypeError(`Header name must be a valid HTTP token [${name}]`);
-                  Object.defineProperty(err, "code", { value: "ERR_INVALID_HTTP_TOKEN" });
-                  throw err;
-              }
-          };
+const validateHeaderName = (name) => {
+    if (!/^[\^`\-\w!#$%&'*+.|~]+$/.test(name)) {
+        const err = new TypeError(`Header name must be a valid HTTP token [${name}]`);
+        Object.defineProperty(err, "code", { value: "ERR_INVALID_HTTP_TOKEN" });
+        throw err;
+    }
+};
 
-const validateHeaderValue =
-    typeof http.validateHeaderValue === "function"
-        ? http.validateHeaderValue
-        : (name, value) => {
-              if (/[^\t\u0020-\u007E\u0080-\u00FF]/.test(value)) {
-                  const err = new TypeError(`Invalid character in header content ["${name}"]`);
-                  Object.defineProperty(err, "code", { value: "ERR_INVALID_CHAR" });
-                  throw err;
-              }
-          };
+const validateHeaderValue = (name, value) => {
+    if (/[^\t\u0020-\u007E\u0080-\u00FF]/.test(value)) {
+        const err = new TypeError(`Invalid character in header content ["${name}"]`);
+        Object.defineProperty(err, "code", { value: "ERR_INVALID_CHAR" });
+        throw err;
+    }
+};
 
 /**
  * @typedef {Headers | Record<string, string> | Iterable<readonly [string, string]> | Iterable<Iterable<string>>} HeadersInit

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "16.6.7";
+export const version = "16.6.8";
 
 export const cdiSupported = ["4.0"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "16.6.7",
+    "version": "16.6.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "16.6.7",
+            "version": "16.6.8",
             "license": "Apache-2.0",
             "dependencies": {
                 "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "16.6.7",
+    "version": "16.6.8",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

remove http dep to fix app dir support

## Related issues

-   

## Test Plan

Manually tested

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
