### PR TITLE
fix: Update docker images + polyfill fetch by node-fetch for tests

### DIFF
--- a/.circleci/config_continue.yml
+++ b/.circleci/config_continue.yml
@@ -7,7 +7,7 @@ orbs:
 jobs:
     test-dev-tag-as-not-passed:
         docker:
-            - image: rishabhpoddar/supertokens_website_sdk_testing_node_20
+            - image: rishabhpoddar/supertokens_website_sdk_testing
         steps:
             - checkout
             - run: (cd .circleci/ && ./markDevTagAsTestNotPassed.sh)
@@ -30,7 +30,7 @@ jobs:
             - slack/status
     test-website:
         docker:
-            - image: rishabhpoddar/supertokens_website_sdk_testing_node_20
+            - image: rishabhpoddar/supertokens_website_sdk_testing
         resource_class: large
         parallelism: 4
         steps:
@@ -45,7 +45,7 @@ jobs:
             - slack/status
     test-authreact:
         docker:
-            - image: rishabhpoddar/supertokens_website_sdk_testing_node_20
+            - image: rishabhpoddar/supertokens_website_sdk_testing_node_16
         resource_class: large
         parallelism: 4
         steps:
@@ -63,7 +63,7 @@ jobs:
             - slack/status
     test-success:
         docker:
-            - image: rishabhpoddar/supertokens_website_sdk_testing_node_20
+            - image: rishabhpoddar/supertokens_website_sdk_testing
         steps:
             - checkout
             - run: (cd .circleci/ && ./markAsSuccess.sh)

--- a/.circleci/config_continue.yml
+++ b/.circleci/config_continue.yml
@@ -13,7 +13,7 @@ jobs:
             - run: (cd .circleci/ && ./markDevTagAsTestNotPassed.sh)
     test-unit:
         docker:
-            - image: rishabhpoddar/supertokens_website_sdk_testing_node_20
+            - image: rishabhpoddar/supertokens_node_driver_testing_node_20
         resource_class: large
         parameters:
             cdi-version:

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
                 "next": "^14.0.4",
                 "next-test-api-route-handler": "^3.1.10",
                 "nock": "11.7.0",
+                "node-fetch": "^2.7.0",
                 "prettier": "2.0.5",
                 "pretty-quick": "^3.1.1",
                 "react": "^18.2.0",
@@ -2155,25 +2156,6 @@
             "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
             "dependencies": {
                 "node-fetch": "^2.6.12"
-            }
-        },
-        "node_modules/cross-fetch/node_modules/node-fetch": {
-            "version": "2.6.12",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-            "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
             }
         },
         "node_modules/cross-spawn": {
@@ -4504,26 +4486,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/next-test-api-route-handler/node_modules/node-fetch": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-            "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-            "dev": true,
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/nise": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
@@ -4577,6 +4539,25 @@
             },
             "engines": {
                 "node": ">= 8.0"
+            }
+        },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
             }
         },
         "node_modules/nodemailer": {
@@ -8299,16 +8280,6 @@
             "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
             "requires": {
                 "node-fetch": "^2.6.12"
-            },
-            "dependencies": {
-                "node-fetch": {
-                    "version": "2.6.12",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-                    "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
-                    "requires": {
-                        "whatwg-url": "^5.0.0"
-                    }
-                }
             }
         },
         "cross-spawn": {
@@ -10112,15 +10083,6 @@
                     "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
                     "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
                     "dev": true
-                },
-                "node-fetch": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-                    "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-                    "dev": true,
-                    "requires": {
-                        "whatwg-url": "^5.0.0"
-                    }
                 }
             }
         },
@@ -10176,6 +10138,14 @@
                 "lodash": "^4.17.13",
                 "mkdirp": "^0.5.0",
                 "propagate": "^2.0.0"
+            }
+        },
+        "node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "requires": {
+                "whatwg-url": "^5.0.0"
             }
         },
         "nodemailer": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {
-        "test": "TEST_MODE=testing npx mocha --timeout 500000",
+        "test": "TEST_MODE=testing npx mocha --node-option no-experimental-fetch -r test/fetch-polyfill.js --timeout 500000",
         "build-check": "cd lib && npx tsc -p tsconfig.json --noEmit && cd ../test/with-typescript && npm run build",
         "build": "cd lib && rm -rf build && npx tsc -p tsconfig.json && cd ../test/with-typescript && npm run build && cd ../.. && npm run post-build",
         "pretty": "npx pretty-quick .",
@@ -79,6 +79,7 @@
         "next": "^14.0.4",
         "next-test-api-route-handler": "^3.1.10",
         "nock": "11.7.0",
+        "node-fetch": "^2.7.0",
         "prettier": "2.0.5",
         "pretty-quick": "^3.1.1",
         "react": "^18.2.0",

--- a/test/fetch-polyfill.js
+++ b/test/fetch-polyfill.js
@@ -1,0 +1,13 @@
+// In Node.js versions 18 and above, nock doesn't support native fetch. To address this, we disable it using the `--no-experimental-fetch` flag. Since our code relies on fetch, we polyfill it with node-fetch.
+// Related Issues:
+// https://github.com/nock/nock/issues/2397
+// https://github.com/nock/nock/issues/2183
+
+const fetch = require("node-fetch");
+
+if (!globalThis.fetch) {
+    globalThis.fetch = fetch;
+    globalThis.Headers = fetch.Headers;
+    globalThis.Request = fetch.Request;
+    globalThis.Response = fetch.Response;
+}


### PR DESCRIPTION
## Summary of change

This PR reverts the docker images for every other test other than unit as those were failing with the newer images.


## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.