### PR TITLE
fix: default to st-auth-mode if getTokenTransferMethod returns any in createNewSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+-   `createNewSession` now defaults to the value of the `st-auth-mode` header (if available) if the configured `getTokenTransferMethod` returns `any`.
+
 ## [16.7.1] - 2024-01-09
 
 -   Fixes type output of `resetPasswordUsingToken` in emailpassword and thirdpartyemailpassword recipe to not include statuses that happen based on email change.

--- a/lib/build/recipe/session/sessionRequestFunctions.js
+++ b/lib/build/recipe/session/sessionRequestFunctions.js
@@ -354,7 +354,13 @@ async function createNewSessionInRequest({
     logger_1.logDebugMessage("createNewSession: Access token payload built");
     let outputTransferMethod = config.getTokenTransferMethod({ req, forCreateNewSession: true, userContext });
     if (outputTransferMethod === "any") {
-        outputTransferMethod = "header";
+        const authModeHeader = cookieAndHeaders_1.getAuthModeFromHeader(req);
+        // We default to header if we can't "parse" it or if it's undefined
+        if (authModeHeader === "cookie") {
+            outputTransferMethod = authModeHeader;
+        } else {
+            outputTransferMethod = "header";
+        }
     }
     logger_1.logDebugMessage("createNewSession: using transfer method " + outputTransferMethod);
     if (

--- a/lib/ts/recipe/session/sessionRequestFunctions.ts
+++ b/lib/ts/recipe/session/sessionRequestFunctions.ts
@@ -12,7 +12,13 @@ import { getRequiredClaimValidators } from "./utils";
 import { getRidFromHeader, isAnIpAddress, normaliseHttpMethod, setRequestInUserContextIfNotDefined } from "../../utils";
 import { logDebugMessage } from "../../logger";
 import { availableTokenTransferMethods, protectedProps } from "./constants";
-import { clearSession, getAntiCsrfTokenFromHeaders, getToken, setCookie } from "./cookieAndHeaders";
+import {
+    clearSession,
+    getAntiCsrfTokenFromHeaders,
+    getAuthModeFromHeader,
+    getToken,
+    setCookie,
+} from "./cookieAndHeaders";
 import { ParsedJWTInfo, parseJWTWithoutSignatureVerification } from "./jwt";
 import { validateAccessTokenStructure } from "./accessToken";
 import { NormalisedAppinfo } from "../../types";
@@ -410,7 +416,13 @@ export async function createNewSessionInRequest({
 
     let outputTransferMethod = config.getTokenTransferMethod({ req, forCreateNewSession: true, userContext });
     if (outputTransferMethod === "any") {
-        outputTransferMethod = "header";
+        const authModeHeader = getAuthModeFromHeader(req);
+        // We default to header if we can't "parse" it or if it's undefined
+        if (authModeHeader === "cookie") {
+            outputTransferMethod = authModeHeader;
+        } else {
+            outputTransferMethod = "header";
+        }
     }
     logDebugMessage("createNewSession: using transfer method " + outputTransferMethod);
 

--- a/test/auth-modes.test.js
+++ b/test/auth-modes.test.js
@@ -156,7 +156,31 @@ describe(`auth-modes: ${printPath("[test/auth-modes.test.js]")}`, function () {
             });
 
             describe("with user provided getTokenTransferMethod", () => {
-                it("should use headers if getTokenTransferMethod returns any", async function () {
+                it("should use headers if getTokenTransferMethod returns any and there is no st-auth-mode header", async function () {
+                    const connectionURI = await startST();
+                    SuperTokens.init({
+                        supertokens: {
+                            connectionURI,
+                        },
+                        appInfo: {
+                            apiDomain: "api.supertokens.io",
+                            appName: "SuperTokens",
+                            websiteDomain: "supertokens.io",
+                        },
+                        recipeList: [Session.init({ antiCsrf: "VIA_TOKEN", getTokenTransferMethod: () => "any" })],
+                    });
+
+                    const app = getTestApp();
+
+                    const resp = await createSession(app, undefined);
+                    assert.strictEqual(resp.accessToken, undefined);
+                    assert.strictEqual(resp.refreshToken, undefined);
+                    assert.strictEqual(resp.antiCsrf, undefined);
+                    assert.notStrictEqual(resp.accessTokenFromHeader, undefined);
+                    assert.notStrictEqual(resp.refreshTokenFromHeader, undefined);
+                });
+
+                it("should use cookies if getTokenTransferMethod returns any and st-auth-mode is set to cookie", async function () {
                     const connectionURI = await startST();
                     SuperTokens.init({
                         supertokens: {
@@ -173,6 +197,30 @@ describe(`auth-modes: ${printPath("[test/auth-modes.test.js]")}`, function () {
                     const app = getTestApp();
 
                     const resp = await createSession(app, "cookie");
+                    assert.notStrictEqual(resp.accessToken, undefined);
+                    assert.notStrictEqual(resp.refreshToken, undefined);
+                    assert.notStrictEqual(resp.antiCsrf, undefined);
+                    assert.strictEqual(resp.accessTokenFromHeader, undefined);
+                    assert.strictEqual(resp.refreshTokenFromHeader, undefined);
+                });
+
+                it("should use headers if getTokenTransferMethod returns any and st-auth-mode is set to header", async function () {
+                    const connectionURI = await startST();
+                    SuperTokens.init({
+                        supertokens: {
+                            connectionURI,
+                        },
+                        appInfo: {
+                            apiDomain: "api.supertokens.io",
+                            appName: "SuperTokens",
+                            websiteDomain: "supertokens.io",
+                        },
+                        recipeList: [Session.init({ antiCsrf: "VIA_TOKEN", getTokenTransferMethod: () => "any" })],
+                    });
+
+                    const app = getTestApp();
+
+                    const resp = await createSession(app, "header");
                     assert.strictEqual(resp.accessToken, undefined);
                     assert.strictEqual(resp.refreshToken, undefined);
                     assert.strictEqual(resp.antiCsrf, undefined);


### PR DESCRIPTION
## Summary of change

`createNewSession` now defaults to the value of the `st-auth-mode` header (if available) if the configured `getTokenTransferMethod` returns `any`.

## Related issues

-   https://discordapp.com/channels/603466164219281420/1195351655093370880

## Test Plan

Added tests that check the output of `createNewSession` if:
- `getTokenTransferMethod` returns any
- `st-auth-mode` is: `cookie`, `header`, or not set

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
