### PR TITLE
fix: dashboard connection uri path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [16.7.3] - 2024-02-26
+
+-   Fixes dashboard URI path. Now it returns the complete user given path instead of just the normalized connectionURI domain.
+
 ## [16.7.2] - 2024-02-19
 
 -   `createNewSession` now defaults to the value of the `st-auth-mode` header (if available) if the configured `getTokenTransferMethod` returns `any`.

--- a/lib/build/recipe/dashboard/api/implementation.js
+++ b/lib/build/recipe/dashboard/api/implementation.js
@@ -38,9 +38,13 @@ function getAPIImplementation() {
             const superTokensInstance = supertokens_1.default.getInstanceOrThrowError();
             const authMode = input.options.config.authMode;
             if (superTokensInstance.supertokens !== undefined) {
-                connectionURI = new normalisedURLDomain_1.default(
-                    superTokensInstance.supertokens.connectionURI.split(";")[0]
-                ).getAsStringDangerous();
+                connectionURI =
+                    new normalisedURLDomain_1.default(
+                        superTokensInstance.supertokens.connectionURI.split(";")[0]
+                    ).getAsStringDangerous() +
+                    new normalisedURLPath_1.default(
+                        superTokensInstance.supertokens.connectionURI.split(";")[0]
+                    ).getAsStringDangerous();
             }
             let isSearchEnabled = false;
             const cdiVersion = await querier_1.Querier.getNewInstanceOrThrowError(

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "16.7.2";
+export declare const version = "16.7.3";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.10";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "16.7.2";
+exports.version = "16.7.3";
 exports.cdiSupported = ["4.0"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.10";

--- a/lib/ts/recipe/dashboard/api/implementation.ts
+++ b/lib/ts/recipe/dashboard/api/implementation.ts
@@ -38,9 +38,13 @@ export default function getAPIImplementation(): APIInterface {
             const authMode: AuthMode = input.options.config.authMode;
 
             if (superTokensInstance.supertokens !== undefined) {
-                connectionURI = new NormalisedURLDomain(
-                    superTokensInstance.supertokens.connectionURI.split(";")[0]
-                ).getAsStringDangerous();
+                connectionURI =
+                    new NormalisedURLDomain(
+                        superTokensInstance.supertokens.connectionURI.split(";")[0]
+                    ).getAsStringDangerous() +
+                    new NormalisedURLPath(
+                        superTokensInstance.supertokens.connectionURI.split(";")[0]
+                    ).getAsStringDangerous();
             }
 
             let isSearchEnabled = false;

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "16.7.2";
+export const version = "16.7.3";
 
 export const cdiSupported = ["4.0"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "16.7.2",
+    "version": "16.7.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "16.7.2",
+            "version": "16.7.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "16.7.2",
+    "version": "16.7.3",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {

--- a/test/dashboard/dashboardGet.test.js
+++ b/test/dashboard/dashboardGet.test.js
@@ -69,7 +69,7 @@ describe(`User Dashboard get: ${printPath("[test/dashboard/dashboardGet.test.js]
         });
 
         it("Test connectionURI contains https protocol", async () => {
-            const connectionURI = "https://try.supertokens.com";
+            const connectionURI = "https://try.supertokens.com/appid-public";
             // removing protocol from the original connectionURI.
             const connectionURIWithoutProtocol = connectionURI.replace("https://", "");
 
@@ -113,8 +113,8 @@ describe(`User Dashboard get: ${printPath("[test/dashboard/dashboardGet.test.js]
         });
 
         it("Test multiple connection URIs", async () => {
-            const firstConnectionURI = await startST();
-            const secondConnectionURI = "https://try.supertokens.com";
+            const firstConnectionURI = "https://try.supertokens.com/appid-public";
+            const secondConnectionURI = await startST();
 
             const multipleConnectionURIs = `${firstConnectionURI};${secondConnectionURI}`;
 


### PR DESCRIPTION
## Summary of change

Fixes dashboard connection URI path.

Previously we used to return only the domain of the normalised connectionURI without the path provided by the user in Supertokens init config. So this change will also include the path followed by the connectionURL domain to the frontend...

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

- Wrote unit tests and manually retested the whole dashboard again.

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
