### PR TITLE
feat: added new remix directory based on NextJS

### DIFF
--- a/lib/build/remix.js
+++ b/lib/build/remix.js
@@ -1,0 +1,326 @@
+"use strict";
+var __rest =
+    (this && this.__rest) ||
+    function (s, e) {
+        var t = {};
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0) t[p] = s[p];
+        if (s != null && typeof Object.getOwnPropertySymbols === "function")
+            for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+                if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i])) t[p[i]] = s[p[i]];
+            }
+        return t;
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withPreParsedRequestResponse = exports.withSession = exports.getSSRSession = exports.getAppDirRequestHandler = exports.superTokensRemixWrapper = void 0;
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+const cookie_1 = require("cookie");
+const express_1 = require("./framework/express");
+const custom_1 = require("./framework/custom");
+const session_1 = __importDefault(require("./recipe/session"));
+const recipe_1 = __importDefault(require("./recipe/session/recipe"));
+const cookieAndHeaders_1 = require("./recipe/session/cookieAndHeaders");
+const constants_1 = require("./recipe/session/constants");
+const jwt_1 = require("./recipe/session/jwt");
+function remix(request, response, resolve, reject) {
+    return async function (middlewareError) {
+        if (middlewareError === undefined) {
+            return resolve();
+        }
+        await express_1.errorHandler()(middlewareError, request, response, (errorHandlerError) => {
+            if (errorHandlerError !== undefined) {
+                return reject(errorHandlerError);
+            }
+            // do nothing, error handler does not resolve the promise.
+        });
+    };
+}
+class Remix {
+    static async superTokensRemixWrapper(middleware, request, response) {
+        return new Promise(async (resolve, reject) => {
+            try {
+                let callbackCalled = false;
+                const result = await middleware((err) => {
+                    callbackCalled = true;
+                    remix(request, response, resolve, reject)(err);
+                });
+                if (!callbackCalled && !response.finished && !response.headersSent) {
+                    return resolve(result);
+                }
+            } catch (err) {
+                await express_1.errorHandler()(err, request, response, (errorHandlerError) => {
+                    if (errorHandlerError !== undefined) {
+                        return reject(errorHandlerError);
+                    }
+                    // do nothing, error handler does not resolve the promise.
+                });
+            }
+        });
+    }
+    static getAppDirRequestHandler(RemixResponse) {
+        const stMiddleware = custom_1.middleware((req) => {
+            const query = Object.fromEntries(new URL(req.url).searchParams.entries());
+            const cookies = Object.fromEntries(req.cookies.getAll().map((cookie) => [cookie.name, cookie.value]));
+            return new custom_1.PreParsedRequest({
+                method: req.method,
+                url: req.url,
+                query: query,
+                headers: req.headers,
+                cookies,
+                getFormBody: () => req.formData(),
+                getJSONBody: () => req.json(),
+            });
+        });
+        return async function handleCall(req) {
+            const baseResponse = new custom_1.CollectingResponse();
+            const { handled, error } = await stMiddleware(req, baseResponse);
+            if (error) {
+                throw error;
+            }
+            if (!handled) {
+                return new RemixResponse("Not found", { status: 404 });
+            }
+            for (const respCookie of baseResponse.cookies) {
+                baseResponse.headers.append(
+                    "Set-Cookie",
+                    cookie_1.serialize(respCookie.key, respCookie.value, {
+                        domain: respCookie.domain,
+                        expires: new Date(respCookie.expires),
+                        httpOnly: respCookie.httpOnly,
+                        path: respCookie.path,
+                        sameSite: respCookie.sameSite,
+                        secure: respCookie.secure,
+                    })
+                );
+            }
+            return new RemixResponse(baseResponse.body, {
+                headers: baseResponse.headers,
+                status: baseResponse.statusCode,
+            });
+        };
+    }
+    static async commonSSRSession(baseRequest, options, userContext) {
+        let baseResponse = new custom_1.CollectingResponse();
+        const recipe = recipe_1.default.getInstanceOrThrowError();
+        const tokenTransferMethod = recipe.config.getTokenTransferMethod({
+            req: baseRequest,
+            forCreateNewSession: false,
+            userContext,
+        });
+        const transferMethods =
+            tokenTransferMethod === "any" ? constants_1.availableTokenTransferMethods : [tokenTransferMethod];
+        const hasToken = transferMethods.some((transferMethod) => {
+            const token = cookieAndHeaders_1.getToken(baseRequest, "access", transferMethod);
+            if (!token) {
+                return false;
+            }
+            try {
+                jwt_1.parseJWTWithoutSignatureVerification(token);
+                return true;
+            } catch (_a) {
+                return false;
+            }
+        });
+        try {
+            let session = await session_1.default.getSession(baseRequest, baseResponse, options, userContext);
+            return {
+                session,
+                hasInvalidClaims: false,
+                hasToken,
+                baseResponse,
+            };
+        } catch (err) {
+            if (session_1.default.Error.isErrorFromSuperTokens(err)) {
+                return {
+                    hasToken,
+                    hasInvalidClaims: err.type === session_1.default.Error.INVALID_CLAIMS,
+                    session: undefined,
+                    baseResponse,
+                    remixResponse: new Response("Authentication required", {
+                        status: err.type === session_1.default.Error.INVALID_CLAIMS ? 403 : 401,
+                    }),
+                };
+            } else {
+                throw err;
+            }
+        }
+    }
+    static async getSSRSession(cookies, headers, options, userContext) {
+        let cookiesObj = Object.fromEntries(cookies.map((cookie) => [cookie.name, cookie.value]));
+        let baseRequest = new custom_1.PreParsedRequest({
+            method: "get",
+            url: "",
+            query: {},
+            headers: headers,
+            cookies: cookiesObj,
+            getFormBody: async () => [],
+            getJSONBody: async () => [],
+        });
+        const _a = await Remix.commonSSRSession(baseRequest, options, userContext),
+            { baseResponse, remixResponse } = _a,
+            result = __rest(_a, ["baseResponse", "remixResponse"]);
+        return result;
+    }
+    static async withSession(req, handler, options, userContext) {
+        try {
+            const query = Object.fromEntries(new URL(req.url).searchParams.entries());
+            const cookies = Object.fromEntries(req.cookies.getAll().map((cookie) => [cookie.name, cookie.value]));
+            let baseRequest = new custom_1.PreParsedRequest({
+                method: req.method,
+                url: req.url,
+                query: query,
+                headers: req.headers,
+                cookies: cookies,
+                getFormBody: () => req.formData(),
+                getJSONBody: () => req.json(),
+            });
+            const { session, remixResponse, baseResponse } = await Remix.commonSSRSession(
+                baseRequest,
+                options,
+                userContext
+            );
+            if (remixResponse) {
+                return remixResponse;
+            }
+            let userResponse;
+            try {
+                userResponse = await handler(undefined, session);
+            } catch (err) {
+                await custom_1.errorHandler()(err, baseRequest, baseResponse, (errorHandlerError) => {
+                    if (errorHandlerError) {
+                        throw errorHandlerError;
+                    }
+                });
+                // The headers in the userResponse are set twice from baseResponse, but the resulting response contains unique headers.
+                userResponse = new Response(baseResponse.body, {
+                    status: baseResponse.statusCode,
+                    headers: baseResponse.headers,
+                });
+            }
+            let didAddCookies = false;
+            let didAddHeaders = false;
+            for (const respCookie of baseResponse.cookies) {
+                didAddCookies = true;
+                userResponse.headers.append(
+                    "Set-Cookie",
+                    cookie_1.serialize(respCookie.key, respCookie.value, {
+                        domain: respCookie.domain,
+                        expires: new Date(respCookie.expires),
+                        httpOnly: respCookie.httpOnly,
+                        path: respCookie.path,
+                        sameSite: respCookie.sameSite,
+                        secure: respCookie.secure,
+                    })
+                );
+            }
+            baseResponse.headers.forEach((value, key) => {
+                didAddHeaders = true;
+                userResponse.headers.set(key, value);
+            });
+            /**
+             * For some deployment services (Vercel for example) production builds can return cached results for
+             * APIs with older header values. In this case if the session tokens have changed (because of refreshing
+             * for example) the cached result would still contain the older tokens and sessions would stop working.
+             *
+             * As a result, if we add cookies or headers from base response we also set the Cache-Control header
+             * to make sure that the final result is not a cached version.
+             */
+            if (didAddCookies || didAddHeaders) {
+                if (!userResponse.headers.has("Cache-Control")) {
+                    // This is needed for production deployments with Vercel
+                    userResponse.headers.set("Cache-Control", "no-cache, no-store, max-age=0, must-revalidate");
+                }
+            }
+            return userResponse;
+        } catch (error) {
+            return await handler(error, undefined);
+        }
+    }
+    static async withPreParsedRequestResponse(req, handler) {
+        const query = Object.fromEntries(new URL(req.url).searchParams.entries());
+        const cookies = Object.fromEntries(req.cookies.getAll().map((cookie) => [cookie.name, cookie.value]));
+        let baseRequest = new custom_1.PreParsedRequest({
+            method: req.method,
+            url: req.url,
+            query: query,
+            headers: req.headers,
+            cookies: cookies,
+            getFormBody: () => req.formData(),
+            getJSONBody: () => req.json(),
+        });
+        let baseResponse = new custom_1.CollectingResponse();
+        let userResponse;
+        try {
+            userResponse = await handler(baseRequest, baseResponse);
+        } catch (err) {
+            await custom_1.errorHandler()(err, baseRequest, baseResponse, (errorHandlerError) => {
+                if (errorHandlerError) {
+                    throw errorHandlerError;
+                }
+            });
+            // The headers in the userResponse are set twice from baseResponse, but the resulting response contains unique headers.
+            userResponse = new Response(baseResponse.body, {
+                status: baseResponse.statusCode,
+                headers: baseResponse.headers,
+            });
+        }
+        let didAddCookies = false;
+        let didAddHeaders = false;
+        for (const respCookie of baseResponse.cookies) {
+            didAddCookies = true;
+            userResponse.headers.append(
+                "Set-Cookie",
+                cookie_1.serialize(respCookie.key, respCookie.value, {
+                    domain: respCookie.domain,
+                    expires: new Date(respCookie.expires),
+                    httpOnly: respCookie.httpOnly,
+                    path: respCookie.path,
+                    sameSite: respCookie.sameSite,
+                    secure: respCookie.secure,
+                })
+            );
+        }
+        baseResponse.headers.forEach((value, key) => {
+            didAddHeaders = true;
+            userResponse.headers.set(key, value);
+        });
+        /**
+         * For some deployment services (Vercel for example) production builds can return cached results for
+         * APIs with older header values. In this case if the session tokens have changed (because of refreshing
+         * for example) the cached result would still contain the older tokens and sessions would stop working.
+         *
+         * As a result, if we add cookies or headers from base response we also set the Cache-Control header
+         * to make sure that the final result is not a cached version.
+         */
+        if (didAddCookies || didAddHeaders) {
+            if (!userResponse.headers.has("Cache-Control")) {
+                // This is needed for production deployments with Vercel
+                userResponse.headers.set("Cache-Control", "no-cache, no-store, max-age=0, must-revalidate");
+            }
+        }
+        return userResponse;
+    }
+}
+exports.default = Remix;
+exports.superTokensRemixWrapper = Remix.superTokensRemixWrapper;
+exports.getAppDirRequestHandler = Remix.getAppDirRequestHandler;
+exports.getSSRSession = Remix.getSSRSession;
+exports.withSession = Remix.withSession;
+exports.withPreParsedRequestResponse = Remix.withPreParsedRequestResponse;

--- a/remix/index.d.ts
+++ b/remix/index.d.ts
@@ -1,0 +1,11 @@
+export * from "../lib/build/nextjs";
+/**
+ * 'export *' does not re-export a default.
+ * import NextJS from "supertokens-node/nextjs";
+ * the above import statement won't be possible unless either
+ * - user add "esModuleInterop": true in their tsconfig.json file
+ * - we do the following change:
+ */
+
+import * as _default from "../lib/build/remix";
+export default _default;

--- a/remix/index.js
+++ b/remix/index.js
@@ -1,0 +1,6 @@
+"use strict";
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+exports.__esModule = true;
+__export(require("../lib/build/remix"));


### PR DESCRIPTION
## Summary of change

The new Remix demo app makes use of the following import statement for its authentication APIs that applies to NextJS:

```shell
import { getAppDirRequestHandler } from "supertokens-node/nextjs/index.js";
```

Given that this function is utilized by both Remix and Next.js, this draft pull request introduces a new remix directory modeled after the existing NextJS that we can continue to build upon. Alternatively, we could refactor `getAppDirRequestHandler` and its related functions into a generic utility that can be invoked by either framework.

My intention is to avoid duplicating this functionality specifically for Remix or attempting to reimplement it within the application itself, as it serves the same purpose across both frameworks. I am open to ideas.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
