### PR TITLE
feat: use firstFactors in the dashboard apis

### DIFF
--- a/lib/build/recipe/dashboard/api/getTenantLoginMethodsInfo.d.ts
+++ b/lib/build/recipe/dashboard/api/getTenantLoginMethodsInfo.d.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { APIInterface, APIOptions } from "../types";
 import { TypeNormalisedInput } from "../../passwordless/types";
+import { UserContext } from "../../../types";
 declare type PasswordlessContactMethod = TypeNormalisedInput["contactMethod"];
 declare type TenantLoginMethodType = {
     tenantId: string;
@@ -30,6 +31,6 @@ export default function getTenantLoginMethodsInfo(
     _: APIInterface,
     __: string,
     ___: APIOptions,
-    userContext: any
+    userContext: UserContext
 ): Promise<Response>;
 export {};

--- a/lib/build/recipe/dashboard/api/getTenantLoginMethodsInfo.js
+++ b/lib/build/recipe/dashboard/api/getTenantLoginMethodsInfo.js
@@ -5,23 +5,26 @@ var __importDefault =
         return mod && mod.__esModule ? mod : { default: mod };
     };
 Object.defineProperty(exports, "__esModule", { value: true });
-const multitenancy_1 = __importDefault(require("../../multitenancy"));
-const recipe_1 = __importDefault(require("../../passwordless/recipe"));
-const recipe_2 = __importDefault(require("../../thirdpartypasswordless/recipe"));
-const recipe_3 = __importDefault(require("../../emailpassword/recipe"));
-const recipe_4 = __importDefault(require("../../thirdpartyemailpassword/recipe"));
-const recipe_5 = __importDefault(require("../../thirdparty/recipe"));
+const recipe_1 = __importDefault(require("../../multitenancy/recipe"));
+const utils_1 = require("../../multitenancy/utils");
+const multifactorauth_1 = require("../../multifactorauth");
 async function getTenantLoginMethodsInfo(_, __, ___, userContext) {
-    const tenantsRes = await multitenancy_1.default.listAllTenants(userContext);
+    const tenantsRes = await recipe_1.default
+        .getInstanceOrThrowError()
+        .recipeInterfaceImpl.listAllTenants({ userContext });
     const finalTenants = [];
     for (let i = 0; i < tenantsRes.tenants.length; i++) {
         const currentTenant = tenantsRes.tenants[i];
-        const normalisedTenantLoginMethodsInfo = normaliseTenantLoginMethodsWithInitConfig({
-            tenantId: currentTenant.tenantId,
-            emailPassword: currentTenant.emailPassword,
-            passwordless: currentTenant.passwordless,
-            thirdParty: currentTenant.thirdParty,
-        });
+        const normalisedTenantLoginMethodsInfo = await normaliseTenantLoginMethodsWithInitConfig(
+            {
+                tenantId: currentTenant.tenantId,
+                emailPassword: currentTenant.emailPassword,
+                passwordless: currentTenant.passwordless,
+                thirdParty: currentTenant.thirdParty,
+                firstFactors: currentTenant.firstFactors,
+            },
+            userContext
+        );
         finalTenants.push(normalisedTenantLoginMethodsInfo);
     }
     return {
@@ -30,7 +33,7 @@ async function getTenantLoginMethodsInfo(_, __, ___, userContext) {
     };
 }
 exports.default = getTenantLoginMethodsInfo;
-function normaliseTenantLoginMethodsWithInitConfig(tenantDetailsFromCore) {
+async function normaliseTenantLoginMethodsWithInitConfig(tenantDetailsFromCore, userContext) {
     const normalisedTenantLoginMethodsInfo = {
         tenantId: tenantDetailsFromCore.tenantId,
         emailPassword: {
@@ -49,38 +52,54 @@ function normaliseTenantLoginMethodsWithInitConfig(tenantDetailsFromCore) {
             enabled: false,
         },
     };
-    if (tenantDetailsFromCore.passwordless.enabled === true) {
-        try {
-            const passwordlessRecipe = recipe_1.default.getInstanceOrThrowError();
+    let firstFactors;
+    let mtInstance = recipe_1.default.getInstanceOrThrowError();
+    if (tenantDetailsFromCore.firstFactors !== undefined) {
+        firstFactors = tenantDetailsFromCore.firstFactors; // highest priority, config from core
+    } else if (mtInstance.staticFirstFactors !== undefined) {
+        firstFactors = mtInstance.staticFirstFactors; // next priority, static config
+    } else {
+        // Fallback to all available factors (de-duplicated)
+        firstFactors = Array.from(new Set(mtInstance.allAvailableFirstFactors));
+    }
+    // we now filter out all available first factors by checking if they are valid because
+    // we want to return the ones that can work. this would be based on what recipes are enabled
+    // on the core and also firstFactors configured in the core and supertokens.init
+    // Also, this way, in the front end, the developer can just check for firstFactors for
+    // enabled recipes in all cases irrespective of whether they are using MFA or not
+    let validFirstFactors = [];
+    for (const factorId of firstFactors) {
+        let validRes = await utils_1.isValidFirstFactor(tenantDetailsFromCore.tenantId, factorId, userContext);
+        if (validRes.status === "OK") {
+            validFirstFactors.push(factorId);
+        }
+        if (validRes.status === "TENANT_NOT_FOUND_ERROR") {
+            throw new Error("Tenant not found");
+        }
+    }
+    if (validFirstFactors.includes(multifactorauth_1.FactorIds.EMAILPASSWORD)) {
+        normalisedTenantLoginMethodsInfo.emailPassword.enabled = true;
+    }
+    if (validFirstFactors.includes(multifactorauth_1.FactorIds.THIRDPARTY)) {
+        normalisedTenantLoginMethodsInfo.thirdParty.enabled = true;
+    }
+    const pwlessEmailEnabled =
+        validFirstFactors.includes(multifactorauth_1.FactorIds.OTP_EMAIL) ||
+        validFirstFactors.includes(multifactorauth_1.FactorIds.LINK_EMAIL);
+    const pwlessPhoneEnabled =
+        validFirstFactors.includes(multifactorauth_1.FactorIds.OTP_PHONE) ||
+        validFirstFactors.includes(multifactorauth_1.FactorIds.LINK_PHONE);
+    if (pwlessEmailEnabled) {
+        if (pwlessPhoneEnabled) {
             normalisedTenantLoginMethodsInfo.passwordless.enabled = true;
-            normalisedTenantLoginMethodsInfo.passwordless.contactMethod = passwordlessRecipe.config.contactMethod;
-        } catch (_) {}
-    }
-    if (tenantDetailsFromCore.thirdParty.enabled === true || tenantDetailsFromCore.passwordless.enabled === true) {
-        try {
-            const thirdpartyPasswordlessRecipe = recipe_2.default.getInstanceOrThrowError();
-            normalisedTenantLoginMethodsInfo.thirdPartyPasswordless.enabled = true;
-            normalisedTenantLoginMethodsInfo.thirdPartyPasswordless.contactMethod =
-                thirdpartyPasswordlessRecipe.config.contactMethod;
-        } catch (_) {}
-    }
-    if (tenantDetailsFromCore.emailPassword.enabled === true) {
-        try {
-            recipe_3.default.getInstanceOrThrowError();
-            normalisedTenantLoginMethodsInfo.emailPassword.enabled = true;
-        } catch (_) {}
-    }
-    if (tenantDetailsFromCore.thirdParty.enabled === true || tenantDetailsFromCore.emailPassword.enabled === true) {
-        try {
-            recipe_4.default.getInstanceOrThrowError();
-            normalisedTenantLoginMethodsInfo.thirdPartyEmailPasssword.enabled = true;
-        } catch (_) {}
-    }
-    if (tenantDetailsFromCore.thirdParty.enabled === true) {
-        try {
-            recipe_5.default.getInstanceOrThrowError();
-            normalisedTenantLoginMethodsInfo.thirdParty.enabled = true;
-        } catch (_) {}
+            normalisedTenantLoginMethodsInfo.passwordless.contactMethod = "EMAIL_OR_PHONE";
+        } else {
+            normalisedTenantLoginMethodsInfo.passwordless.enabled = true;
+            normalisedTenantLoginMethodsInfo.passwordless.contactMethod = "EMAIL";
+        }
+    } else if (pwlessPhoneEnabled) {
+        normalisedTenantLoginMethodsInfo.passwordless.enabled = true;
+        normalisedTenantLoginMethodsInfo.passwordless.contactMethod = "PHONE";
     }
     return normalisedTenantLoginMethodsInfo;
 }


### PR DESCRIPTION
## Summary of change

use firstFactors in the dashboard apis, taking directly from the `getLoginMethods` implementation

## Related issues

-   

## Test Plan

Manual testing:
- works without initializing MFA recipe (or multitenancy)
- takes firstFactors from the tenant config if exists
- prioritizes firstFactor from tenant config over MFA init

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
