### PR TITLE
fix: allow signing up/in even if the session user is unverified if the sign in will verify it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [17.0.1] - 2024-03-08
+
+### Changes
+
+-   We now allow sign in/up even if the session user is conflicting with the current sign in/up (because of the email verification status)
+    -   This makes use-cases where an secondary factor (i.e.: otp-email) is also used as a means of verification.
+
 ## [17.0.0] - 2024-03-08
 
 ### Changes

--- a/lib/build/recipe/accountlinking/recipe.js
+++ b/lib/build/recipe/accountlinking/recipe.js
@@ -236,6 +236,11 @@ class Recipe extends recipeModule_1.default {
                 for (let i = 0; i < users.length; i++) {
                     let currUser = users[i]; // all these are not primary users, so we can use
                     // loginMethods[0] to get the account info.
+                    if (session !== undefined && currUser.id === session.getUserId(userContext)) {
+                        // We do not consider the current session user to be conflicting
+                        // This can be useful in cases where the current sign in will mark the session user as verified
+                        continue;
+                    }
                     let thisIterationIsVerified = false;
                     if (accountInfo.email !== undefined) {
                         if (
@@ -322,6 +327,11 @@ class Recipe extends recipeModule_1.default {
                     // in case email verification is not required, then linking should not be
                     // an issue anyway.
                     return false;
+                }
+                // We do not consider the current session user to be conflicting
+                // This can be useful in cases where the current sign in will mark the session user as verified
+                if (session !== undefined && primaryUser.id === session.getUserId()) {
+                    return true;
                 }
                 // we check for even if one is verified as opposed to all being unverified cause
                 // even if one is verified, we know that the email / phone number is owned by the

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "17.0.0";
+export declare const version = "17.0.1";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.10";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "17.0.0";
+exports.version = "17.0.1";
 exports.cdiSupported = ["5.0"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.10";

--- a/lib/ts/recipe/accountlinking/recipe.ts
+++ b/lib/ts/recipe/accountlinking/recipe.ts
@@ -385,6 +385,13 @@ export default class Recipe extends RecipeModule {
             for (let i = 0; i < users.length; i++) {
                 let currUser = users[i]; // all these are not primary users, so we can use
                 // loginMethods[0] to get the account info.
+
+                if (session !== undefined && currUser.id === session.getUserId(userContext)) {
+                    // We do not consider the current session user to be conflicting
+                    // This can be useful in cases where the current sign in will mark the session user as verified
+                    continue;
+                }
+
                 let thisIterationIsVerified = false;
                 if (accountInfo.email !== undefined) {
                     if (
@@ -468,6 +475,12 @@ export default class Recipe extends RecipeModule {
                 // in case email verification is not required, then linking should not be
                 // an issue anyway.
                 return false;
+            }
+
+            // We do not consider the current session user to be conflicting
+            // This can be useful in cases where the current sign in will mark the session user as verified
+            if (session !== undefined && primaryUser.id === session.getUserId()) {
+                return true;
             }
 
             // we check for even if one is verified as opposed to all being unverified cause

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "17.0.0";
+export const version = "17.0.1";
 
 export const cdiSupported = ["5.0"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "17.0.0",
+    "version": "17.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "17.0.0",
+            "version": "17.0.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "17.0.0",
+    "version": "17.0.1",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

-   We now allow sign in/up even if the session user is conflicting with the current sign in/up (because of the email verification status)
    -   This makes use-cases where an secondary factor (i.e.: otp-email) is also used as a means of verification.

## Related issues

-   https://github.com/supertokens/supertokens-auth-react/actions/runs/8345716229

## Test Plan

Duplicated many of the test cases for the consume code api for create code api.

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] If new thirdparty provider is added,
    -   [x] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [x] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
