### PR TITLE
RID match change for combination recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## Breaking change
+
+-   Removed ThirdPartyEmailPassword and ThirdPartyPasswordless recipes. Instead, you should use ThirdParty + EmailPassword or ThirdParty + Passwordless recipes separately in your recipe list.
+-   Removed `rid` query param from:
+    -   email verification links
+    -   passwordless magic links
+    -   password reset links
+
+## Changes
+
+-   If `rid` header is present in an API call, the routing no only only depends on that. If the SDK cannot resolve a request handler based on the `rid`, request path and method, it will try to resolve a request handler only based on the request path and method (therefore ignoring the `rid` header).
+-   New API handlers ar:
+    -   `GET /emailpassword/email/exists` => email password, does email exist API (used to be `GET /signup/email/exists` with `rid` of `emailpassword` or `thirdpartyemailpassword` which is now deprecated)
+    -   `GET /passwordless/email/exists` => email password, does email exist API (used to be `GET /signup/email/exists` with `rid` of `passwordless` or `thirdpartypasswordless` which is now deprecated)
+    -   `GET /passwordless/phonenumber/exists` => email password, does email exist API (used to be `GET /signup/phonenumber/exists` which is now deprecated)
+
+## Migration guide
+
+-   If you were using `ThirdPartyEmailPassword`, you should now init `ThirdParty` and `EmailPassword` recipes separately. The config for the individual recipes are mostly the same, except the syntax may be different. Check our recipe guides for [ThirdParty](https://supertokens.com/docs/thirdparty/introduction) and [EmailPassword](https://supertokens.com/docs/emailpassword/introduction) for more information.
+
+-   If you were using `ThirdPartyPasswordless`, you should now init `ThirdParty` and `Passwordless` recipes separately. The config for the individual recipes are mostly the same, except the syntax may be different. Check our recipe guides for [ThirdParty](https://supertokens.com/docs/thirdparty/introduction) and [Passwordless](https://supertokens.com/docs/passwordless/introduction) for more information.
+
 ## [17.0.3] - 2024-04-08
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changes
 
 -   If `rid` header is present in an API call, the routing no only only depends on that. If the SDK cannot resolve a request handler based on the `rid`, request path and method, it will try to resolve a request handler only based on the request path and method (therefore ignoring the `rid` header).
--   New API handlers ar:
+-   New API handlers are:
     -   `GET /emailpassword/email/exists` => email password, does email exist API (used to be `GET /signup/email/exists` with `rid` of `emailpassword` or `thirdpartyemailpassword` which is now deprecated)
     -   `GET /passwordless/email/exists` => email password, does email exist API (used to be `GET /signup/email/exists` with `rid` of `passwordless` or `thirdpartypasswordless` which is now deprecated)
     -   `GET /passwordless/phonenumber/exists` => email password, does email exist API (used to be `GET /signup/phonenumber/exists` which is now deprecated)
+-   Support for FDI 1.20
 
 ## Migration guide
 

--- a/frontendDriverInterfaceSupported.json
+++ b/frontendDriverInterfaceSupported.json
@@ -1,4 +1,4 @@
 {
     "_comment": "contains a list of frontend-driver interfaces branch names that this core supports",
-    "versions": ["1.17", "1.18", "1.19"]
+    "versions": ["1.17", "1.18", "1.19", "1.20"]
 }

--- a/lib/build/recipe/emailpassword/api/implementation.js
+++ b/lib/build/recipe/emailpassword/api/implementation.js
@@ -63,7 +63,6 @@ function getAPIImplementation() {
                 let passwordResetLink = utils_1.getPasswordResetLink({
                     appInfo: options.appInfo,
                     token: response.token,
-                    recipeId: options.recipeId,
                     tenantId,
                     request: options.req,
                     userContext,

--- a/lib/build/recipe/emailpassword/constants.d.ts
+++ b/lib/build/recipe/emailpassword/constants.d.ts
@@ -5,4 +5,5 @@ export declare const SIGN_UP_API = "/signup";
 export declare const SIGN_IN_API = "/signin";
 export declare const GENERATE_PASSWORD_RESET_TOKEN_API = "/user/password/reset/token";
 export declare const PASSWORD_RESET_API = "/user/password/reset";
-export declare const SIGNUP_EMAIL_EXISTS_API = "/signup/email/exists";
+export declare const SIGNUP_EMAIL_EXISTS_API_OLD = "/signup/email/exists";
+export declare const SIGNUP_EMAIL_EXISTS_API = "/emailpassword/email/exists";

--- a/lib/build/recipe/emailpassword/constants.js
+++ b/lib/build/recipe/emailpassword/constants.js
@@ -14,11 +14,12 @@
  * under the License.
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.SIGNUP_EMAIL_EXISTS_API = exports.PASSWORD_RESET_API = exports.GENERATE_PASSWORD_RESET_TOKEN_API = exports.SIGN_IN_API = exports.SIGN_UP_API = exports.FORM_FIELD_EMAIL_ID = exports.FORM_FIELD_PASSWORD_ID = void 0;
+exports.SIGNUP_EMAIL_EXISTS_API = exports.SIGNUP_EMAIL_EXISTS_API_OLD = exports.PASSWORD_RESET_API = exports.GENERATE_PASSWORD_RESET_TOKEN_API = exports.SIGN_IN_API = exports.SIGN_UP_API = exports.FORM_FIELD_EMAIL_ID = exports.FORM_FIELD_PASSWORD_ID = void 0;
 exports.FORM_FIELD_PASSWORD_ID = "password";
 exports.FORM_FIELD_EMAIL_ID = "email";
 exports.SIGN_UP_API = "/signup";
 exports.SIGN_IN_API = "/signin";
 exports.GENERATE_PASSWORD_RESET_TOKEN_API = "/user/password/reset/token";
 exports.PASSWORD_RESET_API = "/user/password/reset";
-exports.SIGNUP_EMAIL_EXISTS_API = "/signup/email/exists";
+exports.SIGNUP_EMAIL_EXISTS_API_OLD = "/signup/email/exists";
+exports.SIGNUP_EMAIL_EXISTS_API = "/emailpassword/email/exists";

--- a/lib/build/recipe/emailpassword/index.js
+++ b/lib/build/recipe/emailpassword/index.js
@@ -131,7 +131,6 @@ class Wrapper {
             status: "OK",
             link: utils_1.getPasswordResetLink({
                 appInfo: recipeInstance.getAppInfo(),
-                recipeId: recipeInstance.getRecipeId(),
                 token: token.token,
                 tenantId: tenantId === undefined ? constants_1.DEFAULT_TENANT_ID : tenantId,
                 request: __1.getRequestFromUserContext(ctx),

--- a/lib/build/recipe/emailpassword/recipe.js
+++ b/lib/build/recipe/emailpassword/recipe.js
@@ -78,6 +78,12 @@ class Recipe extends recipeModule_1.default {
                     id: constants_1.SIGNUP_EMAIL_EXISTS_API,
                     disabled: this.apiImpl.emailExistsGET === undefined,
                 },
+                {
+                    method: "get",
+                    pathWithoutApiBasePath: new normalisedURLPath_1.default(constants_1.SIGNUP_EMAIL_EXISTS_API_OLD),
+                    id: constants_1.SIGNUP_EMAIL_EXISTS_API_OLD,
+                    disabled: this.apiImpl.emailExistsGET === undefined,
+                },
             ];
         };
         this.handleAPIRequest = async (id, tenantId, req, res, _path, _method, userContext) => {
@@ -99,7 +105,7 @@ class Recipe extends recipeModule_1.default {
                 return await generatePasswordResetToken_1.default(this.apiImpl, tenantId, options, userContext);
             } else if (id === constants_1.PASSWORD_RESET_API) {
                 return await passwordReset_1.default(this.apiImpl, tenantId, options, userContext);
-            } else if (id === constants_1.SIGNUP_EMAIL_EXISTS_API) {
+            } else if (id === constants_1.SIGNUP_EMAIL_EXISTS_API || id === constants_1.SIGNUP_EMAIL_EXISTS_API_OLD) {
                 return await emailExists_1.default(this.apiImpl, tenantId, options, userContext);
             }
             return false;

--- a/lib/build/recipe/emailpassword/utils.d.ts
+++ b/lib/build/recipe/emailpassword/utils.d.ts
@@ -25,7 +25,6 @@ export declare function defaultEmailValidator(
 export declare function getPasswordResetLink(input: {
     appInfo: NormalisedAppinfo;
     token: string;
-    recipeId: string;
     tenantId: string;
     request: BaseRequest | undefined;
     userContext: UserContext;

--- a/lib/build/recipe/emailpassword/utils.js
+++ b/lib/build/recipe/emailpassword/utils.js
@@ -222,8 +222,6 @@ function getPasswordResetLink(input) {
         input.appInfo.websiteBasePath.getAsStringDangerous() +
         "/reset-password?token=" +
         input.token +
-        "&rid=" +
-        input.recipeId +
         "&tenantId=" +
         input.tenantId
     );

--- a/lib/build/recipe/emailverification/api/implementation.js
+++ b/lib/build/recipe/emailverification/api/implementation.js
@@ -158,7 +158,6 @@ function getAPIInterface() {
                 let emailVerifyLink = utils_1.getEmailVerifyLink({
                     appInfo: options.appInfo,
                     token: response.token,
-                    recipeId: options.recipeId,
                     tenantId,
                     request: options.req,
                     userContext,

--- a/lib/build/recipe/emailverification/index.js
+++ b/lib/build/recipe/emailverification/index.js
@@ -64,7 +64,6 @@ class Wrapper {
             link: utils_1.getEmailVerifyLink({
                 appInfo,
                 token: emailVerificationToken.token,
-                recipeId: recipeInstance.getRecipeId(),
                 tenantId,
                 request: __1.getRequestFromUserContext(ctx),
                 userContext: ctx,

--- a/lib/build/recipe/emailverification/utils.d.ts
+++ b/lib/build/recipe/emailverification/utils.d.ts
@@ -11,7 +11,6 @@ export declare function validateAndNormaliseUserInput(
 export declare function getEmailVerifyLink(input: {
     appInfo: NormalisedAppinfo;
     token: string;
-    recipeId: string;
     tenantId: string;
     request: BaseRequest | undefined;
     userContext: UserContext;

--- a/lib/build/recipe/emailverification/utils.js
+++ b/lib/build/recipe/emailverification/utils.js
@@ -75,8 +75,6 @@ function getEmailVerifyLink(input) {
         "/verify-email" +
         "?token=" +
         input.token +
-        "&rid=" +
-        input.recipeId +
         "&tenantId=" +
         input.tenantId
     );

--- a/lib/build/recipe/passwordless/api/implementation.js
+++ b/lib/build/recipe/passwordless/api/implementation.js
@@ -387,9 +387,7 @@ function getAPIImplementation() {
                         .getAsStringDangerous() +
                     input.options.appInfo.websiteBasePath.getAsStringDangerous() +
                     "/verify" +
-                    "?rid=" +
-                    input.options.recipeId +
-                    "&preAuthSessionId=" +
+                    "?preAuthSessionId=" +
                     response.preAuthSessionId +
                     "&tenantId=" +
                     input.tenantId +
@@ -580,9 +578,7 @@ function getAPIImplementation() {
                                 .getAsStringDangerous() +
                             input.options.appInfo.websiteBasePath.getAsStringDangerous() +
                             "/verify" +
-                            "?rid=" +
-                            input.options.recipeId +
-                            "&preAuthSessionId=" +
+                            "?preAuthSessionId=" +
                             response.preAuthSessionId +
                             "&tenantId=" +
                             input.tenantId +

--- a/lib/build/recipe/passwordless/constants.d.ts
+++ b/lib/build/recipe/passwordless/constants.d.ts
@@ -2,5 +2,7 @@
 export declare const CREATE_CODE_API = "/signinup/code";
 export declare const RESEND_CODE_API = "/signinup/code/resend";
 export declare const CONSUME_CODE_API = "/signinup/code/consume";
-export declare const DOES_EMAIL_EXIST_API = "/signup/email/exists";
-export declare const DOES_PHONE_NUMBER_EXIST_API = "/signup/phonenumber/exists";
+export declare const DOES_EMAIL_EXIST_API_OLD = "/signup/email/exists";
+export declare const DOES_EMAIL_EXIST_API = "/passwordless/email/exists";
+export declare const DOES_PHONE_NUMBER_EXIST_API_OLD = "/signup/phonenumber/exists";
+export declare const DOES_PHONE_NUMBER_EXIST_API = "/passwordless/phonenumber/exists";

--- a/lib/build/recipe/passwordless/constants.js
+++ b/lib/build/recipe/passwordless/constants.js
@@ -14,9 +14,11 @@
  * under the License.
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.DOES_PHONE_NUMBER_EXIST_API = exports.DOES_EMAIL_EXIST_API = exports.CONSUME_CODE_API = exports.RESEND_CODE_API = exports.CREATE_CODE_API = void 0;
+exports.DOES_PHONE_NUMBER_EXIST_API = exports.DOES_PHONE_NUMBER_EXIST_API_OLD = exports.DOES_EMAIL_EXIST_API = exports.DOES_EMAIL_EXIST_API_OLD = exports.CONSUME_CODE_API = exports.RESEND_CODE_API = exports.CREATE_CODE_API = void 0;
 exports.CREATE_CODE_API = "/signinup/code";
 exports.RESEND_CODE_API = "/signinup/code/resend";
 exports.CONSUME_CODE_API = "/signinup/code/consume";
-exports.DOES_EMAIL_EXIST_API = "/signup/email/exists";
-exports.DOES_PHONE_NUMBER_EXIST_API = "/signup/phonenumber/exists";
+exports.DOES_EMAIL_EXIST_API_OLD = "/signup/email/exists";
+exports.DOES_EMAIL_EXIST_API = "/passwordless/email/exists";
+exports.DOES_PHONE_NUMBER_EXIST_API_OLD = "/signup/phonenumber/exists";
+exports.DOES_PHONE_NUMBER_EXIST_API = "/passwordless/phonenumber/exists";

--- a/lib/build/recipe/passwordless/recipe.js
+++ b/lib/build/recipe/passwordless/recipe.js
@@ -65,10 +65,24 @@ class Recipe extends recipeModule_1.default {
                     pathWithoutApiBasePath: new normalisedURLPath_1.default(constants_1.DOES_EMAIL_EXIST_API),
                 },
                 {
+                    id: constants_1.DOES_EMAIL_EXIST_API_OLD,
+                    disabled: this.apiImpl.emailExistsGET === undefined,
+                    method: "get",
+                    pathWithoutApiBasePath: new normalisedURLPath_1.default(constants_1.DOES_EMAIL_EXIST_API_OLD),
+                },
+                {
                     id: constants_1.DOES_PHONE_NUMBER_EXIST_API,
                     disabled: this.apiImpl.phoneNumberExistsGET === undefined,
                     method: "get",
                     pathWithoutApiBasePath: new normalisedURLPath_1.default(constants_1.DOES_PHONE_NUMBER_EXIST_API),
+                },
+                {
+                    id: constants_1.DOES_PHONE_NUMBER_EXIST_API_OLD,
+                    disabled: this.apiImpl.phoneNumberExistsGET === undefined,
+                    method: "get",
+                    pathWithoutApiBasePath: new normalisedURLPath_1.default(
+                        constants_1.DOES_PHONE_NUMBER_EXIST_API_OLD
+                    ),
                 },
                 {
                     id: constants_1.RESEND_CODE_API,
@@ -94,9 +108,12 @@ class Recipe extends recipeModule_1.default {
                 return await consumeCode_1.default(this.apiImpl, tenantId, options, userContext);
             } else if (id === constants_1.CREATE_CODE_API) {
                 return await createCode_1.default(this.apiImpl, tenantId, options, userContext);
-            } else if (id === constants_1.DOES_EMAIL_EXIST_API) {
+            } else if (id === constants_1.DOES_EMAIL_EXIST_API || id === constants_1.DOES_EMAIL_EXIST_API_OLD) {
                 return await emailExists_1.default(this.apiImpl, tenantId, options, userContext);
-            } else if (id === constants_1.DOES_PHONE_NUMBER_EXIST_API) {
+            } else if (
+                id === constants_1.DOES_PHONE_NUMBER_EXIST_API ||
+                id === constants_1.DOES_PHONE_NUMBER_EXIST_API_OLD
+            ) {
                 return await phoneNumberExists_1.default(this.apiImpl, tenantId, options, userContext);
             } else {
                 return await resendCode_1.default(this.apiImpl, tenantId, options, userContext);
@@ -147,9 +164,7 @@ class Recipe extends recipeModule_1.default {
                     .getAsStringDangerous() +
                 appInfo.websiteBasePath.getAsStringDangerous() +
                 "/verify" +
-                "?rid=" +
-                this.getRecipeId() +
-                "&preAuthSessionId=" +
+                "?preAuthSessionId=" +
                 codeInfo.preAuthSessionId +
                 "&tenantId=" +
                 input.tenantId +

--- a/lib/build/supertokens.js
+++ b/lib/build/supertokens.js
@@ -162,25 +162,56 @@ class SuperTokens {
                 requestRID = undefined;
             }
             if (requestRID !== undefined) {
-                let matchedRecipe = undefined;
+                let matchedRecipe = [];
                 // we loop through all recipe modules to find the one with the matching rId
                 for (let i = 0; i < this.recipeModules.length; i++) {
                     logger_1.logDebugMessage(
                         "middleware: Checking recipe ID for match: " + this.recipeModules[i].getRecipeId()
                     );
                     if (this.recipeModules[i].getRecipeId() === requestRID) {
-                        matchedRecipe = this.recipeModules[i];
-                        break;
+                        matchedRecipe.push(this.recipeModules[i]);
+                    } else if (requestRID === "thirdpartyemailpassword") {
+                        if (
+                            this.recipeModules[i].getRecipeId() === "thirdparty" ||
+                            this.recipeModules[i].getRecipeId() === "emailpassword"
+                        ) {
+                            matchedRecipe.push(this.recipeModules[i]);
+                        }
+                    } else if (requestRID === "thirdpartypasswordless") {
+                        if (
+                            this.recipeModules[i].getRecipeId() === "thirdparty" ||
+                            this.recipeModules[i].getRecipeId() === "passwordless"
+                        ) {
+                            matchedRecipe.push(this.recipeModules[i]);
+                        }
                     }
                 }
-                if (matchedRecipe === undefined) {
+                if (matchedRecipe.length === 0) {
                     logger_1.logDebugMessage("middleware: Not handling because no recipe matched");
                     // we could not find one, so we skip
                     return false;
                 }
-                logger_1.logDebugMessage("middleware: Matched with recipe ID: " + matchedRecipe.getRecipeId());
-                let idResult = await matchedRecipe.returnAPIIdIfCanHandleRequest(path, method, userContext);
-                if (idResult === undefined) {
+                for (let i = 0; i < matchedRecipe.length; i++) {
+                    logger_1.logDebugMessage("middleware: Matched with recipe IDs: " + matchedRecipe[i].getRecipeId());
+                }
+                let idResult = undefined;
+                let finalMatchedRecipe = undefined;
+                for (let i = 0; i < matchedRecipe.length; i++) {
+                    // Here we assume that if there are multiple recipes that have matched, then
+                    // the path and methods of the APIs exposed via those recipes is unique.
+                    let currIdResult = await matchedRecipe[i].returnAPIIdIfCanHandleRequest(path, method, userContext);
+                    if (currIdResult !== undefined) {
+                        if (idResult !== undefined) {
+                            throw new Error(
+                                "Two recipes have matched the same API path and method! This is a bug in the SDK. Please contact support."
+                            );
+                        } else {
+                            finalMatchedRecipe = matchedRecipe[i];
+                            idResult = currIdResult;
+                        }
+                    }
+                }
+                if (idResult === undefined || finalMatchedRecipe === undefined) {
                     logger_1.logDebugMessage(
                         "middleware: Not handling because recipe doesn't handle request path or method. Request path: " +
                             path.getAsStringDangerous() +
@@ -192,7 +223,7 @@ class SuperTokens {
                 }
                 logger_1.logDebugMessage("middleware: Request being handled by recipe. ID is: " + idResult.id);
                 // give task to the matched recipe
-                let requestHandled = await matchedRecipe.handleAPIRequest(
+                let requestHandled = await finalMatchedRecipe.handleAPIRequest(
                     idResult.id,
                     idResult.tenantId,
                     request,

--- a/lib/build/supertokens.js
+++ b/lib/build/supertokens.js
@@ -161,7 +161,45 @@ class SuperTokens {
                 // see https://github.com/supertokens/supertokens-node/issues/202
                 requestRID = undefined;
             }
+            async function handleWithoutRid(recipeModules) {
+                for (let i = 0; i < recipeModules.length; i++) {
+                    logger_1.logDebugMessage(
+                        "middleware: Checking recipe ID for match: " +
+                            recipeModules[i].getRecipeId() +
+                            " with path: " +
+                            path.getAsStringDangerous() +
+                            " and method: " +
+                            method
+                    );
+                    let idResult = await recipeModules[i].returnAPIIdIfCanHandleRequest(path, method, userContext);
+                    if (idResult !== undefined) {
+                        logger_1.logDebugMessage("middleware: Request being handled by recipe. ID is: " + idResult.id);
+                        let requestHandled = await recipeModules[i].handleAPIRequest(
+                            idResult.id,
+                            idResult.tenantId,
+                            request,
+                            response,
+                            path,
+                            method,
+                            userContext
+                        );
+                        if (!requestHandled) {
+                            logger_1.logDebugMessage(
+                                "middleware: Not handled because API returned requestHandled as false"
+                            );
+                            return false;
+                        }
+                        logger_1.logDebugMessage("middleware: Ended");
+                        return true;
+                    }
+                }
+                logger_1.logDebugMessage("middleware: Not handling because no recipe matched");
+                return false;
+            }
             if (requestRID !== undefined) {
+                // We have the below matching based on RID header cause
+                // we still support older FDIs (< 1.20). In the newer FDIs,
+                // the API paths across all recipes are unique.
                 let matchedRecipe = [];
                 // we loop through all recipe modules to find the one with the matching rId
                 for (let i = 0; i < this.recipeModules.length; i++) {
@@ -187,9 +225,8 @@ class SuperTokens {
                     }
                 }
                 if (matchedRecipe.length === 0) {
-                    logger_1.logDebugMessage("middleware: Not handling because no recipe matched");
-                    // we could not find one, so we skip
-                    return false;
+                    logger_1.logDebugMessage("middleware: Not handling based on rid match. Trying without rid.");
+                    return handleWithoutRid(this.recipeModules);
                 }
                 for (let i = 0; i < matchedRecipe.length; i++) {
                     logger_1.logDebugMessage("middleware: Matched with recipe IDs: " + matchedRecipe[i].getRecipeId());
@@ -212,14 +249,7 @@ class SuperTokens {
                     }
                 }
                 if (idResult === undefined || finalMatchedRecipe === undefined) {
-                    logger_1.logDebugMessage(
-                        "middleware: Not handling because recipe doesn't handle request path or method. Request path: " +
-                            path.getAsStringDangerous() +
-                            ", request method: " +
-                            method
-                    );
-                    // the matched recipe doesn't handle this path and http method
-                    return false;
+                    return handleWithoutRid(this.recipeModules);
                 }
                 logger_1.logDebugMessage("middleware: Request being handled by recipe. ID is: " + idResult.id);
                 // give task to the matched recipe
@@ -239,35 +269,7 @@ class SuperTokens {
                 logger_1.logDebugMessage("middleware: Ended");
                 return true;
             } else {
-                // we loop through all recipe modules to find the one with the matching path and method
-                for (let i = 0; i < this.recipeModules.length; i++) {
-                    logger_1.logDebugMessage(
-                        "middleware: Checking recipe ID for match: " + this.recipeModules[i].getRecipeId()
-                    );
-                    let idResult = await this.recipeModules[i].returnAPIIdIfCanHandleRequest(path, method, userContext);
-                    if (idResult !== undefined) {
-                        logger_1.logDebugMessage("middleware: Request being handled by recipe. ID is: " + idResult.id);
-                        let requestHandled = await this.recipeModules[i].handleAPIRequest(
-                            idResult.id,
-                            idResult.tenantId,
-                            request,
-                            response,
-                            path,
-                            method,
-                            userContext
-                        );
-                        if (!requestHandled) {
-                            logger_1.logDebugMessage(
-                                "middleware: Not handled because API returned requestHandled as false"
-                            );
-                            return false;
-                        }
-                        logger_1.logDebugMessage("middleware: Ended");
-                        return true;
-                    }
-                }
-                logger_1.logDebugMessage("middleware: Not handling because no recipe matched");
-                return false;
+                return handleWithoutRid(this.recipeModules);
             }
         };
         this.errorHandler = async (err, request, response, userContext) => {

--- a/lib/ts/recipe/emailpassword/api/implementation.ts
+++ b/lib/ts/recipe/emailpassword/api/implementation.ts
@@ -99,7 +99,6 @@ export default function getAPIImplementation(): APIInterface {
                 let passwordResetLink = getPasswordResetLink({
                     appInfo: options.appInfo,
                     token: response.token,
-                    recipeId: options.recipeId,
                     tenantId,
                     request: options.req,
                     userContext,

--- a/lib/ts/recipe/emailpassword/constants.ts
+++ b/lib/ts/recipe/emailpassword/constants.ts
@@ -25,4 +25,6 @@ export const GENERATE_PASSWORD_RESET_TOKEN_API = "/user/password/reset/token";
 
 export const PASSWORD_RESET_API = "/user/password/reset";
 
-export const SIGNUP_EMAIL_EXISTS_API = "/signup/email/exists";
+export const SIGNUP_EMAIL_EXISTS_API_OLD = "/signup/email/exists";
+
+export const SIGNUP_EMAIL_EXISTS_API = "/emailpassword/email/exists";

--- a/lib/ts/recipe/emailpassword/index.ts
+++ b/lib/ts/recipe/emailpassword/index.ts
@@ -292,7 +292,6 @@ export default class Wrapper {
             status: "OK",
             link: getPasswordResetLink({
                 appInfo: recipeInstance.getAppInfo(),
-                recipeId: recipeInstance.getRecipeId(),
                 token: token.token,
                 tenantId: tenantId === undefined ? DEFAULT_TENANT_ID : tenantId,
                 request: getRequestFromUserContext(ctx),

--- a/lib/ts/recipe/emailpassword/recipe.ts
+++ b/lib/ts/recipe/emailpassword/recipe.ts
@@ -25,6 +25,7 @@ import {
     GENERATE_PASSWORD_RESET_TOKEN_API,
     PASSWORD_RESET_API,
     SIGNUP_EMAIL_EXISTS_API,
+    SIGNUP_EMAIL_EXISTS_API_OLD,
 } from "./constants";
 import signUpAPI from "./api/signup";
 import signInAPI from "./api/signin";
@@ -286,6 +287,12 @@ export default class Recipe extends RecipeModule {
                 id: SIGNUP_EMAIL_EXISTS_API,
                 disabled: this.apiImpl.emailExistsGET === undefined,
             },
+            {
+                method: "get",
+                pathWithoutApiBasePath: new NormalisedURLPath(SIGNUP_EMAIL_EXISTS_API_OLD),
+                id: SIGNUP_EMAIL_EXISTS_API_OLD,
+                disabled: this.apiImpl.emailExistsGET === undefined,
+            },
         ];
     };
 
@@ -316,7 +323,7 @@ export default class Recipe extends RecipeModule {
             return await generatePasswordResetTokenAPI(this.apiImpl, tenantId, options, userContext);
         } else if (id === PASSWORD_RESET_API) {
             return await passwordResetAPI(this.apiImpl, tenantId, options, userContext);
-        } else if (id === SIGNUP_EMAIL_EXISTS_API) {
+        } else if (id === SIGNUP_EMAIL_EXISTS_API || id === SIGNUP_EMAIL_EXISTS_API_OLD) {
             return await emailExistsAPI(this.apiImpl, tenantId, options, userContext);
         }
         return false;

--- a/lib/ts/recipe/emailpassword/utils.ts
+++ b/lib/ts/recipe/emailpassword/utils.ts
@@ -252,7 +252,6 @@ export async function defaultEmailValidator(value: any) {
 export function getPasswordResetLink(input: {
     appInfo: NormalisedAppinfo;
     token: string;
-    recipeId: string;
     tenantId: string;
     request: BaseRequest | undefined;
     userContext: UserContext;
@@ -267,8 +266,6 @@ export function getPasswordResetLink(input: {
         input.appInfo.websiteBasePath.getAsStringDangerous() +
         "/reset-password?token=" +
         input.token +
-        "&rid=" +
-        input.recipeId +
         "&tenantId=" +
         input.tenantId
     );

--- a/lib/ts/recipe/emailverification/api/implementation.ts
+++ b/lib/ts/recipe/emailverification/api/implementation.ts
@@ -197,7 +197,6 @@ export default function getAPIInterface(): APIInterface {
                 let emailVerifyLink = getEmailVerifyLink({
                     appInfo: options.appInfo,
                     token: response.token,
-                    recipeId: options.recipeId,
                     tenantId,
                     request: options.req,
                     userContext,

--- a/lib/ts/recipe/emailverification/index.ts
+++ b/lib/ts/recipe/emailverification/index.ts
@@ -99,7 +99,6 @@ export default class Wrapper {
             link: getEmailVerifyLink({
                 appInfo,
                 token: emailVerificationToken.token,
-                recipeId: recipeInstance.getRecipeId(),
                 tenantId,
                 request: getRequestFromUserContext(ctx),
                 userContext: ctx,

--- a/lib/ts/recipe/emailverification/utils.ts
+++ b/lib/ts/recipe/emailverification/utils.ts
@@ -67,7 +67,6 @@ export function validateAndNormaliseUserInput(
 export function getEmailVerifyLink(input: {
     appInfo: NormalisedAppinfo;
     token: string;
-    recipeId: string;
     tenantId: string;
     request: BaseRequest | undefined;
     userContext: UserContext;
@@ -83,8 +82,6 @@ export function getEmailVerifyLink(input: {
         "/verify-email" +
         "?token=" +
         input.token +
-        "&rid=" +
-        input.recipeId +
         "&tenantId=" +
         input.tenantId
     );

--- a/lib/ts/recipe/passwordless/api/implementation.ts
+++ b/lib/ts/recipe/passwordless/api/implementation.ts
@@ -387,9 +387,7 @@ export default function getAPIImplementation(): APIInterface {
                         .getAsStringDangerous() +
                     input.options.appInfo.websiteBasePath.getAsStringDangerous() +
                     "/verify" +
-                    "?rid=" +
-                    input.options.recipeId +
-                    "&preAuthSessionId=" +
+                    "?preAuthSessionId=" +
                     response.preAuthSessionId +
                     "&tenantId=" +
                     input.tenantId +
@@ -591,9 +589,7 @@ export default function getAPIImplementation(): APIInterface {
                                 .getAsStringDangerous() +
                             input.options.appInfo.websiteBasePath.getAsStringDangerous() +
                             "/verify" +
-                            "?rid=" +
-                            input.options.recipeId +
-                            "&preAuthSessionId=" +
+                            "?preAuthSessionId=" +
                             response.preAuthSessionId +
                             "&tenantId=" +
                             input.tenantId +

--- a/lib/ts/recipe/passwordless/constants.ts
+++ b/lib/ts/recipe/passwordless/constants.ts
@@ -19,6 +19,10 @@ export const RESEND_CODE_API = "/signinup/code/resend";
 
 export const CONSUME_CODE_API = "/signinup/code/consume";
 
-export const DOES_EMAIL_EXIST_API = "/signup/email/exists";
+export const DOES_EMAIL_EXIST_API_OLD = "/signup/email/exists";
 
-export const DOES_PHONE_NUMBER_EXIST_API = "/signup/phonenumber/exists";
+export const DOES_EMAIL_EXIST_API = "/passwordless/email/exists";
+
+export const DOES_PHONE_NUMBER_EXIST_API_OLD = "/signup/phonenumber/exists";
+
+export const DOES_PHONE_NUMBER_EXIST_API = "/passwordless/phonenumber/exists";

--- a/lib/ts/recipe/passwordless/recipe.ts
+++ b/lib/ts/recipe/passwordless/recipe.ts
@@ -34,6 +34,8 @@ import {
     CREATE_CODE_API,
     DOES_EMAIL_EXIST_API,
     DOES_PHONE_NUMBER_EXIST_API,
+    DOES_EMAIL_EXIST_API_OLD,
+    DOES_PHONE_NUMBER_EXIST_API_OLD,
     RESEND_CODE_API,
 } from "./constants";
 import EmailDeliveryIngredient from "../../ingredients/emaildelivery";
@@ -477,10 +479,22 @@ export default class Recipe extends RecipeModule {
                 pathWithoutApiBasePath: new NormalisedURLPath(DOES_EMAIL_EXIST_API),
             },
             {
+                id: DOES_EMAIL_EXIST_API_OLD,
+                disabled: this.apiImpl.emailExistsGET === undefined,
+                method: "get",
+                pathWithoutApiBasePath: new NormalisedURLPath(DOES_EMAIL_EXIST_API_OLD),
+            },
+            {
                 id: DOES_PHONE_NUMBER_EXIST_API,
                 disabled: this.apiImpl.phoneNumberExistsGET === undefined,
                 method: "get",
                 pathWithoutApiBasePath: new NormalisedURLPath(DOES_PHONE_NUMBER_EXIST_API),
+            },
+            {
+                id: DOES_PHONE_NUMBER_EXIST_API_OLD,
+                disabled: this.apiImpl.phoneNumberExistsGET === undefined,
+                method: "get",
+                pathWithoutApiBasePath: new NormalisedURLPath(DOES_PHONE_NUMBER_EXIST_API_OLD),
             },
             {
                 id: RESEND_CODE_API,
@@ -515,9 +529,9 @@ export default class Recipe extends RecipeModule {
             return await consumeCodeAPI(this.apiImpl, tenantId, options, userContext);
         } else if (id === CREATE_CODE_API) {
             return await createCodeAPI(this.apiImpl, tenantId, options, userContext);
-        } else if (id === DOES_EMAIL_EXIST_API) {
+        } else if (id === DOES_EMAIL_EXIST_API || id === DOES_EMAIL_EXIST_API_OLD) {
             return await emailExistsAPI(this.apiImpl, tenantId, options, userContext);
-        } else if (id === DOES_PHONE_NUMBER_EXIST_API) {
+        } else if (id === DOES_PHONE_NUMBER_EXIST_API || id === DOES_PHONE_NUMBER_EXIST_API_OLD) {
             return await phoneNumberExistsAPI(this.apiImpl, tenantId, options, userContext);
         } else {
             return await resendCodeAPI(this.apiImpl, tenantId, options, userContext);
@@ -593,9 +607,7 @@ export default class Recipe extends RecipeModule {
                 .getAsStringDangerous() +
             appInfo.websiteBasePath.getAsStringDangerous() +
             "/verify" +
-            "?rid=" +
-            this.getRecipeId() +
-            "&preAuthSessionId=" +
+            "?preAuthSessionId=" +
             codeInfo.preAuthSessionId +
             "&tenantId=" +
             input.tenantId +

--- a/test/accountlinking/emailverificationapis.test.js
+++ b/test/accountlinking/emailverificationapis.test.js
@@ -1479,7 +1479,7 @@ describe(`emailverificationapiTests: ${printPath("[test/accountlinking/emailveri
                             return {
                                 ...oI,
                                 sendEmail: async function (input) {
-                                    token = input.emailVerifyLink.split("?token=")[1].split("&rid=")[0];
+                                    token = input.emailVerifyLink.split("?token=")[1].split("&tenantId=")[0];
                                 },
                             };
                         },
@@ -1623,7 +1623,7 @@ describe(`emailverificationapiTests: ${printPath("[test/accountlinking/emailveri
                             return {
                                 ...oI,
                                 sendEmail: async function (input) {
-                                    token = input.emailVerifyLink.split("?token=")[1].split("&rid=")[0];
+                                    token = input.emailVerifyLink.split("?token=")[1].split("&tenantId=")[0];
                                 },
                             };
                         },

--- a/test/emailpassword/emailverify.test.js
+++ b/test/emailpassword/emailverify.test.js
@@ -596,6 +596,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         const connectionURI = await startST();
 
         let token = null;
+        let rid = undefined;
 
         STExpress.init({
             supertokens: {
@@ -614,6 +615,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
                             sendEmail: async (input) => {
                                 const searchParams = new URLSearchParams(new URL(input.emailVerifyLink).search);
                                 token = searchParams.get("token");
+                                rid = searchParams.get("rid");
                             },
                         },
                     },
@@ -675,6 +677,7 @@ describe(`emailverify: ${printPath("[test/emailpassword/emailverify.test.js]")}`
         assert(JSON.parse(response3.text).status === "OK");
         assert(JSON.parse(response3.text).isVerified === true);
         assert(Object.keys(JSON.parse(response3.text)).length === 2);
+        assert(rid === null);
     });
 
     // Call the API with no session and see the error

--- a/test/emailpassword/passwordreset.test.js
+++ b/test/emailpassword/passwordreset.test.js
@@ -174,7 +174,7 @@ describe(`passwordreset: ${printPath("[test/emailpassword/passwordreset.test.js]
         assert(resetURL === "https://supertokens.io/auth/reset-password");
         assert.notStrictEqual(tokenInfo, undefined);
         assert.notStrictEqual(tokenInfo, null);
-        assert.strictEqual(ridInfo, "emailpassword");
+        assert.strictEqual(ridInfo, null);
         assert.strictEqual(tenantInfo, "public");
     });
 

--- a/test/passwordless/apis.test.js
+++ b/test/passwordless/apis.test.js
@@ -1582,10 +1582,10 @@ describe(`apisFunctions: ${printPath("[test/passwordless/apis.test.js]")}`, func
 
             assert(validCreateCodeResponse.status === "OK");
 
-            // check that the magicLink format is {websiteDomain}{websiteBasePath}/verify?rid=passwordless&preAuthSessionId=<some string>#linkCode
+            // check that the magicLink format is {websiteDomain}{websiteBasePath}/verify?preAuthSessionId=<some string>#linkCode
             assert(magicLinkURL.hostname === "supertokens.io");
             assert(magicLinkURL.pathname === "/auth/verify");
-            assert(magicLinkURL.searchParams.get("rid") === "passwordless");
+            assert(magicLinkURL.searchParams.get("rid") === null);
             assert(magicLinkURL.searchParams.get("preAuthSessionId") === validCreateCodeResponse.preAuthSessionId);
             assert(magicLinkURL.hash.length > 1);
         }

--- a/test/passwordless/apis.test.js
+++ b/test/passwordless/apis.test.js
@@ -1686,6 +1686,101 @@ describe(`apisFunctions: ${printPath("[test/passwordless/apis.test.js]")}`, func
         }
     });
 
+    it("test emailExistsAPI with new path", async function () {
+        const connectionURI = await startST();
+
+        STExpress.init({
+            supertokens: {
+                connectionURI,
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                Session.init({ getTokenTransferMethod: () => "cookie" }),
+                Passwordless.init({
+                    contactMethod: "EMAIL",
+                    flowType: "USER_INPUT_CODE_AND_MAGIC_LINK",
+                    emailDelivery: {
+                        service: {
+                            sendEmail: async (input) => {
+                                return;
+                            },
+                        },
+                    },
+                }),
+            ],
+        });
+
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
+
+        const app = express();
+
+        app.use(middleware());
+
+        app.use(errorHandler());
+
+        {
+            // email does not exist
+            let emailDoesNotExistResponse = await new Promise((resolve) =>
+                request(app)
+                    .get("/auth/passwordless/email/exists")
+                    .query({
+                        email: "test@example.com",
+                    })
+                    .expect(200)
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                            resolve(JSON.parse(res.text));
+                        }
+                    })
+            );
+            assert(emailDoesNotExistResponse.status === "OK");
+            assert(emailDoesNotExistResponse.exists === false);
+        }
+
+        {
+            // email exists
+
+            // create a passwordless user through email
+            let codeInfo = await Passwordless.createCode({
+                tenantId: "public",
+                email: "test@example.com",
+            });
+
+            await Passwordless.consumeCode({
+                tenantId: "public",
+                preAuthSessionId: codeInfo.preAuthSessionId,
+                linkCode: codeInfo.linkCode,
+            });
+
+            let emailExistsResponse = await new Promise((resolve) =>
+                request(app)
+                    .get("/auth/passwordless/email/exists")
+                    .query({
+                        email: "test@example.com",
+                    })
+                    .expect(200)
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                            resolve(JSON.parse(res.text));
+                        }
+                    })
+            );
+            assert(emailExistsResponse.status === "OK");
+            assert(emailExistsResponse.exists === true);
+        }
+    });
+
     it("test phoneNumberExistsAPI", async function () {
         const connectionURI = await startST();
 
@@ -1764,6 +1859,101 @@ describe(`apisFunctions: ${printPath("[test/passwordless/apis.test.js]")}`, func
             let phoneNumberExistsResponse = await new Promise((resolve) =>
                 request(app)
                     .get("/auth/signup/phonenumber/exists")
+                    .query({
+                        phoneNumber: "+1234567890",
+                    })
+                    .expect(200)
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                            resolve(JSON.parse(res.text));
+                        }
+                    })
+            );
+            assert(phoneNumberExistsResponse.status === "OK");
+            assert(phoneNumberExistsResponse.exists === true);
+        }
+    });
+
+    it("test phoneNumberExistsAPI with new path", async function () {
+        const connectionURI = await startST();
+
+        STExpress.init({
+            supertokens: {
+                connectionURI,
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                Session.init({ getTokenTransferMethod: () => "cookie" }),
+                Passwordless.init({
+                    contactMethod: "PHONE",
+                    flowType: "USER_INPUT_CODE_AND_MAGIC_LINK",
+                    smsDelivery: {
+                        service: {
+                            sendSms: async (input) => {
+                                return;
+                            },
+                        },
+                    },
+                }),
+            ],
+        });
+
+        // run test if current CDI version >= 2.11
+        if (!(await isCDIVersionCompatible("2.11"))) {
+            return;
+        }
+
+        const app = express();
+
+        app.use(middleware());
+
+        app.use(errorHandler());
+
+        {
+            // phoneNumber does not exist
+            let phoneNumberDoesNotExistResponse = await new Promise((resolve) =>
+                request(app)
+                    .get("/auth/passwordless/phonenumber/exists")
+                    .query({
+                        phoneNumber: "+1234567890",
+                    })
+                    .expect(200)
+                    .end((err, res) => {
+                        if (err) {
+                            resolve(undefined);
+                        } else {
+                            resolve(JSON.parse(res.text));
+                        }
+                    })
+            );
+            assert(phoneNumberDoesNotExistResponse.status === "OK");
+            assert(phoneNumberDoesNotExistResponse.exists === false);
+        }
+
+        {
+            // phoneNumber exists
+
+            // create a passwordless user through phone
+            let codeInfo = await Passwordless.createCode({
+                tenantId: "public",
+                phoneNumber: "+1234567890",
+            });
+
+            await Passwordless.consumeCode({
+                tenantId: "public",
+                preAuthSessionId: codeInfo.preAuthSessionId,
+                linkCode: codeInfo.linkCode,
+            });
+
+            let phoneNumberExistsResponse = await new Promise((resolve) =>
+                request(app)
+                    .get("/auth/passwordless/phonenumber/exists")
                     .query({
                         phoneNumber: "+1234567890",
                     })

--- a/test/passwordless/recipeFunctions.test.js
+++ b/test/passwordless/recipeFunctions.test.js
@@ -936,7 +936,7 @@ describe(`recipeFunctions: ${printPath("[test/passwordless/recipeFunctions.test.
 
     /*
     - createMagicLink
-    - check that the magicLink format is {websiteDomain}{websiteBasePath}/verify?rid=passwordless&preAuthSessionId=<some string>#linkCode
+    - check that the magicLink format is {websiteDomain}{websiteBasePath}/verify&preAuthSessionId=<some string>#linkCode
     */
 
     it("createMagicLink test", async function () {
@@ -979,7 +979,7 @@ describe(`recipeFunctions: ${printPath("[test/passwordless/recipeFunctions.test.
 
         assert(magicLinkURL.hostname === "supertokens.io");
         assert(magicLinkURL.pathname === "/auth/verify");
-        assert(magicLinkURL.searchParams.get("rid") === "passwordless");
+        assert(magicLinkURL.searchParams.get("rid") === null);
         assert(typeof magicLinkURL.searchParams.get("preAuthSessionId") === "string");
         assert(magicLinkURL.hash.length > 1);
     });

--- a/test/thirdparty/signinupFeature.test.js
+++ b/test/thirdparty/signinupFeature.test.js
@@ -34,6 +34,7 @@ let Session = require("../../recipe/session");
 const EmailVerification = require("../../recipe/emailverification");
 let { middleware, errorHandler } = require("../../framework/express");
 let EmailPassword = require("../../recipe/emailpassword");
+let Passwordless = require("../../recipe/passwordless");
 const { Querier } = require("../../lib/build/querier");
 const { maxVersion } = require("../../lib/build/utils");
 
@@ -157,6 +158,221 @@ describe(`signinupTest: ${printPath("[test/thirdparty/signinupFeature.test.js]")
     after(async function () {
         await killAllST();
         await cleanST();
+    });
+
+    it("test with rid thirdpartypasswordless still works", async function () {
+        const connectionURI = await startST();
+        STExpress.init({
+            supertokens: {
+                connectionURI,
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                Session.init({ getTokenTransferMethod: () => "cookie", antiCsrf: "VIA_TOKEN" }),
+                ThirdPartyRecipe.init({
+                    signInAndUpFeature: {
+                        providers: [this.customProvider6],
+                    },
+                }),
+                Passwordless.init({
+                    contactMethod: "EMAIL_OR_PHONE",
+                    flowType: "MAGIC_LINK",
+                }),
+            ],
+        });
+
+        const app = express();
+
+        app.use(middleware());
+
+        app.use(errorHandler());
+
+        let response1 = await new Promise((resolve) =>
+            request(app)
+                .post("/auth/signinup")
+                .set("rid", "thirdpartypasswordless")
+                .send({
+                    thirdPartyId: "custom",
+                    oAuthTokens: {
+                        access_token: "saodiasjodai",
+                    },
+                })
+                .end((err, res) => {
+                    if (err) {
+                        resolve(undefined);
+                    } else {
+                        resolve(res);
+                    }
+                })
+        );
+        assert.notStrictEqual(response1, undefined);
+        assert.strictEqual(response1.body.status, "OK");
+        assert.strictEqual(response1.body.createdNewRecipeUser, true);
+        assert.strictEqual(response1.body.user.loginMethods[0].thirdParty.id, "custom");
+        assert.strictEqual(response1.body.user.loginMethods[0].thirdParty.userId, "user");
+        assert.strictEqual(response1.body.user.thirdParty[0].id, "custom");
+        assert.strictEqual(response1.body.user.thirdParty[0].userId, "user");
+        assert.strictEqual(response1.body.user.emails[0], "email@test.com");
+
+        let cookies1 = extractInfoFromResponse(response1);
+        assert.notStrictEqual(cookies1.accessToken, undefined);
+        assert.notStrictEqual(cookies1.refreshToken, undefined);
+        assert.notStrictEqual(cookies1.antiCsrf, undefined);
+        assert.notStrictEqual(cookies1.accessTokenExpiry, undefined);
+        assert.notStrictEqual(cookies1.refreshTokenExpiry, undefined);
+        assert.notStrictEqual(cookies1.refreshToken, undefined);
+        assert.strictEqual(cookies1.accessTokenDomain, undefined);
+        assert.strictEqual(cookies1.refreshTokenDomain, undefined);
+        assert.notStrictEqual(cookies1.frontToken, "remove");
+
+        let response2 = await new Promise((resolve) =>
+            request(app)
+                .post("/auth/signinup")
+                .set("rid", "thirdpartypasswordless")
+                .send({
+                    thirdPartyId: "custom",
+                    oAuthTokens: {
+                        access_token: "saodiasjodai",
+                    },
+                })
+                .end((err, res) => {
+                    if (err) {
+                        resolve(undefined);
+                    } else {
+                        resolve(res);
+                    }
+                })
+        );
+
+        assert.notStrictEqual(response2, undefined);
+        assert.strictEqual(response2.body.status, "OK");
+        assert.strictEqual(response2.body.createdNewRecipeUser, false);
+        assert.strictEqual(response2.body.user.loginMethods[0].thirdParty.id, "custom");
+        assert.strictEqual(response2.body.user.loginMethods[0].thirdParty.userId, "user");
+        assert.strictEqual(response2.body.user.thirdParty[0].id, "custom");
+        assert.strictEqual(response2.body.user.thirdParty[0].userId, "user");
+        assert.strictEqual(response2.body.user.emails[0], "email@test.com");
+
+        let cookies2 = extractInfoFromResponse(response2);
+        assert.notStrictEqual(cookies2.accessToken, undefined);
+        assert.notStrictEqual(cookies2.refreshToken, undefined);
+        assert.notStrictEqual(cookies2.antiCsrf, undefined);
+        assert.notStrictEqual(cookies2.accessTokenExpiry, undefined);
+        assert.notStrictEqual(cookies2.refreshTokenExpiry, undefined);
+        assert.notStrictEqual(cookies2.refreshToken, undefined);
+        assert.strictEqual(cookies2.accessTokenDomain, undefined);
+        assert.strictEqual(cookies2.refreshTokenDomain, undefined);
+        assert.notStrictEqual(cookies2.frontToken, "remove");
+    });
+
+    it("test with rid thirdpartyemailpassword still works", async function () {
+        const connectionURI = await startST();
+        STExpress.init({
+            supertokens: {
+                connectionURI,
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                Session.init({ getTokenTransferMethod: () => "cookie", antiCsrf: "VIA_TOKEN" }),
+                ThirdPartyRecipe.init({
+                    signInAndUpFeature: {
+                        providers: [this.customProvider6],
+                    },
+                }),
+                EmailPassword.init(),
+            ],
+        });
+
+        const app = express();
+
+        app.use(middleware());
+
+        app.use(errorHandler());
+
+        let response1 = await new Promise((resolve) =>
+            request(app)
+                .post("/auth/signinup")
+                .set("rid", "thirdpartyemailpassword")
+                .send({
+                    thirdPartyId: "custom",
+                    oAuthTokens: {
+                        access_token: "saodiasjodai",
+                    },
+                })
+                .end((err, res) => {
+                    if (err) {
+                        resolve(undefined);
+                    } else {
+                        resolve(res);
+                    }
+                })
+        );
+        assert.notStrictEqual(response1, undefined);
+        assert.strictEqual(response1.body.status, "OK");
+        assert.strictEqual(response1.body.createdNewRecipeUser, true);
+        assert.strictEqual(response1.body.user.loginMethods[0].thirdParty.id, "custom");
+        assert.strictEqual(response1.body.user.loginMethods[0].thirdParty.userId, "user");
+        assert.strictEqual(response1.body.user.thirdParty[0].id, "custom");
+        assert.strictEqual(response1.body.user.thirdParty[0].userId, "user");
+        assert.strictEqual(response1.body.user.emails[0], "email@test.com");
+
+        let cookies1 = extractInfoFromResponse(response1);
+        assert.notStrictEqual(cookies1.accessToken, undefined);
+        assert.notStrictEqual(cookies1.refreshToken, undefined);
+        assert.notStrictEqual(cookies1.antiCsrf, undefined);
+        assert.notStrictEqual(cookies1.accessTokenExpiry, undefined);
+        assert.notStrictEqual(cookies1.refreshTokenExpiry, undefined);
+        assert.notStrictEqual(cookies1.refreshToken, undefined);
+        assert.strictEqual(cookies1.accessTokenDomain, undefined);
+        assert.strictEqual(cookies1.refreshTokenDomain, undefined);
+        assert.notStrictEqual(cookies1.frontToken, "remove");
+
+        let response2 = await new Promise((resolve) =>
+            request(app)
+                .post("/auth/signinup")
+                .set("rid", "thirdpartyemailpassword")
+                .send({
+                    thirdPartyId: "custom",
+                    oAuthTokens: {
+                        access_token: "saodiasjodai",
+                    },
+                })
+                .end((err, res) => {
+                    if (err) {
+                        resolve(undefined);
+                    } else {
+                        resolve(res);
+                    }
+                })
+        );
+
+        assert.notStrictEqual(response2, undefined);
+        assert.strictEqual(response2.body.status, "OK");
+        assert.strictEqual(response2.body.createdNewRecipeUser, false);
+        assert.strictEqual(response2.body.user.loginMethods[0].thirdParty.id, "custom");
+        assert.strictEqual(response2.body.user.loginMethods[0].thirdParty.userId, "user");
+        assert.strictEqual(response2.body.user.thirdParty[0].id, "custom");
+        assert.strictEqual(response2.body.user.thirdParty[0].userId, "user");
+        assert.strictEqual(response2.body.user.emails[0], "email@test.com");
+
+        let cookies2 = extractInfoFromResponse(response2);
+        assert.notStrictEqual(cookies2.accessToken, undefined);
+        assert.notStrictEqual(cookies2.refreshToken, undefined);
+        assert.notStrictEqual(cookies2.antiCsrf, undefined);
+        assert.notStrictEqual(cookies2.accessTokenExpiry, undefined);
+        assert.notStrictEqual(cookies2.refreshTokenExpiry, undefined);
+        assert.notStrictEqual(cookies2.refreshToken, undefined);
+        assert.strictEqual(cookies2.accessTokenDomain, undefined);
+        assert.strictEqual(cookies2.refreshTokenDomain, undefined);
+        assert.notStrictEqual(cookies2.frontToken, "remove");
     });
 
     it("test that disable api, the default signinup API does not work", async function () {


### PR DESCRIPTION
## Summary of change

Changes rid match method in backend sdk to account for input being thirdpartyemailpassword or thirdpartypasswordless


## Test Plan

- [x] Need to add tests for querying based on combination recipes and making sure result is as expected
- [x] Test new API paths
- [x] Make sure API path matching happens even without rid, and if rid has combination recipe and if rid is just incorrect as well (like random rid)
- [x] Make sure links that are generated have no rid


## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
