### PR TITLE
fixes FDI header parsing logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [17.0.6] - 2024-05-02
+
+-   Fixes how FDI header is parsed from frontend requests to account for more than one version being passed.
+
 ## [17.0.5] - 2024-04-25
 
 -   Support for websiteDomain / apiDomain ending with `.local`: https://github.com/supertokens/supertokens-node/issues/823

--- a/lib/build/utils.d.ts
+++ b/lib/build/utils.d.ts
@@ -21,6 +21,7 @@ export declare function getBackwardsCompatibleUserInfo(
     },
     userContext: UserContext
 ): JSONObject;
+export declare function getLatestFDIVersionFromFDIList(fdiHeaderValue: string): string;
 export declare function doesRequestSupportFDI(req: BaseRequest, version: string): boolean;
 export declare function getRidFromHeader(req: BaseRequest): string | undefined;
 export declare function frontendHasInterceptor(req: BaseRequest): boolean;

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -41,7 +41,7 @@ var __importDefault =
         return mod && mod.__esModule ? mod : { default: mod };
     };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.normaliseEmail = exports.postWithFetch = exports.getFromObjectCaseInsensitive = exports.getTopLevelDomainForSameSiteResolution = exports.setRequestInUserContextIfNotDefined = exports.getUserContext = exports.makeDefaultUserContextFromAPI = exports.humaniseMilliseconds = exports.frontendHasInterceptor = exports.getRidFromHeader = exports.doesRequestSupportFDI = exports.getBackwardsCompatibleUserInfo = exports.isAnIpAddress = exports.send200Response = exports.sendNon200Response = exports.sendNon200ResponseWithMessage = exports.normaliseHttpMethod = exports.normaliseInputAppInfoOrThrowError = exports.maxVersion = exports.getLargestVersionFromIntersection = exports.doFetch = void 0;
+exports.normaliseEmail = exports.postWithFetch = exports.getFromObjectCaseInsensitive = exports.getTopLevelDomainForSameSiteResolution = exports.setRequestInUserContextIfNotDefined = exports.getUserContext = exports.makeDefaultUserContextFromAPI = exports.humaniseMilliseconds = exports.frontendHasInterceptor = exports.getRidFromHeader = exports.doesRequestSupportFDI = exports.getLatestFDIVersionFromFDIList = exports.getBackwardsCompatibleUserInfo = exports.isAnIpAddress = exports.send200Response = exports.sendNon200Response = exports.sendNon200ResponseWithMessage = exports.normaliseHttpMethod = exports.normaliseInputAppInfoOrThrowError = exports.maxVersion = exports.getLargestVersionFromIntersection = exports.doFetch = void 0;
 const psl = __importStar(require("psl"));
 const normalisedURLDomain_1 = __importDefault(require("./normalisedURLDomain"));
 const normalisedURLPath_1 = __importDefault(require("./normalisedURLPath"));
@@ -242,12 +242,22 @@ function getBackwardsCompatibleUserInfo(req, result, userContext) {
     return resp;
 }
 exports.getBackwardsCompatibleUserInfo = getBackwardsCompatibleUserInfo;
+function getLatestFDIVersionFromFDIList(fdiHeaderValue) {
+    let versions = fdiHeaderValue.split(",");
+    let maxVersionStr = versions[0];
+    for (let i = 1; i < versions.length; i++) {
+        maxVersionStr = maxVersion(maxVersionStr, versions[i]);
+    }
+    return maxVersionStr;
+}
+exports.getLatestFDIVersionFromFDIList = getLatestFDIVersionFromFDIList;
 function doesRequestSupportFDI(req, version) {
     let requestFDI = req.getHeaderValue(constants_1.HEADER_FDI);
     if (requestFDI === undefined) {
         // By default we assume they want to use the latest FDI, this also helps with tests
         return true;
     }
+    requestFDI = getLatestFDIVersionFromFDIList(requestFDI);
     if (requestFDI === version || maxVersion(version, requestFDI) !== version) {
         return true;
     }

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "17.0.5";
+export declare const version = "17.0.6";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.11";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "17.0.5";
+exports.version = "17.0.6";
 exports.cdiSupported = ["5.0"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.11";

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -229,12 +229,22 @@ export function getBackwardsCompatibleUserInfo(
     return resp;
 }
 
+export function getLatestFDIVersionFromFDIList(fdiHeaderValue: string): string {
+    let versions = fdiHeaderValue.split(",");
+    let maxVersionStr = versions[0];
+    for (let i = 1; i < versions.length; i++) {
+        maxVersionStr = maxVersion(maxVersionStr, versions[i]);
+    }
+    return maxVersionStr;
+}
+
 export function doesRequestSupportFDI(req: BaseRequest, version: string) {
     let requestFDI = req.getHeaderValue(HEADER_FDI);
     if (requestFDI === undefined) {
         // By default we assume they want to use the latest FDI, this also helps with tests
         return true;
     }
+    requestFDI = getLatestFDIVersionFromFDIList(requestFDI);
     if (requestFDI === version || maxVersion(version, requestFDI) !== version) {
         return true;
     }

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "17.0.5";
+export const version = "17.0.6";
 
 export const cdiSupported = ["5.0"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "17.0.5",
+    "version": "17.0.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "17.0.4",
+            "version": "17.0.6",
             "license": "Apache-2.0",
             "dependencies": {
                 "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "17.0.5",
+    "version": "17.0.6",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

The SDK used to assume that the FDI header would always be `X.Y`. But that assumption is not correct since the header can be `X.Y,X1.Y1` and so on.

## Test Plan

Added a few tests with multiple fdi versions in the header

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

