### PR TITLE
fix: handle getFormData returning FormData type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [17.1.1] - 2024-05-16
+
+### Fixes
+
+-   Fixed an issue when using Apple as a third party provider with our NextJs integration.
+-   Added a compatibility layer into `BaseRequest` to handle the form data parser returning `FormData` instead of the raw parsed object. This is to address/fix the above issues, possibly present in other frameworks.
+
 ## [17.1.0] - 2024-04-25
 
 -   Added `olderCookieDomain` config option in the session recipe. This will allow users to clear cookies from the older domain when the `cookieDomain` is changed.

--- a/lib/build/framework/request.js
+++ b/lib/build/framework/request.js
@@ -23,6 +23,11 @@ class BaseRequest {
             if (this.parsedUrlEncodedFormData === undefined) {
                 this.parsedUrlEncodedFormData = await this.getFormDataFromRequestBody();
             }
+            if (this.parsedUrlEncodedFormData instanceof FormData) {
+                const ret = {};
+                this.parsedUrlEncodedFormData.forEach((value, key) => (ret[key] = value));
+                return ret;
+            }
             return this.parsedUrlEncodedFormData;
         };
         // Note: While it's not recommended to override this method in child classes,

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "17.1.0";
+export declare const version = "17.1.1";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.11";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "17.1.0";
+exports.version = "17.1.1";
 exports.cdiSupported = ["5.0"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.11";

--- a/lib/ts/framework/request.ts
+++ b/lib/ts/framework/request.ts
@@ -42,6 +42,13 @@ export abstract class BaseRequest {
         if (this.parsedUrlEncodedFormData === undefined) {
             this.parsedUrlEncodedFormData = await this.getFormDataFromRequestBody();
         }
+
+        if (this.parsedUrlEncodedFormData instanceof FormData) {
+            const ret: Record<string, FormDataEntryValue | undefined> = {};
+            this.parsedUrlEncodedFormData.forEach((value, key) => (ret[key] = value));
+            return ret;
+        }
+
         return this.parsedUrlEncodedFormData;
     };
 

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "17.1.0";
+export const version = "17.1.1";
 
 export const cdiSupported = ["5.0"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "17.1.0",
+    "version": "17.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "17.1.0",
+            "version": "17.1.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "17.1.0",
+    "version": "17.1.1",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

handle getFormData returning FormData type

## Related issues

-   [Discord thread](https://discord.com/channels/603466164219281420/1239393137596698624)

## Test Plan

Manual testing

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] If new thirdparty provider is added,
    -   [x] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [x] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
