### PR TITLE
ci: fix testing with older auth-react versions

### DIFF
--- a/.circleci/setupAndTestWithAuthReact.sh
+++ b/.circleci/setupAndTestWithAuthReact.sh
@@ -51,7 +51,12 @@ git checkout $2
 npm run init
 (cd ./examples/for-tests && npm run link) # this is there because in linux machine, postinstall in npm doesn't work..
 cd ./test/server/
-npm i git+https://github.com:supertokens/supertokens-node.git#$3
+
+# We do not update the node-SDK in the test server we have in the auth-react repo because:
+#  1. it's only supposed to be used for test setup related things (e.g.: starting/configuring core)
+#  2. the current version may have an incompatible interface with it (this is problem esp with removed/changed recipes & configs)
+# npm i git+https://github.com:supertokens/supertokens-node.git#$3
+
 npm i
 cd ../../
 cd ../project/test/auth-react-server

--- a/test/auth-react-server/index.js
+++ b/test/auth-react-server/index.js
@@ -98,6 +98,9 @@ function saveCode({ email, phoneNumber, preAuthSessionId, urlWithLinkCode, userI
         codes: [],
     };
     device.codes.push({
+        // We add an extra item to the start of the querystring, because there was a bug in older auth-react tests
+        // that only worked because we used to have an `rid` query param before the preAuthSessionId.
+        // This is strictly a test fix, the extra queryparam makes no difference to the actual SDK code.
         urlWithLinkCode: urlWithLinkCode.replace("?preAuthSessionId", "?test=fix&preAuthSessionId"),
         userInputCode,
     });


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
