### PR TITLE
ci: parallelize based on FDI versions

### DIFF
--- a/.circleci/authReact.sh
+++ b/.circleci/authReact.sh
@@ -21,8 +21,6 @@ while IFS='"' read -ra ADDR; do
     done
 done <<< "$version"
 
-someFrontendTestsRan=false
-i=0
 coreDriverVersion=`echo $coreDriverArray | jq ". | last"`
 coreDriverVersion=`echo $coreDriverVersion | tr -d '"'`
 coreFree=`curl -s -X GET \
@@ -34,92 +32,77 @@ then
     exit 1
 fi
 coreFree=$(echo $coreFree | jq .core | tr -d '"')
-while [ $i -lt $frontendDriverLength ]; do 
-    frontendDriverVersion=`echo $frontendDriverArray | jq ".[$i]"`
-    frontendDriverVersion=`echo $frontendDriverVersion | tr -d '"'`
-    i=$((i+1))
 
-    if [[ $frontendDriverVersion == '1.0' ]]; then
-        continue
-    fi
+frontendDriverVersion=$1
+frontendDriverVersion=`echo $frontendDriverVersion | tr -d '"'`
 
-    nodeVersionXY=`curl -s -X GET \
-    "https://api.supertokens.io/0/frontend-driver-interface/dependency/driver/latest?password=$SUPERTOKENS_API_KEY&mode=DEV&version=$frontendDriverVersion&driverName=node&frontendName=auth-react" \
-    -H 'api-version: 1'`
-    if [[ `echo $nodeVersionXY | jq .driver` == "null" ]]
-    then
-        echo "fetching latest X.Y version for driver given frontend-driver-interface X.Y version: $frontendDriverVersion gave response: $nodeVersionXY. Please make sure all relevant drivers have been pushed."
-        exit 1
-    fi
-    nodeVersionXY=$(echo $nodeVersionXY | jq .driver | tr -d '"')
+nodeVersionXY=`curl -s -X GET \
+"https://api.supertokens.io/0/frontend-driver-interface/dependency/driver/latest?password=$SUPERTOKENS_API_KEY&mode=DEV&version=$frontendDriverVersion&driverName=node&frontendName=auth-react" \
+-H 'api-version: 1'`
+if [[ `echo $nodeVersionXY | jq .driver` == "null" ]]
+then
+    echo "fetching latest X.Y version for driver given frontend-driver-interface X.Y version: $frontendDriverVersion gave response: $nodeVersionXY. Please make sure all relevant drivers have been pushed."
+    exit 1
+fi
+nodeVersionXY=$(echo $nodeVersionXY | jq .driver | tr -d '"')
 
-    nodeInfo=`curl -s -X GET \
-    "https://api.supertokens.io/0/driver/latest?password=$SUPERTOKENS_API_KEY&mode=DEV&version=$nodeVersionXY&name=node" \
-    -H 'api-version: 0'`
-    if [[ `echo $nodeInfo | jq .tag` == "null" ]]
-    then
-        echo "fetching latest X.Y.Z version for driver, X.Y version: $nodeVersionXY gave response: $nodeInfo"
-        exit 1
-    fi
-    nodeTag=$(echo $nodeInfo | jq .tag | tr -d '"')
+nodeInfo=`curl -s -X GET \
+"https://api.supertokens.io/0/driver/latest?password=$SUPERTOKENS_API_KEY&mode=DEV&version=$nodeVersionXY&name=node" \
+-H 'api-version: 0'`
+if [[ `echo $nodeInfo | jq .tag` == "null" ]]
+then
+    echo "fetching latest X.Y.Z version for driver, X.Y version: $nodeVersionXY gave response: $nodeInfo"
+    exit 1
+fi
+nodeTag=$(echo $nodeInfo | jq .tag | tr -d '"')
 
-    someFrontendTestsRan=true
+frontendAuthReactVersionXY=`curl -s -X GET \
+"https://api.supertokens.io/0/frontend-driver-interface/dependency/frontend/latest?password=$SUPERTOKENS_API_KEY&frontendName=auth-react&mode=DEV&version=$frontendDriverVersion&driverName=node" \
+-H 'api-version: 1'`
+if [[ `echo $frontendAuthReactVersionXY | jq .frontend` == "null" ]]
+then
+    echo "fetching latest X.Y version for frontend given frontend-driver-interface X.Y version: $frontendDriverVersion, name: auth-react gave response: $frontend. Please make sure all relevant frontend libs have been pushed."
+    exit 1
+fi
+frontendAuthReactVersionXY=$(echo $frontendAuthReactVersionXY | jq .frontend | tr -d '"')
 
-    frontendAuthReactVersionXY=`curl -s -X GET \
-    "https://api.supertokens.io/0/frontend-driver-interface/dependency/frontend/latest?password=$SUPERTOKENS_API_KEY&frontendName=auth-react&mode=DEV&version=$frontendDriverVersion&driverName=node" \
-    -H 'api-version: 1'`
-    if [[ `echo $frontendAuthReactVersionXY | jq .frontend` == "null" ]]
-    then
-        echo "fetching latest X.Y version for frontend given frontend-driver-interface X.Y version: $frontendDriverVersion, name: auth-react gave response: $frontend. Please make sure all relevant frontend libs have been pushed."
-        exit 1
-    fi
-    frontendAuthReactVersionXY=$(echo $frontendAuthReactVersionXY | jq .frontend | tr -d '"')
+frontendAuthReactInfo=`curl -s -X GET \
+"https://api.supertokens.io/0/frontend/latest?password=$SUPERTOKENS_API_KEY&mode=DEV&version=$frontendAuthReactVersionXY&name=auth-react" \
+-H 'api-version: 0'`
+if [[ `echo $frontendAuthReactInfo | jq .tag` == "null" ]]
+then
+    echo "fetching latest X.Y.Z version for frontend, X.Y version: $frontendAuthReactVersionXY gave response: $frontendAuthReactInfo"
+    exit 1
+fi
+frontendAuthReactTag=$(echo $frontendAuthReactInfo | jq .tag | tr -d '"')
+frontendAuthReactVersion=$(echo $frontendAuthReactInfo | jq .version | tr -d '"')
 
-    frontendAuthReactInfo=`curl -s -X GET \
-    "https://api.supertokens.io/0/frontend/latest?password=$SUPERTOKENS_API_KEY&mode=DEV&version=$frontendAuthReactVersionXY&name=auth-react" \
-    -H 'api-version: 0'`
-    if [[ `echo $frontendAuthReactInfo | jq .tag` == "null" ]]
-    then
-        echo "fetching latest X.Y.Z version for frontend, X.Y version: $frontendAuthReactVersionXY gave response: $frontendAuthReactInfo"
-        exit 1
-    fi
-    frontendAuthReactTag=$(echo $frontendAuthReactInfo | jq .tag | tr -d '"')
-    frontendAuthReactVersion=$(echo $frontendAuthReactInfo | jq .version | tr -d '"')
-
-    if [[ $frontendDriverVersion == '1.3' || $frontendDriverVersion == '1.8' ]]; then
-        # we skip this since the tests for auth-react here are not reliable due to race conditions...
-        
-        # we skip 1.8 since the SDK with just 1.8 doesn't have the right scripts
-        continue
-    else
-        tries=1
-        while [ $tries -le 3 ]
-        do
-            tries=$(( $tries + 1 ))
-            ./setupAndTestWithAuthReact.sh $coreFree $frontendAuthReactTag $nodeTag
-            if [[ $? -ne 0 ]]
+if [[ $frontendDriverVersion == '1.3' || $frontendDriverVersion == '1.8' ]]; then
+    # we skip this since the tests for auth-react here are not reliable due to race conditions...
+    
+    # we skip 1.8 since the SDK with just 1.8 doesn't have the right scripts
+    continue
+else
+    tries=1
+    while [ $tries -le 3 ]
+    do
+        tries=$(( $tries + 1 ))
+        ./setupAndTestWithAuthReact.sh $coreFree $frontendAuthReactTag $nodeTag
+        if [[ $? -ne 0 ]]
+        then
+            if [[ $tries -le 3 ]]
             then
-                if [[ $tries -le 3 ]]
-                then
-                    rm -rf ../../supertokens-root
-                    rm -rf ../../supertokens-auth-react
-                    echo "failed test.. retrying!"
-                else
-                    echo "test failed... exiting!"
-                    exit 1
-                fi
-            else
                 rm -rf ../../supertokens-root
                 rm -rf ../../supertokens-auth-react
-                break
+                echo "failed test.. retrying!"
+            else
+                echo "test failed... exiting!"
+                exit 1
             fi
-        done
-    fi
-
-done
-
-if [[ $someFrontendTestsRan = "false" ]]
-then
-    echo "no tests ran... failing!"
-    exit 1
+        else
+            rm -rf ../../supertokens-root
+            rm -rf ../../supertokens-auth-react
+            break
+        fi
+    done
 fi

--- a/.circleci/config_continue.yml
+++ b/.circleci/config_continue.yml
@@ -32,6 +32,9 @@ jobs:
         docker:
             - image: rishabhpoddar/supertokens_website_sdk_testing
         resource_class: large
+        parameters:
+            fdi-version:
+                type: string
         parallelism: 4
         steps:
             - checkout
@@ -41,12 +44,15 @@ jobs:
             - run: npm i -d --force
             - run: update-alternatives --install "/usr/bin/java" "java" "/usr/java/jdk-15.0.1/bin/java" 2
             - run: update-alternatives --install "/usr/bin/javac" "javac" "/usr/java/jdk-15.0.1/bin/javac" 2
-            - run: (cd .circleci/ && ./website.sh)
+            - run: (cd .circleci/ && ./website.sh << parameters.fdi-version >>)
             - slack/status
     test-authreact:
         docker:
             - image: rishabhpoddar/supertokens_website_sdk_testing_node_16
         resource_class: large
+        parameters:
+            fdi-version:
+                type: string
         parallelism: 4
         steps:
             - checkout
@@ -56,7 +62,7 @@ jobs:
             - run: npm i -d --force
             - run: update-alternatives --install "/usr/bin/java" "java" "/usr/java/jdk-15.0.1/bin/java" 2
             - run: update-alternatives --install "/usr/bin/javac" "javac" "/usr/java/jdk-15.0.1/bin/javac" 2
-            - run: (cd .circleci/ && ./authReact.sh)
+            - run: (cd .circleci/ && ./authReact.sh << parameters.fdi-version >>)
             - store_artifacts:
                   path: test_report/backend.log
                   destination: logs
@@ -102,6 +108,9 @@ workflows:
                           only: /dev-v[0-9]+(\.[0-9]+)*/
                       branches:
                           only: /test-cicd\/.*/
+                  matrix:
+                      parameters:
+                          fdi-version: placeholder
             - test-authreact:
                   requires:
                       - test-dev-tag-as-not-passed
@@ -112,6 +121,9 @@ workflows:
                           only: /dev-v[0-9]+(\.[0-9]+)*/
                       branches:
                           only: /test-cicd\/.*/
+                  matrix:
+                      parameters:
+                          fdi-version: placeholder
             - test-success:
                   requires:
                       - test-unit

--- a/.circleci/generateConfig.sh
+++ b/.circleci/generateConfig.sh
@@ -1,9 +1,13 @@
 coreDriverJson=`cat ../coreDriverInterfaceSupported.json`
 coreDriverArray=`echo $coreDriverJson | jq ".versions"`
 
+frontendDriverJson=`cat ../frontendDriverInterfaceSupported.json`
+frontendDriverArray=`echo $frontendDriverJson | jq ".versions"`
+
 if [ -z "$SUPERTOKENS_API_KEY" ]; then
     echo "SUPERTOKENS_API_KEY missing"
     exit 1;
 fi
 
 sed -i -e 's/cdi-version: placeholder/cdi-version: '`printf "%q" $coreDriverArray`'/' config_continue.yml
+sed -i -e 's/fdi-version: placeholder/fdi-version: '`printf "%q" $frontendDriverArray`'/' config_continue.yml

--- a/.circleci/website.sh
+++ b/.circleci/website.sh
@@ -21,8 +21,6 @@ while IFS='"' read -ra ADDR; do
     done
 done <<< "$version"
 
-someFrontendTestsRan=false
-i=0
 coreDriverVersion=`echo $coreDriverArray | jq ". | last"`
 coreDriverVersion=`echo $coreDriverVersion | tr -d '"'`
 coreFree=`curl -s -X GET \
@@ -34,83 +32,70 @@ then
     exit 1
 fi
 coreFree=$(echo $coreFree | jq .core | tr -d '"')
-while [ $i -lt $frontendDriverLength ]; do 
-    frontendDriverVersion=`echo $frontendDriverArray | jq ".[$i]"`
-    frontendDriverVersion=`echo $frontendDriverVersion | tr -d '"'`
-    i=$((i+1))
 
-    if [[ $frontendDriverVersion == '1.0' ]]; then
-        continue
-    fi
+frontendDriverVersion=$1
+frontendDriverVersion=`echo $frontendDriverVersion | tr -d '"'`
 
-    frontendVersionXY=`curl -s -X GET \
-    "https://api.supertokens.io/0/frontend-driver-interface/dependency/frontend/latest?password=$SUPERTOKENS_API_KEY&frontendName=website&mode=DEV&version=$frontendDriverVersion&driverName=node" \
-    -H 'api-version: 1'`
-    if [[ `echo $frontendVersionXY | jq .frontend` == "null" ]]
-    then
-        echo "fetching latest X.Y version for frontend given frontend-driver-interface X.Y version: $frontendDriverVersion, name: website gave response: $frontend. Please make sure all relevant versions have been pushed."
-        exit 1
-    fi
-    frontendVersionXY=$(echo $frontendVersionXY | jq .frontend | tr -d '"')
-
-    frontendInfo=`curl -s -X GET \
-    "https://api.supertokens.io/0/frontend/latest?password=$SUPERTOKENS_API_KEY&mode=DEV&version=$frontendVersionXY&name=website" \
-    -H 'api-version: 0'`
-    if [[ `echo $frontendInfo | jq .tag` == "null" ]]
-    then
-        echo "fetching latest X.Y.Z version for frontend, X.Y version: $frontendVersionXY gave response: $frontendInfo"
-        exit 1
-    fi
-    frontendTag=$(echo $frontendInfo | jq .tag | tr -d '"')
-    frontendVersion=$(echo $frontendInfo | jq .version | tr -d '"')
-
-    nodeVersionXY=`curl -s -X GET \
-    "https://api.supertokens.io/0/frontend-driver-interface/dependency/driver/latest?password=$SUPERTOKENS_API_KEY&mode=DEV&version=$frontendDriverVersion&driverName=node&frontendName=website" \
-    -H 'api-version: 1'`
-    if [[ `echo $nodeVersionXY | jq .driver` == "null" ]]
-    then
-        echo "fetching latest X.Y version for driver given frontend-driver-interface X.Y version: $frontendDriverVersion gave response: $nodeVersionXY. Please make sure all relevant drivers have been pushed."
-        exit 1
-    fi
-    nodeVersionXY=$(echo $nodeVersionXY | jq .driver | tr -d '"')
-
-    nodeInfo=`curl -s -X GET \
-    "https://api.supertokens.io/0/driver/latest?password=$SUPERTOKENS_API_KEY&mode=DEV&version=$nodeVersionXY&name=node" \
-    -H 'api-version: 0'`
-    if [[ `echo $nodeInfo | jq .tag` == "null" ]]
-    then
-        echo "fetching latest X.Y.Z version for driver, X.Y version: $nodeVersionXY gave response: $nodeInfo"
-        exit 1
-    fi
-    nodeTag=$(echo $nodeInfo | jq .tag | tr -d '"')
-
-    someFrontendTestsRan=true
-    tries=1
-    while [ $tries -le 3 ]
-    do
-        tries=$(( $tries + 1 ))
-        ./setupAndTestWithFrontend.sh $coreFree $frontendTag $nodeTag
-        if [[ $? -ne 0 ]]
-        then
-            if [[ $tries -le 3 ]]
-            then
-                rm -rf ../../supertokens-root
-                rm -rf ../../supertokens-website
-                echo "failed test.. retrying!"
-            else
-                echo "test failed... exiting!"
-                exit 1
-            fi
-        else
-            rm -rf ../../supertokens-root
-            rm -rf ../../supertokens-website
-            break
-        fi
-    done
-done
-
-if [[ $someFrontendTestsRan = "false" ]]
+frontendVersionXY=`curl -s -X GET \
+"https://api.supertokens.io/0/frontend-driver-interface/dependency/frontend/latest?password=$SUPERTOKENS_API_KEY&frontendName=website&mode=DEV&version=$frontendDriverVersion&driverName=node" \
+-H 'api-version: 1'`
+if [[ `echo $frontendVersionXY | jq .frontend` == "null" ]]
 then
-    echo "no tests ran... failing!"
+    echo "fetching latest X.Y version for frontend given frontend-driver-interface X.Y version: $frontendDriverVersion, name: website gave response: $frontend. Please make sure all relevant versions have been pushed."
     exit 1
 fi
+frontendVersionXY=$(echo $frontendVersionXY | jq .frontend | tr -d '"')
+
+frontendInfo=`curl -s -X GET \
+"https://api.supertokens.io/0/frontend/latest?password=$SUPERTOKENS_API_KEY&mode=DEV&version=$frontendVersionXY&name=website" \
+-H 'api-version: 0'`
+if [[ `echo $frontendInfo | jq .tag` == "null" ]]
+then
+    echo "fetching latest X.Y.Z version for frontend, X.Y version: $frontendVersionXY gave response: $frontendInfo"
+    exit 1
+fi
+frontendTag=$(echo $frontendInfo | jq .tag | tr -d '"')
+frontendVersion=$(echo $frontendInfo | jq .version | tr -d '"')
+
+nodeVersionXY=`curl -s -X GET \
+"https://api.supertokens.io/0/frontend-driver-interface/dependency/driver/latest?password=$SUPERTOKENS_API_KEY&mode=DEV&version=$frontendDriverVersion&driverName=node&frontendName=website" \
+-H 'api-version: 1'`
+if [[ `echo $nodeVersionXY | jq .driver` == "null" ]]
+then
+    echo "fetching latest X.Y version for driver given frontend-driver-interface X.Y version: $frontendDriverVersion gave response: $nodeVersionXY. Please make sure all relevant drivers have been pushed."
+    exit 1
+fi
+nodeVersionXY=$(echo $nodeVersionXY | jq .driver | tr -d '"')
+
+nodeInfo=`curl -s -X GET \
+"https://api.supertokens.io/0/driver/latest?password=$SUPERTOKENS_API_KEY&mode=DEV&version=$nodeVersionXY&name=node" \
+-H 'api-version: 0'`
+if [[ `echo $nodeInfo | jq .tag` == "null" ]]
+then
+    echo "fetching latest X.Y.Z version for driver, X.Y version: $nodeVersionXY gave response: $nodeInfo"
+    exit 1
+fi
+nodeTag=$(echo $nodeInfo | jq .tag | tr -d '"')
+
+tries=1
+while [ $tries -le 3 ]
+do
+    tries=$(( $tries + 1 ))
+    ./setupAndTestWithFrontend.sh $coreFree $frontendTag $nodeTag
+    if [[ $? -ne 0 ]]
+    then
+        if [[ $tries -le 3 ]]
+        then
+            rm -rf ../../supertokens-root
+            rm -rf ../../supertokens-website
+            echo "failed test.. retrying!"
+        else
+            echo "test failed... exiting!"
+            exit 1
+        fi
+    else
+        rm -rf ../../supertokens-root
+        rm -rf ../../supertokens-website
+        break
+    fi
+done


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
