### PR TITLE
fix: thirdparty recursion and config reference issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [16.7.6] - 2024-05-28
+
+-   Fixes override recursion issue with inbuilt providers
+-   Fixes reference issue with `config` object in `TypeProvider` while overriding
+
 ## [16.7.5] - 2024-03-21
 
 -   Enable smooth switching between `useDynamicAccessTokenSigningKey` settings by allowing refresh calls to change the signing key type of a session

--- a/lib/build/recipe/thirdparty/providers/configUtils.js
+++ b/lib/build/recipe/thirdparty/providers/configUtils.js
@@ -15,38 +15,39 @@ function getProviderConfigForClient(providerConfig, clientConfig) {
 exports.getProviderConfigForClient = getProviderConfigForClient;
 async function fetchAndSetConfig(provider, clientType, userContext) {
     let config = await provider.getConfigForClientType({ clientType, userContext });
-    config = await utils_1.discoverOIDCEndpoints(config);
-    provider.config = config;
+    await utils_1.discoverOIDCEndpoints(config);
+    Object.assign(provider.config, config);
 }
 function createProvider(input) {
-    if (input.config.thirdPartyId.startsWith("active-directory")) {
-        return _1.ActiveDirectory(input);
-    } else if (input.config.thirdPartyId.startsWith("apple")) {
-        return _1.Apple(input);
-    } else if (input.config.thirdPartyId.startsWith("bitbucket")) {
-        return _1.Bitbucket(input);
-    } else if (input.config.thirdPartyId.startsWith("discord")) {
-        return _1.Discord(input);
-    } else if (input.config.thirdPartyId.startsWith("facebook")) {
-        return _1.Facebook(input);
-    } else if (input.config.thirdPartyId.startsWith("github")) {
-        return _1.Github(input);
-    } else if (input.config.thirdPartyId.startsWith("gitlab")) {
-        return _1.Gitlab(input);
-    } else if (input.config.thirdPartyId.startsWith("google-workspaces")) {
-        return _1.GoogleWorkspaces(input);
-    } else if (input.config.thirdPartyId.startsWith("google")) {
-        return _1.Google(input);
-    } else if (input.config.thirdPartyId.startsWith("okta")) {
-        return _1.Okta(input);
-    } else if (input.config.thirdPartyId.startsWith("linkedin")) {
-        return _1.Linkedin(input);
-    } else if (input.config.thirdPartyId.startsWith("twitter")) {
-        return _1.Twitter(input);
-    } else if (input.config.thirdPartyId.startsWith("boxy-saml")) {
-        return _1.BoxySAML(input);
+    const clonedInput = Object.assign({}, input);
+    if (clonedInput.config.thirdPartyId.startsWith("active-directory")) {
+        return _1.ActiveDirectory(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("apple")) {
+        return _1.Apple(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("bitbucket")) {
+        return _1.Bitbucket(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("discord")) {
+        return _1.Discord(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("facebook")) {
+        return _1.Facebook(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("github")) {
+        return _1.Github(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("gitlab")) {
+        return _1.Gitlab(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("google-workspaces")) {
+        return _1.GoogleWorkspaces(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("google")) {
+        return _1.Google(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("okta")) {
+        return _1.Okta(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("linkedin")) {
+        return _1.Linkedin(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("twitter")) {
+        return _1.Twitter(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("boxy-saml")) {
+        return _1.BoxySAML(clonedInput);
     }
-    return custom_1.default(input);
+    return custom_1.default(clonedInput);
 }
 async function findAndCreateProviderInstance(providers, thirdPartyId, clientType, userContext) {
     for (const providerInput of providers) {

--- a/lib/build/recipe/thirdparty/providers/utils.d.ts
+++ b/lib/build/recipe/thirdparty/providers/utils.d.ts
@@ -32,6 +32,4 @@ export declare function verifyIdTokenFromJWKSEndpointAndGetPayload(
     jwks: jose.JWTVerifyGetKey,
     otherOptions: jose.JWTVerifyOptions
 ): Promise<any>;
-export declare function discoverOIDCEndpoints(
-    config: ProviderConfigForClientType
-): Promise<ProviderConfigForClientType>;
+export declare function discoverOIDCEndpoints(config: ProviderConfigForClientType): Promise<void>;

--- a/lib/build/recipe/thirdparty/providers/utils.js
+++ b/lib/build/recipe/thirdparty/providers/utils.js
@@ -143,6 +143,5 @@ async function discoverOIDCEndpoints(config) {
             config.jwksURI = oidcInfo.jwks_uri;
         }
     }
-    return config;
 }
 exports.discoverOIDCEndpoints = discoverOIDCEndpoints;

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "16.7.5";
+export declare const version = "16.7.6";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.10";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "16.7.5";
+exports.version = "16.7.6";
 exports.cdiSupported = ["4.0"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.10";

--- a/lib/ts/recipe/thirdparty/providers/configUtils.ts
+++ b/lib/ts/recipe/thirdparty/providers/configUtils.ts
@@ -36,41 +36,42 @@ export function getProviderConfigForClient(
 async function fetchAndSetConfig(provider: TypeProvider, clientType: string | undefined, userContext: any) {
     let config = await provider.getConfigForClientType({ clientType, userContext });
 
-    config = await discoverOIDCEndpoints(config);
+    await discoverOIDCEndpoints(config);
 
-    provider.config = config;
+    Object.assign(provider.config, config);
 }
 
 function createProvider(input: ProviderInput): TypeProvider {
-    if (input.config.thirdPartyId.startsWith("active-directory")) {
-        return ActiveDirectory(input);
-    } else if (input.config.thirdPartyId.startsWith("apple")) {
-        return Apple(input);
-    } else if (input.config.thirdPartyId.startsWith("bitbucket")) {
-        return Bitbucket(input);
-    } else if (input.config.thirdPartyId.startsWith("discord")) {
-        return Discord(input);
-    } else if (input.config.thirdPartyId.startsWith("facebook")) {
-        return Facebook(input);
-    } else if (input.config.thirdPartyId.startsWith("github")) {
-        return Github(input);
-    } else if (input.config.thirdPartyId.startsWith("gitlab")) {
-        return Gitlab(input);
-    } else if (input.config.thirdPartyId.startsWith("google-workspaces")) {
-        return GoogleWorkspaces(input);
-    } else if (input.config.thirdPartyId.startsWith("google")) {
-        return Google(input);
-    } else if (input.config.thirdPartyId.startsWith("okta")) {
-        return Okta(input);
-    } else if (input.config.thirdPartyId.startsWith("linkedin")) {
-        return Linkedin(input);
-    } else if (input.config.thirdPartyId.startsWith("twitter")) {
-        return Twitter(input);
-    } else if (input.config.thirdPartyId.startsWith("boxy-saml")) {
-        return BoxySAML(input);
+    const clonedInput = { ...input };
+    if (clonedInput.config.thirdPartyId.startsWith("active-directory")) {
+        return ActiveDirectory(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("apple")) {
+        return Apple(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("bitbucket")) {
+        return Bitbucket(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("discord")) {
+        return Discord(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("facebook")) {
+        return Facebook(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("github")) {
+        return Github(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("gitlab")) {
+        return Gitlab(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("google-workspaces")) {
+        return GoogleWorkspaces(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("google")) {
+        return Google(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("okta")) {
+        return Okta(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("linkedin")) {
+        return Linkedin(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("twitter")) {
+        return Twitter(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("boxy-saml")) {
+        return BoxySAML(clonedInput);
     }
 
-    return NewProvider(input);
+    return NewProvider(clonedInput);
 }
 
 export async function findAndCreateProviderInstance(

--- a/lib/ts/recipe/thirdparty/providers/utils.ts
+++ b/lib/ts/recipe/thirdparty/providers/utils.ts
@@ -123,7 +123,7 @@ async function getOIDCDiscoveryInfo(issuer: string): Promise<any> {
     return oidcInfo.jsonResponse!;
 }
 
-export async function discoverOIDCEndpoints(config: ProviderConfigForClientType): Promise<ProviderConfigForClientType> {
+export async function discoverOIDCEndpoints(config: ProviderConfigForClientType): Promise<void> {
     if (config.oidcDiscoveryEndpoint !== undefined) {
         const oidcInfo = await getOIDCDiscoveryInfo(config.oidcDiscoveryEndpoint);
 
@@ -143,6 +143,4 @@ export async function discoverOIDCEndpoints(config: ProviderConfigForClientType)
             config.jwksURI = oidcInfo.jwks_uri;
         }
     }
-
-    return config;
 }

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "16.7.5";
+export const version = "16.7.6";
 
 export const cdiSupported = ["4.0"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "16.7.5",
+    "version": "16.7.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "16.7.5",
+            "version": "16.7.6",
             "license": "Apache-2.0",
             "dependencies": {
                 "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "16.7.5",
+    "version": "16.7.6",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {

--- a/test/thirdparty/provider.config.test.js
+++ b/test/thirdparty/provider.config.test.js
@@ -39,6 +39,159 @@ describe(`providerConfigTest: ${printPath("[test/thirdparty/provider.config.test
         await cleanST();
     });
 
+    it("test the provider override is not increasing call stack", async function () {
+        const connectionURI = await startSTWithMultitenancy();
+
+        let stackCount = [];
+
+        STExpress.init({
+            supertokens: {
+                connectionURI,
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                ThirdPartyRecipe.init({
+                    signInAndUpFeature: {
+                        providers: [
+                            {
+                                config: {
+                                    thirdPartyId: "google",
+                                    clients: [{ clientId: "test", clientSecret: "secret" }],
+                                },
+                                override: (oI) => {
+                                    const err = new Error();
+                                    stackCount.push(err.stack.split("\n").length);
+                                    return {
+                                        ...oI,
+                                        getAuthorisationRedirectURL: async (input) => {
+                                            return await oI.getAuthorisationRedirectURL(input);
+                                        },
+                                    };
+                                },
+                            },
+                        ],
+                    },
+                }),
+            ],
+        });
+
+        for (let i = 0; i < 10; i++) {
+            await (await ThirdParty.getProvider("public", "google")).getAuthorisationRedirectURL({
+                redirectURIOnProviderDashboard: "http://localhost:8080",
+                userContext: {},
+            });
+        }
+
+        for (let i = 1; i < stackCount.length; i++) {
+            assert.equal(stackCount[i], stackCount[i - 1]); // stack should be same and not increasing
+        }
+    });
+
+    it("test the config is same within override and provider instance", async function () {
+        const connectionURI = await startSTWithMultitenancy();
+
+        let oIConfig;
+        STExpress.init({
+            supertokens: {
+                connectionURI,
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                ThirdPartyRecipe.init({
+                    signInAndUpFeature: {
+                        providers: [
+                            {
+                                config: {
+                                    thirdPartyId: "google",
+                                    clients: [{ clientId: "test", clientSecret: "secret" }],
+                                },
+                                override: (oI) => {
+                                    return {
+                                        ...oI,
+                                        getAuthorisationRedirectURL: async (input) => {
+                                            oIConfig = oI.config;
+                                            return await oI.getAuthorisationRedirectURL(input);
+                                        },
+                                    };
+                                },
+                            },
+                        ],
+                    },
+                }),
+            ],
+        });
+
+        const provider = await ThirdParty.getProvider("public", "google");
+        await provider.getAuthorisationRedirectURL({
+            redirectURIOnProviderDashboard: "http://localhost:8080",
+            userContext: {},
+        });
+
+        assert.strictEqual(provider.config, oIConfig);
+    });
+
+    it("test the config is same within override and provider instance when overriding getConfigForClientType", async function () {
+        const connectionURI = await startSTWithMultitenancy();
+
+        let oIConfig;
+        STExpress.init({
+            supertokens: {
+                connectionURI,
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [
+                ThirdPartyRecipe.init({
+                    signInAndUpFeature: {
+                        providers: [
+                            {
+                                config: {
+                                    thirdPartyId: "google",
+                                    clients: [{ clientId: "test", clientSecret: "secret" }],
+                                },
+                                override: (oI) => {
+                                    return {
+                                        ...oI,
+                                        getConfigForClientType: async (input) => {
+                                            return {
+                                                id: "google",
+                                                clientId: "hello",
+                                                authorizationEndpoint: "http://localhost:8080/authorize",
+                                            };
+                                        },
+                                        getAuthorisationRedirectURL: async (input) => {
+                                            oIConfig = oI.config;
+                                            return await oI.getAuthorisationRedirectURL(input);
+                                        },
+                                    };
+                                },
+                            },
+                        ],
+                    },
+                }),
+            ],
+        });
+
+        const provider = await ThirdParty.getProvider("public", "google");
+        await provider.getAuthorisationRedirectURL({
+            redirectURIOnProviderDashboard: "http://localhost:8080",
+            userContext: {},
+        });
+
+        assert.strictEqual(provider.config, oIConfig);
+    });
+
     it("test built-in provider computed config from static config", async function () {
         const connectionURI = await startSTWithMultitenancy();
 


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
