### PR TITLE
fix: thirdparty recursion and config reference issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
             - slack/status
     setup:
         machine:
-            image: ubuntu-2204:2022.04.1
+            image: ubuntu-2204:2024.04.4
         steps:
             - checkout
             - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [15.1.2] - 2024-05-28
 
--   Fixes override recursion issue with inbuilt providers
--   Fixes reference issue with `config` object in `TypeProvider` while overriding
+-   Fixes override recursion build-up in built-in providers due to the modification of the `input.override` object in the ThirdParty providers list.
+-   Fixes issue with reference to `config` object in `TypeProvider` in the provider override. The issue was the `originalImplementation.config` object did not have the updated `config` values that was being used in the provider implementation.
 
 ## [15.1.1] - 2023-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [15.1.2] - 2024-05-28
+
+-   Fixes override recursion issue with inbuilt providers
+-   Fixes reference issue with `config` object in `TypeProvider` while overriding
+
 ## [15.1.1] - 2023-08-14
 
 ### Fixes

--- a/lib/build/recipe/thirdparty/providers/configUtils.js
+++ b/lib/build/recipe/thirdparty/providers/configUtils.js
@@ -48,10 +48,24 @@ function fetchAndSetConfig(provider, clientType, userContext) {
     return __awaiter(this, void 0, void 0, function* () {
         let config = yield provider.getConfigForClientType({ clientType, userContext });
         yield utils_1.discoverOIDCEndpoints(config);
+        // We are doing Object.assign here to retain the reference to the provider.config which originally came from
+        // the impl object in the `custom.ts`. We are doing this because if we replace the provider.config with the
+        // new config object, then when the user overrides a provider function, and access the `originalImplementaion.config`,
+        // it will not receive the updated config, since the user's override would have returned a new provider object and
+        // the config is being set on to it. By doing Object.assign, we retain the original reference and the config is
+        // consistently available in the override as well as the implementation.
         Object.assign(provider.config, config);
     });
 }
 function createProvider(input) {
+    // We are cloning the input object because the built-in providers modify the `override` in the input
+    // object, and we don't want to modify the original input object. If we do not clone the input object,
+    // we add a new function for override and then call the override from the input object, and this way,
+    // the override call stack keeps increasing over time. After a certain number of calls, the call stack
+    // will overflow and the thirdparty provider will start failing.
+    // We are only doing a shallow clone because the `override` is in the top level of the input object,
+    // and other properties are just used for reading. The input object is also not exposed by any of the
+    // interface for modification.
     const clonedInput = Object.assign({}, input);
     if (clonedInput.config.thirdPartyId.startsWith("active-directory")) {
         return _1.ActiveDirectory(clonedInput);

--- a/lib/build/recipe/thirdparty/providers/configUtils.js
+++ b/lib/build/recipe/thirdparty/providers/configUtils.js
@@ -47,37 +47,38 @@ exports.getProviderConfigForClient = getProviderConfigForClient;
 function fetchAndSetConfig(provider, clientType, userContext) {
     return __awaiter(this, void 0, void 0, function* () {
         let config = yield provider.getConfigForClientType({ clientType, userContext });
-        config = yield utils_1.discoverOIDCEndpoints(config);
-        provider.config = config;
+        yield utils_1.discoverOIDCEndpoints(config);
+        Object.assign(provider.config, config);
     });
 }
 function createProvider(input) {
-    if (input.config.thirdPartyId.startsWith("active-directory")) {
-        return _1.ActiveDirectory(input);
-    } else if (input.config.thirdPartyId.startsWith("apple")) {
-        return _1.Apple(input);
-    } else if (input.config.thirdPartyId.startsWith("bitbucket")) {
-        return _1.Bitbucket(input);
-    } else if (input.config.thirdPartyId.startsWith("discord")) {
-        return _1.Discord(input);
-    } else if (input.config.thirdPartyId.startsWith("facebook")) {
-        return _1.Facebook(input);
-    } else if (input.config.thirdPartyId.startsWith("github")) {
-        return _1.Github(input);
-    } else if (input.config.thirdPartyId.startsWith("gitlab")) {
-        return _1.Gitlab(input);
-    } else if (input.config.thirdPartyId.startsWith("google-workspaces")) {
-        return _1.GoogleWorkspaces(input);
-    } else if (input.config.thirdPartyId.startsWith("google")) {
-        return _1.Google(input);
-    } else if (input.config.thirdPartyId.startsWith("okta")) {
-        return _1.Okta(input);
-    } else if (input.config.thirdPartyId.startsWith("linkedin")) {
-        return _1.Linkedin(input);
-    } else if (input.config.thirdPartyId.startsWith("boxy-saml")) {
-        return _1.BoxySAML(input);
+    const clonedInput = Object.assign({}, input);
+    if (clonedInput.config.thirdPartyId.startsWith("active-directory")) {
+        return _1.ActiveDirectory(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("apple")) {
+        return _1.Apple(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("bitbucket")) {
+        return _1.Bitbucket(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("discord")) {
+        return _1.Discord(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("facebook")) {
+        return _1.Facebook(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("github")) {
+        return _1.Github(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("gitlab")) {
+        return _1.Gitlab(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("google-workspaces")) {
+        return _1.GoogleWorkspaces(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("google")) {
+        return _1.Google(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("okta")) {
+        return _1.Okta(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("linkedin")) {
+        return _1.Linkedin(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("boxy-saml")) {
+        return _1.BoxySAML(clonedInput);
     }
-    return custom_1.default(input);
+    return custom_1.default(clonedInput);
 }
 function findAndCreateProviderInstance(providers, thirdPartyId, clientType, userContext) {
     return __awaiter(this, void 0, void 0, function* () {

--- a/lib/build/recipe/thirdparty/providers/utils.d.ts
+++ b/lib/build/recipe/thirdparty/providers/utils.d.ts
@@ -24,6 +24,4 @@ export declare function verifyIdTokenFromJWKSEndpointAndGetPayload(
     jwks: jose.JWTVerifyGetKey,
     otherOptions: jose.JWTVerifyOptions
 ): Promise<any>;
-export declare function discoverOIDCEndpoints(
-    config: ProviderConfigForClientType
-): Promise<ProviderConfigForClientType>;
+export declare function discoverOIDCEndpoints(config: ProviderConfigForClientType): Promise<void>;

--- a/lib/build/recipe/thirdparty/providers/utils.js
+++ b/lib/build/recipe/thirdparty/providers/utils.js
@@ -183,7 +183,6 @@ function discoverOIDCEndpoints(config) {
                 config.jwksURI = oidcInfo.jwks_uri;
             }
         }
-        return config;
     });
 }
 exports.discoverOIDCEndpoints = discoverOIDCEndpoints;

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "15.1.1";
+export declare const version = "15.1.2";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.7";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "15.1.1";
+exports.version = "15.1.2";
 exports.cdiSupported = ["3.0"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.7";

--- a/lib/ts/recipe/thirdparty/providers/configUtils.ts
+++ b/lib/ts/recipe/thirdparty/providers/configUtils.ts
@@ -37,11 +37,26 @@ async function fetchAndSetConfig(provider: TypeProvider, clientType: string | un
 
     await discoverOIDCEndpoints(config);
 
+    // We are doing Object.assign here to retain the reference to the provider.config which originally came from
+    // the impl object in the `custom.ts`. We are doing this because if we replace the provider.config with the
+    // new config object, then when the user overrides a provider function, and access the `originalImplementaion.config`,
+    // it will not receive the updated config, since the user's override would have returned a new provider object and
+    // the config is being set on to it. By doing Object.assign, we retain the original reference and the config is
+    // consistently available in the override as well as the implementation.
     Object.assign(provider.config, config);
 }
 
 function createProvider(input: ProviderInput): TypeProvider {
+    // We are cloning the input object because the built-in providers modify the `override` in the input
+    // object, and we don't want to modify the original input object. If we do not clone the input object,
+    // we add a new function for override and then call the override from the input object, and this way,
+    // the override call stack keeps increasing over time. After a certain number of calls, the call stack
+    // will overflow and the thirdparty provider will start failing.
+    // We are only doing a shallow clone because the `override` is in the top level of the input object,
+    // and other properties are just used for reading. The input object is also not exposed by any of the
+    // interface for modification.
     const clonedInput = { ...input };
+
     if (clonedInput.config.thirdPartyId.startsWith("active-directory")) {
         return ActiveDirectory(clonedInput);
     } else if (clonedInput.config.thirdPartyId.startsWith("apple")) {

--- a/lib/ts/recipe/thirdparty/providers/configUtils.ts
+++ b/lib/ts/recipe/thirdparty/providers/configUtils.ts
@@ -35,39 +35,40 @@ export function getProviderConfigForClient(
 async function fetchAndSetConfig(provider: TypeProvider, clientType: string | undefined, userContext: any) {
     let config = await provider.getConfigForClientType({ clientType, userContext });
 
-    config = await discoverOIDCEndpoints(config);
+    await discoverOIDCEndpoints(config);
 
-    provider.config = config;
+    Object.assign(provider.config, config);
 }
 
 function createProvider(input: ProviderInput): TypeProvider {
-    if (input.config.thirdPartyId.startsWith("active-directory")) {
-        return ActiveDirectory(input);
-    } else if (input.config.thirdPartyId.startsWith("apple")) {
-        return Apple(input);
-    } else if (input.config.thirdPartyId.startsWith("bitbucket")) {
-        return Bitbucket(input);
-    } else if (input.config.thirdPartyId.startsWith("discord")) {
-        return Discord(input);
-    } else if (input.config.thirdPartyId.startsWith("facebook")) {
-        return Facebook(input);
-    } else if (input.config.thirdPartyId.startsWith("github")) {
-        return Github(input);
-    } else if (input.config.thirdPartyId.startsWith("gitlab")) {
-        return Gitlab(input);
-    } else if (input.config.thirdPartyId.startsWith("google-workspaces")) {
-        return GoogleWorkspaces(input);
-    } else if (input.config.thirdPartyId.startsWith("google")) {
-        return Google(input);
-    } else if (input.config.thirdPartyId.startsWith("okta")) {
-        return Okta(input);
-    } else if (input.config.thirdPartyId.startsWith("linkedin")) {
-        return Linkedin(input);
-    } else if (input.config.thirdPartyId.startsWith("boxy-saml")) {
-        return BoxySAML(input);
+    const clonedInput = { ...input };
+    if (clonedInput.config.thirdPartyId.startsWith("active-directory")) {
+        return ActiveDirectory(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("apple")) {
+        return Apple(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("bitbucket")) {
+        return Bitbucket(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("discord")) {
+        return Discord(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("facebook")) {
+        return Facebook(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("github")) {
+        return Github(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("gitlab")) {
+        return Gitlab(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("google-workspaces")) {
+        return GoogleWorkspaces(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("google")) {
+        return Google(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("okta")) {
+        return Okta(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("linkedin")) {
+        return Linkedin(clonedInput);
+    } else if (clonedInput.config.thirdPartyId.startsWith("boxy-saml")) {
+        return BoxySAML(clonedInput);
     }
 
-    return NewProvider(input);
+    return NewProvider(clonedInput);
 }
 
 export async function findAndCreateProviderInstance(

--- a/lib/ts/recipe/thirdparty/providers/utils.ts
+++ b/lib/ts/recipe/thirdparty/providers/utils.ts
@@ -100,7 +100,7 @@ async function getOIDCDiscoveryInfo(issuer: string): Promise<any> {
     return oidcInfo;
 }
 
-export async function discoverOIDCEndpoints(config: ProviderConfigForClientType): Promise<ProviderConfigForClientType> {
+export async function discoverOIDCEndpoints(config: ProviderConfigForClientType): Promise<void> {
     if (config.oidcDiscoveryEndpoint !== undefined) {
         const oidcInfo = await getOIDCDiscoveryInfo(config.oidcDiscoveryEndpoint);
 
@@ -120,6 +120,4 @@ export async function discoverOIDCEndpoints(config: ProviderConfigForClientType)
             config.jwksURI = oidcInfo.jwks_uri;
         }
     }
-
-    return config;
 }

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "15.1.1";
+export const version = "15.1.2";
 
 export const cdiSupported = ["3.0"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "15.1.1",
+    "version": "15.1.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "15.1.1",
+            "version": "15.1.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "15.1.1",
+    "version": "15.1.2",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
