### PR TITLE
fix: error handling in doFetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [18.0.1] - 2024-06-19
+
+### Fixes
+
+-   Fix a bug that was preventing errors from being caught in the fetch function, thus bypassing our error handling.
+
 ## [18.0.0] - 2024-05-23
 
 ### Breaking change

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -49,7 +49,7 @@ const logger_1 = require("./logger");
 const constants_1 = require("./constants");
 const cross_fetch_1 = __importDefault(require("cross-fetch"));
 const processState_1 = require("./processState");
-const doFetch = (input, init) => {
+const doFetch = async (input, init) => {
     // frameworks like nextJS cache fetch GET requests (https://nextjs.org/docs/app/building-your-application/caching#data-cache)
     // we don't want that because it may lead to weird behaviour when querying the core.
     if (init === undefined) {
@@ -69,7 +69,7 @@ const doFetch = (input, init) => {
     }
     const fetchFunction = typeof fetch !== "undefined" ? fetch : cross_fetch_1.default;
     try {
-        return fetchFunction(input, init);
+        return await fetchFunction(input, init);
     } catch (e) {
         // Cloudflare Workers don't support the 'cache' field in RequestInit.
         // To work around this, we delete the 'cache' field and retry the fetch if the error is due to the missing 'cache' field.
@@ -83,7 +83,7 @@ const doFetch = (input, init) => {
         if (!unimplementedCacheError) throw e;
         const newOpts = Object.assign({}, init);
         delete newOpts.cache;
-        return fetchFunction(input, newOpts);
+        return await fetchFunction(input, newOpts);
     }
 };
 exports.doFetch = doFetch;

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "18.0.0";
+export declare const version = "18.0.1";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.11";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "18.0.0";
+exports.version = "18.0.1";
 exports.cdiSupported = ["5.0"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.11";

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -11,7 +11,7 @@ import { LoginMethod, User } from "./user";
 import { SessionContainer } from "./recipe/session";
 import { ProcessState, PROCESS_STATE } from "./processState";
 
-export const doFetch: typeof fetch = (input: RequestInfo | URL, init?: RequestInit | undefined) => {
+export const doFetch: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit | undefined) => {
     // frameworks like nextJS cache fetch GET requests (https://nextjs.org/docs/app/building-your-application/caching#data-cache)
     // we don't want that because it may lead to weird behaviour when querying the core.
     if (init === undefined) {
@@ -27,7 +27,7 @@ export const doFetch: typeof fetch = (input: RequestInfo | URL, init?: RequestIn
     }
     const fetchFunction = typeof fetch !== "undefined" ? fetch : crossFetch;
     try {
-        return fetchFunction(input, init);
+        return await fetchFunction(input, init);
     } catch (e) {
         // Cloudflare Workers don't support the 'cache' field in RequestInit.
         // To work around this, we delete the 'cache' field and retry the fetch if the error is due to the missing 'cache' field.
@@ -43,7 +43,7 @@ export const doFetch: typeof fetch = (input: RequestInfo | URL, init?: RequestIn
         const newOpts = { ...init };
         delete newOpts.cache;
 
-        return fetchFunction(input, newOpts);
+        return await fetchFunction(input, newOpts);
     }
 };
 

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "18.0.0";
+export const version = "18.0.1";
 
 export const cdiSupported = ["5.0"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "18.0.0",
+    "version": "18.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "18.0.0",
+            "version": "18.0.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "18.0.0",
+    "version": "18.0.1",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

In #835 we had added a workaround to retry request without the `cache` field if it was not available. We were not awaiting the response and prevents the catch block from catching the error.

For some reason it worked fine locally and even on CF (for sometime) until it started breaking recently. Adding `await` fixes the issue.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
