### PR TITLE
fix: update access token cookie expiry to 1 year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Defined the entry points of the library using the "exports" field in package.json to make ESM imports more comfortable. This can cause some issues for applications using directory imports from the `lib/build` directory. In those cases we recommend adding `index.js` to the import path.
 
+-   The access token cookie expiry has been changed from 100 years to 1 year due to some browsers capping the maximum expiry at 400 days. No action is needed on your part.
+
 ### Changes
 
 -   `passwordResetPOST`:

--- a/lib/build/recipe/session/constants.d.ts
+++ b/lib/build/recipe/session/constants.d.ts
@@ -3,7 +3,7 @@ import { TokenTransferMethod } from "./types";
 export declare const REFRESH_API_PATH = "/session/refresh";
 export declare const SIGNOUT_API_PATH = "/signout";
 export declare const availableTokenTransferMethods: TokenTransferMethod[];
-export declare const hundredYearsInMs = 3153600000000;
+export declare const oneYearInMs = 31536000000;
 export declare const JWKCacheCooldownInMs = 500;
 export declare const JWKCacheMaxAgeInMs = 60000;
 export declare const protectedProps: string[];

--- a/lib/build/recipe/session/constants.js
+++ b/lib/build/recipe/session/constants.js
@@ -14,11 +14,11 @@
  * under the License.
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.protectedProps = exports.JWKCacheMaxAgeInMs = exports.JWKCacheCooldownInMs = exports.hundredYearsInMs = exports.availableTokenTransferMethods = exports.SIGNOUT_API_PATH = exports.REFRESH_API_PATH = void 0;
+exports.protectedProps = exports.JWKCacheMaxAgeInMs = exports.JWKCacheCooldownInMs = exports.oneYearInMs = exports.availableTokenTransferMethods = exports.SIGNOUT_API_PATH = exports.REFRESH_API_PATH = void 0;
 exports.REFRESH_API_PATH = "/session/refresh";
 exports.SIGNOUT_API_PATH = "/signout";
 exports.availableTokenTransferMethods = ["cookie", "header"];
-exports.hundredYearsInMs = 3153600000000;
+exports.oneYearInMs = 31536000000;
 exports.JWKCacheCooldownInMs = 500;
 exports.JWKCacheMaxAgeInMs = 60000;
 exports.protectedProps = [

--- a/lib/build/recipe/session/utils.js
+++ b/lib/build/recipe/session/utils.js
@@ -254,11 +254,11 @@ function setAccessTokenInResponse(res, accessToken, frontToken, config, transfer
         res,
         "access",
         accessToken,
-        // We set the expiration to 100 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
+        // We set the expiration to 1 year, because we can't really access the expiration of the refresh token everywhere we are setting it.
         // This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
         // Even if the token is expired the presence of the token indicates that the user could have a valid refresh token
-        // Setting them to infinity would require special case handling on the frontend and just adding 100 years seems enough.
-        Date.now() + constants_1.hundredYearsInMs,
+        // Some browsers now cap the maximum expiry at 400 days, so we set it to 1 year, which should suffice.
+        Date.now() + constants_1.oneYearInMs,
         transferMethod,
         req,
         userContext
@@ -269,11 +269,11 @@ function setAccessTokenInResponse(res, accessToken, frontToken, config, transfer
             res,
             "access",
             accessToken,
-            // We set the expiration to 100 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
+            // We set the expiration to 1 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
             // This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
             // Even if the token is expired the presence of the token indicates that the user could have a valid refresh token
-            // Setting them to infinity would require special case handling on the frontend and just adding 100 years seems enough.
-            Date.now() + constants_1.hundredYearsInMs,
+            // Some browsers now cap the maximum expiry at 400 days, so we set it to 1 year, which should suffice.
+            Date.now() + constants_1.oneYearInMs,
             "header",
             req,
             userContext

--- a/lib/ts/recipe/session/constants.ts
+++ b/lib/ts/recipe/session/constants.ts
@@ -20,7 +20,7 @@ export const SIGNOUT_API_PATH = "/signout";
 
 export const availableTokenTransferMethods: TokenTransferMethod[] = ["cookie", "header"];
 
-export const hundredYearsInMs = 3153600000000;
+export const oneYearInMs = 31536000000;
 
 export const JWKCacheCooldownInMs = 500;
 export const JWKCacheMaxAgeInMs = 60000;

--- a/lib/ts/recipe/session/utils.ts
+++ b/lib/ts/recipe/session/utils.ts
@@ -25,7 +25,7 @@ import {
 } from "./types";
 import { setFrontTokenInHeaders, setToken, getAuthModeFromHeader } from "./cookieAndHeaders";
 import SessionRecipe from "./recipe";
-import { REFRESH_API_PATH, hundredYearsInMs } from "./constants";
+import { REFRESH_API_PATH, oneYearInMs } from "./constants";
 import NormalisedURLPath from "../../normalisedURLPath";
 import { NormalisedAppinfo, UserContext } from "../../types";
 import { isAnIpAddress, send200Response } from "../../utils";
@@ -331,11 +331,11 @@ export function setAccessTokenInResponse(
         res,
         "access",
         accessToken,
-        // We set the expiration to 100 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
+        // We set the expiration to 1 year, because we can't really access the expiration of the refresh token everywhere we are setting it.
         // This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
         // Even if the token is expired the presence of the token indicates that the user could have a valid refresh token
-        // Setting them to infinity would require special case handling on the frontend and just adding 100 years seems enough.
-        Date.now() + hundredYearsInMs,
+        // Some browsers now cap the maximum expiry at 400 days, so we set it to 1 year, which should suffice.
+        Date.now() + oneYearInMs,
         transferMethod,
         req,
         userContext
@@ -347,11 +347,11 @@ export function setAccessTokenInResponse(
             res,
             "access",
             accessToken,
-            // We set the expiration to 100 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
+            // We set the expiration to 1 years, because we can't really access the expiration of the refresh token everywhere we are setting it.
             // This should be safe to do, since this is only the validity of the cookie (set here or on the frontend) but we check the expiration of the JWT anyway.
             // Even if the token is expired the presence of the token indicates that the user could have a valid refresh token
-            // Setting them to infinity would require special case handling on the frontend and just adding 100 years seems enough.
-            Date.now() + hundredYearsInMs,
+            // Some browsers now cap the maximum expiry at 400 days, so we set it to 1 year, which should suffice.
+            Date.now() + oneYearInMs,
             "header",
             req,
             userContext


### PR DESCRIPTION
## Summary of change

We decided to update the cookie expiry to 1 year because - 

1. Some browsers cap the max expiry to 400 days. See [this](https://developer.chrome.com/blog/cookie-max-age-expires#:~:text=With%20this%20change%2C%20Chrome%20caps,set%20to%20400%20days%20instead) for info.
2. Our docs mention that access token cookie expiry is 1 year.

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

