### PR TITLE
feat: call isEmailChangeAllowed in pwless updateUser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     -   the user has another email address or phone number associated with it
 -   Account linking based on emails now require the email to be verified in both users if `shouldRequireVerification` is set to `true` instead of only requiring it for the recipe user.
 -   The access token cookie expiry has been changed from 100 years to 1 year due to some browsers capping the maximum expiry at 400 days. No action is needed on your part.
+-   Recipe functions that update the email address of users now call `isEmailChangeAllowed` to check if the email update should be allowed or not.
+    -   This only has an effect if account linking is turned on.
+    -   This is aimed to help you avoid security issues.
+    -   You can "bypass" this check by verifying the email address for the user using the `EmailVerification` recipe. See [here](https://supertokens.com/docs/thirdpartyemailpassword/common-customizations/email-verification/changing-email-verification-status) for more details.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Recipe functions that update the email address of users now call `isEmailChangeAllowed` to check if the email update should be allowed or not.
     -   This only has an effect if account linking is turned on.
     -   This is aimed to help you avoid security issues.
-    -   You can "bypass" this check by verifying the email address for the user using the `EmailVerification` recipe. See [here](https://supertokens.com/docs/thirdpartyemailpassword/common-customizations/email-verification/changing-email-verification-status) for more details.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Recipe functions that update the email address of users now call `isEmailChangeAllowed` to check if the email update should be allowed or not.
     -   This only has an effect if account linking is turned on.
     -   This is aimed to help you avoid security issues.
+    -   `isEmailChangeAllowed` is now called in functions:
+        -   `updateUser` (Passwordless recipe)
+        -   `updateEmailOrPassword` (EmailPassword recipe)
+        -   `manuallyCreateOrUpdateUser` (ThirdParty recipe)
 
 ### Changes
 

--- a/lib/build/recipe/passwordless/recipeImplementation.js
+++ b/lib/build/recipe/passwordless/recipeImplementation.js
@@ -6,6 +6,7 @@ var __importDefault =
     };
 Object.defineProperty(exports, "__esModule", { value: true });
 const recipe_1 = __importDefault(require("../accountlinking/recipe"));
+const recipe_2 = __importDefault(require("../emailverification/recipe"));
 const normalisedURLPath_1 = __importDefault(require("../../normalisedURLPath"));
 const logger_1 = require("../../logger");
 const user_1 = require("../../user");
@@ -147,6 +148,38 @@ function getRecipeInterface(querier) {
             return { status: "OK" };
         },
         updateUser: async function (input) {
+            const accountLinking = recipe_1.default.getInstance();
+            if (input.email) {
+                const user = await __1.getUser(input.recipeUserId.getAsString(), input.userContext);
+                if (user === undefined) {
+                    return { status: "UNKNOWN_USER_ID_ERROR" };
+                }
+                const evInstance = recipe_2.default.getInstance();
+                let isEmailVerified = false;
+                if (evInstance) {
+                    isEmailVerified = await evInstance.recipeInterfaceImpl.isEmailVerified({
+                        recipeUserId: input.recipeUserId,
+                        email: input.email,
+                        userContext: input.userContext,
+                    });
+                }
+                const isEmailChangeAllowed = await accountLinking.isEmailChangeAllowed({
+                    user,
+                    isVerified: isEmailVerified,
+                    newEmail: input.email,
+                    session: undefined,
+                    userContext: input.userContext,
+                });
+                if (!isEmailChangeAllowed.allowed) {
+                    return {
+                        status: "EMAIL_CHANGE_NOT_ALLOWED_ERROR",
+                        reason:
+                            isEmailChangeAllowed.reason === "ACCOUNT_TAKEOVER_RISK"
+                                ? "New email cannot be applied to existing account because of account takeover risks."
+                                : "New email cannot be applied to existing account because of there is another primary user with the same email address.",
+                    };
+                }
+            }
             let response = await querier.sendPutRequest(
                 new normalisedURLPath_1.default(`/recipe/user`),
                 copyAndRemoveUserContextAndTenantId(input),

--- a/lib/ts/recipe/passwordless/recipeImplementation.ts
+++ b/lib/ts/recipe/passwordless/recipeImplementation.ts
@@ -1,6 +1,7 @@
 import { RecipeInterface } from "./types";
 import { Querier } from "../../querier";
 import AccountLinking from "../accountlinking/recipe";
+import EmailVerification from "../emailverification/recipe";
 import NormalisedURLPath from "../../normalisedURLPath";
 import { logDebugMessage } from "../../logger";
 import { User } from "../../user";
@@ -161,6 +162,41 @@ export default function getRecipeInterface(querier: Querier): RecipeInterface {
             return { status: "OK" };
         },
         updateUser: async function (input) {
+            const accountLinking = AccountLinking.getInstance();
+            if (input.email) {
+                const user = await getUser(input.recipeUserId.getAsString(), input.userContext);
+
+                if (user === undefined) {
+                    return { status: "UNKNOWN_USER_ID_ERROR" };
+                }
+
+                const evInstance = EmailVerification.getInstance();
+
+                let isEmailVerified = false;
+                if (evInstance) {
+                    isEmailVerified = await evInstance.recipeInterfaceImpl.isEmailVerified({
+                        recipeUserId: input.recipeUserId,
+                        email: input.email,
+                        userContext: input.userContext,
+                    });
+                }
+                const isEmailChangeAllowed = await accountLinking.isEmailChangeAllowed({
+                    user,
+                    isVerified: isEmailVerified,
+                    newEmail: input.email,
+                    session: undefined,
+                    userContext: input.userContext,
+                });
+                if (!isEmailChangeAllowed.allowed) {
+                    return {
+                        status: "EMAIL_CHANGE_NOT_ALLOWED_ERROR",
+                        reason:
+                            isEmailChangeAllowed.reason === "ACCOUNT_TAKEOVER_RISK"
+                                ? "New email cannot be applied to existing account because of account takeover risks."
+                                : "New email cannot be applied to existing account because of there is another primary user with the same email address.",
+                    };
+                }
+            }
             let response = await querier.sendPutRequest(
                 new NormalisedURLPath(`/recipe/user`),
                 copyAndRemoveUserContextAndTenantId(input),

--- a/test/test-server/src/passwordless.ts
+++ b/test/test-server/src/passwordless.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import SuperTokens from "../../..";
 import Passwordless from "../../../recipe/passwordless";
 import { convertRequestSessionToSessionObject, serializeRecipeUserId, serializeUser } from "./utils";
 import { logger } from "./logger";
@@ -57,6 +58,24 @@ const router = Router()
                 tenantId: req.body.tenantId || "public",
                 userInputCode: req.body.userInputCode,
                 session: req.body.session && (await convertRequestSessionToSessionObject(req.body.session)),
+                userContext: req.body.userContext,
+            });
+            res.json({
+                ...response,
+                ...serializeUser(response),
+                ...serializeRecipeUserId(response),
+            });
+        } catch (e) {
+            next(e);
+        }
+    })
+    .post("/updateuser", async (req, res, next) => {
+        try {
+            logDebugMessage("Passwordless:updateUser %j", req.body);
+            const response = await Passwordless.updateUser({
+                recipeUserId: SuperTokens.convertToRecipeUserId(req.body.recipeUserId),
+                email: req.body.email,
+                phoneNumber: req.body.phoneNumber,
                 userContext: req.body.userContext,
             });
             res.json({


### PR DESCRIPTION
## Summary of change

- call isEmailChangeAllowed in pwless updateUser
- updated changelog

## Related issues

-   

## Test Plan

Adding tests in a separate PR

## Documentation changes

- [ ] Email verification [docs](https://supertokens.com/docs/thirdpartyemailpassword/common-customizations/email-verification/changing-email-verification-status) to mention setting the email address when creating the token if it's different than the current one.

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] If new thirdparty provider is added,
    -   [x] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [x] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
