### PR TITLE
fix: always clear tokens if a refresh results in a 401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [18.0.2] - 2024-07-09
+
+### Changes
+
+-   `refreshPOST` and `refreshSession` now clears all user tokens upon CSRF failures and if no tokens are found. See the latest comment on https://github.com/supertokens/supertokens-node/issues/141 for more details.
+
 ## [18.0.1] - 2024-06-19
 
 ### Fixes

--- a/lib/build/recipe/session/sessionRequestFunctions.js
+++ b/lib/build/recipe/session/sessionRequestFunctions.js
@@ -257,7 +257,7 @@ async function refreshSessionInRequest({ res, req, userContext, config, recipeIn
         throw new error_1.default({
             message: "Refresh token not found. Are you sending the refresh token in the request?",
             payload: {
-                clearTokens: false,
+                clearTokens: true,
             },
             type: error_1.default.UNAUTHORISED,
         });
@@ -280,7 +280,7 @@ async function refreshSessionInRequest({ res, req, userContext, config, recipeIn
                 message: "anti-csrf check failed. Please pass 'rid: \"session\"' header in the request.",
                 type: error_1.default.UNAUTHORISED,
                 payload: {
-                    clearTokens: false, // see https://github.com/supertokens/supertokens-node/issues/141
+                    clearTokens: true, // see https://github.com/supertokens/supertokens-node/issues/141
                 },
             });
         }

--- a/lib/ts/recipe/session/sessionRequestFunctions.ts
+++ b/lib/ts/recipe/session/sessionRequestFunctions.ts
@@ -314,7 +314,7 @@ export async function refreshSessionInRequest({
         throw new SessionError({
             message: "Refresh token not found. Are you sending the refresh token in the request?",
             payload: {
-                clearTokens: false,
+                clearTokens: true,
             },
             type: SessionError.UNAUTHORISED,
         });
@@ -338,7 +338,7 @@ export async function refreshSessionInRequest({
                 message: "anti-csrf check failed. Please pass 'rid: \"session\"' header in the request.",
                 type: SessionError.UNAUTHORISED,
                 payload: {
-                    clearTokens: false, // see https://github.com/supertokens/supertokens-node/issues/141
+                    clearTokens: true, // see https://github.com/supertokens/supertokens-node/issues/141
                 },
             });
         }

--- a/test/auth-modes.test.js
+++ b/test/auth-modes.test.js
@@ -893,15 +893,15 @@ describe(`auth-modes: ${printPath("[test/auth-modes.test.js]")}`, function () {
             describe("from behaviour table", () => {
                 // prettier-ignore
                 const behaviourTable = [
-                    { getTokenTransferMethodRes: "any", authHeader: false, authCookie: false, output: "unauthorised", setTokens: "none", clearedTokens: "none" },
-                    { getTokenTransferMethodRes: "header", authHeader: false, authCookie: false, output: "unauthorised", setTokens: "none", clearedTokens: "none" },
-                    { getTokenTransferMethodRes: "cookie", authHeader: false, authCookie: false, output: "unauthorised", setTokens: "none", clearedTokens: "none" },
+                    { getTokenTransferMethodRes: "any", authHeader: false, authCookie: false, output: "unauthorised", setTokens: "none", clearedTokens: "both" },
+                    { getTokenTransferMethodRes: "header", authHeader: false, authCookie: false, output: "unauthorised", setTokens: "none", clearedTokens: "both" },
+                    { getTokenTransferMethodRes: "cookie", authHeader: false, authCookie: false, output: "unauthorised", setTokens: "none", clearedTokens: "both" },
                     { getTokenTransferMethodRes: "any", authHeader: false, authCookie: true, output: "validatecookie", setTokens: "cookies", clearedTokens: "none" },
-                    { getTokenTransferMethodRes: "header", authHeader: false, authCookie: true, output: "unauthorised", setTokens: "none", clearedTokens: "none" }, // 5
+                    { getTokenTransferMethodRes: "header", authHeader: false, authCookie: true, output: "unauthorised", setTokens: "none", clearedTokens: "both" }, // 5
                     { getTokenTransferMethodRes: "cookie", authHeader: false, authCookie: true, output: "validatecookie", setTokens: "cookies", clearedTokens: "none" },
                     { getTokenTransferMethodRes: "any", authHeader: true, authCookie: false, output: "validateheader", setTokens: "headers", clearedTokens: "none" },
                     { getTokenTransferMethodRes: "header", authHeader: true, authCookie: false, output: "validateheader", setTokens: "headers", clearedTokens: "none" },
-                    { getTokenTransferMethodRes: "cookie", authHeader: true, authCookie: false, output: "unauthorised", setTokens: "none", clearedTokens: "none" }, // 9
+                    { getTokenTransferMethodRes: "cookie", authHeader: true, authCookie: false, output: "unauthorised", setTokens: "none", clearedTokens: "both" }, // 9
                     { getTokenTransferMethodRes: "any", authHeader: true, authCookie: true, output: "validateheader", setTokens: "headers", clearedTokens: "cookies" },
                     { getTokenTransferMethodRes: "header", authHeader: true, authCookie: true, output: "validateheader", setTokens: "headers", clearedTokens: "cookies" },
                     { getTokenTransferMethodRes: "cookie", authHeader: true, authCookie: true, output: "validatecookie", setTokens: "cookies", clearedTokens: "headers" }, // 12
@@ -964,6 +964,13 @@ describe(`auth-modes: ${printPath("[test/auth-modes.test.js]")}`, function () {
                             assert.strictEqual(refreshRes.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
                             assert.strictEqual(refreshRes.refreshToken, "");
                             assert.strictEqual(refreshRes.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+                        } else if (conf.clearedTokens === "both") {
+                            assert.strictEqual(refreshRes.accessTokenFromHeader, "");
+                            assert.strictEqual(refreshRes.refreshTokenFromHeader, "");
+                            assert.strictEqual(refreshRes.accessToken, "");
+                            assert.strictEqual(refreshRes.accessTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
+                            assert.strictEqual(refreshRes.refreshToken, "");
+                            assert.strictEqual(refreshRes.refreshTokenExpiry, "Thu, 01 Jan 1970 00:00:00 GMT");
                         }
 
                         switch (conf.setTokens) {
@@ -985,15 +992,17 @@ describe(`auth-modes: ${printPath("[test/auth-modes.test.js]")}`, function () {
                                 }
                                 break;
                         }
-                        if (conf.setTokens !== "cookies" && conf.clearedTokens !== "cookies") {
-                            assert.strictEqual(refreshRes.accessToken, undefined);
-                            assert.strictEqual(refreshRes.accessTokenExpiry, undefined);
-                            assert.strictEqual(refreshRes.refreshToken, undefined);
-                            assert.strictEqual(refreshRes.refreshTokenExpiry, undefined);
-                        }
-                        if (conf.setTokens !== "headers" && conf.clearedTokens !== "headers") {
-                            assert.strictEqual(refreshRes.accessTokenFromHeader, undefined);
-                            assert.strictEqual(refreshRes.refreshTokenFromHeader, undefined);
+                        if (conf.clearedTokens !== "both") {
+                            if (conf.setTokens !== "cookies" && conf.clearedTokens !== "cookies") {
+                                assert.strictEqual(refreshRes.accessToken, undefined);
+                                assert.strictEqual(refreshRes.accessTokenExpiry, undefined);
+                                assert.strictEqual(refreshRes.refreshToken, undefined);
+                                assert.strictEqual(refreshRes.refreshTokenExpiry, undefined);
+                            }
+                            if (conf.setTokens !== "headers" && conf.clearedTokens !== "headers") {
+                                assert.strictEqual(refreshRes.accessTokenFromHeader, undefined);
+                                assert.strictEqual(refreshRes.refreshTokenFromHeader, undefined);
+                            }
                         }
                     });
                 }


### PR DESCRIPTION
## Summary of change

fix: always clear tokens if a refresh results in a 401

## Related issues

-   

## Test Plan

Updated test cases

## Documentation changes

N/A

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
