### PR TITLE
fix: Prefer exact api path match in the middleware

### DIFF
--- a/lib/build/recipeModule.d.ts
+++ b/lib/build/recipeModule.d.ts
@@ -17,6 +17,7 @@ export default abstract class RecipeModule {
         | {
               id: string;
               tenantId: string;
+              exactMatch: boolean;
           }
         | undefined
     >;

--- a/lib/build/recipeModule.js
+++ b/lib/build/recipeModule.js
@@ -54,7 +54,7 @@ class RecipeModule {
                             tenantIdFromFrontend: constants_1.DEFAULT_TENANT_ID,
                             userContext,
                         });
-                        return { id: currAPI.id, tenantId: finalTenantId };
+                        return { id: currAPI.id, tenantId: finalTenantId, exactMatch: true };
                     } else if (
                         remainingPath !== undefined &&
                         this.appInfo.apiBasePath
@@ -65,7 +65,7 @@ class RecipeModule {
                             tenantIdFromFrontend: tenantId === undefined ? constants_1.DEFAULT_TENANT_ID : tenantId,
                             userContext,
                         });
-                        return { id: currAPI.id, tenantId: finalTenantId };
+                        return { id: currAPI.id, tenantId: finalTenantId, exactMatch: false };
                     }
                 }
             }

--- a/lib/build/supertokens.js
+++ b/lib/build/supertokens.js
@@ -163,6 +163,7 @@ class SuperTokens {
                 requestRID = undefined;
             }
             async function handleWithoutRid(recipeModules) {
+                let bestMatch = undefined;
                 for (let i = 0; i < recipeModules.length; i++) {
                     logger_1.logDebugMessage(
                         "middleware: Checking recipe ID for match: " +
@@ -174,25 +175,39 @@ class SuperTokens {
                     );
                     let idResult = await recipeModules[i].returnAPIIdIfCanHandleRequest(path, method, userContext);
                     if (idResult !== undefined) {
-                        logger_1.logDebugMessage("middleware: Request being handled by recipe. ID is: " + idResult.id);
-                        let requestHandled = await recipeModules[i].handleAPIRequest(
-                            idResult.id,
-                            idResult.tenantId,
-                            request,
-                            response,
-                            path,
-                            method,
-                            userContext
-                        );
-                        if (!requestHandled) {
-                            logger_1.logDebugMessage(
-                                "middleware: Not handled because API returned requestHandled as false"
-                            );
-                            return false;
+                        // The request path may or may not include the tenantId. `returnAPIIdIfCanHandleRequest` handles both cases.
+                        // If one recipe matches with tenantId and another matches exactly, we prefer the exact match.
+                        if (bestMatch === undefined || idResult.exactMatch) {
+                            bestMatch = {
+                                recipeModule: recipeModules[i],
+                                idResult: idResult,
+                            };
                         }
-                        logger_1.logDebugMessage("middleware: Ended");
-                        return true;
+                        if (idResult.exactMatch) {
+                            break;
+                        }
                     }
+                }
+                if (bestMatch !== undefined) {
+                    const { idResult, recipeModule } = bestMatch;
+                    logger_1.logDebugMessage("middleware: Request being handled by recipe. ID is: " + idResult.id);
+                    let requestHandled = await recipeModule.handleAPIRequest(
+                        idResult.id,
+                        idResult.tenantId,
+                        request,
+                        response,
+                        path,
+                        method,
+                        userContext
+                    );
+                    if (!requestHandled) {
+                        logger_1.logDebugMessage(
+                            "middleware: Not handled because API returned requestHandled as false"
+                        );
+                        return false;
+                    }
+                    logger_1.logDebugMessage("middleware: Ended");
+                    return true;
                 }
                 logger_1.logDebugMessage("middleware: Not handling because no recipe matched");
                 return false;
@@ -239,13 +254,18 @@ class SuperTokens {
                     // the path and methods of the APIs exposed via those recipes is unique.
                     let currIdResult = await matchedRecipe[i].returnAPIIdIfCanHandleRequest(path, method, userContext);
                     if (currIdResult !== undefined) {
-                        if (idResult !== undefined) {
+                        if (
+                            idResult === undefined ||
+                            // The request path may or may not include the tenantId. `returnAPIIdIfCanHandleRequest` handles both cases.
+                            // If one recipe matches with tenantId and another matches exactly, we prefer the exact match.
+                            (currIdResult.exactMatch === true && idResult.exactMatch === false)
+                        ) {
+                            finalMatchedRecipe = matchedRecipe[i];
+                            idResult = currIdResult;
+                        } else {
                             throw new Error(
                                 "Two recipes have matched the same API path and method! This is a bug in the SDK. Please contact support."
                             );
-                        } else {
-                            finalMatchedRecipe = matchedRecipe[i];
-                            idResult = currIdResult;
                         }
                     }
                 }

--- a/lib/ts/recipeModule.ts
+++ b/lib/ts/recipeModule.ts
@@ -41,7 +41,7 @@ export default abstract class RecipeModule {
         path: NormalisedURLPath,
         method: HTTPMethod,
         userContext: UserContext
-    ): Promise<{ id: string; tenantId: string } | undefined> => {
+    ): Promise<{ id: string; tenantId: string; exactMatch: boolean } | undefined> => {
         let apisHandled = this.getAPIsHandled();
 
         const basePathStr = this.appInfo.apiBasePath.getAsStringDangerous();
@@ -71,7 +71,7 @@ export default abstract class RecipeModule {
                         tenantIdFromFrontend: DEFAULT_TENANT_ID,
                         userContext,
                     });
-                    return { id: currAPI.id, tenantId: finalTenantId };
+                    return { id: currAPI.id, tenantId: finalTenantId, exactMatch: true };
                 } else if (
                     remainingPath !== undefined &&
                     this.appInfo.apiBasePath
@@ -82,7 +82,7 @@ export default abstract class RecipeModule {
                         tenantIdFromFrontend: tenantId === undefined ? DEFAULT_TENANT_ID : tenantId,
                         userContext,
                     });
-                    return { id: currAPI.id, tenantId: finalTenantId };
+                    return { id: currAPI.id, tenantId: finalTenantId, exactMatch: false };
                 }
             }
         }


### PR DESCRIPTION
## Summary of change

The API request path may or may not include the `tenantId`.  The `returnAPIIdIfCanHandleRequest` function handles both the cases. Currently, the `middleware` function simply calls the first recipe it matches. However, there is a chance that other recipes may have an exact match.

This PR updates the `middlware` such that we prefer an exact match.

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
-   [ ] If added a new entry point, then make sure that it is importable by adding it to the `exports` in `package.json`

