### PR TITLE
fix: make shouldDoAutomaticAccountLinking properly get the primary user when linking to oldest user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [20.0.2] - 2024-08-08
+
+-   Fixes an issue where `shouldDoAutomaticAccountLinking` was called without a primary user when linking in some cases.
+
 ## [20.0.1] - 2024-08-05
 
 -   Fixes an issue with `removeFromPayloadByMerge_internal` for `MultiFactorAuthClaim` where it was not retaining other claims while removing the claim from the payload.

--- a/lib/build/recipe/accountlinking/recipe.js
+++ b/lib/build/recipe/accountlinking/recipe.js
@@ -797,7 +797,7 @@ class Recipe extends recipeModule_1.default {
                     // we can use the 0 index cause targetUser is not a primary user.
                     let shouldDoAccountLinking = await this.config.shouldDoAutomaticAccountLinking(
                         inputUser.loginMethods[0],
-                        primaryUserThatCanBeLinkedToTheInputUser,
+                        createPrimaryUserResult.user,
                         session,
                         tenantId,
                         userContext

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "20.0.1";
+export declare const version = "20.0.2";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.13";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "20.0.1";
+exports.version = "20.0.2";
 exports.cdiSupported = ["5.1"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.13";

--- a/lib/ts/recipe/accountlinking/recipe.ts
+++ b/lib/ts/recipe/accountlinking/recipe.ts
@@ -925,7 +925,7 @@ export default class Recipe extends RecipeModule {
                     // we can use the 0 index cause targetUser is not a primary user.
                     let shouldDoAccountLinking = await this.config.shouldDoAutomaticAccountLinking(
                         inputUser.loginMethods[0],
-                        primaryUserThatCanBeLinkedToTheInputUser,
+                        createPrimaryUserResult.user,
                         session,
                         tenantId,
                         userContext

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "20.0.1";
+export const version = "20.0.2";
 
 export const cdiSupported = ["5.1"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "20.0.1",
+    "version": "20.0.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "20.0.1",
+            "version": "20.0.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "20.0.1",
+    "version": "20.0.2",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

Bugfix

## Related issues

-   https://supertokens.slack.com/archives/C051BN9QJUX/p1723036267092849

## Test Plan

Added a test to [backend-sdk-testing](https://github.com/supertokens/backend-sdk-testing/pull/36)

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] If new thirdparty provider is added,
    -   [x] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [x] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
-   [x] If added a new entry point, then make sure that it is importable by adding it to the `exports` in `package.json`