### PR TITLE
fix: thirdparty debug logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [20.0.4] - 2024-08-30
+
+-   Improves thirdParty debug logging to help with debugging issues with JSON parsing.
+
 ## [20.0.3] - 2024-08-22
 
 -   Fixes issue with dashboard APIs `createOrUpdateThirdPartyConfig` and `deleteThirdPartyConfig` which did not take `includeInNonPublicTenantsByDefault` into account for non-public tenants.

--- a/lib/build/recipe/thirdparty/providers/utils.js
+++ b/lib/build/recipe/thirdparty/providers/utils.js
@@ -61,10 +61,10 @@ async function doGetRequest(url, queryParams, headers) {
     });
     const stringResponse = await response.text();
     let jsonResponse = undefined;
+    logger_1.logDebugMessage(`Received response with status ${response.status} and body ${stringResponse}`);
     if (response.status < 400) {
         jsonResponse = JSON.parse(stringResponse);
     }
-    logger_1.logDebugMessage(`Received response with status ${response.status} and body ${stringResponse}`);
     return {
         stringResponse,
         status: response.status,
@@ -89,10 +89,10 @@ async function doPostRequest(url, params, headers) {
     });
     const stringResponse = await response.text();
     let jsonResponse = undefined;
+    logger_1.logDebugMessage(`Received response with status ${response.status} and body ${stringResponse}`);
     if (response.status < 400) {
         jsonResponse = JSON.parse(stringResponse);
     }
-    logger_1.logDebugMessage(`Received response with status ${response.status} and body ${stringResponse}`);
     return {
         stringResponse,
         status: response.status,

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "20.0.3";
+export declare const version = "20.0.4";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.13";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "20.0.3";
+exports.version = "20.0.4";
 exports.cdiSupported = ["5.1"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.13";

--- a/lib/ts/recipe/thirdparty/providers/utils.ts
+++ b/lib/ts/recipe/thirdparty/providers/utils.ts
@@ -33,11 +33,12 @@ export async function doGetRequest(
     const stringResponse = await response.text();
     let jsonResponse: Record<string, any> | undefined = undefined;
 
+    logDebugMessage(`Received response with status ${response.status} and body ${stringResponse}`);
+
     if (response.status < 400) {
         jsonResponse = JSON.parse(stringResponse);
     }
 
-    logDebugMessage(`Received response with status ${response.status} and body ${stringResponse}`);
     return {
         stringResponse,
         status: response.status,
@@ -75,11 +76,12 @@ export async function doPostRequest(
     const stringResponse = await response.text();
     let jsonResponse: Record<string, any> | undefined = undefined;
 
+    logDebugMessage(`Received response with status ${response.status} and body ${stringResponse}`);
+
     if (response.status < 400) {
         jsonResponse = JSON.parse(stringResponse);
     }
 
-    logDebugMessage(`Received response with status ${response.status} and body ${stringResponse}`);
     return {
         stringResponse,
         status: response.status,

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "20.0.3";
+export const version = "20.0.4";
 
 export const cdiSupported = ["5.1"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "20.0.3",
+    "version": "20.0.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "20.0.3",
+            "version": "20.0.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "20.0.3",
+    "version": "20.0.4",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

Improve thirdParty response logging to help debug JSON parsing issues.

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
-   [ ] If added a new entry point, then make sure that it is importable by adding it to the `exports` in `package.json`

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
