### PR TITLE
feat: skip field validations on non signup routes

### DIFF
--- a/lib/ts/recipe/emailpassword/api/generatePasswordResetToken.ts
+++ b/lib/ts/recipe/emailpassword/api/generatePasswordResetToken.ts
@@ -40,7 +40,8 @@ export default async function generatePasswordResetToken(
         options.config.resetPasswordUsingTokenFeature.formFieldsForGenerateTokenForm,
         requestBody.formFields,
         tenantId,
-        userContext
+        userContext,
+        false
     );
 
     let result = await apiImplementation.generatePasswordResetTokenPOST({

--- a/lib/ts/recipe/emailpassword/api/implementation.ts
+++ b/lib/ts/recipe/emailpassword/api/implementation.ts
@@ -65,7 +65,7 @@ export default function getAPIImplementation(): APIInterface {
             | { status: "PASSWORD_RESET_NOT_ALLOWED"; reason: string }
             | GeneralErrorResponse
         > {
-            const email = formFields.filter((f) => f.id === "email")[0].value;
+            const email = formFields.find((f) => f.id === "email")?.value ?? "";
 
             // this function will be reused in different parts of the flow below..
             async function generateAndSendPasswordResetToken(
@@ -451,7 +451,7 @@ export default function getAPIImplementation(): APIInterface {
                 }
             }
 
-            let newPassword = formFields.filter((f) => f.id === "password")[0].value;
+            let newPassword = formFields.find((f) => f.id === "password")?.value || "";
 
             let tokenConsumptionResponse = await options.recipeImplementation.consumePasswordResetToken({
                 token,
@@ -631,8 +631,8 @@ export default function getAPIImplementation(): APIInterface {
                         "Cannot sign in / up due to security reasons. Please contact support. (ERR_CODE_012)",
                 },
             };
-            let email = formFields.filter((f) => f.id === "email")[0].value;
-            let password = formFields.filter((f) => f.id === "password")[0].value;
+            let email = formFields.find((f) => f.id === "email")?.value ?? "";
+            let password = formFields.find((f) => f.id === "password")?.value ?? "";
 
             const recipeId = "emailpassword";
 

--- a/lib/ts/recipe/emailpassword/api/passwordReset.ts
+++ b/lib/ts/recipe/emailpassword/api/passwordReset.ts
@@ -44,7 +44,8 @@ export default async function passwordReset(
         options.config.resetPasswordUsingTokenFeature.formFieldsForPasswordResetForm,
         requestBody.formFields,
         tenantId,
-        userContext
+        userContext,
+        false
     );
 
     let token = requestBody.token;

--- a/lib/ts/recipe/emailpassword/api/signin.ts
+++ b/lib/ts/recipe/emailpassword/api/signin.ts
@@ -38,7 +38,8 @@ export default async function signInAPI(
         options.config.signInFeature.formFields,
         (await options.req.getJSONBody()).formFields,
         tenantId,
-        userContext
+        userContext,
+        false
     );
 
     let session = await Session.getSession(

--- a/lib/ts/recipe/emailpassword/api/utils.ts
+++ b/lib/ts/recipe/emailpassword/api/utils.ts
@@ -21,7 +21,8 @@ export async function validateFormFieldsOrThrowError(
     configFormFields: NormalisedFormField[],
     formFieldsRaw: any,
     tenantId: string,
-    userContext: UserContext
+    userContext: UserContext,
+    runValidators: boolean = true
 ): Promise<
     {
         id: string;
@@ -69,9 +70,11 @@ export async function validateFormFieldsOrThrowError(
         return field;
     });
 
-    // then run validators through them-----------------------
-    await validateFormOrThrowError(formFields, configFormFields, tenantId, userContext);
-
+    // Run form field validators for only signup, see: https://github.com/supertokens/supertokens-node/issues/447
+    if (runValidators) {
+        // then run validators through them-----------------------
+        await validateFormOrThrowError(formFields, configFormFields, tenantId, userContext);
+    }
     return formFields;
 }
 


### PR DESCRIPTION
## Summary of change

From my understanding of the ticket, we wanted to avoid doing field validations on form fields for non-signup routes, since it is field validation that emits FORM_FIELD errors. This would mean we would be delegating the validation to the core, for say email and password. Please feel free to let me know if this is not the intended change of the ticket and if it is to be done differently. I am quite new to the repo so my understanding is quite limited. I am happy to do it the right way with little guidance. Thank you for your time and patience.

## Related issues

-   https://github.com/supertokens/supertokens-node/issues/447
-   https://github.com/supertokens/supertokens-auth-react/issues/638

## Test Plan

I have yet to run the test cases and update them if necessary, will do it once I get a go on the implementation

## Documentation changes

This might need a Docs update as mentioned in the ticket.

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non-released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

-   [ ] Get clarification on the approach
-   [ ] Maybe update types where necessary (Need some guidance on this part as well)
