### PR TITLE
fix: okta and active directory with endpoints provided without additi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [20.1.1] - 2024-09-10
+
+-   Fixes an issue with Okta / Active Directory providers where we check for additional config if `oidcDiscoveryEndpoint` is not defined. It would not be necessary in the cases where other endpoints are already provided.
+
 ## [20.1.0] - 2024-09-09
 
 -   Add edge compatibility for custom frameworks and Next.JS

--- a/lib/build/recipe/thirdparty/providers/activeDirectory.js
+++ b/lib/build/recipe/thirdparty/providers/activeDirectory.js
@@ -30,19 +30,15 @@ function ActiveDirectory(input) {
         const oGetConfig = originalImplementation.getConfigForClientType;
         originalImplementation.getConfigForClientType = async function ({ clientType, userContext }) {
             const config = await oGetConfig({ clientType, userContext });
-            if (config.additionalConfig == undefined || config.additionalConfig.directoryId == undefined) {
-                if (config.oidcDiscoveryEndpoint === undefined) {
-                    throw new Error(
-                        "Please provide the directoryId in the additionalConfig of the Active Directory provider."
-                    );
-                }
-            } else {
+            if (config.additionalConfig !== undefined && config.additionalConfig.directoryId !== undefined) {
                 config.oidcDiscoveryEndpoint = `https://login.microsoftonline.com/${config.additionalConfig.directoryId}/v2.0/.well-known/openid-configuration`;
             }
-            // The config could be coming from core where we didn't add the well-known previously
-            config.oidcDiscoveryEndpoint = utils_1.normaliseOIDCEndpointToIncludeWellKnown(
-                config.oidcDiscoveryEndpoint
-            );
+            if (config.oidcDiscoveryEndpoint !== undefined) {
+                // The config could be coming from core where we didn't add the well-known previously
+                config.oidcDiscoveryEndpoint = utils_1.normaliseOIDCEndpointToIncludeWellKnown(
+                    config.oidcDiscoveryEndpoint
+                );
+            }
             if (config.scope === undefined) {
                 config.scope = ["openid", "email"];
             }

--- a/lib/build/recipe/thirdparty/providers/okta.js
+++ b/lib/build/recipe/thirdparty/providers/okta.js
@@ -32,19 +32,17 @@ function Okta(input) {
         const oGetConfig = originalImplementation.getConfigForClientType;
         originalImplementation.getConfigForClientType = async function (input) {
             const config = await oGetConfig(input);
-            if (config.additionalConfig == undefined || config.additionalConfig.oktaDomain == undefined) {
-                if (config.oidcDiscoveryEndpoint === undefined) {
-                    throw new Error("Please provide the oktaDomain in the additionalConfig of the Okta provider.");
-                }
-            } else {
+            if (config.additionalConfig !== undefined && config.additionalConfig.oktaDomain !== undefined) {
                 const oidcDomain = new normalisedURLDomain_1.default(config.additionalConfig.oktaDomain);
                 const oidcPath = new normalisedURLPath_1.default("/.well-known/openid-configuration");
                 config.oidcDiscoveryEndpoint = oidcDomain.getAsStringDangerous() + oidcPath.getAsStringDangerous();
             }
-            // The config could be coming from core where we didn't add the well-known previously
-            config.oidcDiscoveryEndpoint = utils_1.normaliseOIDCEndpointToIncludeWellKnown(
-                config.oidcDiscoveryEndpoint
-            );
+            if (config.oidcDiscoveryEndpoint !== undefined) {
+                // The config could be coming from core where we didn't add the well-known previously
+                config.oidcDiscoveryEndpoint = utils_1.normaliseOIDCEndpointToIncludeWellKnown(
+                    config.oidcDiscoveryEndpoint
+                );
+            }
             if (config.scope === undefined) {
                 config.scope = ["openid", "email"];
             }

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "20.1.0";
+export declare const version = "20.1.1";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.13";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "20.1.0";
+exports.version = "20.1.1";
 exports.cdiSupported = ["5.1"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.13";

--- a/lib/ts/recipe/thirdparty/providers/activeDirectory.ts
+++ b/lib/ts/recipe/thirdparty/providers/activeDirectory.ts
@@ -29,18 +29,14 @@ export default function ActiveDirectory(input: ProviderInput): TypeProvider {
         originalImplementation.getConfigForClientType = async function ({ clientType, userContext }) {
             const config = await oGetConfig({ clientType, userContext });
 
-            if (config.additionalConfig == undefined || config.additionalConfig.directoryId == undefined) {
-                if (config.oidcDiscoveryEndpoint === undefined) {
-                    throw new Error(
-                        "Please provide the directoryId in the additionalConfig of the Active Directory provider."
-                    );
-                }
-            } else {
+            if (config.additionalConfig !== undefined && config.additionalConfig.directoryId !== undefined) {
                 config.oidcDiscoveryEndpoint = `https://login.microsoftonline.com/${config.additionalConfig.directoryId}/v2.0/.well-known/openid-configuration`;
             }
 
-            // The config could be coming from core where we didn't add the well-known previously
-            config.oidcDiscoveryEndpoint = normaliseOIDCEndpointToIncludeWellKnown(config.oidcDiscoveryEndpoint);
+            if (config.oidcDiscoveryEndpoint !== undefined) {
+                // The config could be coming from core where we didn't add the well-known previously
+                config.oidcDiscoveryEndpoint = normaliseOIDCEndpointToIncludeWellKnown(config.oidcDiscoveryEndpoint);
+            }
 
             if (config.scope === undefined) {
                 config.scope = ["openid", "email"];

--- a/lib/ts/recipe/thirdparty/providers/okta.ts
+++ b/lib/ts/recipe/thirdparty/providers/okta.ts
@@ -30,19 +30,17 @@ export default function Okta(input: ProviderInput): TypeProvider {
         originalImplementation.getConfigForClientType = async function (input) {
             const config = await oGetConfig(input);
 
-            if (config.additionalConfig == undefined || config.additionalConfig.oktaDomain == undefined) {
-                if (config.oidcDiscoveryEndpoint === undefined) {
-                    throw new Error("Please provide the oktaDomain in the additionalConfig of the Okta provider.");
-                }
-            } else {
+            if (config.additionalConfig !== undefined && config.additionalConfig.oktaDomain !== undefined) {
                 const oidcDomain = new NormalisedURLDomain(config.additionalConfig.oktaDomain);
                 const oidcPath = new NormalisedURLPath("/.well-known/openid-configuration");
 
                 config.oidcDiscoveryEndpoint = oidcDomain.getAsStringDangerous() + oidcPath.getAsStringDangerous();
             }
 
-            // The config could be coming from core where we didn't add the well-known previously
-            config.oidcDiscoveryEndpoint = normaliseOIDCEndpointToIncludeWellKnown(config.oidcDiscoveryEndpoint);
+            if (config.oidcDiscoveryEndpoint !== undefined) {
+                // The config could be coming from core where we didn't add the well-known previously
+                config.oidcDiscoveryEndpoint = normaliseOIDCEndpointToIncludeWellKnown(config.oidcDiscoveryEndpoint);
+            }
 
             if (config.scope === undefined) {
                 config.scope = ["openid", "email"];

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "20.1.0";
+export const version = "20.1.1";
 
 export const cdiSupported = ["5.1"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "20.1.0",
+    "version": "20.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "20.1.0",
+            "version": "20.1.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "20.1.0",
+    "version": "20.1.1",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

fixes okta and active directory with endpoints provided without additional config

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
-   [ ] If added a new entry point, then make sure that it is importable by adding it to the `exports` in `package.json`

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
