### PR TITLE
fix: Add changes to support unknown type in formField values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Added OAuth2Provider recipe
 
+### Breaking change
+
+-   Changes type of value in formField object to be `unknown` instead of `string` to add support for accepting any type of value in form fields.
+
 ## [20.1.2] - 2024-09-14
 
 -   Fixes formFields to accept non string types as well.

--- a/lib/build/recipe/emailpassword/api/implementation.js
+++ b/lib/build/recipe/emailpassword/api/implementation.js
@@ -40,7 +40,16 @@ function getAPIImplementation() {
             };
         },
         generatePasswordResetTokenPOST: async function ({ formFields, tenantId, options, userContext }) {
-            const email = formFields.filter((f) => f.id === "email")[0].value;
+            // NOTE: Check for email being a non-string value. This check will likely
+            // never evaluate to `true` as there is an upper-level check for the type
+            // in validation but kept here to be safe.
+            const emailAsUnknown = formFields.filter((f) => f.id === "email")[0].value;
+            if (typeof emailAsUnknown !== "string")
+                return {
+                    status: "GENERAL_ERROR",
+                    message: "email value needs to be a string",
+                };
+            const email = emailAsUnknown;
             // this function will be reused in different parts of the flow below..
             async function generateAndSendPasswordResetToken(primaryUserId, recipeUserId) {
                 // the user ID here can be primary or recipe level.
@@ -355,7 +364,16 @@ function getAPIImplementation() {
                     };
                 }
             }
-            let newPassword = formFields.filter((f) => f.id === "password")[0].value;
+            // NOTE: Check for password being a non-string value. This check will likely
+            // never evaluate to `true` as there is an upper-level check for the type
+            // in validation but kept here to be safe.
+            const newPasswordAsUnknown = formFields.filter((f) => f.id === "password")[0].value;
+            if (typeof newPasswordAsUnknown !== "string")
+                return {
+                    status: "GENERAL_ERROR",
+                    message: "password value needs to be a string",
+                };
+            let newPassword = newPasswordAsUnknown;
             let tokenConsumptionResponse = await options.recipeImplementation.consumePasswordResetToken({
                 token,
                 tenantId,
@@ -371,7 +389,7 @@ function getAPIImplementation() {
                 // This should happen only cause of a race condition where the user
                 // might be deleted before token creation and consumption.
                 // Also note that this being undefined doesn't mean that the email password
-                // user does not exist, but it means that there is no reicpe or primary user
+                // user does not exist, but it means that there is no recipe or primary user
                 // for whom the token was generated.
                 return {
                     status: "RESET_PASSWORD_INVALID_TOKEN_ERROR",
@@ -503,8 +521,23 @@ function getAPIImplementation() {
                         "Cannot sign in / up due to security reasons. Please contact support. (ERR_CODE_012)",
                 },
             };
-            let email = formFields.filter((f) => f.id === "email")[0].value;
-            let password = formFields.filter((f) => f.id === "password")[0].value;
+            const emailAsUnknown = formFields.filter((f) => f.id === "email")[0].value;
+            const passwordAsUnknown = formFields.filter((f) => f.id === "password")[0].value;
+            // NOTE: Following checks will likely never throw an error as the
+            // check for type is done in a parent function but they are kept
+            // here to be on the safe side.
+            if (typeof emailAsUnknown !== "string")
+                return {
+                    status: "GENERAL_ERROR",
+                    message: "email value needs to be a string",
+                };
+            if (typeof passwordAsUnknown !== "string")
+                return {
+                    status: "GENERAL_ERROR",
+                    message: "password value needs to be a string",
+                };
+            let email = emailAsUnknown;
+            let password = passwordAsUnknown;
             const recipeId = "emailpassword";
             const checkCredentialsOnTenant = async (tenantId) => {
                 return (
@@ -635,8 +668,23 @@ function getAPIImplementation() {
                         "Cannot sign in / up due to security reasons. Please contact support. (ERR_CODE_016)",
                 },
             };
-            let email = formFields.filter((f) => f.id === "email")[0].value;
-            let password = formFields.filter((f) => f.id === "password")[0].value;
+            const emailAsUnknown = formFields.filter((f) => f.id === "email")[0].value;
+            const passwordAsUnknown = formFields.filter((f) => f.id === "password")[0].value;
+            // NOTE: Following checks will likely never throw an error as the
+            // check for type is done in a parent function but they are kept
+            // here to be on the safe side.
+            if (typeof emailAsUnknown !== "string")
+                return {
+                    status: "GENERAL_ERROR",
+                    message: "email value needs to be a string",
+                };
+            if (typeof passwordAsUnknown !== "string")
+                return {
+                    status: "GENERAL_ERROR",
+                    message: "password value needs to be a string",
+                };
+            let email = emailAsUnknown;
+            let password = passwordAsUnknown;
             const preAuthCheckRes = await authUtils_1.AuthUtils.preAuthChecks({
                 authenticatingAccountInfo: {
                     recipeId: "emailpassword",

--- a/lib/build/recipe/emailpassword/api/implementation.js
+++ b/lib/build/recipe/emailpassword/api/implementation.js
@@ -45,10 +45,9 @@ function getAPIImplementation() {
             // in validation but kept here to be safe.
             const emailAsUnknown = formFields.filter((f) => f.id === "email")[0].value;
             if (typeof emailAsUnknown !== "string")
-                return {
-                    status: "GENERAL_ERROR",
-                    message: "email value needs to be a string",
-                };
+                throw new Error(
+                    "Should never come here since we already check that the email value is a string in validateFormFieldsOrThrowError"
+                );
             const email = emailAsUnknown;
             // this function will be reused in different parts of the flow below..
             async function generateAndSendPasswordResetToken(primaryUserId, recipeUserId) {
@@ -369,10 +368,9 @@ function getAPIImplementation() {
             // in validation but kept here to be safe.
             const newPasswordAsUnknown = formFields.filter((f) => f.id === "password")[0].value;
             if (typeof newPasswordAsUnknown !== "string")
-                return {
-                    status: "GENERAL_ERROR",
-                    message: "password value needs to be a string",
-                };
+                throw new Error(
+                    "Should never come here since we already check that the password value is a string in validateFormFieldsOrThrowError"
+                );
             let newPassword = newPasswordAsUnknown;
             let tokenConsumptionResponse = await options.recipeImplementation.consumePasswordResetToken({
                 token,
@@ -527,15 +525,13 @@ function getAPIImplementation() {
             // check for type is done in a parent function but they are kept
             // here to be on the safe side.
             if (typeof emailAsUnknown !== "string")
-                return {
-                    status: "GENERAL_ERROR",
-                    message: "email value needs to be a string",
-                };
+                throw new Error(
+                    "Should never come here since we already check that the email value is a string in validateFormFieldsOrThrowError"
+                );
             if (typeof passwordAsUnknown !== "string")
-                return {
-                    status: "GENERAL_ERROR",
-                    message: "password value needs to be a string",
-                };
+                throw new Error(
+                    "Should never come here since we already check that the password value is a string in validateFormFieldsOrThrowError"
+                );
             let email = emailAsUnknown;
             let password = passwordAsUnknown;
             const recipeId = "emailpassword";
@@ -674,15 +670,13 @@ function getAPIImplementation() {
             // check for type is done in a parent function but they are kept
             // here to be on the safe side.
             if (typeof emailAsUnknown !== "string")
-                return {
-                    status: "GENERAL_ERROR",
-                    message: "email value needs to be a string",
-                };
+                throw new Error(
+                    "Should never come here since we already check that the email value is a string in validateFormFieldsOrThrowError"
+                );
             if (typeof passwordAsUnknown !== "string")
-                return {
-                    status: "GENERAL_ERROR",
-                    message: "password value needs to be a string",
-                };
+                throw new Error(
+                    "Should never come here since we already check that the password value is a string in validateFormFieldsOrThrowError"
+                );
             let email = emailAsUnknown;
             let password = passwordAsUnknown;
             const preAuthCheckRes = await authUtils_1.AuthUtils.preAuthChecks({

--- a/lib/build/recipe/emailpassword/api/utils.d.ts
+++ b/lib/build/recipe/emailpassword/api/utils.d.ts
@@ -9,6 +9,6 @@ export declare function validateFormFieldsOrThrowError(
 ): Promise<
     {
         id: string;
-        value: string;
+        value: unknown;
     }[]
 >;

--- a/lib/build/recipe/emailpassword/api/utils.js
+++ b/lib/build/recipe/emailpassword/api/utils.js
@@ -27,7 +27,7 @@ async function validateFormFieldsOrThrowError(configFormFields, formFieldsRaw, t
         }
         if (curr.id === constants_1.FORM_FIELD_EMAIL_ID || curr.id === constants_1.FORM_FIELD_PASSWORD_ID) {
             if (typeof curr.value !== "string") {
-                throw newBadRequestError("The value of formFields with id = " + curr.id + " must be a string");
+                throw newBadRequestError(`${curr.id} value must be a string`);
             }
         }
         formFields.push(curr);

--- a/lib/build/recipe/emailpassword/api/utils.js
+++ b/lib/build/recipe/emailpassword/api/utils.js
@@ -35,7 +35,9 @@ async function validateFormFieldsOrThrowError(configFormFields, formFieldsRaw, t
     // we trim the email: https://github.com/supertokens/supertokens-core/issues/99
     formFields = formFields.map((field) => {
         if (field.id === constants_1.FORM_FIELD_EMAIL_ID) {
-            return Object.assign(Object.assign({}, field), { value: field.value.trim() });
+            return Object.assign(Object.assign({}, field), {
+                value: typeof field.value === "string" ? field.value.trim() : field.value,
+            });
         }
         return field;
     });

--- a/lib/build/recipe/emailpassword/types.d.ts
+++ b/lib/build/recipe/emailpassword/types.d.ts
@@ -227,7 +227,7 @@ export declare type APIInterface = {
         | ((input: {
               formFields: {
                   id: string;
-                  value: string;
+                  value: unknown;
               }[];
               tenantId: string;
               options: APIOptions;
@@ -247,7 +247,7 @@ export declare type APIInterface = {
         | ((input: {
               formFields: {
                   id: string;
-                  value: string;
+                  value: unknown;
               }[];
               token: string;
               tenantId: string;
@@ -273,7 +273,7 @@ export declare type APIInterface = {
         | ((input: {
               formFields: {
                   id: string;
-                  value: string;
+                  value: unknown;
               }[];
               tenantId: string;
               session: SessionContainerInterface | undefined;
@@ -300,7 +300,7 @@ export declare type APIInterface = {
         | ((input: {
               formFields: {
                   id: string;
-                  value: string;
+                  value: unknown;
               }[];
               tenantId: string;
               session: SessionContainerInterface | undefined;

--- a/lib/ts/recipe/emailpassword/api/generatePasswordResetToken.ts
+++ b/lib/ts/recipe/emailpassword/api/generatePasswordResetToken.ts
@@ -35,7 +35,7 @@ export default async function generatePasswordResetToken(
     // step 1
     let formFields: {
         id: string;
-        value: string;
+        value: unknown;
     }[] = await validateFormFieldsOrThrowError(
         options.config.resetPasswordUsingTokenFeature.formFieldsForGenerateTokenForm,
         requestBody.formFields,

--- a/lib/ts/recipe/emailpassword/api/implementation.ts
+++ b/lib/ts/recipe/emailpassword/api/implementation.ts
@@ -70,10 +70,7 @@ export default function getAPIImplementation(): APIInterface {
             // in validation but kept here to be safe.
             const emailAsUnknown = formFields.filter((f) => f.id === "email")[0].value;
             if (typeof emailAsUnknown !== "string")
-                return {
-                    status: "GENERAL_ERROR",
-                    message: "email value needs to be a string",
-                };
+                throw new Error("Should never come here since we already check that the email value is a string in validateFormFieldsOrThrowError");
             const email: string = emailAsUnknown;
 
             // this function will be reused in different parts of the flow below..
@@ -464,10 +461,7 @@ export default function getAPIImplementation(): APIInterface {
             // in validation but kept here to be safe.
             const newPasswordAsUnknown = formFields.filter((f) => f.id === "password")[0].value;
             if (typeof newPasswordAsUnknown !== "string")
-                return {
-                    status: "GENERAL_ERROR",
-                    message: "password value needs to be a string",
-                };
+                throw new Error("Should never come here since we already check that the password value is a string in validateFormFieldsOrThrowError");
             let newPassword: string = newPasswordAsUnknown;
 
             let tokenConsumptionResponse = await options.recipeImplementation.consumePasswordResetToken({
@@ -657,16 +651,10 @@ export default function getAPIImplementation(): APIInterface {
             // check for type is done in a parent function but they are kept
             // here to be on the safe side.
             if (typeof emailAsUnknown !== "string")
-                return {
-                    status: "GENERAL_ERROR",
-                    message: "email value needs to be a string",
-                };
+                throw new Error("Should never come here since we already check that the email value is a string in validateFormFieldsOrThrowError");
 
             if (typeof passwordAsUnknown !== "string")
-                return {
-                    status: "GENERAL_ERROR",
-                    message: "password value needs to be a string",
-                };
+                throw new Error("Should never come here since we already check that the password value is a string in validateFormFieldsOrThrowError");
 
             let email: string = emailAsUnknown;
             let password: string = passwordAsUnknown;
@@ -828,16 +816,10 @@ export default function getAPIImplementation(): APIInterface {
             // check for type is done in a parent function but they are kept
             // here to be on the safe side.
             if (typeof emailAsUnknown !== "string")
-                return {
-                    status: "GENERAL_ERROR",
-                    message: "email value needs to be a string",
-                };
+                throw new Error("Should never come here since we already check that the email value is a string in validateFormFieldsOrThrowError");
 
             if (typeof passwordAsUnknown !== "string")
-                return {
-                    status: "GENERAL_ERROR",
-                    message: "password value needs to be a string",
-                };
+                throw new Error("Should never come here since we already check that the password value is a string in validateFormFieldsOrThrowError");
 
             let email: string = emailAsUnknown;
             let password: string = passwordAsUnknown;

--- a/lib/ts/recipe/emailpassword/api/implementation.ts
+++ b/lib/ts/recipe/emailpassword/api/implementation.ts
@@ -24,9 +24,9 @@ export default function getAPIImplementation(): APIInterface {
             userContext: UserContext;
         }): Promise<
             | {
-                status: "OK";
-                exists: boolean;
-            }
+                  status: "OK";
+                  exists: boolean;
+              }
             | GeneralErrorResponse
         > {
             // even if the above returns true, we still need to check if there
@@ -60,8 +60,8 @@ export default function getAPIImplementation(): APIInterface {
             userContext,
         }): Promise<
             | {
-                status: "OK";
-            }
+                  status: "OK";
+              }
             | { status: "PASSWORD_RESET_NOT_ALLOWED"; reason: string }
             | GeneralErrorResponse
         > {
@@ -70,7 +70,9 @@ export default function getAPIImplementation(): APIInterface {
             // in validation but kept here to be safe.
             const emailAsUnknown = formFields.filter((f) => f.id === "email")[0].value;
             if (typeof emailAsUnknown !== "string")
-                throw new Error("Should never come here since we already check that the email value is a string in validateFormFieldsOrThrowError");
+                throw new Error(
+                    "Should never come here since we already check that the email value is a string in validateFormFieldsOrThrowError"
+                );
             const email: string = emailAsUnknown;
 
             // this function will be reused in different parts of the flow below..
@@ -79,8 +81,8 @@ export default function getAPIImplementation(): APIInterface {
                 recipeUserId: RecipeUserId | undefined
             ): Promise<
                 | {
-                    status: "OK";
-                }
+                      status: "OK";
+                  }
                 | { status: "PASSWORD_RESET_NOT_ALLOWED"; reason: string }
                 | GeneralErrorResponse
             > {
@@ -93,7 +95,8 @@ export default function getAPIImplementation(): APIInterface {
                 });
                 if (response.status === "UNKNOWN_USER_ID_ERROR") {
                     logDebugMessage(
-                        `Password reset email not sent, unknown user id: ${recipeUserId === undefined ? primaryUserId : recipeUserId.getAsString()
+                        `Password reset email not sent, unknown user id: ${
+                            recipeUserId === undefined ? primaryUserId : recipeUserId.getAsString()
                         }`
                     );
                     return {
@@ -202,9 +205,9 @@ export default function getAPIImplementation(): APIInterface {
                 emailPasswordAccount !== undefined
                     ? emailPasswordAccount
                     : {
-                        recipeId: "emailpassword",
-                        email,
-                    },
+                          recipeId: "emailpassword",
+                          email,
+                      },
                 primaryUserAssociatedWithEmail,
                 undefined,
                 tenantId,
@@ -335,10 +338,10 @@ export default function getAPIImplementation(): APIInterface {
             userContext: UserContext;
         }): Promise<
             | {
-                status: "OK";
-                user: User;
-                email: string;
-            }
+                  status: "OK";
+                  user: User;
+                  email: string;
+              }
             | { status: "RESET_PASSWORD_INVALID_TOKEN_ERROR" }
             | { status: "PASSWORD_POLICY_VIOLATED_ERROR"; failureReason: string }
             | GeneralErrorResponse
@@ -372,10 +375,10 @@ export default function getAPIImplementation(): APIInterface {
                 recipeUserId: RecipeUserId
             ): Promise<
                 | {
-                    status: "OK";
-                    user: User;
-                    email: string;
-                }
+                      status: "OK";
+                      user: User;
+                      email: string;
+                  }
                 | { status: "RESET_PASSWORD_INVALID_TOKEN_ERROR" }
                 | { status: "PASSWORD_POLICY_VIOLATED_ERROR"; failureReason: string }
                 | GeneralErrorResponse
@@ -461,7 +464,9 @@ export default function getAPIImplementation(): APIInterface {
             // in validation but kept here to be safe.
             const newPasswordAsUnknown = formFields.filter((f) => f.id === "password")[0].value;
             if (typeof newPasswordAsUnknown !== "string")
-                throw new Error("Should never come here since we already check that the password value is a string in validateFormFieldsOrThrowError");
+                throw new Error(
+                    "Should never come here since we already check that the password value is a string in validateFormFieldsOrThrowError"
+                );
             let newPassword: string = newPasswordAsUnknown;
 
             let tokenConsumptionResponse = await options.recipeImplementation.consumePasswordResetToken({
@@ -612,22 +617,22 @@ export default function getAPIImplementation(): APIInterface {
             }[];
             tenantId: string;
             session?: SessionContainerInterface;
-            shouldTryLinkingWithSessionUser: boolean | undefined,
+            shouldTryLinkingWithSessionUser: boolean | undefined;
             options: APIOptions;
             userContext: UserContext;
         }): Promise<
             | {
-                status: "OK";
-                session: SessionContainerInterface;
-                user: User;
-            }
+                  status: "OK";
+                  session: SessionContainerInterface;
+                  user: User;
+              }
             | {
-                status: "WRONG_CREDENTIALS_ERROR";
-            }
+                  status: "WRONG_CREDENTIALS_ERROR";
+              }
             | {
-                status: "SIGN_IN_NOT_ALLOWED";
-                reason: string;
-            }
+                  status: "SIGN_IN_NOT_ALLOWED";
+                  reason: string;
+              }
             | GeneralErrorResponse
         > {
             const errorCodeMap = {
@@ -651,10 +656,14 @@ export default function getAPIImplementation(): APIInterface {
             // check for type is done in a parent function but they are kept
             // here to be on the safe side.
             if (typeof emailAsUnknown !== "string")
-                throw new Error("Should never come here since we already check that the email value is a string in validateFormFieldsOrThrowError");
+                throw new Error(
+                    "Should never come here since we already check that the email value is a string in validateFormFieldsOrThrowError"
+                );
 
             if (typeof passwordAsUnknown !== "string")
-                throw new Error("Should never come here since we already check that the password value is a string in validateFormFieldsOrThrowError");
+                throw new Error(
+                    "Should never come here since we already check that the password value is a string in validateFormFieldsOrThrowError"
+                );
 
             let email: string = emailAsUnknown;
             let password: string = passwordAsUnknown;
@@ -777,22 +786,22 @@ export default function getAPIImplementation(): APIInterface {
             }[];
             tenantId: string;
             session?: SessionContainerInterface;
-            shouldTryLinkingWithSessionUser: boolean | undefined,
+            shouldTryLinkingWithSessionUser: boolean | undefined;
             options: APIOptions;
             userContext: UserContext;
         }): Promise<
             | {
-                status: "OK";
-                session: SessionContainerInterface;
-                user: User;
-            }
+                  status: "OK";
+                  session: SessionContainerInterface;
+                  user: User;
+              }
             | {
-                status: "SIGN_UP_NOT_ALLOWED";
-                reason: string;
-            }
+                  status: "SIGN_UP_NOT_ALLOWED";
+                  reason: string;
+              }
             | {
-                status: "EMAIL_ALREADY_EXISTS_ERROR";
-            }
+                  status: "EMAIL_ALREADY_EXISTS_ERROR";
+              }
             | GeneralErrorResponse
         > {
             const errorCodeMap = {
@@ -816,10 +825,14 @@ export default function getAPIImplementation(): APIInterface {
             // check for type is done in a parent function but they are kept
             // here to be on the safe side.
             if (typeof emailAsUnknown !== "string")
-                throw new Error("Should never come here since we already check that the email value is a string in validateFormFieldsOrThrowError");
+                throw new Error(
+                    "Should never come here since we already check that the email value is a string in validateFormFieldsOrThrowError"
+                );
 
             if (typeof passwordAsUnknown !== "string")
-                throw new Error("Should never come here since we already check that the password value is a string in validateFormFieldsOrThrowError");
+                throw new Error(
+                    "Should never come here since we already check that the password value is a string in validateFormFieldsOrThrowError"
+                );
 
             let email: string = emailAsUnknown;
             let password: string = passwordAsUnknown;

--- a/lib/ts/recipe/emailpassword/api/passwordReset.ts
+++ b/lib/ts/recipe/emailpassword/api/passwordReset.ts
@@ -39,7 +39,7 @@ export default async function passwordReset(
     //      a password that meets the password policy.
     let formFields: {
         id: string;
-        value: string;
+        value: unknown;
     }[] = await validateFormFieldsOrThrowError(
         options.config.resetPasswordUsingTokenFeature.formFieldsForPasswordResetForm,
         requestBody.formFields,

--- a/lib/ts/recipe/emailpassword/api/signin.ts
+++ b/lib/ts/recipe/emailpassword/api/signin.ts
@@ -38,7 +38,7 @@ export default async function signInAPI(
     // step 1
     let formFields: {
         id: string;
-        value: string;
+        value: unknown;
     }[] = await validateFormFieldsOrThrowError(
         options.config.signInFeature.formFields,
         body.formFields,

--- a/lib/ts/recipe/emailpassword/api/signup.ts
+++ b/lib/ts/recipe/emailpassword/api/signup.ts
@@ -41,7 +41,7 @@ export default async function signUpAPI(
     // step 1
     let formFields: {
         id: string;
-        value: string;
+        value: unknown;
     }[] = await validateFormFieldsOrThrowError(
         options.config.signUpFeature.formFields,
         requestBody.formFields,

--- a/lib/ts/recipe/emailpassword/api/utils.ts
+++ b/lib/ts/recipe/emailpassword/api/utils.ts
@@ -52,7 +52,7 @@ export async function validateFormFieldsOrThrowError(
         }
         if (curr.id === FORM_FIELD_EMAIL_ID || curr.id === FORM_FIELD_PASSWORD_ID) {
             if (typeof curr.value !== "string") {
-                throw newBadRequestError("The value of formFields with id = " + curr.id + " must be a string");
+                throw newBadRequestError(`${curr.id} value must be a string`);
             }
         }
         formFields.push(curr);

--- a/lib/ts/recipe/emailpassword/api/utils.ts
+++ b/lib/ts/recipe/emailpassword/api/utils.ts
@@ -25,7 +25,7 @@ export async function validateFormFieldsOrThrowError(
 ): Promise<
     {
         id: string;
-        value: string;
+        value: unknown;
     }[]
 > {
     // first we check syntax ----------------------------
@@ -39,7 +39,7 @@ export async function validateFormFieldsOrThrowError(
 
     let formFields: {
         id: string;
-        value: string;
+        value: unknown;
     }[] = [];
 
     for (let i = 0; i < formFieldsRaw.length; i++) {
@@ -63,7 +63,7 @@ export async function validateFormFieldsOrThrowError(
         if (field.id === FORM_FIELD_EMAIL_ID) {
             return {
                 ...field,
-                value: field.value.trim(),
+                value: typeof field.value === "string" ? field.value.trim() : field.value,
             };
         }
         return field;

--- a/lib/ts/recipe/emailpassword/types.ts
+++ b/lib/ts/recipe/emailpassword/types.ts
@@ -230,7 +230,7 @@ export type APIInterface = {
         | ((input: {
               formFields: {
                   id: string;
-                  value: string;
+                  value: unknown;
               }[];
               tenantId: string;
               options: APIOptions;
@@ -251,7 +251,7 @@ export type APIInterface = {
         | ((input: {
               formFields: {
                   id: string;
-                  value: string;
+                  value: unknown;
               }[];
               token: string;
               tenantId: string;
@@ -275,7 +275,7 @@ export type APIInterface = {
         | ((input: {
               formFields: {
                   id: string;
-                  value: string;
+                  value: unknown;
               }[];
               tenantId: string;
               session: SessionContainerInterface | undefined;
@@ -303,7 +303,7 @@ export type APIInterface = {
         | ((input: {
               formFields: {
                   id: string;
-                  value: string;
+                  value: unknown;
               }[];
               tenantId: string;
               session: SessionContainerInterface | undefined;

--- a/test/emailpassword/passwordreset.test.js
+++ b/test/emailpassword/passwordreset.test.js
@@ -111,6 +111,48 @@ describe(`passwordreset: ${printPath("[test/emailpassword/passwordreset.test.js]
         assert(response.body.formFields[0].id === "email");
     });
 
+    it("test invalid email type in generate token API", async function () {
+        const connectionURI = await startST();
+        STExpress.init({
+            supertokens: {
+                connectionURI,
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [EmailPassword.init(), Session.init()],
+        });
+        const app = express();
+
+        app.use(middleware());
+
+        app.use(errorHandler());
+
+        let response = await new Promise((resolve) =>
+            request(app)
+                .post("/auth/user/password/reset/token")
+                .send({
+                    formFields: [
+                        {
+                            id: "email",
+                            value: 123456,
+                        },
+                    ],
+                })
+                .expect(400)
+                .end((err, res) => {
+                    if (err) {
+                        resolve(undefined);
+                    } else {
+                        resolve(res);
+                    }
+                })
+        );
+        assert(response.body.message === "email value must be a string");
+    });
+
     it("test that generated password link is correct", async function () {
         const connectionURI = await startST();
 
@@ -253,6 +295,49 @@ describe(`passwordreset: ${printPath("[test/emailpassword/passwordreset.test.js]
                 })
         );
         assert(response.status !== "FIELD_ERROR");
+    });
+
+    it("test invalid type of password", async function () {
+        const connectionURI = await startST();
+        STExpress.init({
+            supertokens: {
+                connectionURI,
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [EmailPassword.init(), Session.init()],
+        });
+        const app = express();
+
+        app.use(middleware());
+
+        app.use(errorHandler());
+
+        let response = await new Promise((resolve) =>
+            request(app)
+                .post("/auth/user/password/reset")
+                .send({
+                    formFields: [
+                        {
+                            id: "password",
+                            value: 12345,
+                        },
+                    ],
+                    token: "randomToken",
+                })
+                .expect(400)
+                .end((err, res) => {
+                    if (err) {
+                        resolve(undefined);
+                    } else {
+                        resolve(JSON.parse(res.text));
+                    }
+                })
+        );
+        assert(response.message === "password value must be a string");
     });
 
     it("test token missing from input", async function () {

--- a/test/emailpassword/signinFeature.test.js
+++ b/test/emailpassword/signinFeature.test.js
@@ -351,7 +351,7 @@ describe(`signinFeature: ${printPath("[test/emailpassword/signinFeature.test.js]
                     }
                 })
         );
-        assert(JSON.parse(res.text).message === "The value of formFields with id = password must be a string");
+        assert(JSON.parse(res.text).message === "password value must be a string");
     });
 
     it("test email must be of type string in input", async function () {
@@ -404,7 +404,7 @@ describe(`signinFeature: ${printPath("[test/emailpassword/signinFeature.test.js]
                     }
                 })
         );
-        assert(JSON.parse(res.text).message === "The value of formFields with id = email must be a string");
+        assert(JSON.parse(res.text).message === "email value must be a string");
     });
 
     /*

--- a/test/emailpassword/signupFeature.test.js
+++ b/test/emailpassword/signupFeature.test.js
@@ -357,6 +357,102 @@ describe(`signupFeature: ${printPath("[test/emailpassword/signupFeature.test.js]
         assert.strictEqual(badInputResponse.message, "Missing input param: formFields");
     });
 
+    it("test bad input, invalid password type in /signup API", async function () {
+        const connectionURI = await startST();
+
+        STExpress.init({
+            supertokens: {
+                connectionURI,
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [EmailPassword.init(), Session.init({ getTokenTransferMethod: () => "cookie" })],
+        });
+
+        const app = express();
+
+        app.use(middleware());
+
+        app.use(errorHandler());
+
+        let badInputResponse = await new Promise((resolve) =>
+            request(app)
+                .post("/auth/signup")
+                .send({
+                    formFields: [
+                        {
+                            id: "email",
+                            value: "random@gmail.com",
+                        },
+                        {
+                            id: "password",
+                            value: 1234,
+                        },
+                    ],
+                })
+                .expect(400)
+                .end((err, res) => {
+                    if (err) {
+                        resolve(undefined);
+                    } else {
+                        resolve(JSON.parse(res.text));
+                    }
+                })
+        );
+        assert(badInputResponse.message === "password value must be a string");
+    });
+
+    it("test bad input, invalid email type in /signup API", async function () {
+        const connectionURI = await startST();
+
+        STExpress.init({
+            supertokens: {
+                connectionURI,
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [EmailPassword.init(), Session.init({ getTokenTransferMethod: () => "cookie" })],
+        });
+
+        const app = express();
+
+        app.use(middleware());
+
+        app.use(errorHandler());
+
+        let badInputResponse = await new Promise((resolve) =>
+            request(app)
+                .post("/auth/signup")
+                .send({
+                    formFields: [
+                        {
+                            id: "email",
+                            value: 12435,
+                        },
+                        {
+                            id: "password",
+                            value: "1234",
+                        },
+                    ],
+                })
+                .expect(400)
+                .end((err, res) => {
+                    if (err) {
+                        resolve(undefined);
+                    } else {
+                        resolve(JSON.parse(res.text));
+                    }
+                })
+        );
+        assert(badInputResponse.message === "email value must be a string");
+    });
+
     it("test bad input, formFields is not an array in /signup API", async function () {
         const connectionURI = await startST();
 

--- a/test/with-typescript/index.ts
+++ b/test/with-typescript/index.ts
@@ -1348,8 +1348,26 @@ EmailPassword.init({
                 signInPOST: async (input) => {
                     let formFields = input.formFields;
                     let options = input.options;
-                    let email = formFields.filter((f) => f.id === "email")[0].value;
-                    let password = formFields.filter((f) => f.id === "password")[0].value;
+                    const emailAsUnknown = formFields.filter((f) => f.id === "email")[0].value;
+                    const passwordAsUnknown = formFields.filter((f) => f.id === "password")[0].value;
+
+                    // NOTE: Following checks will likely never throw an error as the
+                    // check for type is done in a parent function but they are kept
+                    // here to be on the safe side.
+                    if (typeof emailAsUnknown !== "string")
+                        return {
+                            status: "GENERAL_ERROR",
+                            message: "email value needs to be a string",
+                        };
+
+                    if (typeof passwordAsUnknown !== "string")
+                        return {
+                            status: "GENERAL_ERROR",
+                            message: "password value needs to be a string",
+                        };
+
+                    let email: string = emailAsUnknown;
+                    let password: string = passwordAsUnknown;
 
                     let response = await options.recipeImplementation.signIn({
                         email,


### PR DESCRIPTION
## Summary of change

Makes the internal type of formField values to be `unknown` instead of `string`. Also adds test for signup/password reset API's when they get non string type of values for email/password.

> PS: Updated the bad input error for email/password being invalid to keep it same as Go/Python SDK's

> NOTE: Did not update Changelog as that was updated in the previous PR to indicate that `any` support is added for formField values.

## Test Plan

- `signup`, `signin` and `passwordReset` tests for emailpassword should pass.

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
-   [ ] If added a new entry point, then make sure that it is importable by adding it to the `exports` in `package.json`

## Remaining TO-DO's

- [x] Run `build-pretty` once the base branch issues are fixed  
