### PR TITLE
feat: replace psl deprecation warning by using tldts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [20.1.3] - 2024-09-30
+
+-   Replaces `psl` with `tldts` to avoid `punycode` deprecation warning.
+
 ## [20.1.2] - 2024-09-14
 
 -   Fixes formFields to accept non string types as well.

--- a/examples/cloudflare-workers/with-email-password-hono-be-only/index.ts
+++ b/examples/cloudflare-workers/with-email-password-hono-be-only/index.ts
@@ -41,8 +41,8 @@ app.get("/sessioninfo", (c) => {
 
 app.get("/", (c) => {
     return c.json({
-        "message": "Hello from Supertokens"
-    })
-})
+        message: "Hello from Supertokens",
+    });
+});
 
 export default app;

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -1,40 +1,4 @@
 "use strict";
-var __createBinding =
-    (this && this.__createBinding) ||
-    (Object.create
-        ? function (o, m, k, k2) {
-              if (k2 === undefined) k2 = k;
-              Object.defineProperty(o, k2, {
-                  enumerable: true,
-                  get: function () {
-                      return m[k];
-                  },
-              });
-          }
-        : function (o, m, k, k2) {
-              if (k2 === undefined) k2 = k;
-              o[k2] = m[k];
-          });
-var __setModuleDefault =
-    (this && this.__setModuleDefault) ||
-    (Object.create
-        ? function (o, v) {
-              Object.defineProperty(o, "default", { enumerable: true, value: v });
-          }
-        : function (o, v) {
-              o["default"] = v;
-          });
-var __importStar =
-    (this && this.__importStar) ||
-    function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null)
-            for (var k in mod)
-                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-        __setModuleDefault(result, mod);
-        return result;
-    };
 var __importDefault =
     (this && this.__importDefault) ||
     function (mod) {
@@ -42,7 +6,7 @@ var __importDefault =
     };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.isBuffer = exports.decodeBase64 = exports.encodeBase64 = exports.isTestEnv = exports.getBuffer = exports.getProcess = exports.normaliseEmail = exports.postWithFetch = exports.getFromObjectCaseInsensitive = exports.getTopLevelDomainForSameSiteResolution = exports.setRequestInUserContextIfNotDefined = exports.getUserContext = exports.makeDefaultUserContextFromAPI = exports.humaniseMilliseconds = exports.frontendHasInterceptor = exports.getRidFromHeader = exports.hasGreaterThanEqualToFDI = exports.getLatestFDIVersionFromFDIList = exports.getBackwardsCompatibleUserInfo = exports.isAnIpAddress = exports.send200Response = exports.sendNon200Response = exports.sendNon200ResponseWithMessage = exports.normaliseHttpMethod = exports.normaliseInputAppInfoOrThrowError = exports.maxVersion = exports.getLargestVersionFromIntersection = exports.doFetch = void 0;
-const psl = __importStar(require("psl"));
+const tldts_1 = require("tldts");
 const normalisedURLDomain_1 = __importDefault(require("./normalisedURLDomain"));
 const normalisedURLPath_1 = __importDefault(require("./normalisedURLPath"));
 const logger_1 = require("./logger");
@@ -355,13 +319,13 @@ function getTopLevelDomainForSameSiteResolution(url) {
         // we treat these as the same TLDs since we can use sameSite lax for all of them.
         return "localhost";
     }
-    let parsedURL = psl.parse(hostname);
-    if (parsedURL.domain === null) {
-        if (hostname.endsWith(".amazonaws.com") && parsedURL.tld === hostname) {
+    let parsedURL = tldts_1.parse(hostname);
+    if (!parsedURL.domain) {
+        if (hostname.endsWith(".amazonaws.com") && parsedURL.publicSuffix === hostname) {
             return hostname;
         }
         // support for .local domain
-        if (hostname.endsWith(".local") && parsedURL.tld === null) {
+        if (hostname.endsWith(".local") && !parsedURL.publicSuffix) {
             return hostname;
         }
         throw new Error("Please make sure that the apiDomain and websiteDomain have correct values");

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "20.1.2";
+export declare const version = "20.1.3";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.13";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "20.1.2";
+exports.version = "20.1.3";
 exports.cdiSupported = ["5.1"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.13";

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -1,4 +1,4 @@
-import * as psl from "psl";
+import { parse } from "tldts";
 
 import type { AppInfo, NormalisedAppinfo, HTTPMethod, JSONObject, UserContext } from "./types";
 import NormalisedURLDomain from "./normalisedURLDomain";
@@ -345,13 +345,13 @@ export function getTopLevelDomainForSameSiteResolution(url: string): string {
         return "localhost";
     }
 
-    let parsedURL = psl.parse(hostname) as psl.ParsedDomain;
-    if (parsedURL.domain === null) {
-        if (hostname.endsWith(".amazonaws.com") && parsedURL.tld === hostname) {
+    let parsedURL = parse(hostname);
+    if (!parsedURL.domain) {
+        if (hostname.endsWith(".amazonaws.com") && parsedURL.publicSuffix === hostname) {
             return hostname;
         }
         // support for .local domain
-        if (hostname.endsWith(".local") && parsedURL.tld === null) {
+        if (hostname.endsWith(".local") && !parsedURL.publicSuffix) {
             return hostname;
         }
         throw new Error("Please make sure that the apiDomain and websiteDomain have correct values");

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "20.1.2";
+export const version = "20.1.3";
 
 export const cdiSupported = ["5.1"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,8 @@
                 "pako": "^2.1.0",
                 "pkce-challenge": "^3.0.0",
                 "process": "^0.11.10",
-                "psl": "1.8.0",
                 "supertokens-js-override": "^0.0.4",
+                "tldts": "^6.1.48",
                 "twilio": "^4.19.3"
             },
             "devDependencies": {
@@ -6597,11 +6597,6 @@
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
             "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
-        "node_modules/psl": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-            "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
-        },
         "node_modules/pump": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -7579,6 +7574,22 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/tldts": {
+            "version": "6.1.48",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.48.tgz",
+            "integrity": "sha512-SPbnh1zaSzi/OsmHb1vrPNnYuwJbdWjwo5TbBYYMlTtH3/1DSb41t8bcSxkwDmmbG2q6VLPVvQc7Yf23T+1EEw==",
+            "dependencies": {
+                "tldts-core": "^6.1.48"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "6.1.48",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.48.tgz",
+            "integrity": "sha512-3gD9iKn/n2UuFH1uilBviK9gvTNT6iYwdqrj1Vr5mh8FuelvpRNaYVH4pNYqUgOGU4aAdL9X35eLuuj0gRsx+A=="
         },
         "node_modules/to-fast-properties": {
             "version": "2.0.0",
@@ -13361,11 +13372,6 @@
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
             "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
-        "psl": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-            "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
-        },
         "pump": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -14135,6 +14141,19 @@
             "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-7.0.6.tgz",
             "integrity": "sha512-zNYO0Kvgn5rXzWpL0y3RS09sMK67eGaQj9805jlK9G6pSadfriTczzLHFXa/xcW4mIRfmlB9HyQ/+SgL0V1uow==",
             "dev": true
+        },
+        "tldts": {
+            "version": "6.1.48",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.48.tgz",
+            "integrity": "sha512-SPbnh1zaSzi/OsmHb1vrPNnYuwJbdWjwo5TbBYYMlTtH3/1DSb41t8bcSxkwDmmbG2q6VLPVvQc7Yf23T+1EEw==",
+            "requires": {
+                "tldts-core": "^6.1.48"
+            }
+        },
+        "tldts-core": {
+            "version": "6.1.48",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.48.tgz",
+            "integrity": "sha512-3gD9iKn/n2UuFH1uilBviK9gvTNT6iYwdqrj1Vr5mh8FuelvpRNaYVH4pNYqUgOGU4aAdL9X35eLuuj0gRsx+A=="
         },
         "to-fast-properties": {
             "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "20.1.2",
+    "version": "20.1.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -124,8 +124,8 @@
         "pako": "^2.1.0",
         "pkce-challenge": "^3.0.0",
         "process": "^0.11.10",
-        "psl": "1.8.0",
         "supertokens-js-override": "^0.0.4",
+        "tldts": "^6.1.48",
         "twilio": "^4.19.3"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "20.1.2",
+    "version": "20.1.3",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,5 +1,5 @@
 const assert = require("assert");
-const { getFromObjectCaseInsensitive } = require("../lib/build/utils");
+const { getFromObjectCaseInsensitive, getTopLevelDomainForSameSiteResolution } = require("../lib/build/utils");
 
 describe("SuperTokens utils test", () => {
     it("Test getFromObjectCaseInsensitive", () => {
@@ -16,5 +16,41 @@ describe("SuperTokens utils test", () => {
         assert.equal(getFromObjectCaseInsensitive("Authorization", testObj), "test");
         // Weird casing
         assert.equal(getFromObjectCaseInsensitive("authoriZation", testObj), "test");
+    });
+});
+
+describe("getTopLevelDomainForSameSiteResolution test", () => {
+    it('should return "localhost" for localhost URLs', () => {
+        assert.equal(getTopLevelDomainForSameSiteResolution("http://localhost:3000"), "localhost");
+        assert.equal(getTopLevelDomainForSameSiteResolution("https://localhost"), "localhost");
+    });
+
+    it('should return "localhost" for localhost.org URLs', () => {
+        assert.equal(getTopLevelDomainForSameSiteResolution("http://localhost.org"), "localhost");
+        assert.equal(getTopLevelDomainForSameSiteResolution("https://localhost.org/test-path"), "localhost");
+    });
+
+    it('should return "localhost" for IP addresses', () => {
+        assert.equal(getTopLevelDomainForSameSiteResolution("http://127.0.0.1"), "localhost");
+        assert.equal(getTopLevelDomainForSameSiteResolution("https://192.168.1.1"), "localhost");
+    });
+
+    it("should return the correct domain for normal URLs", () => {
+        assert.equal(getTopLevelDomainForSameSiteResolution("https://www.example.com"), "example.com");
+        assert.equal(getTopLevelDomainForSameSiteResolution("http://sub.domain.co.uk"), "domain.co.uk");
+    });
+
+    it("should handle .amazonaws.com domains correctly", () => {
+        assert.equal(getTopLevelDomainForSameSiteResolution("https://my-instance.amazonaws.com"), "amazonaws.com");
+    });
+
+    it("should handle .local domains correctly", () => {
+        assert.equal(getTopLevelDomainForSameSiteResolution("http://myserver.local"), "myserver.local");
+    });
+
+    it("should throw an error for invalid domains", () => {
+        assert.throws(() => {
+            getTopLevelDomainForSameSiteResolution("http://invalid..com");
+        }, Error);
     });
 });


### PR DESCRIPTION
## Summary of change

This PR fixes a deprecation warning regarding the `punycode` module which was not a direct dependency but a dependency of `psl` module. The `psl` module has the fix merged [[reference PR](https://github.com/lupomontero/psl/pull/298)] but has not had a release since the last 2 years (no release after the fix was merged).

This PR uses an alternative package `tldts` for replacing the functionality provided by the `psl` package.

## Related issues

-   https://github.com/supertokens/supertokens-core/issues/1049

## Test Plan

- All `utils.test.js` tests should pass.

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
-   [ ] If added a new entry point, then make sure that it is importable by adding it to the `exports` in `package.json`
