### PR TITLE
fix: failing tests for domain parse util function

### DIFF
--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -319,8 +319,18 @@ function getTopLevelDomainForSameSiteResolution(url) {
         // we treat these as the same TLDs since we can use sameSite lax for all of them.
         return "localhost";
     }
-    let parsedURL = tldts_1.parse(hostname);
+    // Before `tldts`, `psl` was being used and that library automatically
+    // handled parsing private domains. With `tldts`, `allowPrivateDomains` is
+    // required to be passed to handle that.
+    //
+    // This is important for parsing ec2 public URL's that were initially
+    // reported to be breaking in the following issue:
+    // https://github.com/supertokens/supertokens-python/issues/394
+    let parsedURL = tldts_1.parse(hostname, { allowPrivateDomains: true });
     if (!parsedURL.domain) {
+        // If the URL is an AWS public URL, return the entire URL since it is
+        // considered a suffix entirely (instead of just amazonaws.com). This
+        // was initially reported in https://github.com/supertokens/supertokens-python/issues/394
         if (hostname.endsWith(".amazonaws.com") && parsedURL.publicSuffix === hostname) {
             return hostname;
         }

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -319,11 +319,18 @@ function getTopLevelDomainForSameSiteResolution(url) {
         // we treat these as the same TLDs since we can use sameSite lax for all of them.
         return "localhost";
     }
+    // According to tests, if it is an ec2 subdomain, we want to return the subdomain
+    // as well. With `psl` library, this was not an issue because the library
+    // would return a `null` value for `domain` for ec2 urls.
+    //
+    // With tldts library, it parses the ec2 urls and returns the .amazonaws.com
+    // as the domain (instead of `null`) so we need to do the amazonaws check
+    // regardless of the domain being null.
+    if (hostname.endsWith(".amazonaws.com")) {
+        return hostname;
+    }
     let parsedURL = tldts_1.parse(hostname);
     if (!parsedURL.domain) {
-        if (hostname.endsWith(".amazonaws.com") && parsedURL.publicSuffix === hostname) {
-            return hostname;
-        }
         // support for .local domain
         if (hostname.endsWith(".local") && !parsedURL.publicSuffix) {
             return hostname;

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -319,18 +319,11 @@ function getTopLevelDomainForSameSiteResolution(url) {
         // we treat these as the same TLDs since we can use sameSite lax for all of them.
         return "localhost";
     }
-    // According to tests, if it is an ec2 subdomain, we want to return the subdomain
-    // as well. With `psl` library, this was not an issue because the library
-    // would return a `null` value for `domain` for ec2 urls.
-    //
-    // With tldts library, it parses the ec2 urls and returns the .amazonaws.com
-    // as the domain (instead of `null`) so we need to do the amazonaws check
-    // regardless of the domain being null.
-    if (hostname.endsWith(".amazonaws.com")) {
-        return hostname;
-    }
     let parsedURL = tldts_1.parse(hostname);
     if (!parsedURL.domain) {
+        if (hostname.endsWith(".amazonaws.com") && parsedURL.publicSuffix === hostname) {
+            return hostname;
+        }
         // support for .local domain
         if (hostname.endsWith(".local") && !parsedURL.publicSuffix) {
             return hostname;

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -345,11 +345,19 @@ export function getTopLevelDomainForSameSiteResolution(url: string): string {
         return "localhost";
     }
 
+    // According to tests, if it is an ec2 subdomain, we want to return the subdomain
+    // as well. With `psl` library, this was not an issue because the library
+    // would return a `null` value for `domain` for ec2 urls.
+    //
+    // With tldts library, it parses the ec2 urls and returns the .amazonaws.com
+    // as the domain (instead of `null`) so we need to do the amazonaws check
+    // regardless of the domain being null.
+    if (hostname.endsWith(".amazonaws.com")) {
+        return hostname;
+    }
+
     let parsedURL = parse(hostname);
     if (!parsedURL.domain) {
-        if (hostname.endsWith(".amazonaws.com") && parsedURL.publicSuffix === hostname) {
-            return hostname;
-        }
         // support for .local domain
         if (hostname.endsWith(".local") && !parsedURL.publicSuffix) {
             return hostname;

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -345,8 +345,18 @@ export function getTopLevelDomainForSameSiteResolution(url: string): string {
         return "localhost";
     }
 
-    let parsedURL = parse(hostname);
+    // Before `tldts`, `psl` was being used and that library automatically
+    // handled parsing private domains. With `tldts`, `allowPrivateDomains` is
+    // required to be passed to handle that.
+    //
+    // This is important for parsing ec2 public URL's that were initially
+    // reported to be breaking in the following issue:
+    // https://github.com/supertokens/supertokens-python/issues/394
+    let parsedURL = parse(hostname, { allowPrivateDomains: true });
     if (!parsedURL.domain) {
+        // If the URL is an AWS public URL, return the entire URL since it is
+        // considered a suffix entirely (instead of just amazonaws.com). This
+        // was initially reported in https://github.com/supertokens/supertokens-python/issues/394
         if (hostname.endsWith(".amazonaws.com") && parsedURL.publicSuffix === hostname) {
             return hostname;
         }

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -345,19 +345,11 @@ export function getTopLevelDomainForSameSiteResolution(url: string): string {
         return "localhost";
     }
 
-    // According to tests, if it is an ec2 subdomain, we want to return the subdomain
-    // as well. With `psl` library, this was not an issue because the library
-    // would return a `null` value for `domain` for ec2 urls.
-    //
-    // With tldts library, it parses the ec2 urls and returns the .amazonaws.com
-    // as the domain (instead of `null`) so we need to do the amazonaws check
-    // regardless of the domain being null.
-    if (hostname.endsWith(".amazonaws.com")) {
-        return hostname;
-    }
-
     let parsedURL = parse(hostname);
     if (!parsedURL.domain) {
+        if (hostname.endsWith(".amazonaws.com") && parsedURL.publicSuffix === hostname) {
+            return hostname;
+        }
         // support for .local domain
         if (hostname.endsWith(".local") && !parsedURL.publicSuffix) {
             return hostname;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "20.1.2",
+            "version": "20.1.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "buffer": "^6.0.3",

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -40,9 +40,10 @@ describe("getTopLevelDomainForSameSiteResolution test", () => {
         assert.equal(getTopLevelDomainForSameSiteResolution("http://sub.domain.co.uk"), "domain.co.uk");
     });
 
-    it("should handle .amazonaws.com domains correctly", () => {
-        assert.equal(getTopLevelDomainForSameSiteResolution("https://my-instance.amazonaws.com"), "amazonaws.com");
-    });
+    assert.strictEqual(
+        getTopLevelDomainForSameSiteResolution("https://ec2-xx-yyy-zzz-0.compute-1.amazonaws.com"),
+        "ec2-xx-yyy-zzz-0.compute-1.amazonaws.com"
+    );
 
     it("should handle .local domains correctly", () => {
         assert.equal(getTopLevelDomainForSameSiteResolution("http://myserver.local"), "myserver.local");

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -40,10 +40,9 @@ describe("getTopLevelDomainForSameSiteResolution test", () => {
         assert.equal(getTopLevelDomainForSameSiteResolution("http://sub.domain.co.uk"), "domain.co.uk");
     });
 
-    assert.strictEqual(
-        getTopLevelDomainForSameSiteResolution("https://ec2-xx-yyy-zzz-0.compute-1.amazonaws.com"),
-        "ec2-xx-yyy-zzz-0.compute-1.amazonaws.com"
-    );
+    it("should handle .amazonaws.com domains correctly", () => {
+        assert.equal(getTopLevelDomainForSameSiteResolution("https://my-instance.amazonaws.com"), "amazonaws.com");
+    });
 
     it("should handle .local domains correctly", () => {
         assert.equal(getTopLevelDomainForSameSiteResolution("http://myserver.local"), "myserver.local");


### PR DESCRIPTION
## Summary of change

This commit fixes the updated domain parse util function (that uses tldts) to make sure all tests pass.

Tests were failing as a side effect of #930 due to some behavioural changes between `psl` and `tldts`.

## Related issues

## Test Plan

Both `config.test.js` and `utils.test.js` should pass

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
-   [ ] If added a new entry point, then make sure that it is importable by adding it to the `exports` in `package.json`
