### PR TITLE
fix: fix the session revocation throwing when email verification links in a non-default tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [20.1.4] - 2024-10-07
+
+-   Fixes an issue where revoking sessions for a specific tenant didn't work well
+-   Fixes an issue where the automatic session revocation after linking didn't work across all tenants
+
 ## [20.1.3] - 2024-09-30
 
 -   Replaces `psl` with `tldts` to avoid `punycode` deprecation warning.

--- a/lib/build/recipe/emailverification/recipe.js
+++ b/lib/build/recipe/emailverification/recipe.js
@@ -221,7 +221,7 @@ class Recipe extends recipeModule_1.default {
                         await session_1.default.revokeAllSessionsForUser(
                             input.recipeUserIdWhoseEmailGotVerified.getAsString(),
                             false,
-                            input.session.getTenantId(),
+                            undefined,
                             input.userContext
                         );
                         // create a new session and return that..

--- a/lib/build/recipe/emailverification/recipeImplementation.js
+++ b/lib/build/recipe/emailverification/recipeImplementation.js
@@ -71,6 +71,7 @@ function getRecipeInterface(querier, getEmailForRecipeUserId) {
                     },
                 };
             } else {
+                console.error("Email verification failed", response);
                 return {
                     status: "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR",
                 };

--- a/lib/build/recipe/session/index.js
+++ b/lib/build/recipe/session/index.js
@@ -209,6 +209,7 @@ class SessionWrapper {
         return recipe_1.default.getInstanceOrThrowError().recipeInterfaceImpl.revokeAllSessionsForUser({
             userId,
             tenantId: tenantId === undefined ? constants_1.DEFAULT_TENANT_ID : tenantId,
+            revokeAcrossAllTenants: tenantId === undefined,
             revokeSessionsForLinkedAccounts,
             userContext: utils_2.getUserContext(userContext),
         });

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "20.1.3";
+export declare const version = "20.1.4";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.13";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "20.1.3";
+exports.version = "20.1.4";
 exports.cdiSupported = ["5.1"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.13";

--- a/lib/ts/recipe/emailverification/recipe.ts
+++ b/lib/ts/recipe/emailverification/recipe.ts
@@ -339,7 +339,7 @@ export default class Recipe extends RecipeModule {
                     await Session.revokeAllSessionsForUser(
                         input.recipeUserIdWhoseEmailGotVerified.getAsString(),
                         false,
-                        input.session.getTenantId(),
+                        undefined,
                         input.userContext
                     );
 

--- a/lib/ts/recipe/emailverification/recipeImplementation.ts
+++ b/lib/ts/recipe/emailverification/recipeImplementation.ts
@@ -97,6 +97,7 @@ export default function getRecipeInterface(
                     },
                 };
             } else {
+                console.error("Email verification failed", response);
                 return {
                     status: "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR",
                 };

--- a/lib/ts/recipe/emailverification/recipeImplementation.ts
+++ b/lib/ts/recipe/emailverification/recipeImplementation.ts
@@ -97,7 +97,6 @@ export default function getRecipeInterface(
                     },
                 };
             } else {
-                console.error("Email verification failed", response);
                 return {
                     status: "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR",
                 };

--- a/lib/ts/recipe/session/index.ts
+++ b/lib/ts/recipe/session/index.ts
@@ -338,6 +338,7 @@ export default class SessionWrapper {
         return Recipe.getInstanceOrThrowError().recipeInterfaceImpl.revokeAllSessionsForUser({
             userId,
             tenantId: tenantId === undefined ? DEFAULT_TENANT_ID : tenantId,
+            revokeAcrossAllTenants: tenantId === undefined,
             revokeSessionsForLinkedAccounts,
             userContext: getUserContext(userContext),
         });

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "20.1.3";
+export const version = "20.1.4";
 
 export const cdiSupported = ["5.1"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "20.1.3",
+    "version": "20.1.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "20.1.3",
+            "version": "20.1.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "20.1.3",
+    "version": "20.1.4",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Summary of change

-   Fixes an issue where revoking sessions for a specific tenant didn't work well
-   Fixes an issue where the automatic session revocation after linking didn't work across all tenants

## Related issues

-   Issue reported by a user over email

## Test Plan

Tests added in backend-sdk-testing [PR](https://github.com/supertokens/backend-sdk-testing/pull/41)

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [x] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
-   [x] If added a new entry point, then make sure that it is importable by adding it to the `exports` in `package.json`
