### PR TITLE
feat: Add changes to run tests using circle ci for partial reruns

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,6 @@ jobs:
                   configuration_path: .circleci/config_continue.yml # use newly generated config to continue
 
 workflows:
-    version: 2
     tagged-build:
         when: # One must be true to trigger
             or:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
                   configuration_path: .circleci/config_continue.yml # use newly generated config to continue
 
 workflows:
+    version: 2
     tagged-build:
         when: # One must be true to trigger
             or:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,15 +60,6 @@ jobs:
                       cd .circleci && ./generateConfig.sh << pipeline.parameters.force >> '<< pipeline.parameters.cdi-core-map >>' '<< pipeline.parameters.cdi-plugin-interface-map >>' '<< pipeline.parameters.fdi-node-map >>' '<< pipeline.parameters.fdi-auth-react-map >>' '<< pipeline.parameters.fdi-website-map >>'
             - continuation/continue:
                   configuration_path: .circleci/config_continue.yml # use newly generated config to continue
-    print-context:
-        docker:
-            - image: cimg/base:stable
-        steps:
-            - run:
-                  command: |
-                      echo "Branch: << pipeline.git.branch >>"
-                      echo "Tag: << pipeline.git.tag >>"
-                      echo "Force: << pipeline.parameters.force >>"
 
 workflows:
     version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,15 @@ jobs:
                       cd .circleci && ./generateConfig.sh << pipeline.parameters.force >> '<< pipeline.parameters.cdi-core-map >>' '<< pipeline.parameters.cdi-plugin-interface-map >>' '<< pipeline.parameters.fdi-node-map >>' '<< pipeline.parameters.fdi-auth-react-map >>' '<< pipeline.parameters.fdi-website-map >>'
             - continuation/continue:
                   configuration_path: .circleci/config_continue.yml # use newly generated config to continue
+    print-context:
+        docker:
+            - image: cimg/base:stable
+        steps:
+            - run:
+                  command: |
+                      echo "Branch: << pipeline.git.branch >>"
+                      echo "Tag: << pipeline.git.tag >>"
+                      echo "Force: << pipeline.parameters.force >>"
 
 workflows:
     version: 2

--- a/.circleci/config_continue.yml
+++ b/.circleci/config_continue.yml
@@ -47,6 +47,10 @@ jobs:
         parameters:
             cdi-version:
                 type: string
+            fdi-version:
+                type: string
+        environment:
+            MOCHA_FILE: ~/test_report/report_node-<< parameters.fdi-version >>.xml
         parallelism: 4
         steps:
             - checkout
@@ -56,6 +60,8 @@ jobs:
             - run: update-alternatives --install "/usr/bin/java" "java" "/usr/java/jdk-15.0.1/bin/java" 2
             - run: update-alternatives --install "/usr/bin/javac" "javac" "/usr/java/jdk-15.0.1/bin/javac" 2
             - run: (cd .circleci/ && ./doUnitTests.sh << parameters.cdi-version >>)
+            - store_test_results:
+                  path: ~/test_report/report_node-<< parameters.fdi-version >>.xml
             - slack/status
     test-backend-sdk-testing:
         docker:
@@ -173,6 +179,7 @@ workflows:
                   matrix:
                       parameters:
                           cdi-version: placeholder
+                          fdi-version: placeholder
             - test-backend-sdk-testing:
                   requires:
                       - test-dev-tag-as-not-passed

--- a/.circleci/config_continue.yml
+++ b/.circleci/config_continue.yml
@@ -172,7 +172,7 @@ workflows:
                           only: /test-cicd\/.*/
                   matrix:
                       parameters:
-                          cdi-version: [<< parameters.cdi-version >>]
+                          cdi-version: [placeholder]
             - test-backend-sdk-testing:
                   requires:
                       - test-dev-tag-as-not-passed
@@ -185,8 +185,8 @@ workflows:
                           only: /test-cicd\/.*/
                   matrix:
                       parameters:
-                          cdi-version: placeholder
-                          fdi-version: placeholder
+                          cdi-version: [placeholder]
+                          fdi-version: [placeholder]
             - test-website:
                   requires:
                       - test-dev-tag-as-not-passed
@@ -199,7 +199,7 @@ workflows:
                           only: /test-cicd\/.*/
                   matrix:
                       parameters:
-                          fdi-version: placeholder
+                          fdi-version: [placeholder]
             - test-authreact:
                   requires:
                       - test-dev-tag-as-not-passed
@@ -212,7 +212,7 @@ workflows:
                           only: /test-cicd\/.*/
                   matrix:
                       parameters:
-                          fdi-version: placeholder
+                          fdi-version: [placeholder]
             - test-success:
                   requires:
                       - test-unit

--- a/.circleci/config_continue.yml
+++ b/.circleci/config_continue.yml
@@ -82,7 +82,7 @@ jobs:
             - run: update-alternatives --install "/usr/bin/javac" "javac" "/usr/java/jdk-15.0.1/bin/javac" 2
             - run: (cd .circleci/ && ./doBackendSDKTests.sh << parameters.cdi-version >> << parameters.fdi-version >>)
             - store_test_results:
-                  path: test-results/junit.xml
+                  path: ~/backend-sdk-testing/test-results/junit.xml
             - slack/status
     test-website:
         docker:

--- a/.circleci/config_continue.yml
+++ b/.circleci/config_continue.yml
@@ -74,7 +74,7 @@ jobs:
             fdi-version:
                 type: string
         environment:
-            MOCHA_FILE: ~/test_report/report_node-<< parameters.fdi-version >>.xml
+            MOCHA_FILE: test_report/report_node-<< parameters.fdi-version >>.xml
         steps:
             - checkout
             - run: echo "127.0.0.1 localhost.org" >> /etc/hosts

--- a/.circleci/config_continue.yml
+++ b/.circleci/config_continue.yml
@@ -47,8 +47,6 @@ jobs:
         parameters:
             cdi-version:
                 type: string
-            fdi-version:
-                type: string
         parallelism: 4
         steps:
             - checkout
@@ -171,7 +169,6 @@ workflows:
                   matrix:
                       parameters:
                           cdi-version: placeholder
-                          fdi-version: placeholder
             - test-backend-sdk-testing:
                   requires:
                       - test-dev-tag-as-not-passed

--- a/.circleci/config_continue.yml
+++ b/.circleci/config_continue.yml
@@ -73,8 +73,6 @@ jobs:
                 type: string
             fdi-version:
                 type: string
-        environment:
-            MOCHA_FILE: test_report/report_node-<< parameters.fdi-version >>.xml
         steps:
             - checkout
             - run: echo "127.0.0.1 localhost.org" >> /etc/hosts
@@ -84,7 +82,7 @@ jobs:
             - run: update-alternatives --install "/usr/bin/javac" "javac" "/usr/java/jdk-15.0.1/bin/javac" 2
             - run: (cd .circleci/ && ./doBackendSDKTests.sh << parameters.cdi-version >> << parameters.fdi-version >>)
             - store_test_results:
-                  path: test_report/report_node-<< parameters.fdi-version >>.xml
+                  path: test-results/junit.xml
             - slack/status
     test-website:
         docker:

--- a/.circleci/config_continue.yml
+++ b/.circleci/config_continue.yml
@@ -67,6 +67,8 @@ jobs:
                 type: string
             fdi-version:
                 type: string
+        environment:
+            MOCHA_FILE: ~/test_report/report_node-<< parameters.fdi-version >>.xml
         steps:
             - checkout
             - run: echo "127.0.0.1 localhost.org" >> /etc/hosts
@@ -75,6 +77,8 @@ jobs:
             - run: update-alternatives --install "/usr/bin/java" "java" "/usr/java/jdk-15.0.1/bin/java" 2
             - run: update-alternatives --install "/usr/bin/javac" "javac" "/usr/java/jdk-15.0.1/bin/javac" 2
             - run: (cd .circleci/ && ./doBackendSDKTests.sh << parameters.cdi-version >> << parameters.fdi-version >>)
+            - store_test_results:
+                  path: ~/test_report/report_node-<< parameters.fdi-version >>.xml
             - slack/status
     test-website:
         docker:
@@ -84,6 +88,8 @@ jobs:
         parameters:
             fdi-version:
                 type: string
+        environment:
+            MOCHA_FILE: ~/test_report/report_node-<< parameters.fdi-version >>.xml
         parallelism: 4
         steps:
             - checkout
@@ -94,6 +100,8 @@ jobs:
             - run: update-alternatives --install "/usr/bin/java" "java" "/usr/java/jdk-15.0.1/bin/java" 2
             - run: update-alternatives --install "/usr/bin/javac" "javac" "/usr/java/jdk-15.0.1/bin/javac" 2
             - run: (cd .circleci/ && ./website.sh << parameters.fdi-version >>)
+            - store_test_results:
+                  path: ~/test_report/report_node-<< parameters.fdi-version >>.xml
             - slack/status
     test-authreact:
         docker:
@@ -164,7 +172,7 @@ workflows:
                           only: /test-cicd\/.*/
                   matrix:
                       parameters:
-                          cdi-version: placeholder
+                          cdi-version: [<< parameters.cdi-version >>]
             - test-backend-sdk-testing:
                   requires:
                       - test-dev-tag-as-not-passed

--- a/.circleci/config_continue.yml
+++ b/.circleci/config_continue.yml
@@ -84,7 +84,7 @@ jobs:
             - run: update-alternatives --install "/usr/bin/javac" "javac" "/usr/java/jdk-15.0.1/bin/javac" 2
             - run: (cd .circleci/ && ./doBackendSDKTests.sh << parameters.cdi-version >> << parameters.fdi-version >>)
             - store_test_results:
-                  path: ~/test_report/report_node-<< parameters.fdi-version >>.xml
+                  path: test_report/report_node-<< parameters.fdi-version >>.xml
             - slack/status
     test-website:
         docker:

--- a/.circleci/config_continue.yml
+++ b/.circleci/config_continue.yml
@@ -49,8 +49,6 @@ jobs:
                 type: string
             fdi-version:
                 type: string
-        environment:
-            MOCHA_FILE: ~/test_report/report_node-<< parameters.fdi-version >>.xml
         parallelism: 4
         steps:
             - checkout
@@ -61,7 +59,7 @@ jobs:
             - run: update-alternatives --install "/usr/bin/javac" "javac" "/usr/java/jdk-15.0.1/bin/javac" 2
             - run: (cd .circleci/ && ./doUnitTests.sh << parameters.cdi-version >>)
             - store_test_results:
-                  path: ~/test_report/report_node-<< parameters.fdi-version >>.xml
+                  path: ~/test_report/free-core-junit.xml
             - slack/status
     test-backend-sdk-testing:
         docker:
@@ -92,8 +90,6 @@ jobs:
         parameters:
             fdi-version:
                 type: string
-        environment:
-            MOCHA_FILE: ~/test_report/report_node-<< parameters.fdi-version >>.xml
         parallelism: 4
         steps:
             - checkout
@@ -105,7 +101,7 @@ jobs:
             - run: update-alternatives --install "/usr/bin/javac" "javac" "/usr/java/jdk-15.0.1/bin/javac" 2
             - run: (cd .circleci/ && ./website.sh << parameters.fdi-version >>)
             - store_test_results:
-                  path: ~/test_report/report_node-<< parameters.fdi-version >>.xml
+                  path: ~/test_report/website-junit.xml
             - slack/status
     test-authreact:
         docker:
@@ -115,8 +111,6 @@ jobs:
         parameters:
             fdi-version:
                 type: string
-        environment:
-            MOCHA_FILE: ~/test_report/report_node-<< parameters.fdi-version >>.xml
         parallelism: 4
         steps:
             - checkout
@@ -137,7 +131,7 @@ jobs:
                   path: ~/test_report/react-logs
                   destination: react-logs
             - store_test_results:
-                  path: ~/test_report/report_node-<< parameters.fdi-version >>.xml
+                  path: ~/test_report/auth-react-junit.xml
             - slack/status
     test-success:
         docker:

--- a/.circleci/config_continue.yml
+++ b/.circleci/config_continue.yml
@@ -172,7 +172,7 @@ workflows:
                           only: /test-cicd\/.*/
                   matrix:
                       parameters:
-                          cdi-version: [placeholder]
+                          cdi-version: placeholder
             - test-backend-sdk-testing:
                   requires:
                       - test-dev-tag-as-not-passed
@@ -185,8 +185,8 @@ workflows:
                           only: /test-cicd\/.*/
                   matrix:
                       parameters:
-                          cdi-version: [placeholder]
-                          fdi-version: [placeholder]
+                          cdi-version: placeholder
+                          fdi-version: placeholder
             - test-website:
                   requires:
                       - test-dev-tag-as-not-passed
@@ -199,7 +199,7 @@ workflows:
                           only: /test-cicd\/.*/
                   matrix:
                       parameters:
-                          fdi-version: [placeholder]
+                          fdi-version: placeholder
             - test-authreact:
                   requires:
                       - test-dev-tag-as-not-passed
@@ -212,7 +212,7 @@ workflows:
                           only: /test-cicd\/.*/
                   matrix:
                       parameters:
-                          fdi-version: [placeholder]
+                          fdi-version: placeholder
             - test-success:
                   requires:
                       - test-unit

--- a/.circleci/setupAndTestBackendSDKWithFreeCore.sh
+++ b/.circleci/setupAndTestBackendSDKWithFreeCore.sh
@@ -61,8 +61,6 @@ fi
 
 echo "Testing with FREE core: $coreVersion, plugin-interface: $pluginInterfaceVersion"
 
-mkdir -p ~/test_report
-
 cd ../../
 git clone git@github.com:supertokens/supertokens-root.git
 cd supertokens-root
@@ -117,6 +115,7 @@ export NODE_PORT=8081
 export INSTALL_PATH=../supertokens-root
 export multi="spec=- mocha-junit-reporter=/dev/null"
 
+mkdir test_report
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
 echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --reporter mocha-multi --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --timeout 500000 --no-config" --verbose --split-by=timings
 

--- a/.circleci/setupAndTestBackendSDKWithFreeCore.sh
+++ b/.circleci/setupAndTestBackendSDKWithFreeCore.sh
@@ -110,7 +110,7 @@ npm install
 npm run build
 
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
-API_PORT=$API_PORT TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=~/test_report/junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch --reporter mocha-multi --timeout 40000 --no-config" --verbose --split-by=timings
+API_PORT=$API_PORT TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=~/test_report/junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch --timeout 40000 --no-config" --verbose --split-by=timings
 
 # kill test-server
 kill $(lsof -t -i:$API_PORT)

--- a/.circleci/setupAndTestBackendSDKWithFreeCore.sh
+++ b/.circleci/setupAndTestBackendSDKWithFreeCore.sh
@@ -115,9 +115,9 @@ export NODE_PORT=8081
 export INSTALL_PATH=../supertokens-root
 export multi="spec=- mocha-junit-reporter=/dev/null"
 
-mkdir test_report
+mkdir -p test-results
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
-echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --reporter mocha-multi --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --timeout 500000 --no-config" --verbose --split-by=timings
+echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --reporter mocha-multi --reporter-options mocha-junit-reporter:output=test-results/junit.xml --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --timeout 500000 --no-config" --verbose --split-by=timings
 
 # kill test-server
 kill $(lsof -t -i:$API_PORT)

--- a/.circleci/setupAndTestBackendSDKWithFreeCore.sh
+++ b/.circleci/setupAndTestBackendSDKWithFreeCore.sh
@@ -113,11 +113,12 @@ export TEST_MODE=testing
 export SUPERTOKENS_CORE_TAG=$coreTag
 export NODE_PORT=8081
 export INSTALL_PATH=../supertokens-root
-export multi="spec=- mocha-junit-reporter=/dev/null"
+export MOCHA_FILE=test-results/junit.xml
+multi="spec=- mocha-junit-reporter=$MOCHA_FILE"
 
 mkdir -p test-results
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
-echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --reporter mocha-multi --reporter-options mocha-junit-reporter:output=test-results/junit.xml --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --timeout 500000 --no-config" --verbose --split-by=timings
+echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --reporter mocha-multi --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --timeout 500000 --no-config" --verbose --split-by=timings
 
 # kill test-server
 kill $(lsof -t -i:$API_PORT)

--- a/.circleci/setupAndTestBackendSDKWithFreeCore.sh
+++ b/.circleci/setupAndTestBackendSDKWithFreeCore.sh
@@ -114,7 +114,7 @@ export SUPERTOKENS_CORE_TAG=$coreTag
 export NODE_PORT=8081
 export INSTALL_PATH=../supertokens-root
 export MOCHA_FILE=test-results/junit.xml
-multi="spec=- mocha-junit-reporter=$MOCHA_FILE"
+export multi="spec=- mocha-junit-reporter=$MOCHA_FILE"
 
 mkdir -p test-results
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")

--- a/.circleci/setupAndTestBackendSDKWithFreeCore.sh
+++ b/.circleci/setupAndTestBackendSDKWithFreeCore.sh
@@ -110,7 +110,7 @@ npm install
 npm run build
 
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
-API_PORT=$API_PORT TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=~/test_report/junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --reporter mocha-multi --require @babel/register --require test/test.mocha.env --timeout 40000 --no-config" --verbose --split-by=timings
+API_PORT=$API_PORT TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=~/test_report/junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch --reporter mocha-multi --require test/test.mocha.env --timeout 40000 --no-config" --verbose --split-by=timings
 
 # kill test-server
 kill $(lsof -t -i:$API_PORT)

--- a/.circleci/setupAndTestBackendSDKWithFreeCore.sh
+++ b/.circleci/setupAndTestBackendSDKWithFreeCore.sh
@@ -107,11 +107,7 @@ git checkout $frontendDriverVersion
 npm install
 npm run build
 
-if ! [[ -z "${CIRCLE_NODE_TOTAL}" ]]; then
-    API_PORT=$API_PORT TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root npx mocha --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --no-config --timeout 500000 $(npx mocha-split-tests -r ./runtime.log -t $CIRCLE_NODE_TOTAL -g $CIRCLE_NODE_INDEX -f 'test/**/*.test.js')
-else
-    API_PORT=$API_PORT TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root npm test
-fi
+API_PORT=$API_PORT TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=./junit-results.xml" circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --reporter mocha-multi --require @babel/register --require test/test.mocha.env --timeout 40000 --no-config -f test/**/*.test.js" --verbose --split-by=timings
 
 # kill test-server
 kill $(lsof -t -i:$API_PORT)

--- a/.circleci/setupAndTestBackendSDKWithFreeCore.sh
+++ b/.circleci/setupAndTestBackendSDKWithFreeCore.sh
@@ -110,7 +110,7 @@ npm install
 npm run build
 
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
-API_PORT=$API_PORT TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=~/test_report/junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch --timeout 40000 --no-config" --verbose --split-by=timings
+API_PORT=$API_PORT TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --timeout 500000 --no-config" --verbose --split-by=timings
 
 # kill test-server
 kill $(lsof -t -i:$API_PORT)

--- a/.circleci/setupAndTestBackendSDKWithFreeCore.sh
+++ b/.circleci/setupAndTestBackendSDKWithFreeCore.sh
@@ -119,6 +119,9 @@ export multi="spec=- mocha-junit-reporter=$MOCHA_FILE"
 mkdir -p test-results
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
 echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --reporter mocha-multi --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --timeout 500000 --no-config" --verbose --split-by=timings
+ls -al
+echo "Printing previous directory"
+cd .. && ls -al
 
 # kill test-server
 kill $(lsof -t -i:$API_PORT)

--- a/.circleci/setupAndTestBackendSDKWithFreeCore.sh
+++ b/.circleci/setupAndTestBackendSDKWithFreeCore.sh
@@ -119,7 +119,7 @@ export multi="spec=- mocha-junit-reporter=$MOCHA_FILE"
 mkdir -p test-results
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
 echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --reporter mocha-multi --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --timeout 500000 --no-config" --verbose --split-by=timings
-ls -al test-results
+ls -al ~/backend-sdk-testing/test-results
 
 # kill test-server
 kill $(lsof -t -i:$API_PORT)

--- a/.circleci/setupAndTestBackendSDKWithFreeCore.sh
+++ b/.circleci/setupAndTestBackendSDKWithFreeCore.sh
@@ -119,7 +119,6 @@ export multi="spec=- mocha-junit-reporter=$MOCHA_FILE"
 mkdir -p test-results
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
 echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --reporter mocha-multi --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --timeout 500000 --no-config" --verbose --split-by=timings
-ls -al ~/backend-sdk-testing/test-results
 
 # kill test-server
 kill $(lsof -t -i:$API_PORT)

--- a/.circleci/setupAndTestBackendSDKWithFreeCore.sh
+++ b/.circleci/setupAndTestBackendSDKWithFreeCore.sh
@@ -107,7 +107,7 @@ git clone git@github.com:supertokens/backend-sdk-testing.git
 cd backend-sdk-testing
 git checkout $frontendDriverVersion
 npm install
-npm i mocha-multi
+npm i mocha-multi mocha-junit-reporter
 npm run build
 
 export API_PORT=$API_PORT

--- a/.circleci/setupAndTestBackendSDKWithFreeCore.sh
+++ b/.circleci/setupAndTestBackendSDKWithFreeCore.sh
@@ -107,6 +107,7 @@ git clone git@github.com:supertokens/backend-sdk-testing.git
 cd backend-sdk-testing
 git checkout $frontendDriverVersion
 npm install
+npm i mocha-multi
 npm run build
 
 export API_PORT=$API_PORT
@@ -116,7 +117,7 @@ export NODE_PORT=8081
 export INSTALL_PATH=../supertokens-root
 
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
-echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --timeout 500000 --no-config" --verbose --split-by=timings
+multi="spec=- mocha-junit-reporter=/dev/null" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --reporter mocha-multi --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --timeout 500000 --no-config" --verbose --split-by=timings
 
 # kill test-server
 kill $(lsof -t -i:$API_PORT)

--- a/.circleci/setupAndTestBackendSDKWithFreeCore.sh
+++ b/.circleci/setupAndTestBackendSDKWithFreeCore.sh
@@ -119,9 +119,7 @@ export multi="spec=- mocha-junit-reporter=$MOCHA_FILE"
 mkdir -p test-results
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
 echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --reporter mocha-multi --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --timeout 500000 --no-config" --verbose --split-by=timings
-ls -al
-echo "Printing previous directory"
-cd .. && ls -al
+ls -al test-results
 
 # kill test-server
 kill $(lsof -t -i:$API_PORT)

--- a/.circleci/setupAndTestBackendSDKWithFreeCore.sh
+++ b/.circleci/setupAndTestBackendSDKWithFreeCore.sh
@@ -109,8 +109,14 @@ git checkout $frontendDriverVersion
 npm install
 npm run build
 
+export API_PORT=$API_PORT
+export TEST_MODE=testing
+export SUPERTOKENS_CORE_TAG=$coreTag
+export NODE_PORT=8081
+export INSTALL_PATH=../supertokens-root
+
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
-API_PORT=$API_PORT TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --timeout 500000 --no-config" --verbose --split-by=timings
+echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --timeout 500000 --no-config" --verbose --split-by=timings
 
 # kill test-server
 kill $(lsof -t -i:$API_PORT)

--- a/.circleci/setupAndTestBackendSDKWithFreeCore.sh
+++ b/.circleci/setupAndTestBackendSDKWithFreeCore.sh
@@ -115,9 +115,10 @@ export TEST_MODE=testing
 export SUPERTOKENS_CORE_TAG=$coreTag
 export NODE_PORT=8081
 export INSTALL_PATH=../supertokens-root
+export multi="spec=- mocha-junit-reporter=/dev/null"
 
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
-multi="spec=- mocha-junit-reporter=/dev/null" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --reporter mocha-multi --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --timeout 500000 --no-config" --verbose --split-by=timings
+echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --reporter mocha-multi --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --timeout 500000 --no-config" --verbose --split-by=timings
 
 # kill test-server
 kill $(lsof -t -i:$API_PORT)

--- a/.circleci/setupAndTestBackendSDKWithFreeCore.sh
+++ b/.circleci/setupAndTestBackendSDKWithFreeCore.sh
@@ -110,7 +110,7 @@ npm install
 npm run build
 
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
-API_PORT=$API_PORT TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=~/test_report/junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch --reporter mocha-multi --require test/test.mocha.env --timeout 40000 --no-config" --verbose --split-by=timings
+API_PORT=$API_PORT TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=~/test_report/junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch --reporter mocha-multi --timeout 40000 --no-config" --verbose --split-by=timings
 
 # kill test-server
 kill $(lsof -t -i:$API_PORT)

--- a/.circleci/setupAndTestBackendSDKWithFreeCore.sh
+++ b/.circleci/setupAndTestBackendSDKWithFreeCore.sh
@@ -61,6 +61,8 @@ fi
 
 echo "Testing with FREE core: $coreVersion, plugin-interface: $pluginInterfaceVersion"
 
+mkdir -p ~/test_report
+
 cd ../../
 git clone git@github.com:supertokens/supertokens-root.git
 cd supertokens-root
@@ -107,7 +109,8 @@ git checkout $frontendDriverVersion
 npm install
 npm run build
 
-API_PORT=$API_PORT TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=./junit-results.xml" circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --reporter mocha-multi --require @babel/register --require test/test.mocha.env --timeout 40000 --no-config -f test/**/*.test.js" --verbose --split-by=timings
+TEST_FILES=$(circleci tests glob "test/**/*.test.js")
+API_PORT=$API_PORT TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=~/test_report/junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --reporter mocha-multi --require @babel/register --require test/test.mocha.env --timeout 40000 --no-config" --verbose --split-by=timings
 
 # kill test-server
 kill $(lsof -t -i:$API_PORT)

--- a/.circleci/setupAndTestWithAuthReact.sh
+++ b/.circleci/setupAndTestWithAuthReact.sh
@@ -159,7 +159,8 @@ done
 sleep 2 # Because the server is responding does not mean the app is ready. Let's wait another 2secs to make sure the app is up.
 echo "Start mocha testing"
 
-export multi="spec=- mocha-junit-reporter=/dev/null"
+export MOCHA_FILE=~/test_report/auth-react-junit.xml
+export multi="spec=- mocha-junit-reporter=$MOCHA_FILE"
 export TEST_MODE=testing
 export APP_SERVER=$apiPort
 export SCREENSHOT_ROOT=~/test_report/screenshots

--- a/.circleci/setupAndTestWithAuthReact.sh
+++ b/.circleci/setupAndTestWithAuthReact.sh
@@ -159,8 +159,13 @@ done
 sleep 2 # Because the server is responding does not mean the app is ready. Let's wait another 2secs to make sure the app is up.
 echo "Start mocha testing"
 
+export multi="spec=- mocha-junit-reporter=/dev/null"
+export TEST_MODE=testing
+export APP_SERVER=$apiPort
+export SCREENSHOT_ROOT=~/test_report/screenshots
+
 export SPEC_FILES=$(circleci tests glob 'test/end-to-end/**/*.test.js' 'test/unit/**/*.test.js')
-echo $SPEC_FILES | SCREENSHOT_ROOT=~/test_report/screenshots APP_SERVER=$apiPort TEST_MODE=testing multi="spec=- mocha-junit-reporter=/dev/null" circleci tests run --command="xargs npx mocha mocha --reporter mocha-multi --require @babel/register --require test/test.mocha.env --timeout 40000 --no-config" --verbose --split-by=timings
+echo $SPEC_FILES | circleci tests run --command="xargs npx mocha mocha --reporter mocha-multi --require @babel/register --require test/test.mocha.env --timeout 40000 --no-config" --verbose --split-by=timings
 
 testPassed=$?;
 cp ../supertokens-root/logs/error.log ~/test_report/logs/core_error.log

--- a/.circleci/setupAndTestWithFreeCore.sh
+++ b/.circleci/setupAndTestWithFreeCore.sh
@@ -89,5 +89,10 @@ cd ../project/
 # Set the script to exit on error
 set -e
 
+export TEST_MODE=testing
+export SUPERTOKENS_CORE_TAG=$coreTag
+export NODE_PORT=8081
+export INSTALL_PATH=../supertokens-root
+
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
-TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch --timeout 40000 --no-config" --verbose --split-by=timings
+echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch --timeout 40000 --no-config" --verbose --split-by=timings

--- a/.circleci/setupAndTestWithFreeCore.sh
+++ b/.circleci/setupAndTestWithFreeCore.sh
@@ -85,6 +85,7 @@ cd ../
 echo $SUPERTOKENS_API_KEY > apiPassword
 ./utils/setupTestEnvLocal
 cd ../project/
+npm i mocha-multi
 
 # Set the script to exit on error
 set -e
@@ -95,4 +96,4 @@ export NODE_PORT=8081
 export INSTALL_PATH=../supertokens-root
 
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
-echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch --timeout 40000 --no-config" --verbose --split-by=timings
+multi="spec=- mocha-junit-reporter=/dev/null" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --reporter mocha-multi --node-option no-experimental-fetch --timeout 40000 --no-config" --verbose --split-by=timings

--- a/.circleci/setupAndTestWithFreeCore.sh
+++ b/.circleci/setupAndTestWithFreeCore.sh
@@ -90,4 +90,4 @@ cd ../project/
 set -e
 
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
-TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=./junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch --reporter mocha-multi --require test/test.mocha.env --timeout 40000 --no-config" --verbose --split-by=timings
+TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=./junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch --reporter mocha-multi --timeout 40000 --no-config" --verbose --split-by=timings

--- a/.circleci/setupAndTestWithFreeCore.sh
+++ b/.circleci/setupAndTestWithFreeCore.sh
@@ -90,4 +90,4 @@ cd ../project/
 set -e
 
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
-TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=./junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --reporter mocha-multi --require @babel/register --require test/test.mocha.env --timeout 40000 --no-config" --verbose --split-by=timings
+TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=./junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch --reporter mocha-multi --require test/test.mocha.env --timeout 40000 --no-config" --verbose --split-by=timings

--- a/.circleci/setupAndTestWithFreeCore.sh
+++ b/.circleci/setupAndTestWithFreeCore.sh
@@ -94,7 +94,8 @@ export TEST_MODE=testing
 export SUPERTOKENS_CORE_TAG=$coreTag
 export NODE_PORT=8081
 export INSTALL_PATH=../supertokens-root
-export multi="spec=- mocha-junit-reporter=/dev/null"
+export MOCHA_FILE=~/test_report/free-core-junit.xml
+export multi="spec=- mocha-junit-reporter=$MOCHA_FILE"
 
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
 echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --reporter mocha-multi --node-option no-experimental-fetch --timeout 40000 --no-config" --verbose --split-by=timings

--- a/.circleci/setupAndTestWithFreeCore.sh
+++ b/.circleci/setupAndTestWithFreeCore.sh
@@ -85,7 +85,7 @@ cd ../
 echo $SUPERTOKENS_API_KEY > apiPassword
 ./utils/setupTestEnvLocal
 cd ../project/
-npm i mocha-multi
+npm i mocha-multi mocha-junit-reporter
 
 # Set the script to exit on error
 set -e

--- a/.circleci/setupAndTestWithFreeCore.sh
+++ b/.circleci/setupAndTestWithFreeCore.sh
@@ -88,8 +88,4 @@ cd ../project/
 # Set the script to exit on error
 set -e
 
-if ! [[ -z "${CIRCLE_NODE_TOTAL}" ]]; then
-    TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root npx mocha --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --no-config --timeout 500000 $(npx mocha-split-tests -r ./runtime.log -t $CIRCLE_NODE_TOTAL -g $CIRCLE_NODE_INDEX -f 'test/**/*.test.js')
-else
-    TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root npm test
-fi
+TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=./junit-results.xml" circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --reporter mocha-multi --require @babel/register --require test/test.mocha.env --timeout 40000 --no-config -f test/**/*.test.js" --verbose --split-by=timings

--- a/.circleci/setupAndTestWithFreeCore.sh
+++ b/.circleci/setupAndTestWithFreeCore.sh
@@ -90,4 +90,4 @@ cd ../project/
 set -e
 
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
-TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=./junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch --reporter mocha-multi --timeout 40000 --no-config" --verbose --split-by=timings
+TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=./junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch --timeout 40000 --no-config" --verbose --split-by=timings

--- a/.circleci/setupAndTestWithFreeCore.sh
+++ b/.circleci/setupAndTestWithFreeCore.sh
@@ -94,6 +94,7 @@ export TEST_MODE=testing
 export SUPERTOKENS_CORE_TAG=$coreTag
 export NODE_PORT=8081
 export INSTALL_PATH=../supertokens-root
+export multi="spec=- mocha-junit-reporter=/dev/null"
 
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
-multi="spec=- mocha-junit-reporter=/dev/null" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --reporter mocha-multi --node-option no-experimental-fetch --timeout 40000 --no-config" --verbose --split-by=timings
+echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --reporter mocha-multi --node-option no-experimental-fetch --timeout 40000 --no-config" --verbose --split-by=timings

--- a/.circleci/setupAndTestWithFreeCore.sh
+++ b/.circleci/setupAndTestWithFreeCore.sh
@@ -90,4 +90,4 @@ cd ../project/
 set -e
 
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
-TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=./junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch --timeout 40000 --no-config" --verbose --split-by=timings
+TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch --timeout 40000 --no-config" --verbose --split-by=timings

--- a/.circleci/setupAndTestWithFreeCore.sh
+++ b/.circleci/setupAndTestWithFreeCore.sh
@@ -60,6 +60,7 @@ then
 fi
 echo "Testing with FREE core: $coreVersion, plugin-interface: $pluginInterfaceVersion"
 
+mkdir -p ~/test_report
 cd ../../
 git clone git@github.com:supertokens/supertokens-root.git
 cd supertokens-root
@@ -88,4 +89,5 @@ cd ../project/
 # Set the script to exit on error
 set -e
 
-TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=./junit-results.xml" circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --reporter mocha-multi --require @babel/register --require test/test.mocha.env --timeout 40000 --no-config -f test/**/*.test.js" --verbose --split-by=timings
+TEST_FILES=$(circleci tests glob "test/**/*.test.js")
+TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=./junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --reporter mocha-multi --require @babel/register --require test/test.mocha.env --timeout 40000 --no-config" --verbose --split-by=timings

--- a/.circleci/setupAndTestWithFrontend.sh
+++ b/.circleci/setupAndTestWithFrontend.sh
@@ -99,7 +99,7 @@ cd ../../
 npm i -d
 
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
-TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=./junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch --reporter mocha-multi --timeout 40000 --no-config" --verbose --split-by=timings
+TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=./junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch --timeout 40000 --no-config" --verbose --split-by=timings
 
 if [[ $? -ne 0 ]]
 then

--- a/.circleci/setupAndTestWithFrontend.sh
+++ b/.circleci/setupAndTestWithFrontend.sh
@@ -98,8 +98,8 @@ npm i
 cd ../../
 npm i -d
 
-TEST_FILES=$(circleci tests glob "test/**/*.test.js")
-TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=./junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch --timeout 40000 --no-config" --verbose --split-by=timings
+TEST_FILES=$(circleci tests glob "test/*.test.js")
+TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=/dev/null" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha npx mocha --exit --reporter mocha-multi --no-config --require isomorphic-fetch --timeout 500000" --verbose --split-by=timings
 
 if [[ $? -ne 0 ]]
 then

--- a/.circleci/setupAndTestWithFrontend.sh
+++ b/.circleci/setupAndTestWithFrontend.sh
@@ -96,11 +96,7 @@ npm i
 cd ../../
 npm i -d
 
-if ! [[ -z "${CIRCLE_NODE_TOTAL}" ]]; then
-    TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root npx mocha --exit --no-config --require isomorphic-fetch --timeout 500000 $(npx mocha-split-tests -r ./runtime.log -t $CIRCLE_NODE_TOTAL -g $CIRCLE_NODE_INDEX -f 'test/*.test.js')
-else
-    TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root npm test
-fi
+TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=./junit-results.xml" circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --reporter mocha-multi --require @babel/register --require test/test.mocha.env --timeout 40000 --no-config -f test/**/*.test.js" --verbose --split-by=timings
 
 if [[ $? -ne 0 ]]
 then

--- a/.circleci/setupAndTestWithFrontend.sh
+++ b/.circleci/setupAndTestWithFrontend.sh
@@ -99,7 +99,7 @@ cd ../../
 npm i -d
 
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
-TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=./junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --reporter mocha-multi --require @babel/register --require test/test.mocha.env --timeout 40000 --no-config" --verbose --split-by=timings
+TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=./junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch --reporter mocha-multi --require test/test.mocha.env --timeout 40000 --no-config" --verbose --split-by=timings
 
 if [[ $? -ne 0 ]]
 then

--- a/.circleci/setupAndTestWithFrontend.sh
+++ b/.circleci/setupAndTestWithFrontend.sh
@@ -61,6 +61,8 @@ fi
 
 echo "Testing with frontend website: $2, FREE core: $coreVersion, plugin-interface: $pluginInterfaceVersion"
 
+mkdir -p ~/test_report
+
 cd ../../
 git clone git@github.com:supertokens/supertokens-root.git
 cd supertokens-root
@@ -96,7 +98,8 @@ npm i
 cd ../../
 npm i -d
 
-TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=./junit-results.xml" circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --reporter mocha-multi --require @babel/register --require test/test.mocha.env --timeout 40000 --no-config -f test/**/*.test.js" --verbose --split-by=timings
+TEST_FILES=$(circleci tests glob "test/**/*.test.js")
+TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=./junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch -r test/fetch-polyfill.mjs --reporter mocha-multi --require @babel/register --require test/test.mocha.env --timeout 40000 --no-config" --verbose --split-by=timings
 
 if [[ $? -ne 0 ]]
 then

--- a/.circleci/setupAndTestWithFrontend.sh
+++ b/.circleci/setupAndTestWithFrontend.sh
@@ -102,7 +102,8 @@ export TEST_MODE=testing
 export SUPERTOKENS_CORE_TAG=$coreTag
 export NODE_PORT=8081
 export INSTALL_PATH=../supertokens-root
-export multi="spec=- mocha-junit-reporter=/dev/null"
+export MOCHA_FILE=~/test_report/website-junit.xml
+export multi="spec=- mocha-junit-reporter=$MOCHA_FILE"
 
 TEST_FILES=$(circleci tests glob "test/*.test.js")
 echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha npx mocha --exit --reporter mocha-multi --no-config --require isomorphic-fetch --timeout 500000" --verbose --split-by=timings

--- a/.circleci/setupAndTestWithFrontend.sh
+++ b/.circleci/setupAndTestWithFrontend.sh
@@ -98,8 +98,14 @@ npm i
 cd ../../
 npm i -d
 
+export TEST_MODE=testing
+export SUPERTOKENS_CORE_TAG=$coreTag
+export NODE_PORT=8081
+export INSTALL_PATH=../supertokens-root
+export multi="spec=- mocha-junit-reporter=/dev/null"
+
 TEST_FILES=$(circleci tests glob "test/*.test.js")
-TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=/dev/null" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha npx mocha --exit --reporter mocha-multi --no-config --require isomorphic-fetch --timeout 500000" --verbose --split-by=timings
+echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha npx mocha --exit --reporter mocha-multi --no-config --require isomorphic-fetch --timeout 500000" --verbose --split-by=timings
 
 if [[ $? -ne 0 ]]
 then

--- a/.circleci/setupAndTestWithFrontend.sh
+++ b/.circleci/setupAndTestWithFrontend.sh
@@ -99,7 +99,7 @@ cd ../../
 npm i -d
 
 TEST_FILES=$(circleci tests glob "test/**/*.test.js")
-TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=./junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch --reporter mocha-multi --require test/test.mocha.env --timeout 40000 --no-config" --verbose --split-by=timings
+TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag NODE_PORT=8081 INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=./junit-results.xml" echo "$TEST_FILES" | circleci tests run --command="xargs npx mocha mocha --node-option no-experimental-fetch --reporter mocha-multi --timeout 40000 --no-config" --verbose --split-by=timings
 
 if [[ $? -ne 0 ]]
 then


### PR DESCRIPTION
## Summary of change

This PR updates the circle CI related test run files to use circleCI for running tests in order to achieve partial re-run functionality.

## Test Plan

- Tests should run fine on CircleCI
- Failed tests should be partially re-runnable through CircleCI

[Reference workflow](https://app.circleci.com/pipelines/gh/supertokens/supertokens-node/6412)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
-   [ ] If added a new entry point, then make sure that it is importable by adding it to the `exports` in `package.json`
