### PR TITLE
fix: types for signin and signup for webauthn

### DIFF
--- a/lib/ts/recipe/webauthn/api/implementation.ts
+++ b/lib/ts/recipe/webauthn/api/implementation.ts
@@ -20,7 +20,7 @@ import { getRecoverAccountLink } from "../utils";
 import { logDebugMessage } from "../../../logger";
 import { RecipeLevelUser } from "../../accountlinking/types";
 import { getUser } from "../../..";
-import { CredentialPayload, ResidentKey, UserVerification } from "../types";
+import { AuthenticationPayload, RegistrationPayload, ResidentKey, UserVerification } from "../types";
 
 export default function getAPIImplementation(): APIInterface {
     return {
@@ -195,7 +195,7 @@ export default function getAPIImplementation(): APIInterface {
             userContext,
         }: {
             webauthnGeneratedOptionsId: string;
-            credential: CredentialPayload;
+            credential: RegistrationPayload;
             tenantId: string;
             session: SessionContainerInterface | undefined;
             shouldTryLinkingWithSessionUser: boolean | undefined;
@@ -364,7 +364,7 @@ export default function getAPIImplementation(): APIInterface {
             userContext,
         }: {
             webauthnGeneratedOptionsId: string;
-            credential: CredentialPayload;
+            credential: AuthenticationPayload;
             tenantId: string;
             session?: SessionContainerInterface;
             shouldTryLinkingWithSessionUser: boolean | undefined;
@@ -846,7 +846,7 @@ export default function getAPIImplementation(): APIInterface {
         }: {
             token: string;
             webauthnGeneratedOptionsId: string;
-            credential: CredentialPayload;
+            credential: RegistrationPayload;
             tenantId: string;
             options: APIOptions;
             userContext: UserContext;

--- a/lib/ts/recipe/webauthn/index.ts
+++ b/lib/ts/recipe/webauthn/index.ts
@@ -24,6 +24,7 @@ import {
     UserVerification,
     ResidentKey,
     Attestation,
+    AuthenticationPayload,
 } from "./types";
 import RecipeUserId from "../../recipeUserId";
 import { DEFAULT_TENANT_ID } from "../multitenancy/constants";
@@ -312,7 +313,7 @@ export default class Wrapper {
     }: {
         tenantId?: string;
         webauthnGeneratedOptionsId: string;
-        credential: CredentialPayload;
+        credential: AuthenticationPayload;
         session?: SessionContainerInterface;
         userContext?: Record<string, any>;
     }): Promise<
@@ -345,7 +346,7 @@ export default class Wrapper {
     }: {
         tenantId?: string;
         webauthnGeneratedOptionsId: string;
-        credential: CredentialPayload;
+        credential: AuthenticationPayload;
         userContext?: Record<string, any>;
     }): Promise<{ status: "OK" } | { status: "INVALID_CREDENTIALS_ERROR" }> {
         const resp = await Recipe.getInstanceOrThrowError().recipeInterfaceImpl.verifyCredentials({

--- a/lib/ts/recipe/webauthn/types.ts
+++ b/lib/ts/recipe/webauthn/types.ts
@@ -238,7 +238,7 @@ export type RecipeInterface = {
 
     signUp(input: {
         webauthnGeneratedOptionsId: string;
-        credential: CredentialPayload;
+        credential: RegistrationPayload;
         session: SessionContainerInterface | undefined;
         shouldTryLinkingWithSessionUser: boolean | undefined;
         tenantId: string;
@@ -267,7 +267,7 @@ export type RecipeInterface = {
 
     signIn(input: {
         webauthnGeneratedOptionsId: string;
-        credential: CredentialPayload;
+        credential: AuthenticationPayload;
         session: SessionContainerInterface | undefined;
         shouldTryLinkingWithSessionUser: boolean | undefined;
         tenantId: string;
@@ -288,7 +288,7 @@ export type RecipeInterface = {
 
     verifyCredentials(input: {
         webauthnGeneratedOptionsId: string;
-        credential: CredentialPayload;
+        credential: AuthenticationPayload;
         tenantId: string;
         userContext: UserContext;
     }): Promise<
@@ -303,7 +303,7 @@ export type RecipeInterface = {
     // called during operations like creating a user during password reset flow.
     createNewRecipeUser(input: {
         webauthnGeneratedOptionsId: string;
-        credential: CredentialPayload;
+        credential: RegistrationPayload;
         tenantId: string;
         userContext: UserContext;
     }): Promise<
@@ -357,7 +357,7 @@ export type RecipeInterface = {
     // (in consumeRecoverAccountToken invalidating the token and in registerOptions for storing the email in the generated options)
     registerCredential(input: {
         webauthnGeneratedOptionsId: string;
-        credential: CredentialPayload;
+        credential: RegistrationPayload;
         userContext: UserContext;
         recipeUserId: RecipeUserId;
     }): Promise<
@@ -636,7 +636,7 @@ export type APIInterface = {
         | undefined
         | ((input: {
               webauthnGeneratedOptionsId: string;
-              credential: CredentialPayload;
+              credential: RegistrationPayload;
               tenantId: string;
               session: SessionContainerInterface | undefined;
               shouldTryLinkingWithSessionUser: boolean | undefined;
@@ -666,7 +666,7 @@ export type APIInterface = {
         | undefined
         | ((input: {
               webauthnGeneratedOptionsId: string;
-              credential: CredentialPayload;
+              credential: AuthenticationPayload;
               tenantId: string;
               session: SessionContainerInterface | undefined;
               shouldTryLinkingWithSessionUser: boolean | undefined;
@@ -711,7 +711,7 @@ export type APIInterface = {
         | ((input: {
               token: string;
               webauthnGeneratedOptionsId: string;
-              credential: CredentialPayload;
+              credential: RegistrationPayload;
               tenantId: string;
               options: APIOptions;
               userContext: UserContext;
@@ -760,16 +760,43 @@ export type TypeWebauthnRecoverAccountEmailDeliveryInput = {
 
 export type TypeWebauthnEmailDeliveryInput = TypeWebauthnRecoverAccountEmailDeliveryInput;
 
-export type CredentialPayload = {
+export type CredentialPayloadBase = {
     id: string;
     rawId: string;
+    authenticatorAttachment?: "platform" | "cross-platform";
+    clientExtensionResults: Record<string, unknown>;
+    type: "public-key";
+};
+
+export type AuthenticatorAssertionResponseJSON = {
+    clientDataJSON: Base64URLString;
+    authenticatorData: Base64URLString;
+    signature: Base64URLString;
+    userHandle?: Base64URLString;
+};
+
+export type AuthenticatorAttestationResponseJSON = {
+    clientDataJSON: Base64URLString;
+    attestationObject: Base64URLString;
+    authenticatorData?: Base64URLString;
+    transports?: ("ble" | "cable" | "hybrid" | "internal" | "nfc" | "smart-card" | "usb")[];
+    publicKeyAlgorithm?: COSEAlgorithmIdentifier;
+    publicKey?: Base64URLString;
+};
+
+export type AuthenticationPayload = CredentialPayloadBase & {
+    response: AuthenticatorAssertionResponseJSON;
+};
+
+export type RegistrationPayload = CredentialPayloadBase & {
+    response: AuthenticatorAttestationResponseJSON;
+};
+
+export type CredentialPayload = CredentialPayloadBase & {
     response: {
         clientDataJSON: string;
         attestationObject: string;
         transports?: ("ble" | "cable" | "hybrid" | "internal" | "nfc" | "smart-card" | "usb")[];
         userHandle: string;
     };
-    authenticatorAttachment: "platform" | "cross-platform";
-    clientExtensionResults: Record<string, unknown>;
-    type: "public-key";
 };


### PR DESCRIPTION
## Summary of change

This PR updates the credential types for signup & signin endpoints based on the payload returned by native webauthn library that we are using in web-js (which can be considered as a safe source of truth).

## Related issues

## Test Plan

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
-   [ ] If added a new entry point, then make sure that it is importable by adding it to the `exports` in `package.json`