### PR TITLE
fix: Add possible fix for response body being already consumed issue

### DIFF
--- a/lib/build/querier.js
+++ b/lib/build/querier.js
@@ -229,6 +229,7 @@ class Querier {
                     ) {
                         this.invalidateCoreCallCache(userContext, false);
                     }
+                    logger_1.logDebugMessage("Checking cache existence");
                     if (
                         !Querier.disableCache &&
                         uniqueKey in
@@ -238,10 +239,14 @@ class Querier {
                                 ? _c
                                 : {})
                     ) {
-                        return userContext._default.coreCallCache[uniqueKey];
+                        // Clone the cached response before returning it
+                        const cachedResponse = userContext._default.coreCallCache[uniqueKey];
+                        return cachedResponse.clone();
                     }
                     /* CACHE CHECK END */
+                    logger_1.logDebugMessage("Cache does not exist, making network request");
                     if (Querier.networkInterceptor !== undefined) {
+                        logger_1.logDebugMessage("Network interceptor found, applying interceptor");
                         let request = Querier.networkInterceptor(
                             {
                                 url: url,
@@ -271,15 +276,15 @@ class Querier {
                         return response;
                     }
                     if (response.status === 200 && !Querier.disableCache) {
-                        // If the request was successful, we save the result into the cache
-                        // plus we update the cache tag
+                        // Clone the response before caching it
+                        const responseClone = response.clone();
                         userContext._default = Object.assign(Object.assign({}, userContext._default), {
                             coreCallCache: Object.assign(
                                 Object.assign(
                                     {},
                                     (_d = userContext._default) === null || _d === void 0 ? void 0 : _d.coreCallCache
                                 ),
-                                { [uniqueKey]: response }
+                                { [uniqueKey]: responseClone }
                             ),
                             globalCacheTag: Querier.globalCacheTag,
                         });

--- a/lib/build/utils.d.ts
+++ b/lib/build/utils.d.ts
@@ -72,3 +72,16 @@ export declare const isTestEnv: () => boolean;
 export declare const encodeBase64: (value: string) => string;
 export declare const decodeBase64: (value: string) => string;
 export declare const isBuffer: (obj: any) => boolean;
+/**
+ * Clones a response by teeing the body so we can return two independent
+ * ReadableStreams from it. This avoids the bug in the undici library around
+ * response cloning.
+ *
+ * After cloning, the original response's body will be consumed and closed.
+ *
+ * @see https://github.com/supertokens/supertokens-node/issues/977
+ *
+ * @param original - The original response to clone.
+ * @returns A clone of the original response.
+ */
+export declare function cloneResponse(original: Response): Response;

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -5,7 +5,7 @@ var __importDefault =
         return mod && mod.__esModule ? mod : { default: mod };
     };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.isBuffer = exports.decodeBase64 = exports.encodeBase64 = exports.isTestEnv = exports.getBuffer = exports.getProcess = exports.transformObjectKeys = exports.toSnakeCase = exports.toCamelCase = exports.normaliseEmail = exports.postWithFetch = exports.getFromObjectCaseInsensitive = exports.getTopLevelDomainForSameSiteResolution = exports.setRequestInUserContextIfNotDefined = exports.getUserContext = exports.makeDefaultUserContextFromAPI = exports.humaniseMilliseconds = exports.frontendHasInterceptor = exports.getRidFromHeader = exports.hasGreaterThanEqualToFDI = exports.getLatestFDIVersionFromFDIList = exports.getBackwardsCompatibleUserInfo = exports.getNormalisedShouldTryLinkingWithSessionUserFlag = exports.isAnIpAddress = exports.send200Response = exports.sendNon200Response = exports.sendNon200ResponseWithMessage = exports.normaliseHttpMethod = exports.normaliseInputAppInfoOrThrowError = exports.maxVersion = exports.getLargestVersionFromIntersection = exports.doFetch = void 0;
+exports.cloneResponse = exports.isBuffer = exports.decodeBase64 = exports.encodeBase64 = exports.isTestEnv = exports.getBuffer = exports.getProcess = exports.transformObjectKeys = exports.toSnakeCase = exports.toCamelCase = exports.normaliseEmail = exports.postWithFetch = exports.getFromObjectCaseInsensitive = exports.getTopLevelDomainForSameSiteResolution = exports.setRequestInUserContextIfNotDefined = exports.getUserContext = exports.makeDefaultUserContextFromAPI = exports.humaniseMilliseconds = exports.frontendHasInterceptor = exports.getRidFromHeader = exports.hasGreaterThanEqualToFDI = exports.getLatestFDIVersionFromFDIList = exports.getBackwardsCompatibleUserInfo = exports.getNormalisedShouldTryLinkingWithSessionUserFlag = exports.isAnIpAddress = exports.send200Response = exports.sendNon200Response = exports.sendNon200ResponseWithMessage = exports.normaliseHttpMethod = exports.normaliseInputAppInfoOrThrowError = exports.maxVersion = exports.getLargestVersionFromIntersection = exports.doFetch = void 0;
 const tldts_1 = require("tldts");
 const normalisedURLDomain_1 = __importDefault(require("./normalisedURLDomain"));
 const normalisedURLPath_1 = __importDefault(require("./normalisedURLPath"));
@@ -480,3 +480,37 @@ const isBuffer = (obj) => {
     return exports.getBuffer().isBuffer(obj);
 };
 exports.isBuffer = isBuffer;
+/**
+ * Clones a response by teeing the body so we can return two independent
+ * ReadableStreams from it. This avoids the bug in the undici library around
+ * response cloning.
+ *
+ * After cloning, the original response's body will be consumed and closed.
+ *
+ * @see https://github.com/supertokens/supertokens-node/issues/977
+ *
+ * @param original - The original response to clone.
+ * @returns A clone of the original response.
+ */
+function cloneResponse(original) {
+    // If the response has no body, we can return the original response
+    // because there is nothing to consume, making it safe to reuse.
+    if (!original.body) {
+        return original;
+    }
+    // Check if the body is locked
+    if (original.body.locked) {
+        throw new Error("Cannot clone a response with a locked body.");
+    }
+    const [body] = original.body.tee();
+    const cloned = new Response(body, {
+        status: original.status,
+        statusText: original.statusText,
+        headers: new Headers(original.headers),
+    });
+    Object.defineProperty(cloned, "url", {
+        value: original.url,
+    });
+    return cloned;
+}
+exports.cloneResponse = cloneResponse;

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -512,3 +512,42 @@ export const isBuffer = (obj: any): boolean => {
      */
     return getBuffer().isBuffer(obj);
 };
+
+/**
+ * Clones a response by teeing the body so we can return two independent
+ * ReadableStreams from it. This avoids the bug in the undici library around
+ * response cloning.
+ *
+ * After cloning, the original response's body will be consumed and closed.
+ *
+ * @see https://github.com/supertokens/supertokens-node/issues/977
+ *
+ * @param original - The original response to clone.
+ * @returns A clone of the original response.
+ */
+export function cloneResponse(original: Response): Response {
+    // If the response has no body, we can return the original response
+    // because there is nothing to consume, making it safe to reuse.
+    if (!original.body) {
+        return original;
+    }
+
+    // Check if the body is locked
+    if (original.body.locked) {
+        throw new Error("Cannot clone a response with a locked body.");
+    }
+
+    const [body] = original.body.tee();
+
+    const cloned = new Response(body, {
+        status: original.status,
+        statusText: original.statusText,
+        headers: new Headers(original.headers),
+    });
+
+    Object.defineProperty(cloned, "url", {
+        value: original.url,
+    });
+
+    return cloned;
+}


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
-   [ ] If added a new entry point, then make sure that it is importable by adding it to the `exports` in `package.json`

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
