### PR TITLE
feat: inferring pkce based on OIDC response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [22.1.0] - 2025-04-04
+
+-   Adds support for using `code_challenge_method` from OIDC provider response to determine whether to use PKCE or not.
+
 ## [22.0.1] - 2025-03-26
 
 -   Added Dashboard support for WebAuthn
@@ -43,10 +47,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     -   Added `hasSameWebauthnInfoAs` method for credential comparison
 
 -   Updated FDI support to `4.1`
-
-## [21.2.0] - 2025-04-04
-
--   Adds support for using `code_challenge_method` from OIDC provider response to determine whether to use PKCE or not.
 
 ## [21.1.1] - 2025-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated FDI support to `4.1`
 
+## [21.1.2] - 2025-04-04
+
+-   Adds support for using `code_challenge_method` from OIDC provider response to determine whether to use PKCE or not.
+
 ## [21.1.1] - 2025-03-18
 
 -   Fixes an issue where the response body was not being cloned when using cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated FDI support to `4.1`
 
-## [21.1.2] - 2025-04-04
+## [21.2.0] - 2025-04-04
 
 -   Adds support for using `code_challenge_method` from OIDC provider response to determine whether to use PKCE or not.
 

--- a/lib/build/recipe/thirdparty/providers/custom.js
+++ b/lib/build/recipe/thirdparty/providers/custom.js
@@ -178,6 +178,7 @@ function NewProvider(input) {
             throw new Error(`Could not find client config for clientType: ${clientType}`);
         },
         getAuthorisationRedirectURL: async function ({ redirectURIOnProviderDashboard }) {
+            var _a;
             const queryParams = {
                 client_id: impl.config.clientId,
                 redirect_uri: redirectURIOnProviderDashboard,
@@ -187,7 +188,17 @@ function NewProvider(input) {
                 queryParams.scope = impl.config.scope.join(" ");
             }
             let pkceCodeVerifier = undefined;
-            if (impl.config.clientSecret === undefined || impl.config.forcePKCE) {
+            // Check if the OIDC response had specified PKCE to be used.
+            // Reference: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+            //
+            // Generally, we should try to use the best method supported by the provider.
+            // However, we will only use the S256 method if it is present and ignore otherwise,
+            // i.e. if `plain` is present etc.
+            const isS256MethodSupported =
+                (_a = impl.config.codeChallengeMethodsSupported) === null || _a === void 0
+                    ? void 0
+                    : _a.includes("S256");
+            if (impl.config.clientSecret === undefined || impl.config.forcePKCE || isS256MethodSupported) {
                 const { code_challenge, code_verifier } = pkce_challenge_1.default(64); // According to https://www.rfc-editor.org/rfc/rfc7636, length must be between 43 and 128
                 queryParams["code_challenge"] = code_challenge;
                 queryParams["code_challenge_method"] = "S256";

--- a/lib/build/recipe/thirdparty/providers/utils.js
+++ b/lib/build/recipe/thirdparty/providers/utils.js
@@ -121,6 +121,12 @@ async function discoverOIDCEndpoints(config) {
         if (oidcInfo.jwks_uri !== undefined && config.jwksURI === undefined) {
             config.jwksURI = oidcInfo.jwks_uri;
         }
+        if (
+            oidcInfo.code_challenge_methods_supported !== undefined &&
+            config.codeChallengeMethodsSupported === undefined
+        ) {
+            config.codeChallengeMethodsSupported = oidcInfo.code_challenge_methods_supported;
+        }
     }
 }
 exports.discoverOIDCEndpoints = discoverOIDCEndpoints;

--- a/lib/build/recipe/thirdparty/types.d.ts
+++ b/lib/build/recipe/thirdparty/types.d.ts
@@ -61,6 +61,7 @@ declare type CommonProviderConfig = {
         [key: string]: string | null;
     };
     jwksURI?: string;
+    codeChallengeMethodsSupported?: string[];
     oidcDiscoveryEndpoint?: string;
     userInfoMap?: UserInfoMap;
     validateIdTokenPayload?: (input: {

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,4 +1,4 @@
 // @ts-nocheck
-export declare const version = "22.0.1";
+export declare const version = "22.1.0";
 export declare const cdiSupported: string[];
 export declare const dashboardVersion = "0.15";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,7 +15,7 @@ exports.dashboardVersion = exports.cdiSupported = exports.version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.version = "22.0.1";
+exports.version = "22.1.0";
 exports.cdiSupported = ["5.3"];
 // Note: The actual script import for dashboard uses v{DASHBOARD_VERSION}
 exports.dashboardVersion = "0.15";

--- a/lib/ts/recipe/thirdparty/providers/custom.ts
+++ b/lib/ts/recipe/thirdparty/providers/custom.ts
@@ -195,7 +195,15 @@ export default function NewProvider(input: ProviderInput): TypeProvider {
 
             let pkceCodeVerifier: string | undefined = undefined;
 
-            if (impl.config.clientSecret === undefined || impl.config.forcePKCE) {
+            // Check if the OIDC response had specified PKCE to be used.
+            // Reference: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+            //
+            // Generally, we should try to use the best method supported by the provider.
+            // However, we will only use the S256 method if it is present and ignore otherwise,
+            // i.e. if `plain` is present etc.
+            const isS256MethodSupported = impl.config.codeChallengeMethodsSupported?.includes("S256");
+
+            if (impl.config.clientSecret === undefined || impl.config.forcePKCE || isS256MethodSupported) {
                 const { code_challenge, code_verifier } = pkceChallenge(64); // According to https://www.rfc-editor.org/rfc/rfc7636, length must be between 43 and 128
                 queryParams["code_challenge"] = code_challenge;
                 queryParams["code_challenge_method"] = "S256";

--- a/lib/ts/recipe/thirdparty/providers/utils.ts
+++ b/lib/ts/recipe/thirdparty/providers/utils.ts
@@ -118,6 +118,13 @@ export async function discoverOIDCEndpoints(config: ProviderConfigForClientType)
         if (oidcInfo.jwks_uri !== undefined && config.jwksURI === undefined) {
             config.jwksURI = oidcInfo.jwks_uri;
         }
+
+        if (
+            oidcInfo.code_challenge_methods_supported !== undefined &&
+            config.codeChallengeMethodsSupported === undefined
+        ) {
+            config.codeChallengeMethodsSupported = oidcInfo.code_challenge_methods_supported;
+        }
     }
 }
 

--- a/lib/ts/recipe/thirdparty/types.ts
+++ b/lib/ts/recipe/thirdparty/types.ts
@@ -60,6 +60,7 @@ type CommonProviderConfig = {
     userInfoEndpointQueryParams?: { [key: string]: string | null };
     userInfoEndpointHeaders?: { [key: string]: string | null };
     jwksURI?: string;
+    codeChallengeMethodsSupported?: string[];
     oidcDiscoveryEndpoint?: string;
     userInfoMap?: UserInfoMap;
     validateIdTokenPayload?: (input: {

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,7 +12,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const version = "22.0.1";
+export const version = "22.1.0";
 
 export const cdiSupported = ["5.3"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-node",
-    "version": "22.0.1",
+    "version": "22.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-node",
-            "version": "22.0.1",
+            "version": "22.1.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-node",
-    "version": "22.0.1",
+    "version": "22.1.0",
     "description": "NodeJS driver for SuperTokens core",
     "main": "index.js",
     "scripts": {

--- a/test/thirdparty/oidc.test.js
+++ b/test/thirdparty/oidc.test.js
@@ -1,0 +1,94 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { printPath, setupST, startSTWithMultitenancy, killAllST, cleanST, removeAppAndTenants } = require("../utils");
+let STExpress = require("../../");
+let assert = require("assert");
+let { ProcessState } = require("../../lib/build/processState");
+let ThirdPartyRecipe = require("../../lib/build/recipe/thirdparty/recipe").default;
+let Multitenancy = require("../../lib/build/recipe/multitenancy");
+let Session = require("../../lib/build/recipe/session");
+let ThirdParty = require("../../lib/build/recipe/thirdparty");
+let nock = require("nock");
+const express = require("express");
+const request = require("supertest");
+const { default: fetch } = require("cross-fetch");
+let { middleware, errorHandler } = require("../../framework/express");
+const { configsForVerification, providers } = require("./tpConfigsForVerification");
+
+describe(`oidcTest: ${printPath("[test/thirdparty/oidc.test.js]")}`, function () {
+    beforeEach(async function () {
+        await killAllST();
+        await setupST();
+        ProcessState.getInstance().reset();
+    });
+
+    after(async function () {
+        await killAllST();
+        await cleanST();
+    });
+
+    it("test the code challenge method is used if supported by the provider", async function () {
+        const connectionURI = await startSTWithMultitenancy();
+
+        STExpress.init({
+            supertokens: {
+                connectionURI,
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [ThirdPartyRecipe.init()],
+        });
+
+        await Multitenancy.createOrUpdateThirdPartyConfig("public", {
+            thirdPartyId: "custom-google",
+            name: "Custom provider",
+            clients: [
+                {
+                    clientId: "...",
+                    clientSecret: "...",
+                    scope: ["profile", "email"],
+                },
+            ],
+            oidcDiscoveryEndpoint: "https://accounts.google.com/.well-known/openid-configuration",
+            userInfoMap: {
+                fromIdTokenPayload: {
+                    userId: "id",
+                    email: "email",
+                    emailVerified: "email_verified",
+                },
+            },
+        });
+
+        const providerInfo = await ThirdParty.getProvider("public", "custom-google");
+        assert.deepStrictEqual(providerInfo.config.codeChallengeMethodsSupported, ["plain", "S256"]);
+
+        const authUrl = await providerInfo.getAuthorisationRedirectURL({
+            redirectURIOnProviderDashboard: "http://localhost:3000/callback",
+        });
+        assert.ok(authUrl.pkceCodeVerifier);
+        const authUrlObject = new URL(authUrl.urlWithQueryParams);
+        const codeChallengeMethod = authUrlObject.searchParams.get("code_challenge_method");
+        const codeChallenge = authUrlObject.searchParams.get("code_challenge");
+
+        // Check for existence of code_challenge and code_challenge_method
+        assert.ok(codeChallenge);
+        assert.ok(codeChallengeMethod);
+        assert.strictEqual(codeChallengeMethod, "S256");
+    });
+});

--- a/test/thirdparty/oidc.test.js
+++ b/test/thirdparty/oidc.test.js
@@ -13,20 +13,13 @@
  * under the License.
  */
 
-const { printPath, setupST, startSTWithMultitenancy, killAllST, cleanST, removeAppAndTenants } = require("../utils");
+const { printPath, setupST, startSTWithMultitenancy, killAllST, cleanST } = require("../utils");
 let STExpress = require("../../");
 let assert = require("assert");
 let { ProcessState } = require("../../lib/build/processState");
 let ThirdPartyRecipe = require("../../lib/build/recipe/thirdparty/recipe").default;
 let Multitenancy = require("../../lib/build/recipe/multitenancy");
-let Session = require("../../lib/build/recipe/session");
 let ThirdParty = require("../../lib/build/recipe/thirdparty");
-let nock = require("nock");
-const express = require("express");
-const request = require("supertest");
-const { default: fetch } = require("cross-fetch");
-let { middleware, errorHandler } = require("../../framework/express");
-const { configsForVerification, providers } = require("./tpConfigsForVerification");
 
 describe(`oidcTest: ${printPath("[test/thirdparty/oidc.test.js]")}`, function () {
     beforeEach(async function () {
@@ -40,7 +33,7 @@ describe(`oidcTest: ${printPath("[test/thirdparty/oidc.test.js]")}`, function ()
         await cleanST();
     });
 
-    it("test the code challenge method is used if supported by the provider", async function () {
+    it("should use code challenge method S256 if supported by the provider", async function () {
         const connectionURI = await startSTWithMultitenancy();
 
         STExpress.init({
@@ -77,6 +70,104 @@ describe(`oidcTest: ${printPath("[test/thirdparty/oidc.test.js]")}`, function ()
 
         const providerInfo = await ThirdParty.getProvider("public", "custom-google");
         assert.deepStrictEqual(providerInfo.config.codeChallengeMethodsSupported, ["plain", "S256"]);
+
+        const authUrl = await providerInfo.getAuthorisationRedirectURL({
+            redirectURIOnProviderDashboard: "http://localhost:3000/callback",
+        });
+        assert.ok(authUrl.pkceCodeVerifier);
+        const authUrlObject = new URL(authUrl.urlWithQueryParams);
+        const codeChallengeMethod = authUrlObject.searchParams.get("code_challenge_method");
+        const codeChallenge = authUrlObject.searchParams.get("code_challenge");
+
+        // Check for existence of code_challenge and code_challenge_method
+        assert.ok(codeChallenge);
+        assert.ok(codeChallengeMethod);
+        assert.strictEqual(codeChallengeMethod, "S256");
+    });
+
+    it("should not use pkce if oidc response does not support S256", async function () {
+        const connectionURI = await startSTWithMultitenancy();
+
+        STExpress.init({
+            supertokens: {
+                connectionURI,
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [ThirdPartyRecipe.init()],
+        });
+
+        await Multitenancy.createOrUpdateThirdPartyConfig("public", {
+            thirdPartyId: "custom-fb",
+            name: "Custom provider",
+            clients: [
+                {
+                    clientId: "...",
+                    clientSecret: "...",
+                    scope: ["profile", "email"],
+                },
+            ],
+            oidcDiscoveryEndpoint: "https://facebook.com/.well-known/openid-configuration",
+            userInfoMap: {
+                fromIdTokenPayload: {
+                    userId: "id",
+                    email: "email",
+                    emailVerified: "email_verified",
+                },
+            },
+        });
+
+        const providerInfo = await ThirdParty.getProvider("public", "custom-fb");
+        assert.deepStrictEqual(providerInfo.config.codeChallengeMethodsSupported, undefined);
+
+        const authUrl = await providerInfo.getAuthorisationRedirectURL({
+            redirectURIOnProviderDashboard: "http://localhost:3000/callback",
+        });
+        assert.strictEqual(authUrl.urlWithQueryParams.includes("code_challenge"), false);
+        assert.strictEqual(authUrl.urlWithQueryParams.includes("code_challenge_method"), false);
+    });
+
+    it("should use pkce if oidc response does not support S256 but forcePKCE is true", async function () {
+        const connectionURI = await startSTWithMultitenancy();
+
+        STExpress.init({
+            supertokens: {
+                connectionURI,
+            },
+            appInfo: {
+                apiDomain: "api.supertokens.io",
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+            },
+            recipeList: [ThirdPartyRecipe.init()],
+        });
+
+        await Multitenancy.createOrUpdateThirdPartyConfig("public", {
+            thirdPartyId: "custom-fb",
+            name: "Custom provider",
+            clients: [
+                {
+                    clientId: "...",
+                    clientSecret: "...",
+                    scope: ["profile", "email"],
+                    forcePKCE: true,
+                },
+            ],
+            oidcDiscoveryEndpoint: "https://facebook.com/.well-known/openid-configuration",
+            userInfoMap: {
+                fromIdTokenPayload: {
+                    userId: "id",
+                    email: "email",
+                    emailVerified: "email_verified",
+                },
+            },
+        });
+
+        const providerInfo = await ThirdParty.getProvider("public", "custom-fb");
+        assert.deepStrictEqual(providerInfo.config.codeChallengeMethodsSupported, undefined);
 
         const authUrl = await providerInfo.getAuthorisationRedirectURL({
             redirectURIOnProviderDashboard: "http://localhost:3000/callback",


### PR DESCRIPTION
## Summary of change

This PR adds support for inferring whether pkce should be used or not based on the OIDC response.

## Related issues

## Test Plan

All OIDC related tests and existing tests should pass

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
-   [ ] If added a new entry point, then make sure that it is importable by adding it to the `exports` in `package.json`
