### PR TITLE
fix: failing authorisation unit test

### DIFF
--- a/test/thirdparty/authorisationUrlFeature.test.js
+++ b/test/thirdparty/authorisationUrlFeature.test.js
@@ -230,11 +230,20 @@ describe(`authorisationTest: ${printPath("[test/thirdparty/authorisationFeature.
                 })
         );
 
+        // Check for existence of `code_challenge` in the url
+        let url = new URL(response1.body.urlWithQueryParams);
+        let codeChallenge = url.searchParams.get("code_challenge");
+        assert.notStrictEqual(codeChallenge, undefined);
+
+        // Value of `code_challenge` will be variable so we cannot do a strict match
+        // thus we will get rid of it from the url.
+        url.searchParams.delete("code_challenge");
+
         assert.notStrictEqual(response1, undefined);
         assert.strictEqual(response1.body.status, "OK");
         assert.strictEqual(
-            response1.body.urlWithQueryParams,
-            "https://accounts.google.com/o/oauth2/v2/auth?client_id=google-client-id&redirect_uri=redirect&response_type=code&scope=openid+email&included_grant_scopes=true&access_type=offline"
+            url.toString(),
+            "https://accounts.google.com/o/oauth2/v2/auth?client_id=google-client-id&redirect_uri=redirect&response_type=code&scope=openid+email&code_challenge_method=S256&included_grant_scopes=true&access_type=offline"
         );
     });
 

--- a/test/thirdparty/provider.test.js
+++ b/test/thirdparty/provider.test.js
@@ -103,7 +103,7 @@ describe(`providerTest: ${printPath("[test/thirdparty/provider.test.js]")}`, fun
             redirectURIOnProviderDashboard: "redirect",
             userContext: {},
         });
-        assert.deepStrictEqual(authUrlResult.pkceCodeVerifier, undefined);
+        assert.notStrictEqual(authUrlResult.pkceCodeVerifier, undefined);
 
         const authUrl = new URL(authUrlResult.urlWithQueryParams);
         assert.deepStrictEqual(authUrl.origin + authUrl.pathname, "https://accounts.google.com/o/oauth2/v2/auth");
@@ -117,6 +117,12 @@ describe(`providerTest: ${printPath("[test/thirdparty/provider.test.js]")}`, fun
             return result;
         }
         const authParams = paramsToObject(new URLSearchParams(authUrl.search.substring(1)).entries());
+
+        // Drop code_challenge since we cannot determine the value of it
+        // but validate that it is present in the url.
+        assert.notStrictEqual(authParams.code_challenge, undefined);
+        delete authParams.code_challenge;
+
         assert.deepEqual(authParams, {
             access_type: "offline",
             client_id: "test",
@@ -124,6 +130,7 @@ describe(`providerTest: ${printPath("[test/thirdparty/provider.test.js]")}`, fun
             redirect_uri: "redirect",
             response_type: "code",
             scope: "openid email",
+            code_challenge_method: "S256",
         });
 
         let tokenBody = {};
@@ -200,7 +207,7 @@ describe(`providerTest: ${printPath("[test/thirdparty/provider.test.js]")}`, fun
             redirectURIOnProviderDashboard: "redirect",
             userContext: {},
         });
-        assert.deepStrictEqual(authUrlResult.pkceCodeVerifier, undefined);
+        assert.notStrictEqual(authUrlResult.pkceCodeVerifier, undefined);
 
         const authUrl = new URL(authUrlResult.urlWithQueryParams);
         assert.deepStrictEqual(authUrl.origin + authUrl.pathname, "https://accounts.google.com/o/oauth2/v2/auth");
@@ -214,6 +221,12 @@ describe(`providerTest: ${printPath("[test/thirdparty/provider.test.js]")}`, fun
             return result;
         }
         const authParams = paramsToObject(new URLSearchParams(authUrl.search.substring(1)).entries());
+
+        // Drop code_challenge since we cannot determine the value of it
+        // but validate that it is present in the url.
+        assert.notStrictEqual(authParams.code_challenge, undefined);
+        delete authParams.code_challenge;
+
         assert.deepEqual(authParams, {
             access_type: "offline",
             client_id: "test",
@@ -223,6 +236,7 @@ describe(`providerTest: ${printPath("[test/thirdparty/provider.test.js]")}`, fun
             scope: "openid email",
             key1: "value1",
             key2: "value2",
+            code_challenge_method: "S256",
         });
     });
 
@@ -270,7 +284,7 @@ describe(`providerTest: ${printPath("[test/thirdparty/provider.test.js]")}`, fun
             redirectURIOnProviderDashboard: "redirect",
             userContext: {},
         });
-        assert.deepStrictEqual(authUrlResult.pkceCodeVerifier, undefined);
+        assert.notStrictEqual(authUrlResult.pkceCodeVerifier, undefined);
 
         const authUrl = new URL(authUrlResult.urlWithQueryParams);
         assert.deepStrictEqual(authUrl.origin + authUrl.pathname, "https://accounts.google.com/o/oauth2/v2/auth");
@@ -284,6 +298,12 @@ describe(`providerTest: ${printPath("[test/thirdparty/provider.test.js]")}`, fun
             return result;
         }
         const authParams = paramsToObject(new URLSearchParams(authUrl.search.substring(1)).entries());
+
+        // Drop code_challenge since we cannot determine the value of it
+        // but validate that it is present in the url.
+        assert.notStrictEqual(authParams.code_challenge, undefined);
+        delete authParams.code_challenge;
+
         assert.deepEqual(authParams, {
             access_type: "offline",
             client_id: "test",
@@ -291,6 +311,7 @@ describe(`providerTest: ${printPath("[test/thirdparty/provider.test.js]")}`, fun
             redirect_uri: "redirect",
             response_type: "code",
             scope: "test-scope-1 test-scope-2",
+            code_challenge_method: "S256",
         });
     });
 


### PR DESCRIPTION
## Summary of change

Fixes an unit test that was affected due to addition of auto inferring use of PKCE.

## Related issues

## Test Plan

All tests should pass

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
-   [ ] If added a new entry point, then make sure that it is importable by adding it to the `exports` in `package.json`
