### PR TITLE
fix: Add required recipeUserId field in registerCredential API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated FDI support to 4.2
 -   Added `recipeUserId` in the WebAuthn list credentials response
+-   Added `recipeUserId` as required field for registering new WebAuthn credentials endpoint
 
 ## [23.0.0] - 2025-07-21
 

--- a/lib/build/recipe/webauthn/api/implementation.js
+++ b/lib/build/recipe/webauthn/api/implementation.js
@@ -943,6 +943,7 @@ function getAPIImplementation() {
             };
         },
         registerCredentialPOST: async function ({
+            recipeUserId,
             webauthnGeneratedOptionsId,
             credential,
             tenantId,
@@ -958,6 +959,22 @@ function getAPIImplementation() {
                 INVALID_CREDENTIALS_ERROR:
                     "The credentials are incorrect. Please make sure you are using the correct credentials. (ERR_CODE_025)",
             };
+            const user = await (0, __1.getUser)(session.getUserId(), userContext);
+            if (!user) {
+                return {
+                    status: "GENERAL_ERROR",
+                    message: "User not found",
+                };
+            }
+            const loginMethod = user.loginMethods.find(
+                (lm) => lm.recipeId === "webauthn" && lm.recipeUserId.getAsString() === recipeUserId
+            );
+            if (!loginMethod) {
+                return {
+                    status: "GENERAL_ERROR",
+                    message: "User not found",
+                };
+            }
             const generatedOptions = await options.recipeImplementation.getGeneratedOptions({
                 webauthnGeneratedOptionsId,
                 tenantId,
@@ -967,6 +984,12 @@ function getAPIImplementation() {
                 return generatedOptions;
             }
             const email = generatedOptions.email;
+            if (email !== loginMethod.email) {
+                return {
+                    status: "GENERAL_ERROR",
+                    message: "Email mismatch",
+                };
+            }
             // NOTE: Following checks will likely never throw an error as the
             // check for type is done in a parent function but they are kept
             // here to be on the safe side.

--- a/lib/build/recipe/webauthn/api/registerCredential.js
+++ b/lib/build/recipe/webauthn/api/registerCredential.js
@@ -45,7 +45,15 @@ async function registerCredentialAPI(apiImplementation, tenantId, options, userC
             message: "A valid session is required to register a credential",
         });
     }
+    const recipeUserId = requestBody.recipeUserId;
+    if (recipeUserId === undefined) {
+        throw new error_1.default({
+            type: error_1.default.BAD_INPUT_ERROR,
+            message: "Please provide the recipeUserId",
+        });
+    }
     const result = await apiImplementation.registerCredentialPOST({
+        recipeUserId,
         credential,
         webauthnGeneratedOptionsId,
         tenantId,

--- a/lib/build/recipe/webauthn/types.d.ts
+++ b/lib/build/recipe/webauthn/types.d.ts
@@ -684,6 +684,7 @@ export type APIInterface = {
               session: SessionContainerInterface;
               options: APIOptions;
               userContext: UserContext;
+              recipeUserId: string;
           }) => Promise<
               | {
                     status: "OK";

--- a/lib/ts/recipe/webauthn/api/registerCredential.ts
+++ b/lib/ts/recipe/webauthn/api/registerCredential.ts
@@ -44,7 +44,16 @@ export default async function registerCredentialAPI(
         });
     }
 
+    const recipeUserId = requestBody.recipeUserId;
+    if (recipeUserId === undefined) {
+        throw new STError({
+            type: STError.BAD_INPUT_ERROR,
+            message: "Please provide the recipeUserId",
+        });
+    }
+
     const result = await apiImplementation.registerCredentialPOST({
+        recipeUserId,
         credential,
         webauthnGeneratedOptionsId,
         tenantId,

--- a/lib/ts/recipe/webauthn/types.ts
+++ b/lib/ts/recipe/webauthn/types.ts
@@ -630,6 +630,7 @@ export type APIInterface = {
               session: SessionContainerInterface;
               options: APIOptions;
               userContext: UserContext;
+              recipeUserId: string;
           }) => Promise<
               | {
                     status: "OK";


### PR DESCRIPTION
…ate related logic

## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
-   [ ] If added a new entry point, then make sure that it is importable by adding it to the `exports` in `package.json`

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
