### PR TITLE
Return the proper response when the OAuth2 refresh token is invalid

### DIFF
--- a/lib/ts/recipe/oauth2provider/recipeImplementation.ts
+++ b/lib/ts/recipe/oauth2provider/recipeImplementation.ts
@@ -471,6 +471,16 @@ export default function getRecipeInterface(
                     return tokenInfo;
                 }
 
+                if (!tokenInfo.active) {
+                    return {
+                        status: "ERROR",
+                        statusCode: 400,
+                        error: "invalid_grant",
+                        errorDescription:
+                            "The provided refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.",
+                    };
+                }
+
                 if (tokenInfo.active === true) {
                     const sessionHandle = tokenInfo.sessionHandle as string;
 


### PR DESCRIPTION
## Summary of change

Returns the proper error response when a refresh token is invalid. As per [the OAuth2 spec](https://www.rfc-editor.org/rfc/rfc6749#section-5.2)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
-   [ ] If added a new entry point, then make sure that it is importable by adding it to the `exports` in `package.json`

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
