### PR TITLE
fix: Use correct recipeUserId when registering a WebAuthn credential

### DIFF
--- a/lib/build/recipe/webauthn/api/implementation.js
+++ b/lib/build/recipe/webauthn/api/implementation.js
@@ -1009,27 +1009,26 @@ function getAPIImplementation() {
             if (generatedOptions.status !== "OK") {
                 return generatedOptions;
             }
-            const email = generatedOptions.email;
-            if (email !== loginMethod.email) {
+            // NOTE: Following checks will likely never throw an error as the
+            // check for type is done in a parent function but they are kept
+            // here to be on the safe side.
+            if (!generatedOptions.email) {
+                throw new Error(
+                    "Should never come here since we already check that the email value is a string in validateEmailAddress"
+                );
+            }
+            if (generatedOptions.email !== loginMethod.email) {
                 return {
                     status: "GENERAL_ERROR",
                     message: "Email mismatch",
                 };
-            }
-            // NOTE: Following checks will likely never throw an error as the
-            // check for type is done in a parent function but they are kept
-            // here to be on the safe side.
-            if (!email) {
-                throw new Error(
-                    "Should never come here since we already check that the email value is a string in validateEmailAddress"
-                );
             }
             // we are using the email from the register options
             const registerCredentialResponse = await options.recipeImplementation.registerCredential({
                 webauthnGeneratedOptionsId,
                 credential,
                 userContext,
-                recipeUserId: session.getRecipeUserId().getAsString(),
+                recipeUserId,
             });
             if (registerCredentialResponse.status !== "OK") {
                 return authUtils_1.AuthUtils.getErrorStatusResponseWithReason(

--- a/lib/ts/recipe/webauthn/api/implementation.ts
+++ b/lib/ts/recipe/webauthn/api/implementation.ts
@@ -1078,21 +1078,20 @@ export default function getAPIImplementation(): APIInterface {
                 return generatedOptions;
             }
 
-            const email = generatedOptions.email;
-            if (email !== loginMethod.email) {
+            // NOTE: Following checks will likely never throw an error as the
+            // check for type is done in a parent function but they are kept
+            // here to be on the safe side.
+            if (!generatedOptions.email) {
+                throw new Error(
+                    "Should never come here since we already check that the email value is a string in validateEmailAddress"
+                );
+            }
+
+            if (generatedOptions.email !== loginMethod.email) {
                 return {
                     status: "GENERAL_ERROR",
                     message: "Email mismatch",
                 };
-            }
-
-            // NOTE: Following checks will likely never throw an error as the
-            // check for type is done in a parent function but they are kept
-            // here to be on the safe side.
-            if (!email) {
-                throw new Error(
-                    "Should never come here since we already check that the email value is a string in validateEmailAddress"
-                );
             }
 
             // we are using the email from the register options
@@ -1100,7 +1099,7 @@ export default function getAPIImplementation(): APIInterface {
                 webauthnGeneratedOptionsId,
                 credential,
                 userContext,
-                recipeUserId: session.getRecipeUserId().getAsString(),
+                recipeUserId,
             });
 
             if (registerCredentialResponse.status !== "OK") {


### PR DESCRIPTION
use the recipe user id from the payload and not from the session when registering a new credential

## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
-   [ ] If added a new entry point, then make sure that it is importable by adding it to the `exports` in `package.json`

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
