### PR TITLE
fix: webauthn double verification of credentials at sign in

### DIFF
--- a/.changes/header.md
+++ b/.changes/header.md
@@ -4,3 +4,5 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+
+## [Unreleased]

--- a/.changes/unreleased/Fixed-20260723-105202.yaml
+++ b/.changes/unreleased/Fixed-20260723-105202.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'webauthn: fix sign in failing for counter-incrementing authenticators (e.g. Windows Hello) — the assertion was verified against the core twice.'
+time: 2026-07-23T10:52:02.879012+02:00

--- a/.changes/v1.1.0.md
+++ b/.changes/v1.1.0.md
@@ -3,4 +3,3 @@
 ### Added
 
 -   Support for [CDI version 2.0](https://github.com/supertokens/core-driver-interface/blob/master/v2.0.0.txt)
-

--- a/.changes/v24.0.2.md
+++ b/.changes/v24.0.2.md
@@ -1,11 +1,17 @@
 ## [24.0.2] - 2026-03-20
 
 ### Fixed
-- Upgrade cross-fetch to v4.1.0 to fix XMLHttpRequest error in Cloudflare Workers edge runtime
-- Handle null form field values in signup instead of throwing (fixes
-- Add explicit GeneralErrorResponse handling to SAML login and callback API handlers
+
+-   Upgrade cross-fetch to v4.1.0 to fix XMLHttpRequest error in Cloudflare Workers edge runtime
+-   Handle null form field values in signup instead of throwing (fixes #1026)
+-   Add explicit GeneralErrorResponse handling to SAML login and callback API handlers
+
 ### Infrastructure
-- Add SAML test-server integration routes for the shared backend-sdk-testing suite
+
+-   Add SAML test-server integration routes for the shared backend-sdk-testing suite
+
 ### Security
-- Bump nodemailer from 6.9 to 8.0.2 to address CVE
-- Fix open redirect vulnerability in SAML login when client_id is invalid (RFC 6749 §4.1.2.1)
+
+-   Bump nodemailer from 6.9 to 8.0.2 to address CVE
+-   Fix open redirect vulnerability in SAML login when client_id is invalid (RFC 6749 §4.1.2.1)
+

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -5,7 +5,7 @@ changelogPath: CHANGELOG.md
 versionExt: md
 versionFormat: '## [{{.VersionNoPrefix}}] - {{.Time.Format "2006-01-02"}}'
 kindFormat: "### {{.Kind}}"
-changeFormat: "- {{.Body}}"
+changeFormat: "-   {{.Body}}"
 
 kinds:
     - label: Added
@@ -26,9 +26,11 @@ kinds:
       auto: patch
 
 newlines:
-    afterChangelogHeader: 2
-    afterVersion: 1
-    beforeChangelogVersion: 1
+    afterChangelogHeader: 1
+    afterKind: 1
+    beforeKind: 1
+    beforeChangelogVersion: 0
+    endOfVersion: 2
 
 replacements:
     - path: package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,29 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
-
 ## [Unreleased]
 
 ## [24.0.2] - 2026-03-20
 
 ### Fixed
-- Upgrade cross-fetch to v4.1.0 to fix XMLHttpRequest error in Cloudflare Workers edge runtime
-- Handle null form field values in signup instead of throwing (fixes
-- Add explicit GeneralErrorResponse handling to SAML login and callback API handlers
+
+-   Upgrade cross-fetch to v4.1.0 to fix XMLHttpRequest error in Cloudflare Workers edge runtime
+-   Handle null form field values in signup instead of throwing (fixes #1026)
+-   Add explicit GeneralErrorResponse handling to SAML login and callback API handlers
+
 ### Infrastructure
-- Add SAML test-server integration routes for the shared backend-sdk-testing suite
+
+-   Add SAML test-server integration routes for the shared backend-sdk-testing suite
+
 ### Security
-- Bump nodemailer from 6.9 to 8.0.2 to address CVE
-- Fix open redirect vulnerability in SAML login when client_id is invalid (RFC 6749 §4.1.2.1)
+
+-   Bump nodemailer from 6.9 to 8.0.2 to address CVE
+-   Fix open redirect vulnerability in SAML login when client_id is invalid (RFC 6749 §4.1.2.1)
+
 ## [24.0.1] - 2025-03-14
 
 -   Fix SAML exported function return types
 
-
 ## [24.0.0] - 2025-12-02
 
 -   Adds support for SAML
-
 
 ## [23.1.0] - 2025-11-27
 
@@ -35,7 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Updates custom framework to following correct CollectingResponse flow order (to ensure that subsequent calls to the `sendJSONResponse` doesn't overwrite the response).
 -   Updated/expanded plugin support.
 -   Reworked internals to avoid dynamic requires and circular dependencies
-
 
 ## [23.0.1] - 2025-07-31
 
@@ -45,7 +47,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Fix WebAuthn credential listing and removal to work even when the WebAuthn user is not the primary user and when there are multiple WebAuthn users linked
 -   Prevent removal of WebAuthn credentials unless all session claims are satisfied
 -   Change how sessions are fetched before listing, removing and adding WebAuthn credentials
-
 
 ## [23.0.0] - 2025-07-21
 
@@ -66,7 +67,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Upgrade typedoc and the reference docs
 -   Add a method for verifying if a recipe is initialized or not
 
-
 ## [22.1.1] - 2025-06-20
 
 -   Migrates backend-sdk-testing test to use a containerized core
@@ -79,17 +79,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Refactors internal logic of parsing cookies to check accessToken and optimizes it to avoid parsing unrelated cookies.
 -   Fixes an issue with fetch not supporting `cache: no-cache` in Cloudflare Workers.
 
-
 ## [22.1.0] - 2025-04-04
 
 -   Adds support for using `code_challenge_method` from OIDC provider response to determine whether to use PKCE or not.
 -   Fixes issue with ThirdParty provider info on dashboard
 
-
 ## [22.0.1] - 2025-03-26
 
 -   Added Dashboard support for WebAuthn
-
 
 ## [22.0.0] - 2025-03-19
 
@@ -126,7 +123,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated FDI support to `4.1`
 
-
 ## [21.1.1] - 2025-03-18
 
 -   Fixes an issue where the response body was not being cloned when using cache
@@ -135,14 +131,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     -   Return type of `authGET` in `APIInterface` in `oauth2provider` recipe
     -   Return type of `loginGET` in `APIInterface` in `oauth2provider` recipe
 
-
 ## [21.1.0] - 2024-11-19
 
 -   Adds `getCookieNameForTokenType` config option to allow customizing the cookie name for a token type.
 -   Adds `getResponseHeaderNameForTokenType` config option to allow customizing the response header name for a token type.
     -   Please note, that using this will require further customizations on the frontend
 -   Fixes an issue where `removeDevice` API allowed removing verified TOTP devices without the user completing MFA.
-
 
 ## [21.0.0] - 2024-10-07
 
@@ -303,65 +297,53 @@ import { getAppDirRequestHandler } from "supertokens-node/nextjs";
 const handleCall = getAppDirRequestHandler();
 ```
 
-
 ## [20.1.5] - 2024-10-09
 
 -   Fixes an issue where users were not able to reset their password if a user with the same email address was created before account linking was enabled.
 -   Fixes and re-works some security checks connected to password reset.
-
 
 ## [20.1.4] - 2024-10-07
 
 -   Fixes an issue where revoking sessions for a specific tenant didn't work well
 -   Fixes an issue where the automatic session revocation after linking didn't work across all tenants
 
-
 ## [20.1.3] - 2024-09-30
 
 -   Replaces `psl` with `tldts` to avoid `punycode` deprecation warning.
-
 
 ## [20.1.2] - 2024-09-14
 
 -   Fixes formFields to accept non string types as well.
 
-
 ## [20.1.1] - 2024-09-10
 
 -   Fixes an issue with Okta / Active Directory providers where we check for additional config if `oidcDiscoveryEndpoint` is not defined. It would not be necessary in the cases where other endpoints are already provided.
-
 
 ## [20.1.0] - 2024-09-09
 
 -   Add edge compatibility for custom frameworks and Next.JS
 
-
 ## [20.0.5] - 2024-09-02
 
 -   Optional form fields are now truly optional, can be omitted from the payload.
 
-
 ## [20.0.4] - 2024-08-30
 
 -   Improves thirdParty debug logging to help with debugging issues with JSON parsing.
-
 
 ## [20.0.3] - 2024-08-22
 
 -   Fixes issue with dashboard APIs `createOrUpdateThirdPartyConfig` and `deleteThirdPartyConfig` which did not take `includeInNonPublicTenantsByDefault` into account for non-public tenants.
 -   Updates test server to support dashboard tests.
 
-
 ## [20.0.2] - 2024-08-08
 
 -   Fixes an issue where `shouldDoAutomaticAccountLinking` was called without a primary user when linking in some cases.
-
 
 ## [20.0.1] - 2024-08-05
 
 -   Fixes an issue with `removeFromPayloadByMerge_internal` for `MultiFactorAuthClaim` where it was not retaining other claims while removing the claim from the payload.
 -   Updates testing with backend-sdk-testing repo to run against all supported FDI versions.
-
 
 ## [20.0.0] - 2024-07-24
 
@@ -430,11 +412,9 @@ ThirdParty.init({
 });
 ```
 
-
 ## [19.0.1] - 2024-07-18
 
 -   Fixes issue in fetching `thirdPartyConfig` for dashboard when OIDC discovery endpoint is added in core.
-
 
 ## [19.0.0] - 2024-07-10
 
@@ -660,18 +640,15 @@ for (const tenant of tenantsRes.tenants) {
 }
 ```
 
-
 ## [18.0.2] - 2024-07-09
 
 -   `refreshPOST` and `refreshSession` now clears all user tokens upon CSRF failures and if no tokens are found. See the latest comment on https://github.com/supertokens/supertokens-node/issues/141 for more details.
-
 
 ## [18.0.1] - 2024-06-19
 
 ### Fixes
 
 -   Fix a bug that was preventing errors from being caught in the fetch function, thus bypassing our error handling.
-
 
 ## [18.0.0] - 2024-05-23
 
@@ -704,13 +681,11 @@ for (const tenant of tenantsRes.tenants) {
 -   Fixes override recursion build-up in built-in providers due to the modification of the `input.override` object in the ThirdParty providers list.
 -   Fixes issue with reference to `config` object in `TypeProvider` in the provider override. The issue was the `originalImplementation.config` object did not have the updated `config` values that was being used in the provider implementation.
 
-
 ## [17.1.2] - 2024-05-21
 
 ### Fixes
 
 -   Add workaround for unsupported 'cache' field in Cloudflare Workers. We retry fetch requests without the 'cache' field if they fail due to it not being implemented.
-
 
 ## [17.1.1] - 2024-05-16
 
@@ -718,7 +693,6 @@ for (const tenant of tenantsRes.tenants) {
 
 -   Fixed an issue when using Apple as a third party provider with our NextJs integration.
 -   Added a compatibility layer into `BaseRequest` to handle the form data parser returning `FormData` instead of the raw parsed object. This is to address/fix the above issues, possibly present in other frameworks.
-
 
 ## [17.1.0] - 2024-04-25
 
@@ -752,21 +726,17 @@ With this update, verifySession will return a 401 error if it detects multiple a
 5. The original API call is retried, but because it sends both the old and new cookies, it again results in a 401 response.
 6. The frontend tries to refresh the session with multiple access tokens: - If `olderCookieDomain` is not set, the refresh fails with a 500 error. - The user remains stuck until they clear cookies manually or `olderCookieDomain` is set. - If `olderCookieDomain` is set, the refresh clears the older cookie, returning a 200 response. - The frontend retries the original API call, sending only the new cookie (`domain=.example.com`), resulting in a successful request.
 
-
 ## [17.0.7] - 2024-05-03
 
 -   Adds `no-cache` header when querying core, so that frameworks like NextJS don't cache GET requests (https://nextjs.org/docs/app/building-your-application/caching#data-cache)
-
 
 ## [17.0.6] - 2024-05-02
 
 -   Fixes how FDI header is parsed from frontend requests to account for more than one version being passed.
 
-
 ## [17.0.5] - 2024-04-25
 
 -   Support for websiteDomain / apiDomain ending with `.local`: https://github.com/supertokens/supertokens-node/issues/823
-
 
 ## [17.0.4] - 2024-04-09
 
@@ -774,7 +744,6 @@ With this update, verifySession will return a 401 error if it detects multiple a
 
 -   Improved error message to help debugging if MFA was enabled without account linking.
 -   Now the `resyncSessionAndFetchMFAInfoPUT` will throw if the user is in a stuck state, because they are required to complete factors, but they are not allowed to because of some configuration issue.
-
 
 ## [17.0.3] - 2024-04-08
 
@@ -785,11 +754,9 @@ With this update, verifySession will return a 401 error if it detects multiple a
     -   Fixed an interaction with the `firstFactors` config of the `MultiFactorAuth` recipe in `createCodePOST`
     -   Fixed an issue in `resendCodePOST` where the email/text message included a magic link when it shouldn't have in some MFA cases
 
-
 ## [17.0.2] - 2024-03-20
 
 -   Remove tenants listing dashboard API and update `getTenantLoginMethodsInfo` dashboard API to remove querying core in loop and return only firstFactors.
-
 
 ## [17.0.1] - 2024-03-08
 
@@ -797,7 +764,6 @@ With this update, verifySession will return a 401 error if it detects multiple a
 
 -   We now allow sign in/up even if the session user is conflicting with the current sign in/up (because of the email verification status)
     -   This makes use-cases where an secondary factor (i.e.: otp-email) is also used as a means of verification.
-
 
 ## [17.0.0] - 2024-03-08
 
@@ -1199,26 +1165,21 @@ Passwordless.init({
 }),
 ```
 
-
 ## [16.7.4] - 2024-03-01
 
 -   Adds a user friendly error screen that provides helpful information regarding Content Security Policy (CSP) issues..
-
 
 ## [16.7.3] - 2024-02-26
 
 -   Fixes dashboard URI path. Now it returns the complete user given path instead of just the normalized connectionURI domain.
 
-
 ## [16.7.2] - 2024-02-19
 
 -   `createNewSession` now defaults to the value of the `st-auth-mode` header (if available) if the configured `getTokenTransferMethod` returns `any`.
 
-
 ## [16.7.1] - 2024-01-09
 
 -   Fixes type output of `resetPasswordUsingToken` in emailpassword and thirdpartyemailpassword recipe to not include statuses that happen based on email change.
-
 
 ## [16.7.0] - 2023-12-22
 
@@ -1226,48 +1187,39 @@ Passwordless.init({
 -   Previously, the custom framework's `errorHandler` callback function was invoked only upon encountering an error. This behavior has been rectified, and now the callback is invoked in both error and success cases.
 -   Added user creation apis on dashboard recipe to create Emailpassword and Passwordless recipe users.
 
-
 ## [16.6.8] - 2023-12-18
 
 -   Fix App dir support by removing the import of the "http" module
 
-
 ## [16.6.7] - 2023-12-18
 
 -   Adds facebook user data by checking the scopes provided in the config
-
 
 ## [16.6.6] - 2023-12-17
 
 -   Adds `userContext` input to the `validate` function in form fields. You can use this to fetch the request object from the `userContext`, read the request body, and then read the other form fields from there. If doing so, keep in mind that for the email and password validators, the request object may not always be available in the `validate` function, and even if it's available, it may not have the request body of the sign up API since the `validate` functions are also called from other operations (like in password reset API). For custom form fields that you have added to the sign up API, the request object will always be there in the `userContext`.
 -   Fixes support for the custom framework on node 16 by optionally using an implementation of the Headers class (from `node-fetch`)
 
-
 ## [16.6.5] - 2023-12-12
 
 -   CI/CD changes
 -   Fixes connectionURI domain normalisation.
 
-
 ## [16.6.4] - 2023-12-05
 
 -   Fixes typing of `verifySession` adding generic to extend the fastify base request.
-
 
 ## [16.6.3] - 2023-12-05
 
 -   Fixes issue with LinkedIn OAuth ([#751](https://github.com/supertokens/supertokens-node/issues/751))
 
-
 ## [16.6.2] - 2023-12-02
 
 -   Fixes implementation of `getBackwardsCompatibleUserInfo` to not throw an error in case of session and user id mismatch.
 
-
 ## [16.6.1] - 2023-11-29
 
 -   Removed dependency on the `crypto` library to enable Apple OAuth usage in Cloudflare Workers.
-
 
 ## [16.6.0] - 2023-11-23
 
@@ -1275,16 +1227,13 @@ Passwordless.init({
 
 -   Added User roles and permissions feature to dashboard recipe.
 
-
 ## [16.5.2] - 2023-11-21
 
 -   Fixes issue with `passwordReset` in emailpassword recipe for custom frameworks ([#746](https://github.com/supertokens/supertokens-node/issues/746))
 
-
 ## [16.5.1] - 2023-11-15
 
 -   Fixes issue with `createResetPasswordLink` and `sendResetPasswordEmail` in thirdpartyemailpassword recipe.
-
 
 ## [16.5.0] - 2023-11-10
 
@@ -1292,11 +1241,9 @@ Passwordless.init({
     -   This can be used to capture/modify all the HTTP requests sent to the core.
     -   Closes the issue - https://github.com/supertokens/supertokens-core/issues/865
 
-
 ## [16.4.0] - 2023-10-26
 
 -   Added `debug` property to `TypeInput`. When set to `true`, it will enable debug logs.
-
 
 ## [16.3.4] - 2023-10-22
 
@@ -1304,11 +1251,9 @@ Passwordless.init({
 
 -   Fixes an issue where sometimes the `Access-Control-Expose-Headers` header value would contain duplicates
 
-
 ## [16.3.3] - 2023-10-19
 
 -   Tests `null` values in `ProviderConfig` saved in core
-
 
 ## [16.3.2] - 2023-10-16
 
@@ -1317,13 +1262,11 @@ Passwordless.init({
 -   `getUsersNewestFirst` and `getUsersOldestFirst` will now properly filter users by tenantId.
 -   Fixes issue with missed email verification claim update that caused the frontend pre built UI to call the email verify API multiple times.
 
-
 ## [16.3.1] - 2023-10-12
 
 ### Fixes
 
 -   Handle AWS Public URLs (ending with `.amazonaws.com`) separately while extracting TLDs for SameSite attribute.
-
 
 ## [16.3.0] - 2023-10-10
 
@@ -1344,11 +1287,9 @@ Passwordless.init({
 -   Using built-in fetch whenever available instead of cross-fetch
 -   Improved edge-function support
 
-
 ## [16.2.1] - 2023-10-06
 
 -   Slight refactors logic to code for social providers to make it consistent across all providers
-
 
 ## [16.2.0] - 2023-09-29
 
@@ -1356,11 +1297,9 @@ Passwordless.init({
 
 -   Added `validateAccessToken` to the configuration for social login providers, this function allows you to verify the access token returned by the social provider. If you are using Github as a provider, there is a default implmentation provided for this function.
 
-
 ## [16.1.0] - 2023-09-26
 
 -   Added `twitter` as a built-in thirdparty provider
-
 
 ## [16.0.0] - 2023-09-25
 
@@ -1603,13 +1542,11 @@ app.post("/change-email", verifySession(), async (req: SessionRequest, res: expr
 });
 ```
 
-
 ## [15.2.1] - 2023-09-22
 
 ### Fixes
 
 -   Fixes an issue where the response for the JWKs API would contain additional properties
-
 
 ## [15.2.0] - 2023-09-11
 
@@ -1621,13 +1558,11 @@ app.post("/change-email", verifySession(), async (req: SessionRequest, res: expr
 
 -   Dashboard APIs now return a status code `403` for all non-GET requests if the currently logged in Dashboard User is not listed in the `admins` array
 
-
 ## [15.1.1] - 2023-08-14
 
 ### Fixes
 
 -   Improve edge function compatibility by removing our `raw-body` dependency.
-
 
 ## [15.1.0] - 2023-08-14
 
@@ -1639,26 +1574,21 @@ app.post("/change-email", verifySession(), async (req: SessionRequest, res: expr
     -   It defaults to `60` or the value set in the cache-control header returned by the core
     -   This is optional (so you are not required to update your overrides). Returning undefined means that the header is not set.
 
-
 ## [15.0.4] - 2023-08-11
 
 -   Fixes apple redirect
-
 
 ## [15.0.3] - 2023-08-10
 
 -   Adds logic to retry network calls if the core returns status 429
 
-
 ## [15.0.2] - 2023-07-31
 
 -   Fixes an issue where the user management dashboard would incorrectly show an email as unverified even if it was verified
 
-
 ## [15.0.1] - 2023-07-19
 
 -   Passes missing `tenantId` to claim build function
-
 
 ## [15.0.0] - 2023-07-19
 
@@ -2139,7 +2069,6 @@ app.post("/change-email", verifySession(), async (req: SessionRequest, res: expr
     -   supertokens-web-js@0.7.0
     -   supertokens-website@17.0.2
 
-
 ## [14.1.3] - 2023-07-03
 
 ### Changes
@@ -2149,7 +2078,6 @@ app.post("/change-email", verifySession(), async (req: SessionRequest, res: expr
 ### Fixes
 
 -   Now properly ignoring missing anti-csrf tokens in optional session validation
-
 
 ## [14.1.2] - 2023-06-07
 
@@ -2163,20 +2091,17 @@ app.post("/change-email", verifySession(), async (req: SessionRequest, res: expr
 -   Now assuming latest token version if the claim is missing from the header
 -   Make `verifySession` send the appropriate response instead of throwing (and sending 500) if session validation fails in koa, hapi and loopback (already happening in other frameworks).
 
-
 ## [14.1.1] - 2023-05-24
 
 ### Added
 
 -   Adds additional debug logs whenever the SDK throws a `TRY_REFRESH_TOKEN` or `UNAUTHORISED` error to make debugging easier
 
-
 ## [14.1.0] - 2023-05-23
 
 ### Changes
 
 -   Added a new `getRequestFromUserContext` function that can be used to read the original network request from the user context in overridden APIs and recipe functions
-
 
 ## [14.0.2] - 2023-05-11
 
@@ -2185,11 +2110,9 @@ app.post("/change-email", verifySession(), async (req: SessionRequest, res: expr
 -   Made the access token string optional in the overrideable `getSession` function
 -   Moved checking if the access token is defined into the overrideable `getSession` function
 
-
 ## [14.0.1] - 2023-05-11
 
 -   Fixes an issue where API key based login with dashboard would return invalid API key even if the entered API key was valid
-
 
 ## [14.0.0] - 2023-05-04
 
@@ -2473,38 +2396,31 @@ Session.init({
 });
 ```
 
-
 ## [13.6.0] - 2023-04-26
 
 -   Added missing arguments from `getUsersNewestFirst` and `getUsersOldestFirst`
-
 
 ## [13.5.0] - 2023-04-22
 
 -   Adds new config to change the access token's path
 
-
 ## [13.4.2] - 2023-04-11
 
 -   Modified email templates to make them render fine in gmail.
-
 
 ## [13.4.1] - 2023-04-11
 
 -   Modified email templates to make them render fine in outlook.
 
-
 ## [13.4.0] - 2023-03-31
 
 -   Adds APIs to enable search functionality to the dashboard recipe
-
 
 ## [13.3.0] - 2023-03-30
 
 ### Added
 
 -   Adds a telemetry API to the dashboard recipe
-
 
 ## [13.2.0] - 2023-03-29
 
@@ -2516,7 +2432,6 @@ Session.init({
 
 -   Login with bitbucket and gitlab (single tenant only)
 
-
 ## [13.1.5] - 2023-03-17
 
 ### Fixes
@@ -2524,13 +2439,11 @@ Session.init({
 -   Fixed an issue where BaseRequest implmentations for frameworks such as AWS Lambda would not consider case sensitivity when fetching request headers
 -   Fixes an issue where dashboard recipe APIs would return 404 for Hapi
 
-
 ## [13.1.4] - 2023-03-16
 
 ### Fixes
 
 -   Fixes an issue where importing recipes without importing the package index file would cause crashes
-
 
 ## [13.1.3] - 2023-03-08
 
@@ -2538,34 +2451,28 @@ Session.init({
 
 -   The dashboard recipe is no longer intialised automatically
 
-
 ## [13.1.2] - 2023-02-27
 
 ### Fixes
 
 -   Fixed request parsing issue during third-party (Apple) sign in in NextJS
 
-
 ## [13.1.1] - 2023-02-24
 
 -   Refactor dashboard recipe to use auth mode instead of manually checking for api key
 
-
 ## [13.1.0] - 2023-02-22
 
 -   Adds APIs and logic to the dashboard recipe to enable email password based login
-
 
 ## [13.0.2] - 2023-02-10
 
 -   Package version update for twilio to ^4.7.2 and verify-apple-id-token to ^3.0.1
 -   Package typescript version changed to 4.2
 
-
 ## [13.0.1] - 2023-02-08
 
 -   Email template updates
-
 
 ## [13.0.0] - 2023-02-01
 
@@ -2614,37 +2521,30 @@ app.post("/create", async (req, res) => {
 });
 ```
 
-
 ## [12.1.6] - 2023-01-22
 
 -   Updates jsonwebtoken dependency to version 9.0.0 to fix vulnerability in it's `verify` function.
 
-
 ## [12.1.5] - 2022-12-10
 
 -   Fixes Content-type header in AWS lambda framework
-
 
 ## [12.1.4] - 2022-12-26
 
 -   Updates dashboard version
 -   Updates user GET API for the dashboard recipe
 
-
 ## [12.1.3] - 2022-12-12
 
 -   Updates some dependencies cause of `npm audit`
-
 
 ## [12.1.2] - 2022-12-06
 
 -   Fixes issue where if sendEmail is overridden with a different email, it will reset that email.
 
-
 ## [12.1.1] - 2022-11-25
 
 -   Fixed an issue with importing the wrong recipe in the dashboard APIs
-
 
 ## [12.1.0] - 2022-11-17
 
@@ -2656,7 +2556,6 @@ app.post("/create", async (req, res) => {
 
 -   Updates dashboard version to 0.2
 
-
 ## [12.0.6] - 2022-11-09
 
 ### Fixes
@@ -2664,11 +2563,9 @@ app.post("/create", async (req, res) => {
 -   Adds updating of session claims in email verification token generation API in case the session claims are outdated.
 -   Fixed mergeIntoAccessTokenPayload not updating the JWT payload
 
-
 ## [12.0.5] - 2022-10-17
 
 -   Updated google token endpoint.
-
 
 ## [12.0.4] - 2022-10-14
 
@@ -2677,13 +2574,11 @@ app.post("/create", async (req, res) => {
 -   Removed default defaultMaxAge from session claim base classes
 -   Added a 5 minute defaultMaxAge to UserRoleClaim, PermissionClaim and EmailVerificationClaim
 
-
 ## [12.0.3] - 2022-09-29
 
 ### Refactor:
 
 -   clear cookies logic refactored for unauthorised error response
-
 
 ## [12.0.2] - 2022-09-22
 
@@ -2691,13 +2586,11 @@ app.post("/create", async (req, res) => {
 
 -   Properly rethrowing generic errors in email verification endpoints.
 
-
 ## [12.0.1] - 2022-09-22
 
 ### Changed
 
 -   Email verification endpoints will now clear the session if called by a deleted/unknown user
-
 
 ## [12.0.0] - 2022-09-14
 
@@ -2883,13 +2776,11 @@ The UserRoles recipe now adds role and permission information into the access to
 -   You need to configure the "Access Denied" response.
 -   Please check our updated guide on our website
 
-
 ## [11.3.0] - 2022-08-30
 
 ### Added:
 
 -   `authUsername` option in smtp config for when email is different than the username for auth.
-
 
 ## [11.2.0] - 2022-08-26
 
@@ -2897,20 +2788,17 @@ The UserRoles recipe now adds role and permission information into the access to
 
 -   Adds a Dashboard recipe
 
-
 ## [11.1.2] - 2022-08-25
 
 ### Type fix:
 
 -   Makes `userContext` optional in `sendEmail` and `sendSms` function in all recipe exposed functions.
 
-
 ## [11.1.1] - 2022-08-11
 
 ### Bug fix:
 
 -   Adds missing `force` param from `createUserIdMapping` and `deleteUserIdMapping` functions
-
 
 ## [11.1.0] - 2022-08-11
 
@@ -2919,20 +2807,17 @@ The UserRoles recipe now adds role and permission information into the access to
 -   UserId Mapping functionality and compatibility with CDI 2.15
 -   Adds `createUserIdMapping`, `getUserIdMapping`, `deleteUserIdMapping`, `updateOrDeleteUserIdMappingInfo` functions
 
-
 ## [11.0.3] - 2022-08-05
 
 ### Bug fix:
 
 -   Fixes overrides not applying correctly in methods called on SessionContainer instances
 
-
 ## [11.0.2] - 2022-08-02
 
 ### Bug fix:
 
 -   Solves the issue of request getting stuck in non returning state while parsing form data for nextjs request
-
 
 ## [11.0.1] - 2022-07-18
 
@@ -2943,7 +2828,6 @@ The UserRoles recipe now adds role and permission information into the access to
 ### Adds:
 
 -   Improved type definitions for `SessionWrapper.getSession`.
-
 
 ## [11.0.0] - 2022-07-05
 
@@ -2959,7 +2843,6 @@ The UserRoles recipe now adds role and permission information into the access to
 ### Bug fix:
 
 -   Clears cookies when revokeSession is called using the session container, even if the session did not exist from before: https://github.com/supertokens/supertokens-node/issues/343
-
 
 ## [10.0.1] - 2022-06-28
 
@@ -2978,7 +2861,6 @@ signIn: async function (input) {
     }
 }
 ```
-
 
 ## [10.0.0] - 2022-06-2
 
@@ -3005,7 +2887,6 @@ signIn: async function (input) {
 ### Fixes
 
 -   Fixes email undefined error when resending the passwordless login email.
-
 
 ## [9.3.0] - 2022-06-17
 
@@ -3100,11 +2981,9 @@ SuperTokens.init({
 })
 ```
 
-
 ## [9.2.3] - 2022-06-03
 
 -   Changes `getUserMetadata` to return `any` type for metadata so that it's easier to use.
-
 
 ## [9.2.2] - 2022-05-24
 
@@ -3112,13 +2991,11 @@ SuperTokens.init({
 
 -   Calling the setImmediate function inside assertThatBodyParserHasBeenUsedForExpressLikeRequest only if the function is getting executed in NextJS env. Fixes #313
 
-
 ## [9.2.1] - 2022-05-19
 
 ### Fixes:
 
 -   Fixes the routes issue for Hapi framework plugin
-
 
 ## [9.2.0] - 2022-04-18
 
@@ -3127,7 +3004,6 @@ SuperTokens.init({
 -   Adds UserMetadata recipe
 -   Fixes debug log statement when custom header is not passed during refresh session
 
-
 ## [9.1.2] - 2022-04-01
 
 ### Added
@@ -3135,24 +3011,20 @@ SuperTokens.init({
 -   Adds debug logging functionality
 -   removed jsonschema dependency
 
-
 ## [9.1.1] - 2022-03-24
 
 ### Fixes:
 
 -   Changes Github and Discord providers to check if email is `undefined` or not before assigning the email object to the profile info.
 
-
 ## [9.1.0] - 2022-03-17
 
 -   Added `ThirdPartyPasswordless` recipe + tests
-
 
 ## [9.0.1] - 2022-03-02
 
 -   Fixes #269. The json body parser will additionally be used to parse the request body if the request body is of type `{}`
 -   `init` function will throw error if there are empty items in recipeList when passing the config
-
 
 ## [9.0.0] - 2022-02-20
 
@@ -3176,13 +3048,11 @@ SuperTokens.init({
 
 -   Uses recipe interface inside session class so that any modification to those get reflected in the session class functions too.
 
-
 ## [8.6.1] - 2022-02-09
 
 ### Refactor
 
 -   Removes unused property from session recipe
-
 
 ## [8.6.0] - 2022-01-31
 
@@ -3202,7 +3072,6 @@ SuperTokens.init({
 -   Allows passing of custom user context everywhere: https://github.com/supertokens/supertokens-node/issues/215
 -   Returns session object from API interface functions which create a new session: https://github.com/supertokens/supertokens-node/issues/215
 
-
 ## [8.5.0] - 2022-01-14
 
 ### Added
@@ -3211,13 +3080,11 @@ SuperTokens.init({
 -   Adds compatibility with FDI 1.12 and CDI 2.11
 -   Adds passwordless tests
 
-
 ## [8.4.0] - 2021-12-20
 
 ### Added
 
 -   Delete user functionality
-
 
 ## [8.3.1] - 2021-12-20
 
@@ -3225,20 +3092,17 @@ SuperTokens.init({
 
 -   Exposes all essential `types` files. Fixes [#230](https://github.com/supertokens/supertokens-node/issues/230)
 
-
 ## [8.3.0] - 2021-12-08
 
 ### Added
 
 -   The ability to enable JWT creation with session management, this allows easier integration with services that require JWT based authentication: https://github.com/supertokens/supertokens-core/issues/250
 
-
 ## [8.2.1] - 2021-12-07
 
 ### Fixes
 
 -   Removes use of apiGatewayPath from apple's redirect URI since that is already there in the apiBasePath
-
 
 ## [8.2.0] - 2021-11-15
 
@@ -3252,18 +3116,15 @@ SuperTokens.init({
 -   Changes `sendJSONResponse to not allow setting of result if it has already been set
 -   AWS lambda middleware will return `404` response if the API route is not served by the middleware and user has not passed a handler.
 
-
 ## [8.1.2] - 2021-11-15
 
 -   Uses supertokens-js-override from npm
-
 
 ## [8.1.1] - 2021-11-08
 
 ### Changes
 
 -   When routing, ignores `rid` value `"anti-csrf"`: https://github.com/supertokens/supertokens-node/issues/202
-
 
 ## [8.1.0] - 2021-10-29
 
@@ -3277,20 +3138,17 @@ SuperTokens.init({
 -   Verifies ID Token sent for sign in with apple as per https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/verifying_a_user
 -   `sendHTMLResponse` and `getFormData` functions for frameworks
 
-
 ## [8.0.4] - 2021-10-28
 
 ### Fixes
 
 -   Uses `accessTokenPayload` instead of `jwtPayload` when creating SessionInformation object
 
-
 ## [8.0.3] - 2021-10-27
 
 ### Changes
 
 -   Removes `SessionRequest` as an exported member of session recipe's index file
-
 
 ## [8.0.2] - 2021-10-27
 
@@ -3299,13 +3157,11 @@ SuperTokens.init({
 -   Uses non arrow functions in api and recipe interface impl to allow for "true" inheritance in override: https://github.com/supertokens/supertokens-node/issues/199
 -   Uses `bind(this)` when calling original implementation
 
-
 ## [8.0.1] - 2021-10-22
 
 ### Changed
 
 -   Trying to handle errors closer to the source in middlewares instead of relying on the global error handler.
-
 
 ## [8.0.0] - 2021-10-20
 
@@ -3315,7 +3171,6 @@ SuperTokens.init({
 -   Removes all deprecated functions
 -   Renames all "JWT" related functions in session recipe to use "AccessToken" instead
 -   Removes support for CDI 2.7 (which used some of the new deprecated APIs in the core)
-
 
 ## [7.3.1] - 2021-10-18
 
@@ -3327,13 +3182,11 @@ SuperTokens.init({
 
 -   URL protocol is being taken into account when determining the value of cookie same site: https://github.com/supertokens/supertokens-golang/issues/36
 
-
 ## [7.3.0] - 2021-10-11
 
 ### Added
 
 -   Adds OAuth development keys for Google and Github for faster recipe implementation.
-
 
 ## [7.2.1] - 2021-10-02
 
@@ -3341,14 +3194,12 @@ SuperTokens.init({
 
 -   Updated dependencies.
 
-
 ## [7.2.0]
 
 ### Added
 
 -   JWT recipe to create signed JWT tokens
 -   New API to fetch keys used for JWT verification using JWKS
-
 
 ## [7.1.0]
 
@@ -3370,7 +3221,6 @@ SuperTokens.init({
 -   `verifySession` middleware ts issue fix for Hapi framework
 -   ts import for `verifySession` fix for koa
 
-
 ## [7.0.1] - 2021-09-10
 
 ### Breaking Change
@@ -3380,7 +3230,6 @@ SuperTokens.init({
 ### Fixes
 
 -   fixes issue #175 regarding making error handlers async, session error callabacks async and making VerifySessionOptions optional for verifySession middleware.
-
 
 ## [7.0.0] - 2021-07-31
 
@@ -3426,13 +3275,11 @@ SuperTokens.init({
 
 -   https://github.com/supertokens/supertokens-node/issues/156
 
-
 ## [6.1.1] - 2021-09-08
 
 ## Fixes
 
 -   updated function `getUserByEmail` in `recipe/thirdpartyemailpassword/recipeImplementation/emailPasswordRecipeImplementation.ts` to use `getUsersByEmail` instead of `getUserByEmail`
-
 
 ## [6.1.0] - 2021-06-24
 
@@ -3452,13 +3299,11 @@ SuperTokens.init({
 -   Adds `updateEmailOrPassword` recipe function to emailpassword and thirdpartyemailpassword recipes: https://github.com/supertokens/supertokens-core/issues/275
 -   Adds emailverification recipe functions to all recipes: https://github.com/supertokens/supertokens-core/issues/270
 
-
 ## [6.0.4] - 2021-07-29
 
 ### Fixes
 
 -   Fixes typescript issue with default imports. (Related to https://github.com/supertokens/supertokens-auth-react/issues/297)
-
 
 ## [6.0.3] - 2021-07-08
 
@@ -3466,20 +3311,17 @@ SuperTokens.init({
 
 -   signInUpPOST default implementation will return accessToken api response data instead of axios response
 
-
 ## [6.0.2] - 2021-06-28
 
 ### Fixes
 
 -   https://github.com/supertokens/supertokens-node/issues/141
 
-
 ## [6.0.1] - 2021-06-19
 
 ### Fixes
 
 -   https://github.com/supertokens/supertokens-node/issues/136
-
 
 ## [6.0.0] - 2021-06-18
 
@@ -3501,7 +3343,6 @@ SuperTokens.init({
 -   Removes duplicate signout APIs from all auth recipes since it's already exposed from the session recipe.
 -   Marked `setJwtPayload` and `setSessionData` as deprecated.
 
-
 ## [5.1.0] - 2021-06-13
 
 ### Fixes:
@@ -3509,13 +3350,11 @@ SuperTokens.init({
 -   https://github.com/supertokens/supertokens-node/pull/135: In serverless env, waits for email to be sent before returning the response cause sometimes, serverless envs quite the process early on.
 -   https://github.com/supertokens/supertokens-node/issues/127: In serverless env, sends telemetry with a 30% probability.
 
-
 ## [5.0.1] - 2021-05-06
 
 ### Fixes:
 
 -   https://github.com/supertokens/supertokens-node/issues/122: Calling verifySession in another file (via router), before the init function is called throws a not initialized error.
-
 
 ## [5.0.0] - 2021-05-02
 
@@ -3526,13 +3365,11 @@ SuperTokens.init({
 -   changes `enableAntiCsrf` config to `antiCsrf`.
 -   removes deprecated `apiWebProxyPath` config. Use `appInfo -> apiGatewayPath` instead.
 
-
 ## [4.4.1] - 2021-04-29
 
 ### Fixed:
 
 -   Runs JSON body parser only if `req.body` is `undefined` or if it is buffer
-
 
 ## [4.4.0] - 2021-04-28
 
@@ -3540,13 +3377,11 @@ SuperTokens.init({
 
 -   `apiGatewayPath` in `appInfo` during `init`. This deprecates `apiWebProxyPath`.
 
-
 ## [4.3.3] - 2021-04-25
 
 ### Changed:
 
 -   Fixes case when bodyParser is not used in serverless functions - We now attempt to use bodyParser even if `req.body` is not `undefined` - as long as it's not a valid JSON.
-
 
 ## [4.3.2] - 2021-04-24
 
@@ -3554,13 +3389,11 @@ SuperTokens.init({
 
 -   Complies with FDI 1.7.1 for issue https://github.com/supertokens/supertokens-core/issues/233
 
-
 ## [4.3.1] - 2021-04-17
 
 ### Fixed
 
 -   Issue https://github.com/supertokens/supertokens-node/issues/113: If the `idRefreshToken` is present in the request, but the refresh token is missing, we clear the `idRefreshToken` as well.
-
 
 ## [4.3.0] - 2021-04-15
 
@@ -3574,7 +3407,6 @@ SuperTokens.init({
 -   handlePostSignUp parameter in signUpFeature for emailpassword recipe.
 -   deprecation warning for handleCustomFormFieldsPostSignUp parameter.
 -   handlePostSignIn parameter in signInFeature for emailpassword recipe.
-
 
 ## [4.2.0] - 2021-03-09
 
@@ -3592,13 +3424,11 @@ SuperTokens.init({
 -   verifySession now accepts an object as a parameter. Two valid parameters are sessionRequired and antiCsrfCheck. sessionRequired can be by user if they intends to make the session requirement optional for the API.
 -   Allows ";" at the end of connectionURI to core
 
-
 ## [4.1.3] - 2021-03-19
 
 ### Changed
 
 -   Fixes bug in NextJS wrapper which called resolve even though there was an error
-
 
 ## [4.1.2] - 2021-03-05
 
@@ -3606,13 +3436,11 @@ SuperTokens.init({
 
 -   Fix Domain normalisation with "/.netlify/functions/api"
 
-
 ## [4.1.1] - 2021-03-05
 
 ### Changed
 
 -   Fix Path normalisation with "/.netlify/functions/api"
-
 
 ## [4.1.0] - 2021-02-23
 
@@ -3622,13 +3450,11 @@ SuperTokens.init({
 -   sessionFeature config that allows user to set jwtPayload and sessionData during signup or signin
 -   Changed error handling
 
-
 ## [4.0.1] - 2021-03-01
 
 ### Changed
 
 -   Type of authorisationRedirect params to include a function
-
 
 ## [4.0.0] - 2021-02-02
 
@@ -3640,13 +3466,11 @@ SuperTokens.init({
 -   Implements thirdparty recipe
 -   Sends telemetryId for telemetry
 
-
 ## [3.4.2] - 2021-01-09
 
 ## Added
 
 -   Telemetry as per https://github.com/supertokens/supertokens-node/issues/85
-
 
 ## [3.4.1] - 2021-02-06
 
@@ -3654,7 +3478,6 @@ SuperTokens.init({
 
 -   Allow users to pass FaunaDB client directly when using Session.init
 -   Fixes https://github.com/supertokens/supertokens-node/issues/83
-
 
 ## [3.4.0] - 2021-01-28
 
@@ -3666,20 +3489,17 @@ SuperTokens.init({
 -   if the apiDomain and websiteDomain values are different (no common top level domain), then cookieSameSite will be set to none by default, else set it to lax
 -   Fixed https://github.com/supertokens/supertokens-node/issues/63
 
-
 ## [3.3.2] - 2021-01-29
 
 ### Fixed
 
 -   Always sets httpOnly flag to be true for session cookies regardless of if secure flag is on or off.
 
-
 ## [3.3.1] - 2021-01-20
 
 ### Changed
 
 -   Update superTokensNextWrapper to add a return value.
-
 
 ## [3.3.0] - 2021-01-13
 
@@ -3695,13 +3515,11 @@ SuperTokens.init({
 
 -   Bump axios from 0.19 to 0.21 to fix Critical Dependency
 
-
 ## [3.2.2] - 2020-12-18
 
 ### Fixed
 
 -   Removes the need for Proxy in NextJS so that if a session is created manually by the user, it still works
-
 
 ## [3.2.1] - 2020-12-16
 
@@ -3710,13 +3528,11 @@ SuperTokens.init({
 -   Fixes bug for missing return in nextjs helper
 -   Changed name from supertokenMiddleware to superTokensMiddleware
 
-
 ## [3.2.0] - 2020-12-13
 
 ### Changed
 
 -   Add NextJS helper
-
 
 ## [3.1.1] - 2020-12-12
 
@@ -3724,14 +3540,12 @@ SuperTokens.init({
 
 -   If `init` is called multiple times, it does not throw an error
 
-
 ## [3.1.0] - 2020-11-26
 
 ### Added
 
 -   Added changes as per new FDI: https://github.com/supertokens/frontend-driver-interface/issues/3
     -   API to check if an email exists
-
 
 ## [3.0.0] - 2020-11-18
 
@@ -3748,20 +3562,17 @@ SuperTokens.init({
     -   https://github.com/supertokens/supertokens-node/pull/25
     -   https://github.com/supertokens/supertokens-node/pull/45
 
-
 ## [2.5.0] - 2020-09-19
 
 ### Added
 
 -   FaunaDB integration
 
-
 ## [2.4.1] - 2020-10-15
 
 ### Fixed
 
 -   Issue #17 - Do not clear cookies if they do not exist in the first place
-
 
 ## [2.4.0] - 2020-09-10
 
@@ -3770,7 +3581,6 @@ SuperTokens.init({
 -   Support for CDI 2.3 and FDI 1.2
 -   Fixes issue #7
 -   Remove compatibility with CDI 1.0
-
 
 ## [2.3.0] - 2020-08-05
 
@@ -3781,20 +3591,17 @@ SuperTokens.init({
 -   Automatically adds a refresh API if the user calls the `init` function inside `app.use()`
 -   Support for CDI 2.2
 
-
 ## [2.2.2] - 2020-07-30
 
 ### Fixed
 
 -   Fixes #2 - Prevents duplicate `Access-Control-Allow-Credentials` header value
 
-
 ## [2.2.1] - 2020-07-14
 
 ### Fixed
 
 -   Fixed typo in exported typescript type
-
 
 ## [2.2.0] - 2020-06-29
 
@@ -3803,13 +3610,11 @@ SuperTokens.init({
 -   Support for API key
 -   Compatibility with CDI 2.1
 
-
 ## [2.1.0] - 2020-06-18
 
 ### Changes
 
 -   config changes and code refactor
-
 
 ## [2.0.0] - 2020-05-04
 
@@ -3827,10 +3632,8 @@ SuperTokens.init({
 
 -   Changed `revokeSessionUsingSessionHandle` => `revokeSession`
 
-
 ## [1.1.0] - 2020-04-19
 
 ### Added
 
 -   Support for [CDI version 2.0](https://github.com/supertokens/core-driver-interface/blob/master/v2.0.0.txt)
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 
+## [Unreleased]
+
+### Fixed
+- webauthn: fix sign in failing for counter-incrementing authenticators (e.g. Windows Hello) — the assertion was verified against the core twice ([supertokens-core#1195](https://github.com/supertokens/supertokens-core/issues/1195)). Adds `completeSignIn` to the recipe interface; `signInPOST` no longer calls `signIn`, so move `signIn` override logic for the API flow to `completeSignIn`. Masked sign-in errors are now debug-logged
+
 
 ## [24.0.2] - 2026-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- webauthn: fix sign in failing for counter-incrementing authenticators (e.g. Windows Hello) — the assertion was verified against the core twice ([supertokens-core#1195](https://github.com/supertokens/supertokens-core/issues/1195)). Adds `completeSignIn` to the recipe interface; `signInPOST` no longer calls `signIn`, so move `signIn` override logic for the API flow to `completeSignIn`. Masked sign-in errors are now debug-logged
-
-
 ## [24.0.2] - 2026-03-20
 
 ### Fixed

--- a/lib/ts/recipe/webauthn/api/implementation.ts
+++ b/lib/ts/recipe/webauthn/api/implementation.ts
@@ -316,6 +316,15 @@ export default function getAPIImplementation(stInstance: SuperTokens): APIInterf
                 userContext,
             });
             if (verifyResult.status !== "OK") {
+                logDebugMessage(
+                    `signInPOST: returning INVALID_CREDENTIALS_ERROR because verifyCredentials returned ${
+                        verifyResult.status
+                    }${
+                        (verifyResult as { reason?: string }).reason !== undefined
+                            ? ` (reason: ${(verifyResult as { reason?: string }).reason})`
+                            : ""
+                    }`
+                );
                 return { status: "INVALID_CREDENTIALS_ERROR" };
             }
 
@@ -325,6 +334,9 @@ export default function getAPIImplementation(stInstance: SuperTokens): APIInterf
                 userContext,
             });
             if (generatedOptions.status !== "OK") {
+                logDebugMessage(
+                    `signInPOST: returning INVALID_CREDENTIALS_ERROR because getGeneratedOptions returned ${generatedOptions.status}`
+                );
                 return {
                     status: "INVALID_CREDENTIALS_ERROR",
                 };
@@ -395,29 +407,20 @@ export default function getAPIImplementation(stInstance: SuperTokens): APIInterf
                 };
             }
 
-            const signInResponse = await options.recipeImplementation.signIn({
-                webauthnGeneratedOptionsId,
-                credential,
+            // The credential was already verified against the core by the verifyCredentials
+            // call above, so we only run the post-verification steps here. Calling signIn
+            // (which verifies again) would present the same assertion to the core twice and
+            // trip its signature-counter clone detection for counter-incrementing
+            // authenticators (https://github.com/supertokens/supertokens-core/issues/1195).
+            const signInResponse = await options.recipeImplementation.completeSignIn({
+                verifiedCredentials: verifyResult,
                 session,
                 shouldTryLinkingWithSessionUser,
                 tenantId,
                 userContext,
             });
 
-            if (signInResponse.status === "INVALID_CREDENTIALS_ERROR") {
-                return signInResponse;
-            }
-            if (
-                signInResponse.status === "INVALID_OPTIONS_ERROR" ||
-                signInResponse.status === "INVALID_AUTHENTICATOR_ERROR" ||
-                signInResponse.status === "CREDENTIAL_NOT_FOUND_ERROR" ||
-                signInResponse.status === "UNKNOWN_USER_ID_ERROR" ||
-                signInResponse.status === "OPTIONS_NOT_FOUND_ERROR"
-            ) {
-                return {
-                    status: "INVALID_CREDENTIALS_ERROR",
-                };
-            } else if (signInResponse.status !== "OK") {
+            if (signInResponse.status !== "OK") {
                 return AuthUtils.getErrorStatusResponseWithReason(signInResponse, errorCodeMap, "SIGN_IN_NOT_ALLOWED");
             }
 

--- a/lib/ts/recipe/webauthn/recipeImplementation.ts
+++ b/lib/ts/recipe/webauthn/recipeImplementation.ts
@@ -186,31 +186,47 @@ export default function getRecipeInterface(
                 return response;
             }
 
-            const loginMethod: LoginMethod = response.user.loginMethods.find(
-                (lm: LoginMethod) => lm.recipeUserId.getAsString() === response.recipeUserId.getAsString()
+            return this.completeSignIn({
+                verifiedCredentials: response,
+                session,
+                shouldTryLinkingWithSessionUser,
+                tenantId,
+                userContext,
+            });
+        },
+
+        completeSignIn: async function (
+            this: RecipeInterface,
+            { verifiedCredentials, tenantId, session, shouldTryLinkingWithSessionUser, userContext }
+        ) {
+            const { recipeUserId } = verifiedCredentials;
+            let user = verifiedCredentials.user;
+
+            const loginMethod: LoginMethod = user.loginMethods.find(
+                (lm: LoginMethod) => lm.recipeUserId.getAsString() === recipeUserId.getAsString()
             )!;
 
             if (!loginMethod.verified) {
                 await stInstance
                     .getRecipeInstanceOrThrow("accountlinking")
                     .verifyEmailForRecipeUserIfLinkedAccountsAreVerified({
-                        user: response.user,
-                        recipeUserId: response.recipeUserId,
+                        user,
+                        recipeUserId,
                         userContext,
                     });
 
                 // We do this so that we get the updated user (in case the above
                 // function updated the verification status) and can return that
-                response.user = (await stInstance
+                user = (await stInstance
                     .getRecipeInstanceOrThrow("accountlinking")
-                    .recipeInterfaceImpl.getUser({ userId: response.recipeUserId!.getAsString(), userContext }))!;
+                    .recipeInterfaceImpl.getUser({ userId: recipeUserId.getAsString(), userContext }))!;
             }
 
             const linkResult = await AuthUtils.linkToSessionIfRequiredElseCreatePrimaryUserIdOrLinkByAccountInfo({
                 stInstance,
                 tenantId,
-                inputUser: response.user,
-                recipeUserId: response.recipeUserId,
+                inputUser: user,
+                recipeUserId,
                 session,
                 shouldTryLinkingWithSessionUser,
                 userContext,
@@ -218,9 +234,8 @@ export default function getRecipeInterface(
             if (linkResult.status === "LINKING_TO_SESSION_USER_FAILED") {
                 return linkResult;
             }
-            response.user = linkResult.user;
 
-            return response;
+            return { status: "OK", user: linkResult.user, recipeUserId };
         },
 
         verifyCredentials: async function ({ credential, webauthnGeneratedOptionsId, tenantId, userContext }) {

--- a/lib/ts/recipe/webauthn/types.ts
+++ b/lib/ts/recipe/webauthn/types.ts
@@ -280,6 +280,32 @@ export type RecipeInterface = {
         userContext: UserContext;
     }): Promise<{ status: "OK"; user: User; recipeUserId: RecipeUserId } | SignInErrorResponse>;
 
+    /**
+     * Runs the post-verification part of sign in (email verification propagation and
+     * account linking) against an already-verified credential. Called by signInPOST
+     * after its verifyCredentials guard so that the assertion is verified against the
+     * core exactly once per request — verifying the same assertion twice trips the
+     * core's signature-counter clone detection for counter-incrementing authenticators
+     * (https://github.com/supertokens/supertokens-core/issues/1195).
+     */
+    completeSignIn(input: {
+        verifiedCredentials: { user: User; recipeUserId: RecipeUserId };
+        session: SessionContainerInterface | undefined;
+        shouldTryLinkingWithSessionUser: boolean | undefined;
+        tenantId: string;
+        userContext: UserContext;
+    }): Promise<
+        | { status: "OK"; user: User; recipeUserId: RecipeUserId }
+        | {
+              status: "LINKING_TO_SESSION_USER_FAILED";
+              reason:
+                  | "EMAIL_VERIFICATION_REQUIRED"
+                  | "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
+                  | "ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR"
+                  | "SESSION_USER_ACCOUNT_INFO_ALREADY_ASSOCIATED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR";
+          }
+    >;
+
     verifyCredentials(input: {
         webauthnGeneratedOptionsId: string;
         credential: AuthenticationPayload;

--- a/test/webauthn/lib/softAuthenticator.js
+++ b/test/webauthn/lib/softAuthenticator.js
@@ -1,0 +1,199 @@
+const crypto = require("crypto");
+
+/**
+ * A minimal software WebAuthn authenticator with full control over the
+ * signature counter (signCount) — unlike the wasm helper in getWebAuthnLib.js,
+ * which keeps the counter at 0 and therefore never trips the core's
+ * clone-detection check (WebAuthn L3 §7.2 step 24).
+ *
+ * Produces `fmt: "none"` attestations, which the core accepts because it
+ * verifies with webauthn4j's non-strict manager.
+ */
+
+// --- minimal CBOR encoder (only the subset needed for attestation objects) ---
+
+function cborHead(major, n) {
+    if (n < 24) return Buffer.from([(major << 5) | n]);
+    if (n < 0x100) return Buffer.from([(major << 5) | 24, n]);
+    if (n < 0x10000) {
+        const b = Buffer.alloc(3);
+        b[0] = (major << 5) | 25;
+        b.writeUInt16BE(n, 1);
+        return b;
+    }
+    const b = Buffer.alloc(5);
+    b[0] = (major << 5) | 26;
+    b.writeUInt32BE(n, 1);
+    return b;
+}
+
+// value: number (int) | string | Buffer | Array of [key, value] pairs (map)
+function cborEncode(value) {
+    if (typeof value === "number") {
+        if (!Number.isInteger(value)) throw new Error("only integers supported");
+        return value >= 0 ? cborHead(0, value) : cborHead(1, -1 - value);
+    }
+    if (typeof value === "string") {
+        const utf8 = Buffer.from(value, "utf8");
+        return Buffer.concat([cborHead(3, utf8.length), utf8]);
+    }
+    if (Buffer.isBuffer(value)) {
+        return Buffer.concat([cborHead(2, value.length), value]);
+    }
+    if (Array.isArray(value)) {
+        // treated as a map of [key, value] pairs (preserves integer keys for COSE)
+        const parts = [cborHead(5, value.length)];
+        for (const [k, v] of value) {
+            parts.push(cborEncode(k), cborEncode(v));
+        }
+        return Buffer.concat(parts);
+    }
+    throw new Error("unsupported CBOR value: " + typeof value);
+}
+
+// --- helpers ---
+
+const b64url = (buf) => Buffer.from(buf).toString("base64url");
+
+function sha256(data) {
+    return crypto.createHash("sha256").update(data).digest();
+}
+
+function counterBytes(signCount) {
+    const b = Buffer.alloc(4);
+    b.writeUInt32BE(signCount, 0);
+    return b;
+}
+
+const FLAG_UP = 0x01;
+const FLAG_UV = 0x04;
+const FLAG_AT = 0x40;
+
+/**
+ * Creates a soft authenticator bound to one credential (one P-256 keypair).
+ *
+ * @param {{ rpId: string, origin: string }} config — must match the SDK's
+ *   relying party id (default: apiDomain host) and origin (default: websiteDomain).
+ */
+function createSoftAuthenticator({ rpId, origin }) {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync("ec", { namedCurve: "P-256" });
+    const jwk = publicKey.export({ format: "jwk" });
+    const x = Buffer.from(jwk.x, "base64url");
+    const y = Buffer.from(jwk.y, "base64url");
+    const credentialId = crypto.randomBytes(32);
+    const rpIdHash = sha256(rpId);
+
+    // COSE_Key: kty(1)=EC2(2), alg(3)=ES256(-7), crv(-1)=P-256(1), x(-2), y(-3)
+    const coseKey = cborEncode([
+        [1, 2],
+        [3, -7],
+        [-1, 1],
+        [-2, x],
+        [-3, y],
+    ]);
+
+    return {
+        credentialId,
+
+        /**
+         * @param registerOptions — response body of POST /auth/webauthn/options/register
+         * @param {{ signCount?: number }} opts — initial counter value stored by the RP
+         * @returns a RegistrationPayload for POST /auth/webauthn/signup
+         */
+        createAttestation(registerOptions, { signCount = 0 } = {}) {
+            const clientDataJSON = Buffer.from(
+                JSON.stringify({
+                    type: "webauthn.create",
+                    challenge: registerOptions.challenge,
+                    origin,
+                    crossOrigin: false,
+                }),
+                "utf8"
+            );
+
+            const attestedCredentialData = Buffer.concat([
+                Buffer.alloc(16), // aaguid (zero = "none")
+                (() => {
+                    const len = Buffer.alloc(2);
+                    len.writeUInt16BE(credentialId.length, 0);
+                    return len;
+                })(),
+                credentialId,
+                coseKey,
+            ]);
+
+            const authData = Buffer.concat([
+                rpIdHash,
+                Buffer.from([FLAG_UP | FLAG_UV | FLAG_AT]),
+                counterBytes(signCount),
+                attestedCredentialData,
+            ]);
+
+            const attestationObject = cborEncode([
+                ["fmt", "none"],
+                ["attStmt", []],
+                ["authData", authData],
+            ]);
+
+            return {
+                id: b64url(credentialId),
+                rawId: b64url(credentialId),
+                response: {
+                    clientDataJSON: b64url(clientDataJSON),
+                    attestationObject: b64url(attestationObject),
+                    transports: ["internal"],
+                },
+                type: "public-key",
+                clientExtensionResults: {},
+                authenticatorAttachment: "platform",
+            };
+        },
+
+        /**
+         * @param signInOptions — response body of POST /auth/webauthn/options/signin
+         * @param {{ signCount: number, userHandle: string }} opts — signCount is the
+         *   counter value this assertion reports (a real authenticator increments it
+         *   on every use; Apple/Google passkeys keep it at 0); userHandle is
+         *   registerOptions.user.id from registration.
+         * @returns an AuthenticationPayload for POST /auth/webauthn/signin
+         */
+        createAssertion(signInOptions, { signCount, userHandle }) {
+            const clientDataJSON = Buffer.from(
+                JSON.stringify({
+                    type: "webauthn.get",
+                    challenge: signInOptions.challenge,
+                    origin,
+                    crossOrigin: false,
+                }),
+                "utf8"
+            );
+
+            const authenticatorData = Buffer.concat([
+                rpIdHash,
+                Buffer.from([FLAG_UP | FLAG_UV]),
+                counterBytes(signCount),
+            ]);
+
+            const signature = crypto
+                .createSign("SHA256")
+                .update(Buffer.concat([authenticatorData, sha256(clientDataJSON)]))
+                .sign(privateKey); // DER-encoded ECDSA, as WebAuthn ES256 requires
+
+            return {
+                id: b64url(credentialId),
+                rawId: b64url(credentialId),
+                response: {
+                    clientDataJSON: b64url(clientDataJSON),
+                    authenticatorData: b64url(authenticatorData),
+                    signature: b64url(signature),
+                    userHandle,
+                },
+                type: "public-key",
+                clientExtensionResults: {},
+                authenticatorAttachment: "platform",
+            };
+        },
+    };
+}
+
+module.exports = createSoftAuthenticator;

--- a/test/webauthn/signInDoubleVerify.test.js
+++ b/test/webauthn/signInDoubleVerify.test.js
@@ -1,0 +1,187 @@
+/* Copyright (c) 2026, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Reproduces https://github.com/supertokens/supertokens-core/issues/1195
+ *
+ * signInPOST verifies the same assertion twice against the core
+ * (verifyCredentials at the top, then signIn -> verifyCredentials again).
+ * The core persists the signature counter on every verification, so the
+ * second call presents a non-increasing signCount and webauthn4j rejects it
+ * as a cloned authenticator ("Malicious counter value is detected...").
+ *
+ * This only triggers for authenticators that actually increment signCount
+ * (Windows Hello, security keys, Chrome virtual authenticators). Apple and
+ * Google passkeys keep signCount at 0 forever, which skips the check and
+ * hides the bug — hence the control tests below.
+ */
+
+const { printPath, createCoreApplication, resetAll } = require("../utils");
+let STExpress = require("../../");
+let assert = require("assert");
+let { ProcessState } = require("../../lib/build/processState");
+let WebAuthn = require("../../recipe/webauthn");
+let Session = require("../../recipe/session");
+const request = require("supertest");
+const express = require("express");
+const { middleware, errorHandler } = require("../../framework/express");
+const createSoftAuthenticator = require("./lib/softAuthenticator");
+
+// Must be a consistent pair: the core validates that the origin host ends with
+// the relying party id. (The defaults derived from appInfo — rpId=apiDomain
+// host, origin=websiteDomain — do NOT satisfy this, so we set them explicitly.)
+const RP_ID = "supertokens.io";
+const ORIGIN = "https://supertokens.io";
+
+async function initSTAndGetApp() {
+    const connectionURI = await createCoreApplication();
+    STExpress.init({
+        supertokens: { connectionURI },
+        appInfo: {
+            apiDomain: "api.supertokens.io",
+            appName: "SuperTokens",
+            websiteDomain: "supertokens.io",
+        },
+        recipeList: [
+            WebAuthn.init({
+                getRelyingPartyId: async () => RP_ID,
+                getOrigin: async () => ORIGIN,
+            }),
+            Session.init(),
+        ],
+    });
+
+    const app = express();
+    app.use(middleware());
+    app.use(errorHandler());
+    return app;
+}
+
+function post(app, path, body) {
+    return new Promise((resolve, reject) =>
+        request(app)
+            .post(path)
+            .send(body)
+            .expect(200)
+            .end((err, res) => (err ? reject(err) : resolve(JSON.parse(res.text))))
+    );
+}
+
+// Registers a fresh user+passkey whose stored counter starts at `signCount`.
+async function registerUser(app, authenticator, { signCount }) {
+    const email = `${Math.random().toString().slice(2)}@supertokens.com`;
+
+    const registerOptions = await post(app, "/auth/webauthn/options/register", { email });
+    assert.strictEqual(registerOptions.status, "OK");
+
+    const signUpResponse = await post(app, "/auth/webauthn/signup", {
+        credential: authenticator.createAttestation(registerOptions, { signCount }),
+        webauthnGeneratedOptionsId: registerOptions.webauthnGeneratedOptionsId,
+        shouldTryLinkingWithSessionUser: false,
+    });
+    assert.strictEqual(signUpResponse.status, "OK");
+
+    return { email, userHandle: registerOptions.user.id };
+}
+
+describe(`signInDoubleVerify: ${printPath("[test/webauthn/signInDoubleVerify.test.js]")}`, function () {
+    beforeEach(async function () {
+        ProcessState.getInstance().reset();
+        resetAll();
+    });
+
+    /**
+     * THE REPRODUCTION — fails on current main with INVALID_CREDENTIALS_ERROR.
+     *
+     * A single, perfectly legitimate sign-in API call with an authenticator
+     * that increments its signature counter must succeed. Today the second
+     * internal verification sees the already-persisted counter and the core
+     * returns INVALID_AUTHENTICATOR_ERROR ("Malicious counter value is
+     * detected. Cloned authenticators exist in parallel."), which signInPOST
+     * masks as INVALID_CREDENTIALS_ERROR.
+     */
+    it("single sign-in API call succeeds with a counter-incrementing authenticator (core#1195)", async function () {
+        const app = await initSTAndGetApp();
+        const authenticator = createSoftAuthenticator({ rpId: RP_ID, origin: ORIGIN });
+        const { userHandle } = await registerUser(app, authenticator, { signCount: 1 });
+
+        const signInOptions = await post(app, "/auth/webauthn/options/signin", {});
+        assert.strictEqual(signInOptions.status, "OK");
+
+        // ONE sign-in with the counter correctly incremented past the stored value.
+        const signInResponse = await post(app, "/auth/webauthn/signin", {
+            credential: authenticator.createAssertion(signInOptions, { signCount: 2, userHandle }),
+            webauthnGeneratedOptionsId: signInOptions.webauthnGeneratedOptionsId,
+            shouldTryLinkingWithSessionUser: false,
+        });
+
+        assert.strictEqual(
+            signInResponse.status,
+            "OK",
+            "A single sign-in with an incrementing signCount must succeed. " +
+                "Failure here means signInPOST verified the assertion twice against the core " +
+                "and tripped its own clone detection (supertokens-core#1195). Got: " +
+                JSON.stringify(signInResponse)
+        );
+    });
+
+    /**
+     * CONTROL 1 — passes on current main.
+     *
+     * The exact same credential/assertion accepted via the recipe function,
+     * which verifies only once. Proves the assertion and counter handling are
+     * valid, isolating the API-layer double verification as the failure cause.
+     */
+    it("direct recipe signIn succeeds with the same counter-incrementing authenticator", async function () {
+        const app = await initSTAndGetApp();
+        const authenticator = createSoftAuthenticator({ rpId: RP_ID, origin: ORIGIN });
+        const { userHandle } = await registerUser(app, authenticator, { signCount: 1 });
+
+        const signInOptions = await post(app, "/auth/webauthn/options/signin", {});
+
+        const signInResult = await WebAuthn.signIn({
+            webauthnGeneratedOptionsId: signInOptions.webauthnGeneratedOptionsId,
+            credential: authenticator.createAssertion(signInOptions, { signCount: 2, userHandle }),
+            session: undefined,
+            shouldTryLinkingWithSessionUser: false,
+            tenantId: "public",
+        });
+
+        assert.strictEqual(signInResult.status, "OK", "Got: " + JSON.stringify(signInResult));
+    });
+
+    /**
+     * CONTROL 2 — passes on current main.
+     *
+     * With signCount pinned to 0 (Apple/Google passkey behavior) the spec skips
+     * the counter check entirely, so the double verification goes unnoticed.
+     * This is why the bug was invisible in most manual testing.
+     */
+    it("sign-in API call succeeds when signCount stays 0 (why the bug is hidden)", async function () {
+        const app = await initSTAndGetApp();
+        const authenticator = createSoftAuthenticator({ rpId: RP_ID, origin: ORIGIN });
+        const { userHandle } = await registerUser(app, authenticator, { signCount: 0 });
+
+        const signInOptions = await post(app, "/auth/webauthn/options/signin", {});
+
+        const signInResponse = await post(app, "/auth/webauthn/signin", {
+            credential: authenticator.createAssertion(signInOptions, { signCount: 0, userHandle }),
+            webauthnGeneratedOptionsId: signInOptions.webauthnGeneratedOptionsId,
+            shouldTryLinkingWithSessionUser: false,
+        });
+
+        assert.strictEqual(signInResponse.status, "OK", "Got: " + JSON.stringify(signInResponse));
+    });
+});


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] If new thirdparty provider is added,
    -   [ ] update switch statement in `recipe/thirdparty/providers/configUtils.ts` file, `createProvider` function.
    -   [ ] add an icon on the user management dashboard.
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If have added a new web framework, update the `add-ts-no-check.js` file to include that
-   [ ] If added a new recipe / api interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If added a new recipe, then make sure to expose it inside the recipe folder present in the root of this repo. We also need to expose its types.
-   [ ] If added a new entry point, then make sure that it is importable by adding it to the `exports` in `package.json`

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
