### PR TITLE
chore(deps): bump nodemailer to ^9.0.1 to address GHSA-p6gq-j5cr-w38f

### DIFF
--- a/.changes/unreleased/Security-20260910-120000.yaml
+++ b/.changes/unreleased/Security-20260910-120000.yaml
@@ -1,0 +1,3 @@
+kind: Security
+body: Bump nodemailer from 8.0.2 to 9.0.1 to address GHSA-p6gq-j5cr-w38f
+time: 2026-09-10T12:00:00.000000000+01:00

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "debug": "^4.3.3",
                 "jose": "^4.13.1",
                 "libphonenumber-js": "^1.9.44",
-                "nodemailer": "^8.0.2",
+                "nodemailer": "^9.0.1",
                 "pako": "^2.1.0",
                 "pkce-challenge": "^3.0.0",
                 "process": "^0.11.10",
@@ -6317,9 +6317,9 @@
             "dev": true
         },
         "node_modules/nodemailer": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.2.tgz",
-            "integrity": "sha512-zbj002pZAIkWQFxyAaqoxvn+zoIwRnS40hgjqTXudKOOJkiFFgBeNqjgD3/YCR12sZnrghWYBY+yP1ZucdDRpw==",
+            "version": "9.1.1",
+            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.1.1.tgz",
+            "integrity": "sha512-izw9mVKFix6YSnC9eLgV6g1opl9DUlRio9ZNcq+Wu9Ujn2UwF+8Nl0B8nz22kEC+CTZCvinkxwJ0DeFbb6NwcQ==",
             "license": "MIT-0",
             "engines": {
                 "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
         "debug": "^4.3.3",
         "jose": "^4.13.1",
         "libphonenumber-js": "^1.9.44",
-        "nodemailer": "^8.0.2",
+        "nodemailer": "^9.0.1",
         "pako": "^2.1.0",
         "pkce-challenge": "^3.0.0",
         "process": "^0.11.10",


### PR DESCRIPTION
## Summary of change

`supertokens-node` depends on `nodemailer: "^8.0.2"`. GHSA-p6gq-j5cr-w38f covers
`nodemailer <= 9.0.0`, and the 8.x line was never patched — the newest 8.x release,
8.0.11, is still affected. Every install of `supertokens-node@>=9.3.0` therefore
resolves to a vulnerable nodemailer, and `npm audit fix --force` "fixes" it by
downgrading to `supertokens-node@9.2.3`. Today the only way out is a dependency
override (npm `overrides`, yarn `resolutions`).

This bumps the range to `^9.0.1`, the first patched release.

The upgrade is a no-op for this SDK's usage. All four SMTP services
(`emailpassword`, `emailverification`, `passwordless`, `webauthn`) use
`createTransport(...)` plus `sendMail({ from, to, subject, html | text })`. None
passes the message-level `raw` option the advisory is about, those options are
unchanged from v8 to v9, and `engines` is identical in both lines (`node >= 6.0.0`),
so the supported Node range does not move.

Not v10 on purpose: nodemailer 10 raises its floor to Node 20, which would put it
above the Node version this repo's test suite runs on (>= 16.20.0, < 17.0.0). 9.x
is the newest line that clears the advisory without touching CI.

## Related issues

-   Closes #1037
-   Follows #1042, which moved the range 6.9 -> 8.0.2 for the earlier advisories

## Test Plan

`npm install` resolves nodemailer 9.1.1 and `npm audit` reports the nodemailer
advisory gone. The SMTP send path is unchanged; verified by inspection that no call
site passes `raw`.

## Documentation changes

None.

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook

Nothing under `lib/` changes, so no rebuild or interface-version bump applies.
